### PR TITLE
Redesign marketing website and add Developers page

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,7 @@
 exclude = [
   "^mailto:",
   "^https://github.com/marketplace$",
+  "^https://www.linkedin.com/company/aletheore$",
   "^https://www.aletheore.com",
   "^https://aletheore.com"
 ]

--- a/website/developers.html
+++ b/website/developers.html
@@ -34,7 +34,7 @@
         <a href="developers.html">Developers</a>
         <a href="terms.html">Terms</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
         <a class="btn btn-primary" href="https://app.aletheore.com/">Get Started</a>
       </div>
@@ -236,7 +236,7 @@ aletheore dashboard .</code></pre>
       </div>
       <div>
         <h4>Community</h4>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://github.com/sponsors/ArihantK15">Sponsor</a>
         <a href="https://github.com/Aletheore/Aletheore/issues">Issues</a>
       </div>

--- a/website/developers.html
+++ b/website/developers.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Aletheore Developers — CLI, MCP, AIR, and Source-Grounded Tools</title>
+  <meta name="description" content="Developer guide for Aletheore: pip install, CLI commands, query subcommands, MCP tools, AIR evidence files, semantic search, AIRview, and managed audits.">
+  <link rel="canonical" href="https://www.aletheore.com/developers">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Aletheore">
+  <meta property="og:url" content="https://www.aletheore.com/developers">
+  <meta property="og:title" content="Aletheore Developers — CLI, MCP, AIR, and Source-Grounded Tools">
+  <meta property="og:description" content="Install Aletheore from PyPI, scan repositories locally, query AIR evidence, run MCP tools for coding agents, and use AIRview for architecture intelligence.">
+  <meta property="og:image" content="https://www.aletheore.com/assets/logo-mark.png">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Aletheore Developers — CLI, MCP, AIR, and Source-Grounded Tools">
+  <meta name="twitter:description" content="CLI commands, query subcommands, MCP tools, and AIR evidence files for source-grounded code intelligence.">
+  <meta name="twitter:image" content="https://www.aletheore.com/assets/logo-mark.png">
+
+  <link rel="icon" type="image/png" href="assets/logo-mark.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <nav class="site-nav" aria-label="Main navigation">
+      <a class="wordmark" href="index.html">
+        <img src="assets/logo-mark.png" alt="" width="28" height="28">
+        Aletheore
+      </a>
+      <div class="nav-links">
+        <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
+        <a href="terms.html">Terms</a>
+        <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://app.aletheore.com/">Dashboard</a>
+        <a class="btn btn-primary" href="https://app.aletheore.com/">Get Started</a>
+      </div>
+    </nav>
+
+    <main>
+      <section class="developer-hero">
+        <div>
+          <p class="eyebrow">For developers and coding agents</p>
+          <h1>Source-grounded repository intelligence from one command.</h1>
+          <p>Install Aletheore from PyPI, scan a repository locally, and expose the same evidence to CLI queries, MCP tools, AIRview, dashboard views, and managed audits.</p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="#quickstart">Install from PyPI</a>
+            <a class="btn btn-secondary" href="#mcp">View MCP tools</a>
+          </div>
+        </div>
+        <div class="install-card" aria-label="Aletheore install and first scan commands">
+          <div class="terminal-title">
+            <span class="terminal-controls"></span>
+            <strong>Quickstart</strong>
+          </div>
+          <pre><code>pip install Aletheore
+
+aletheore scan .
+aletheore query endpoints
+aletheore dashboard</code></pre>
+        </div>
+      </section>
+
+      <section id="quickstart" class="developer-section">
+        <div class="section-heading">
+          <p class="eyebrow">CLI workflow</p>
+          <h2>Scan once. Query the evidence many ways.</h2>
+          <p>The deterministic scan writes AIR, Aletheore's Intermediate Representation. Downstream commands read AIR instead of scanning blindly again.</p>
+        </div>
+        <div class="command-grid">
+          <article>
+            <h3>Install and scan</h3>
+            <pre><code>pip install Aletheore
+aletheore scan .</code></pre>
+            <p>Builds <code>.aletheore/air.json</code>, <code>.aletheore/air.toon</code>, and history snapshots.</p>
+          </article>
+          <article>
+            <h3>Audit locally or managed</h3>
+            <pre><code>aletheore audit .
+aletheore audit . --managed</code></pre>
+            <p>Use your own provider locally, or run a managed audit with an Aletheore API token.</p>
+          </article>
+          <article>
+            <h3>Search and dashboard</h3>
+            <pre><code>aletheore index .
+aletheore query search-codebase "auth flow"
+aletheore dashboard .</code></pre>
+            <p>Build a local semantic index, ask targeted questions, and inspect evidence visually.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="developer-section">
+        <div class="section-heading">
+          <p class="eyebrow">Query subcommands</p>
+          <h2>Ask precise questions without sending the whole repo.</h2>
+        </div>
+        <div class="query-board">
+          <div>
+            <h3>Repository structure</h3>
+            <code>imports</code>
+            <code>imported-by</code>
+            <code>symbols</code>
+            <code>cluster</code>
+            <code>branch</code>
+            <code>changes</code>
+          </div>
+          <div>
+            <h3>Risk and operations</h3>
+            <code>secrets</code>
+            <code>vulnerabilities</code>
+            <code>licenses</code>
+            <code>endpoints</code>
+            <code>dead-code</code>
+            <code>hotspots</code>
+          </div>
+          <div>
+            <h3>Code intelligence</h3>
+            <code>database</code>
+            <code>infrastructure</code>
+            <code>environment-variables</code>
+            <code>symbol-source</code>
+            <code>search-codebase</code>
+            <code>answer</code>
+          </div>
+          <div>
+            <h3>Evidence resolution</h3>
+            <code>evidence-for-endpoint</code>
+            <code>evidence-for-symbol</code>
+            <code>evidence-for-dependency</code>
+            <code>ownership</code>
+          </div>
+        </div>
+      </section>
+
+      <section id="mcp" class="developer-section mcp-section">
+        <div>
+          <p class="eyebrow">MCP server</p>
+          <h2>Give coding agents tools, not a giant prompt.</h2>
+          <p>Aletheore's MCP server exposes repository evidence as structured, TOON-encoded tool results. Agents can ask for imports, owners, endpoints, symbols, semantic search, source evidence, and managed audits without pasting the whole repository into context.</p>
+          <pre><code>aletheore mcp .</code></pre>
+        </div>
+        <div class="mcp-tool-list">
+          <span>aletheore_scan</span>
+          <span>aletheore_imports</span>
+          <span>aletheore_imported_by</span>
+          <span>aletheore_symbols</span>
+          <span>aletheore_neighborhood</span>
+          <span>aletheore_search</span>
+          <span>aletheore_symbol_source</span>
+          <span>aletheore_find_evidence_for_endpoint</span>
+          <span>aletheore_find_evidence_for_symbol</span>
+          <span>aletheore_find_evidence_for_dependency</span>
+          <span>aletheore_healthcheck</span>
+          <span>aletheore_search_codebase</span>
+          <span>aletheore_answer</span>
+          <span>aletheore_managed_audit</span>
+        </div>
+      </section>
+
+      <section class="developer-section evidence-contract">
+        <div>
+          <p class="eyebrow">Evidence contract</p>
+          <h2>One source of truth.</h2>
+          <p>Everything downstream reads the same deterministic evidence. AIRview, dashboard, query, MCP, and audits do not invent files, routes, symbols, or owners that are not present in AIR.</p>
+        </div>
+        <div class="contract-list">
+          <article>
+            <h3>.aletheore/air.json</h3>
+            <p>Canonical repository evidence: modules, symbols, dependencies, endpoints, architecture, security, ownership, and history.</p>
+          </article>
+          <article>
+            <h3>.aletheore/air.toon</h3>
+            <p>TOON-encoded evidence for agent-facing and model-facing contexts where token cost matters.</p>
+          </article>
+          <article>
+            <h3>.aletheore/history/</h3>
+            <p>Snapshots used for changes, drift, and continuity between scans.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="developer-section deep-features">
+        <div class="section-heading">
+          <p class="eyebrow">Depth without mystery</p>
+          <h2>Technical surfaces that stay evidence-first.</h2>
+        </div>
+        <div class="pillar-grid">
+          <article class="pillar-card">
+            <span class="pillar-index">AIRview</span>
+            <h3>Architecture maps</h3>
+            <p>AI-written subsystem pages and dependency diagrams grounded in deterministic architecture clusters.</p>
+          </article>
+          <article class="pillar-card">
+            <span class="pillar-index">MCP</span>
+            <h3>Agent context savings</h3>
+            <p>Agents request focused evidence instead of dragging entire repositories into model context.</p>
+          </article>
+          <article class="pillar-card">
+            <span class="pillar-index">Security</span>
+            <h3>Risk resolution</h3>
+            <p>Secrets, vulnerabilities, dependencies, endpoints, and infrastructure findings trace back to source.</p>
+          </article>
+          <article class="pillar-card">
+            <span class="pillar-index">Health</span>
+            <h3>Endpoint checks</h3>
+            <p><code>aletheore healthcheck</code> runs GET-only checks against mapped API endpoints and saves the result locally.</p>
+          </article>
+          <article class="pillar-card">
+            <span class="pillar-index">Local</span>
+            <h3>Privacy by default</h3>
+            <p>The CLI scan runs locally. Managed and hosted flows use derived evidence according to the selected workflow.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <a class="wordmark" href="index.html">
+          <img src="assets/logo-mark.png" alt="" width="24" height="24">
+          Aletheore
+        </a>
+        <p class="footer-note">Evidence-grounded repository audits. Open source, local-first.</p>
+      </div>
+      <div>
+        <h4>Product</h4>
+        <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
+        <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
+      </div>
+      <div>
+        <h4>Community</h4>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://github.com/sponsors/ArihantK15">Sponsor</a>
+        <a href="https://github.com/Aletheore/Aletheore/issues">Issues</a>
+      </div>
+      <div>
+        <h4>Legal</h4>
+        <a href="terms.html">Terms</a>
+        <a href="privacy.html">Privacy</a>
+        <a href="refund.html">Refund Policy</a>
+      </div>
+    </div>
+  </footer>
+  <script src="vendor/motion.js"></script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -87,8 +87,10 @@
       </a>
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
         <a href="terms.html">Terms</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
         <a class="btn btn-primary" href="https://app.aletheore.com/">Get Started</a>
       </div>
