### PR TITLE
fix mobile marketing nav

### DIFF
--- a/website/styles.css
+++ b/website/styles.css
@@ -1161,12 +1161,32 @@ footer a:hover {
   }
 
   .site-nav {
+    width: 100%;
     flex-direction: column;
+    gap: 18px;
   }
 
   .nav-links {
+    width: 100%;
     flex-wrap: wrap;
-    gap: 14px;
+    gap: 10px;
+  }
+
+  .nav-links a:not(.btn) {
+    min-height: 38px;
+    padding: 8px 11px;
+    border: 1px solid rgba(23, 20, 15, 0.08);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.34);
+    font-size: 14px;
+    line-height: 1.2;
+  }
+
+  .nav-links .btn {
+    flex: 1 1 150px;
+    min-height: 42px;
+    padding: 10px 14px;
+    font-size: 14px;
   }
 
   .hero,


### PR DESCRIPTION
## Summary

Fixes the mobile marketing-site navigation so page links and the Get Started CTA wrap cleanly instead of overflowing or stretching awkwardly.

## Validation

- Verified mobile nav geometry at 390px width across Home, Developers, and Pricing
- Verified no horizontal overflow: page scroll width equals viewport width
- npm run format:check
- npm run lint:spelling
- npm run lint:markdown
- git diff --check

Note: local link check could not run because lychee is not installed locally; CI runs the canonical link check.