### PR TITLE
test: verify Veridion PR diff composite action

### DIFF
--- a/.github/workflows/veridion-diff-test.yml
+++ b/.github/workflows/veridion-diff-test.yml
@@ -1,0 +1,13 @@
+name: Veridion Diff Test
+on:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        id: veridion
+        with:
+          fail-on-new-secrets: "false"
+      - run: echo "${{ steps.veridion.outputs.diff-json }}"

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Install Veridion
       shell: bash
-      run: pip install "git+https://github.com/ArihantK15/Veridion.git@${{ github.action_ref }}#subdirectory=prototype"
+      run: pip install "${{ github.action_path }}/prototype"
 
     - name: Scan base
       shell: bash

--- a/docs/superpowers/plans/2026-07-15-veridion-ci-pr-integration.md
+++ b/docs/superpowers/plans/2026-07-15-veridion-ci-pr-integration.md
@@ -353,7 +353,7 @@ runs:
 
     - name: Install Veridion
       shell: bash
-      run: pip install "git+https://github.com/ArihantK15/Veridion.git@${{ github.action_ref }}#subdirectory=prototype"
+      run: pip install "${{ github.action_path }}/prototype"
 
     - name: Scan base
       shell: bash
@@ -407,8 +407,18 @@ dev shell for this one-off manual check — it is not added as a project depende
 Re-read `docs/superpowers/specs/2026-07-15-veridion-ci-pr-integration-design.md`'s "action.yml:
 Composite GitHub Action" section side-by-side with the file just written. Confirm: all 4 inputs
 present with correct defaults, the `diff-json` output wired to `steps.diff.outputs.diff-json`,
-all 7 steps present in the documented order, the `github.action_ref` pinning present in the
-install step exactly as specified.
+all 7 steps present in the documented order, the `github.action_path`-based install present in
+the install step exactly as specified.
+
+**Update after live testing (Task 3 Step 3):** the install step originally used
+`git+https://github.com/ArihantK15/Veridion.git@${{ github.action_ref }}#subdirectory=prototype`.
+The first live run via `uses: ./` failed — `github.action_ref` is only set when an action is
+referenced by tag/branch/SHA, and is empty for a local path reference, producing an invalid pip
+URL with no revision after `@`. Fixed to `pip install "${{ github.action_path }}/prototype"`,
+which works identically for `uses: ./` and `uses: owner/repo@v1` since it installs from wherever
+the action's own source is already checked out, with no network git-fetch involved. Both this
+plan and the design spec were updated to match; `action.yml` itself was fixed and re-verified
+live (see Task 3).
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/specs/2026-07-15-veridion-ci-pr-integration-design.md
+++ b/docs/superpowers/specs/2026-07-15-veridion-ci-pr-integration-design.md
@@ -86,12 +86,18 @@ inherits the main repo's visibility rather than starting from zero).
 1. `actions/checkout@v4` with `ref: ${{ inputs.base-ref }}`, `path: veridion-base`
 2. `actions/checkout@v4` with `ref: ${{ inputs.head-ref }}`, `path: veridion-head`
 3. `actions/setup-python@v5`, Python 3.12 (matching this project's own floor)
-4. Install: `pip install "git+https://github.com/ArihantK15/Veridion.git@${{ github.action_ref }}#subdirectory=prototype"`
-   — confirmed necessary (no PyPI package exists for Veridion; `pip index versions veridion`
-   returns no match). `github.action_ref` is GitHub Actions' own context variable for "the ref
-   of the action currently being executed" — using it means a consumer pinned to `@v1` installs
-   the matching tagged Veridion version, not whatever happens to be on the default branch at
-   that instant.
+4. Install: `pip install "${{ github.action_path }}/prototype"` — confirmed necessary (no PyPI
+   package exists for Veridion; `pip index versions veridion` returns no match).
+   **Correction found via live testing** (Task 3 Step 3 of the implementation plan): the
+   original design used `git+https://github.com/ArihantK15/Veridion.git@${{ github.action_ref
+   }}#subdirectory=prototype`, reasoning that `github.action_ref` would pin the install to the
+   consumer's referenced tag. This broke immediately in the first live end-to-end test — GitHub
+   only sets `action_ref` when the action is referenced by tag/branch/SHA, and is **empty**
+   when referenced via a local path (`uses: ./`, exactly how same-repo testing before the first
+   tag exists must work), producing an invalid pip URL with an empty revision after `@`.
+   `github.action_path` (the path where the action's own source is already checked out) is set
+   correctly regardless of reference style, requires no network git-fetch at all, and works
+   identically for same-repo (`uses: ./`) and cross-repo (`uses: owner/repo@v1`) consumption.
 5. `veridion scan veridion-base --no-check-vulnerabilities`
 6. `veridion scan veridion-head --no-check-vulnerabilities`
    (Vulnerability checking is off by default in the action, since it calls OSV.dev twice per


### PR DESCRIPTION
Throwaway PR to verify action.yml (composite GitHub Action for PR diffing) actually runs end to end - checks out both base/head refs, scans both, runs veridion diff, and correctly surfaces the diff-json output.

Not meant to be merged. Will be closed/deleted once verified per docs/superpowers/plans/2026-07-15-veridion-ci-pr-integration.md Task 3 Step 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated pull request workflow that runs the Veridion diff check.
  * The workflow reports detected differences for review without failing on newly detected secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->