@@ -96,118 +98,157 @@
 
     <section class="hero">
       <div>
-        <h1>I got tired of code-review tools that just guess. So I built one that <span class="accent">has to show its work.</span></h1>
-        <p>Aletheore starts as a deterministic repository scanner - no LLM in the scan path, every claim traced to evidence in your repo - and grows into a hosted GitHub App that detects dead code, monitors your API endpoints live, keeps AIRview - an AI-generated map of your architecture - current on every push, and reviews every pull request automatically.</p>
+        <p class="eyebrow">Evidence-driven code intelligence</p>
+        <h1>AI code intelligence that <span class="accent">has to show its work.</span></h1>
+        <p>Aletheore reviews, audits, and monitors repositories with every finding traced back to source evidence: file, line, symbol, owner, commit, dependency, and risk.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="https://app.aletheore.com/">Start Your First Audit</a>
-          <a class="btn btn-secondary" href="https://github.com/Aletheore/Aletheore">Read the Protocol</a>
+          <a class="btn btn-primary" href="https://app.aletheore.com/">Start Free Audit</a>
+          <a class="btn btn-secondary" href="https://github.com/Aletheore/Aletheore">View GitHub</a>
+          <a class="btn btn-ghost" href="https://www.linkedin.com/company/alethoeore">Follow Updates</a>
+        </div>
+        <div class="hero-trust">
+          <span>Open source</span>
+          <span>Local-first CLI</span>
+          <span>Hosted GitHub App</span>
         </div>
       </div>
-      <div class="hero-mark">
-        <img src="assets/logo-mark.png" alt="Aletheore A monogram">
+      <div class="evidence-preview" aria-label="Aletheore product evidence preview">
+        <div class="preview-header">
+          <div>
+            <span class="status-dot"></span>
+            Production alert
+          </div>
+          <span class="preview-badge">Resolved to code</span>
+        </div>
+        <div class="preview-title">
+          <span>GET</span>
+          <strong>/v1/users</strong>
+          <em>is down</em>
+        </div>
+        <div class="preview-code">
+          <span>handled by</span>
+          <strong>controllers/user.controller.ts:42</strong>
+        </div>
+        <dl class="evidence-grid">
+          <div>
+            <dt>Symbol</dt>
+            <dd>listUsers</dd>
+          </div>
+          <div>
+            <dt>Owner</dt>
+            <dd>@platform</dd>
+          </div>
+          <div>
+            <dt>Commit</dt>
+            <dd>8f42c91</dd>
+          </div>
+          <div>
+            <dt>Risk</dt>
+            <dd>High</dd>
+          </div>
+        </dl>
+        <div class="preview-note">
+          Most tools say it failed. Aletheore shows where it is handled, who owns it, and what changed.
+        </div>
       </div>
     </section>
 
-    <section id="why">
-      <h2>Why deterministic-first.</h2>
-      <p class="section-intro">No LLM ever runs in the scan path. Aletheore reads your repository with tree-sitter and git log, writes what it found to <code>air.json</code> - the AIR, Aletheore's Intermediate Representation - and every other command - <code>query</code>, <code>diff</code>, the dashboard, the MCP server, even <code>audit</code>'s written report - reads from that same file. Nothing downstream states a claim it can't point back to a specific field in it.</p>
+    <section class="evidence-strip" aria-label="Evidence fields">
+      <p>Every alert, review, audit, and query resolves back to:</p>
+      <div>
+        <span>file</span>
+        <span>line</span>
+        <span>symbol</span>
+        <span>owner</span>
+        <span>commit</span>
+        <span>dependency</span>
+        <span>risk</span>
+      </div>
     </section>
 
-    <section id="how">
-      <h2>How it actually works.</h2>
-      <p class="section-intro"><code>aletheore scan</code> runs once and writes two files: <code>air.json</code> (the canonical record - languages, dependency graph, clusters, git activity, secrets, licenses, vulnerabilities, API endpoints) and <code>air.toon</code>, a <a href="https://toonformat.dev">TOON</a>-encoded copy of the same data specifically for the MCP server's tool results and the coding-agent adapter <code>audit</code> uses - because that's where token cost is actually paid, not in the file Aletheore itself keeps on disk. Everything downstream - <code>query</code>, <code>diff</code>, the dashboard, the MCP server, the GitHub App - reads the same AIR. One evidence format, one source of truth, one name for it.</p>
+    <section class="proof-panel">
+      <div>
+        <p class="eyebrow">Why it is different</p>
+        <h2>Most AI tools summarize. Aletheore resolves.</h2>
+      </div>
+      <p>Aletheore starts with deterministic repository evidence, then lets AI reason only over what the scanner can prove. The result is friendlier than raw static analysis and more trustworthy than a generic AI summary.</p>
     </section>
 
     <section id="features">
-      <h2>What it actually checks.</h2>
-      <p class="section-intro">Every capability below runs from the same <code>air.json</code> - nothing here is aspirational copy.</p>
-      <div class="feature-grid">
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore scan</p>
-          <h3>Deterministic scan</h3>
-          <p>Secrets, dependency vulnerabilities and licenses across 11 languages (Python, JavaScript, TypeScript, Go, Rust, Java, Ruby, PHP, C, C++, C#), API endpoint mapping, architecture clustering, and full git history - all from tree-sitter and git log, no LLM involved.</p>
+      <div class="section-heading">
+        <p class="eyebrow">What it covers</p>
+        <h2>One evidence layer. Four useful surfaces.</h2>
+        <p>Run locally with the CLI, install as a GitHub App, or give coding agents a smaller evidence context through MCP.</p>
+      </div>
+      <div class="pillar-grid">
+        <article class="pillar-card">
+          <span class="pillar-index">01</span>
+          <h3>Code Review</h3>
+          <p>Automatic PR comments, Flash reviews, managed audits, and branch-protection checks that cite the changed file and line.</p>
+          <ul>
+            <li>Review only what changed</li>
+            <li>Catch secrets before merge</li>
+            <li>Keep findings source-grounded</li>
+          </ul>
         </article>
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore query dead-code</p>
-          <h3>Dead code detection</h3>
-          <p>Flags unreachable modules and functions from real call-graph analysis - not a guess, a traced absence of any incoming edge from a known entry point.</p>
+        <article class="pillar-card">
+          <span class="pillar-index">02</span>
+          <h3>Repository Intelligence</h3>
+          <p>Architecture clusters, dependency graphs, hotspots, owners, dead code, and AIRview maps from the same canonical evidence.</p>
+          <ul>
+            <li>Understand unfamiliar repos faster</li>
+            <li>Map systems without hand-written docs</li>
+            <li>Give agents precise context</li>
+          </ul>
         </article>
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore query hotspots</p>
-          <h3>Git hotspot intelligence</h3>
-          <p>Surfaces the files that change most and who actually owns them, straight from git log - the parts of your codebase most likely to need a careful review.</p>
+        <article class="pillar-card">
+          <span class="pillar-index">03</span>
+          <h3>Security &amp; Dependencies</h3>
+          <p>Secrets, vulnerable packages, licenses, infrastructure, database usage, and AI usage are detected before an audit is written.</p>
+          <ul>
+            <li>11 language ecosystems</li>
+            <li>No fake coverage or invented signals</li>
+            <li>Risk tied to code evidence</li>
+          </ul>
         </article>
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore query database</p>
-          <h3>Database &amp; infrastructure detection</h3>
-          <p>Finds ORM frameworks, migration directories, schema files, Docker Compose services, Kubernetes manifests, and declared environment variable names (never values) - all from static analysis, nothing executed.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">on: pull_request</p>
-          <h3>GitHub Action</h3>
-          <p>Posts a PR comment and inline annotations on new secrets, plus a step summary on every run - so review happens where the code already lives.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore mcp</p>
-          <h3>MCP server</h3>
-          <p>Gives any coding agent direct, tool-based access to your evidence: imports, dependents, full-text and semantic search, health checks.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore index</p>
-          <h3>Semantic code search</h3>
-          <p>A local vector index over your code, embedded with Ollama and queried with cited answers - nothing leaves your machine.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore audit</p>
-          <h3>Multi-provider reports</h3>
-          <p>Claude, OpenAI, Gemini, Mistral, Grok, or a fully local Ollama model - bring your own key, with consent shown every single time.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">$ aletheore dashboard</p>
-          <h3>Local dashboard</h3>
-          <p>Visualize the dependency graph, clusters, and every finding in a browser tab - reads the same evidence file, nothing else to configure.</p>
+        <article class="pillar-card">
+          <span class="pillar-index">04</span>
+          <h3>Production Monitoring</h3>
+          <p>Source-mapped endpoint health checks alert when a route breaks and point back to the handler that owns it.</p>
+          <ul>
+            <li>Reachability and latency checks</li>
+            <li>Slack and Teams alerts</li>
+            <li>Status data grounded in source</li>
+          </ul>
         </article>
       </div>
     </section>
 
-    <section id="github-app">
-      <h2>Also available as a hosted GitHub App.</h2>
-      <p class="section-intro">Everything above runs locally with the CLI. If you'd rather it just run on every pull request without you doing anything, the Aletheore GitHub App posts the same evidence-grounded findings as PR comments and branch-protection check runs automatically - free on every plan.</p>
-      <div class="feature-grid">
-        <article class="feature-card">
-          <p class="feature-cmd">on: pull_request</p>
-          <h3>Automatic PR comments</h3>
-          <p>Every pull request gets a comment listing new secrets, vulnerabilities, and license issues - free, no setup beyond installing the App.</p>
+    <section id="github-app" class="workflow-section">
+      <div class="section-heading">
+        <p class="eyebrow">How teams use it</p>
+        <h2>Start local. Then let the GitHub App keep watch.</h2>
+      </div>
+      <div class="workflow-grid">
+        <article>
+          <span>$ aletheore scan</span>
+          <h3>Build the evidence</h3>
+          <p>Tree-sitter and git history produce <code>air.json</code> and <code>air.toon</code>. No LLM in the scan path.</p>
         </article>
-        <article class="feature-card">
-          <p class="feature-cmd">on: pull_request</p>
-          <h3>Branch-protection check runs</h3>
-          <p>A check run fails the pull request when a new secret is detected, so it can gate merges the same way any other required check does.</p>
+        <article>
+          <span>$ aletheore query</span>
+          <h3>Ask grounded questions</h3>
+          <p>Query architecture, owners, dependencies, endpoints, secrets, hotspots, and semantic search from one evidence file.</p>
         </article>
-        <article class="feature-card">
-          <p class="feature-cmd">/aletheore audit</p>
-          <h3>AI-powered managed audits (paid plans)</h3>
-          <p>Comment <code>/aletheore audit</code> on any pull request for a full narrative audit report - security, architecture, and investor-style perspectives, grounded in the same deterministic evidence, no API key required. Model quality scales with your plan tier - see <a href="pricing.html">Pricing</a>.</p>
+        <article>
+          <span>on: pull_request</span>
+          <h3>Review every change</h3>
+          <p>The GitHub App comments on PRs, gates new secrets, and can run managed audits or Flash reviews on paid plans.</p>
         </article>
-        <article class="feature-card">
-          <p class="feature-cmd">/dashboard/.../wiki</p>
-          <h3>AIRview (paid plans)</h3>
-          <p>An LLM-written, always-current map of your repo's architecture - real dependency diagrams grounded in the scanner's own evidence, regenerated automatically on every push.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">on: pull_request</p>
-          <h3>Automatic Flash reviews (paid plans)</h3>
-          <p>Every push to an open pull request gets a fast, citation-constrained review of just the new diff - every finding names an exact file and line, or it isn't reported at all.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">Slack / Teams</p>
-          <h3>Alerts on new findings (paid plans)</h3>
-          <p>Point Aletheore at a Slack or Microsoft Teams webhook and get notified the moment a new secret or vulnerability lands on a pull request.</p>
-        </article>
-        <article class="feature-card">
-          <p class="feature-cmd">GET /v1/health/...</p>
-          <h3>Endpoint health monitoring (paid plans)</h3>
-          <p>Aletheore maps your API endpoints from source, then checks them live on a schedule across multiple targets, and alerts on reachability or latency regressions.</p>
+        <article>
+          <span>GET /health</span>
+          <h3>Monitor what shipped</h3>
+          <p>Live endpoint checks alert on outages and latency regressions with source handler context.</p>
         </article>
       </div>
       <p class="section-intro">
@@ -293,10 +334,12 @@
       <div>
         <h4>Product</h4>
         <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
       </div>
       <div>
         <h4>Community</h4>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
         <a href="https://github.com/sponsors/ArihantK15">Sponsor</a>
         <a href="https://github.com/Aletheore/Aletheore/issues">Issues</a>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -90,7 +90,7 @@
         <a href="developers.html">Developers</a>
         <a href="terms.html">Terms</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
         <a class="btn btn-primary" href="https://app.aletheore.com/">Get Started</a>
       </div>
@@ -104,7 +104,7 @@
         <div class="hero-actions">
           <a class="btn btn-primary" href="https://app.aletheore.com/">Start Free Audit</a>
           <a class="btn btn-secondary" href="https://github.com/Aletheore/Aletheore">View GitHub</a>
-          <a class="btn btn-ghost" href="https://www.linkedin.com/company/alethoeore">Follow Updates</a>
+          <a class="btn btn-ghost" href="https://www.linkedin.com/company/aletheore">Follow Updates</a>
         </div>
         <div class="hero-trust">
           <span>Open source</span>
@@ -303,7 +303,7 @@
     <section class="humanist">
       <div>
         <h2>Humanist tools for a technical world.</h2>
-        <p>Nothing leaves your machine when you run the deterministic local scan. Bring your own API key for agentic audit reports, or skip them entirely: the evidence pipeline stands on its own.</p>
+        <p>Nothing leaves your machine when you run the deterministic local scan. Bring your own API key for AI-assisted audit reports, or skip them entirely: the evidence pipeline stands on its own.</p>
         <ul>
           <li>Open source and local-first.</li>
           <li>Query, diff, dashboard, MCP, and reports all read the same evidence.</li>
@@ -339,7 +339,7 @@
       </div>
       <div>
         <h4>Community</h4>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://github.com/sponsors/ArihantK15">Sponsor</a>
         <a href="https://github.com/Aletheore/Aletheore/issues">Issues</a>
       </div>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -27,7 +27,7 @@
         <a href="developers.html">Developers</a>
         <a href="terms.html">Terms</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
         <a class="btn btn-primary" href="https://app.aletheore.com/">Get Started</a>
       </div>
@@ -109,7 +109,7 @@
       </div>
       <div>
         <h4>Community</h4>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://github.com/sponsors/ArihantK15">Sponsor</a>
       </div>
       <div>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -24,8 +24,10 @@
       </a>
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
         <a href="terms.html">Terms</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
         <a class="btn btn-primary" href="https://app.aletheore.com/">Get Started</a>
       </div>
@@ -102,10 +104,12 @@
       <div>
         <h4>Product</h4>
         <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
       </div>
       <div>
         <h4>Community</h4>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
         <a href="https://github.com/sponsors/ArihantK15">Sponsor</a>
       </div>
       <div>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -16,7 +16,9 @@
       </a>
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
       </div>
     </nav>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -18,7 +18,7 @@
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
       </div>
     </nav>
@@ -28,7 +28,7 @@
       <p>Last updated: July 2026</p>
 
       <h2>The free CLI</h2>
-      <p>Running <code>aletheore scan</code> locally sends nothing to Aletheore's servers. Evidence is written to your own machine. If you use an agentic audit command, evidence, not source code, is sent to whichever LLM provider you configure, using your own API key.</p>
+      <p>Running <code>aletheore scan</code> locally sends nothing to Aletheore's servers. Evidence is written to your own machine. If you use an AI-assisted audit command, evidence, not source code, is sent to whichever LLM provider you configure, using your own API key.</p>
 
       <h2>The GitHub App paid tiers</h2>
       <p>Installing the GitHub App is a different trust boundary. Source code is transiently cloned to run a scan, then immediately discarded. Only derived evidence, such as secrets findings, dependency graphs, and endpoint health rows, is stored. Managed audit and AIRview runs send evidence, not source code, to the LLM provider your plan uses (DeepSeek, OpenAI, or Anthropic, depending on tier - see <a href="pricing.html">Pricing</a>), using our shared key.</p>

--- a/website/refund.html
+++ b/website/refund.html
@@ -16,7 +16,9 @@
       </a>
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
       </div>
     </nav>

--- a/website/refund.html
+++ b/website/refund.html
@@ -18,7 +18,7 @@
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
       </div>
     </nav>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -13,6 +13,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.aletheore.com/developers</loc>
+    <lastmod>2026-07-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://www.aletheore.com/terms</loc>
     <lastmod>2026-07-18</lastmod>
     <changefreq>yearly</changefreq>

--- a/website/styles.css
+++ b/website/styles.css
@@ -5,6 +5,8 @@
   --text-muted: #6b6459;
   --accent: #e0863a;
   --accent-hover: #c96f26;
+  --accent-soft: #fff3e6;
+  --success: #3f8f72;
   --card-bg: #ffffff;
   --border-subtle: rgba(0, 0, 0, 0.08);
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
@@ -118,17 +120,35 @@ code {
   border-color: var(--text-primary);
 }
 
+.btn-ghost {
+  border: 1px solid transparent;
+  color: var(--text-muted);
+}
+
+.btn-ghost:hover {
+  color: var(--text-primary);
+}
+
+.eyebrow {
+  margin-bottom: 14px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.9fr);
+  grid-template-columns: minmax(0, 1.08fr) minmax(360px, 0.92fr);
   gap: 48px;
   align-items: center;
-  padding: 64px 0 56px;
+  padding: 70px 0 42px;
 }
 
 .hero h1 {
-  max-width: 720px;
-  font-size: clamp(36px, 6vw, 58px);
+  max-width: 760px;
+  font-size: clamp(40px, 6vw, 68px);
   line-height: 1.08;
   font-weight: 760;
 }
@@ -139,7 +159,7 @@ code {
 }
 
 .hero p {
-  max-width: 590px;
+  max-width: 620px;
   margin: 22px 0 30px;
   color: var(--text-muted);
   font-size: 18px;
@@ -151,17 +171,159 @@ code {
   gap: 14px;
 }
 
-.hero-mark {
+.hero-trust {
   display: flex;
-  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 28px;
 }
 
-.hero-mark img {
-  width: min(100%, 360px);
-  aspect-ratio: 1;
-  object-fit: cover;
+.hero-trust span {
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.45);
+  padding: 7px 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.evidence-preview {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(23, 20, 15, 0.12);
   border-radius: 16px;
-  box-shadow: 0 24px 60px rgba(23, 20, 15, 0.16);
+  background: #fffaf2;
+  box-shadow: 0 28px 70px rgba(23, 20, 15, 0.16);
+}
+
+.evidence-preview::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 4px;
+  background: linear-gradient(90deg, var(--accent), var(--success));
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 18px 20px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.preview-header div {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #d94747;
+  box-shadow: 0 0 0 4px rgba(217, 71, 71, 0.13);
+}
+
+.preview-badge {
+  border: 1px solid rgba(63, 143, 114, 0.28);
+  border-radius: 999px;
+  background: rgba(63, 143, 114, 0.09);
+  padding: 5px 9px;
+  color: var(--success);
+  white-space: nowrap;
+}
+
+.preview-title {
+  padding: 28px 24px 10px;
+  font-size: 30px;
+  line-height: 1.2;
+}
+
+.preview-title span {
+  display: inline-flex;
+  margin-right: 9px;
+  border-radius: 6px;
+  background: var(--bg-dark);
+  padding: 5px 8px;
+  color: var(--accent);
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  vertical-align: middle;
+}
+
+.preview-title em {
+  display: block;
+  margin-top: 4px;
+  color: #d94747;
+  font-size: 17px;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.preview-code {
+  margin: 0 24px 22px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: #fff;
+  padding: 14px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+}
+
+.preview-code span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--text-muted);
+  font-family: var(--font);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0 24px 24px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--border-subtle);
+}
+
+.evidence-grid div {
+  background: #fff;
+  padding: 14px;
+}
+
+.evidence-grid dt {
+  margin-bottom: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.evidence-grid dd {
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.preview-note {
+  border-top: 1px solid var(--border-subtle);
+  background: var(--accent-soft);
+  padding: 18px 24px;
+  color: #6a4423;
+  font-size: 14px;
+  line-height: 1.6;
 }
 
 section {
@@ -180,6 +342,394 @@ section h2 {
   color: var(--text-muted);
   font-size: 17px;
   text-align: center;
+}
+
+.section-heading {
+  max-width: 720px;
+  margin: 0 auto 34px;
+  text-align: center;
+}
+
+.section-heading h2 {
+  margin-bottom: 14px;
+}
+
+.section-heading p:not(.eyebrow) {
+  max-width: 620px;
+  margin: 0 auto;
+  color: var(--text-muted);
+  font-size: 17px;
+}
+
+.evidence-strip {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.42fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: center;
+  margin: 18px 0 34px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.52);
+  padding: 22px;
+}
+
+.evidence-strip p {
+  color: var(--text-muted);
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.evidence-strip div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.evidence-strip span {
+  border: 1px solid rgba(224, 134, 58, 0.22);
+  border-radius: 999px;
+  background: #fff;
+  padding: 7px 11px;
+  color: var(--text-primary);
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+.proof-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1fr);
+  gap: 44px;
+  align-items: center;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.proof-panel h2 {
+  margin-bottom: 0;
+  font-size: clamp(28px, 4vw, 42px);
+}
+
+.proof-panel > p {
+  color: var(--text-muted);
+  font-size: 19px;
+  line-height: 1.65;
+}
+
+.pillar-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.pillar-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--card-bg);
+  padding: 24px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.pillar-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(224, 134, 58, 0.36);
+  box-shadow: 0 18px 36px rgba(23, 20, 15, 0.07);
+}
+
+.pillar-index {
+  display: inline-block;
+  margin-bottom: 18px;
+  color: var(--accent);
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.pillar-card h3 {
+  margin-bottom: 10px;
+  font-size: 20px;
+}
+
+.pillar-card p {
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.pillar-card ul {
+  margin-top: 16px;
+  padding-left: 0;
+  list-style: none;
+}
+
+.pillar-card li {
+  position: relative;
+  margin-bottom: 9px;
+  padding-left: 18px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.pillar-card li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.68em;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.workflow-section {
+  padding-top: 34px;
+}
+
+.workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--border-subtle);
+}
+
+.workflow-grid article {
+  background: #fff;
+  padding: 24px;
+}
+
+.workflow-grid span {
+  display: inline-block;
+  margin-bottom: 16px;
+  border-radius: 6px;
+  background: var(--bg-dark);
+  padding: 5px 9px;
+  color: var(--accent);
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+.workflow-grid h3 {
+  margin-bottom: 8px;
+  font-size: 17px;
+}
+
+.workflow-grid p {
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.developer-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.78fr);
+  gap: 48px;
+  align-items: center;
+  padding: 64px 0 48px;
+}
+
+.developer-hero h1 {
+  max-width: 760px;
+  margin-bottom: 22px;
+  font-size: clamp(38px, 5vw, 62px);
+  line-height: 1.08;
+}
+
+.developer-hero p:not(.eyebrow) {
+  max-width: 640px;
+  margin-bottom: 28px;
+  color: var(--text-muted);
+  font-size: 18px;
+}
+
+.install-card {
+  overflow: hidden;
+  border: 1px solid rgba(23, 20, 15, 0.12);
+  border-radius: 14px;
+  background: var(--bg-dark);
+  box-shadow: 0 24px 60px rgba(23, 20, 15, 0.16);
+}
+
+.terminal-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 15px 18px;
+  color: #b9b1a4;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.terminal-title .terminal-controls {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 18px 0 0 #d6b06d, 36px 0 0 var(--success);
+}
+
+.terminal-title strong {
+  margin-left: 36px;
+  font: inherit;
+}
+
+pre {
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.install-card pre,
+.command-grid pre,
+.mcp-section pre {
+  margin: 0;
+  background: var(--bg-dark);
+  color: #efe7d8;
+  padding: 22px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 14px;
+  line-height: 1.75;
+}
+
+.developer-section {
+  padding: 54px 0;
+}
+
+.command-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.command-grid article {
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.command-grid h3 {
+  padding: 20px 20px 0;
+  font-size: 18px;
+}
+
+.command-grid pre {
+  margin: 18px 0;
+  border-radius: 0;
+  font-size: 13px;
+}
+
+.command-grid p {
+  padding: 0 20px 20px;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.query-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--border-subtle);
+}
+
+.query-board div {
+  background: #fff;
+  padding: 24px;
+}
+
+.query-board h3 {
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+
+.query-board code,
+.mcp-tool-list span {
+  display: inline-flex;
+  margin: 0 7px 8px 0;
+  border: 1px solid rgba(224, 134, 58, 0.22);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  padding: 6px 9px;
+  color: #6a4423;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+.mcp-section {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1fr);
+  gap: 42px;
+  align-items: center;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.mcp-section h2,
+.evidence-contract h2 {
+  margin-bottom: 16px;
+  font-size: clamp(28px, 4vw, 42px);
+}
+
+.mcp-section p:not(.eyebrow),
+.evidence-contract p {
+  color: var(--text-muted);
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.mcp-section pre {
+  margin-top: 22px;
+  border-radius: 8px;
+}
+
+.mcp-tool-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 0;
+}
+
+.evidence-contract {
+  display: grid;
+  grid-template-columns: minmax(0, 0.7fr) minmax(0, 1fr);
+  gap: 42px;
+  align-items: start;
+}
+
+.contract-list {
+  display: grid;
+  gap: 14px;
+}
+
+.contract-list article {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: #fff;
+  padding: 20px;
+}
+
+.contract-list h3 {
+  margin-bottom: 8px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 15px;
+}
+
+.contract-list p {
+  font-size: 14px;
+}
+
+.deep-features {
+  padding-top: 36px;
+}
+
+.deep-features .pillar-grid {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
 .card-grid {
@@ -620,9 +1170,18 @@ footer a:hover {
   }
 
   .hero,
+  .developer-hero,
   .humanist,
+  .evidence-strip,
+  .proof-panel,
+  .command-grid,
+  .query-board,
+  .mcp-section,
+  .evidence-contract,
   .card-grid,
   .feature-grid,
+  .pillar-grid,
+  .workflow-grid,
   .showcase-grid,
   .pricing-grid,
   .footer-grid {
@@ -633,12 +1192,43 @@ footer a:hover {
     padding-top: 42px;
   }
 
-  .hero-mark {
-    justify-content: flex-start;
+  .evidence-preview {
+    max-width: 520px;
   }
 
-  .hero-mark img {
-    max-width: 240px;
+  .preview-title {
+    font-size: 24px;
+  }
+
+  .developer-hero {
+    padding-top: 42px;
+  }
+
+  .evidence-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .proof-panel {
+    gap: 18px;
+  }
+
+  .proof-panel > p {
+    font-size: 16px;
+  }
+
+  .mcp-section,
+  .evidence-contract {
+    gap: 24px;
+  }
+
+  .deep-features .pillar-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .install-card pre,
+  .command-grid pre,
+  .mcp-section pre {
+    font-size: 12px;
   }
 
   section {

--- a/website/terms.html
+++ b/website/terms.html
@@ -16,7 +16,9 @@
       </a>
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
+        <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
+        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
       </div>
     </nav>

--- a/website/terms.html
+++ b/website/terms.html
@@ -18,7 +18,7 @@
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
-        <a href="https://www.linkedin.com/company/alethoeore">LinkedIn</a>
+        <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
       </div>
     </nav>


### PR DESCRIPTION
## Summary

This PR updates the Aletheore marketing website to make the product clearer, friendlier, and more technically credible.

## Included

- Redesigned homepage hero with a product-style source-evidence preview
- Clear evidence promise: file, line, symbol, owner, commit, dependency, and risk
- Four-pillar product section for review, repository intelligence, security, and production monitoring
- New Developers page with PyPI install, CLI workflow, real query subcommands, MCP tool names, AIR evidence contract, AIRview, health checks, and local-first positioning
- LinkedIn links across nav/footer
- Sitemap entry for /developers
- Fixed Quickstart terminal title layout on desktop and mobile

## Verification

- Desktop and mobile browser QA for homepage and Developers page
- No oversized text boxes detected in browser checks
- npm run format:check
- npm run lint:markdown
- npm run lint:spelling
- git diff --check

## Notes

Latest GitHub tag is v0.4.0 and origin/master is currently 121 commits ahead of it, so the next release tag should include a broad changelog/release note pass.