### PR TITLE
Add model routing cost controls

### DIFF
--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -1,18 +1,52 @@
+import logging
+from datetime import date
+
+logger = logging.getLogger(__name__)
+
 # Cache-miss, list-price rates only - provider list prices, confirm still
 # current before relying on them for real spend accounting. Overestimating
 # cost is the safe direction for a hard cap, so when in doubt round up.
+# verified_at is the date these numbers were last checked against the
+# provider's own pricing page - not a promise the price hasn't moved
+# since, just an honest record of how stale it might be.
 MODEL_RATES_PER_MILLION_USD = {
-    "deepseek-v4-pro": {"input": 0.435, "output": 0.87},
-    "deepseek-v4-flash": {"input": 0.14, "output": 0.28},
-    "gpt-4o": {"input": 2.50, "output": 10.00},
-    "claude-opus-4-8": {"input": 15.00, "output": 75.00},
+    "deepseek-v4-pro": {"input": 0.435, "output": 0.87, "verified_at": "2026-07-23"},
+    "deepseek-v4-flash": {"input": 0.14, "output": 0.28, "verified_at": "2026-07-23"},
+    "gpt-4o": {"input": 2.50, "output": 10.00, "verified_at": "2026-07-23"},
+    "claude-opus-4-8": {"input": 15.00, "output": 75.00, "verified_at": "2026-07-23"},
 }
 
+STALE_PRICE_MAX_AGE_DAYS = 90
+
 EXTRA_SEAT_MONTHLY_COST_USD = 2.00
+
+# Warn once per process per model, not once per call - cost_for_usage()
+# runs on every token-usage callback, and a real deploy could otherwise
+# emit thousands of identical warnings for one stale price.
+_warned_stale_models: set[str] = set()
+
+
+def stale_models(as_of: date | None = None, max_age_days: int = STALE_PRICE_MAX_AGE_DAYS) -> list[str]:
+    reference = as_of or date.today()
+    stale = []
+    for model, rates in MODEL_RATES_PER_MILLION_USD.items():
+        verified_at = date.fromisoformat(rates["verified_at"])
+        if (reference - verified_at).days > max_age_days:
+            stale.append(model)
+    return stale
 
 
 def cost_for_usage(model: str, prompt_tokens: int, completion_tokens: int) -> float:
     rates = MODEL_RATES_PER_MILLION_USD[model]
+    if model not in _warned_stale_models and model in stale_models():
+        logger.warning(
+            "price for %s was last verified on %s, more than %d days ago - "
+            "confirm it's still accurate against the provider's pricing page",
+            model,
+            rates["verified_at"],
+            STALE_PRICE_MAX_AGE_DAYS,
+        )
+        _warned_stale_models.add(model)
     return (prompt_tokens * rates["input"] + completion_tokens * rates["output"]) / 1_000_000
 
 

--- a/github-app/migrations/013_flash_review_cache.sql
+++ b/github-app/migrations/013_flash_review_cache.sql
@@ -1,0 +1,19 @@
+-- Per-installation similarity cache for Flash review diff findings.
+-- Rows are always queried by installation_id and repo_full_name before any
+-- Python-side similarity comparison happens.
+CREATE TABLE IF NOT EXISTS flash_review_cache (
+    id               BIGSERIAL PRIMARY KEY,
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    content_hash     TEXT NOT NULL,
+    embedding        DOUBLE PRECISION[] NOT NULL,
+    diff_text        TEXT NOT NULL,
+    findings         JSONB NOT NULL,
+    model_used       TEXT NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_hit_at      TIMESTAMPTZ,
+    hit_count        INT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS flash_review_cache_lookup
+ON flash_review_cache (installation_id, repo_full_name, created_at DESC);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -567,3 +567,73 @@ def record_evidence_packet_cache_hit(dsn: str, row_id: int) -> None:
                 (row_id,),
             )
         conn.commit()
+
+
+def insert_flash_review_cache_row(
+    dsn: str,
+    installation_id: int,
+    repo_full_name: str,
+    content_hash: str,
+    embedding: list[float],
+    diff_text: str,
+    findings: list[dict],
+    model_used: str,
+) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO flash_review_cache
+                    (installation_id, repo_full_name, content_hash, embedding,
+                     diff_text, findings, model_used)
+                VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s)
+                """,
+                (
+                    installation_id,
+                    repo_full_name,
+                    content_hash,
+                    embedding,
+                    diff_text,
+                    json.dumps(findings),
+                    model_used,
+                ),
+            )
+        conn.commit()
+
+
+def list_recent_flash_review_cache_rows(
+    dsn: str, installation_id: int, repo_full_name: str, limit: int = 200
+) -> list[dict]:
+    import psycopg.rows
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT id, content_hash, embedding, diff_text, findings, model_used, hit_count
+                FROM flash_review_cache
+                WHERE installation_id = %s AND repo_full_name = %s
+                ORDER BY created_at DESC
+                LIMIT %s
+                """,
+                (installation_id, repo_full_name, limit),
+            )
+            return cur.fetchall()
+
+
+def record_flash_review_cache_hit(dsn: str, row_id: int) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE flash_review_cache
+                SET hit_count = hit_count + 1, last_hit_at = now()
+                WHERE id = %s
+                """,
+                (row_id,),
+            )
+        conn.commit()

--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import re
 from collections.abc import Callable
 
 from aletheore.evidence_resolution import (
@@ -13,6 +15,8 @@ from scan_worker.github_api import (
     MAX_CONTEXT_TOTAL_BYTES,
     fetch_file_content,
 )
+
+logger = logging.getLogger(__name__)
 
 FLASH_REVIEW_SYSTEM_PROMPT = """You are reviewing a code diff for potential issues. You may also be
 given the full current content of the changed files for context. You must respond with ONLY a
@@ -105,14 +109,93 @@ def build_code_evidence_context(evidence: dict | None, changed_files: list[str])
     return "--- deterministic code evidence for changed files ---\n" + "\n".join(lines)
 
 
+_FILE_MARKER_RE = re.compile(r"^--- (.+) ---$")
+_HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def _diff_valid_lines(diff_text: str) -> dict[str, set[int]]:
+    """Maps each file to new-file line numbers present in its diff hunks."""
+    valid_lines: dict[str, set[int]] = {}
+    current_file: str | None = None
+    current_line: int | None = None
+    for line in diff_text.splitlines():
+        file_match = _FILE_MARKER_RE.match(line)
+        if file_match:
+            current_file = file_match.group(1)
+            valid_lines.setdefault(current_file, set())
+            current_line = None
+            continue
+        hunk_match = _HUNK_HEADER_RE.match(line)
+        if hunk_match:
+            current_line = int(hunk_match.group(1))
+            continue
+        if line == "":
+            continue
+        if current_file is None or current_line is None:
+            continue
+        if line.startswith("-"):
+            continue
+        valid_lines[current_file].add(current_line)
+        current_line += 1
+    return valid_lines
+
+
+def _validate_findings(findings: list[dict], diff_text: str) -> list[dict]:
+    valid_lines = _diff_valid_lines(diff_text)
+    return [f for f in findings if f["line"] in valid_lines.get(f["file"], set())]
+
+
+_NON_SUBSTANTIVE_FILENAMES = {
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "Pipfile.lock",
+    "Cargo.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "uv.lock",
+}
+_NON_SUBSTANTIVE_PATH_PREFIXES = ("dist/", "build/", "vendor/", "node_modules/")
+_NON_SUBSTANTIVE_SUFFIXES = (".min.js", ".min.css")
+
+
+def _is_non_substantive_path(path: str) -> bool:
+    filename = path.rsplit("/", 1)[-1]
+    if filename in _NON_SUBSTANTIVE_FILENAMES:
+        return True
+    if path.startswith(_NON_SUBSTANTIVE_PATH_PREFIXES):
+        return True
+    if filename.endswith(_NON_SUBSTANTIVE_SUFFIXES):
+        return True
+    return False
+
+
+def is_non_substantive_diff(changed_files: list[str]) -> bool:
+    return bool(changed_files) and all(_is_non_substantive_path(f) for f in changed_files)
+
+
 def review_diff(
     diff_text: str,
     file_context: str = "",
     code_evidence_context: str = "",
     on_usage: Callable[[int, int], None] | None = None,
+    *,
+    cache_lookup: Callable[[str], list[dict] | None] | None = None,
+    cache_write: Callable[[str, list[dict], str], None] | None = None,
+    model_used: str = "deepseek-v4-flash",
 ) -> list[dict]:
     if not diff_text.strip():
         return []
+
+    if cache_lookup is not None:
+        try:
+            cached = cache_lookup(diff_text)
+        except Exception as exc:
+            logger.warning("flash review cache lookup failed (%s); treating as miss", type(exc).__name__)
+            cached = None
+        if cached is not None:
+            return _validate_findings(cached, diff_text)
 
     adapter = OpenAICompatibleAdapter(
         name="DeepSeek",
@@ -160,4 +243,11 @@ def review_diff(
         if isinstance(suggestion, str) and suggestion.strip() and "```" not in suggestion:
             result["suggestion"] = suggestion.strip()
         valid.append(result)
-    return valid
+
+    if cache_write is not None:
+        try:
+            cache_write(diff_text, valid, model_used)
+        except Exception as exc:
+            logger.warning("flash review cache write failed (%s); continuing without cache", type(exc).__name__)
+
+    return _validate_findings(valid, diff_text)

--- a/github-app/scan_worker/flash_review_cache.py
+++ b/github-app/scan_worker/flash_review_cache.py
@@ -1,0 +1,94 @@
+"""Per-installation similarity cache for Flash review diff findings.
+
+Callers must re-validate cached findings against the current diff's
+actual hunks before serving them. This module only finds similar past
+diffs and stores raw model output.
+"""
+
+import hashlib
+import logging
+import math
+
+from scan_worker.db import (
+    insert_flash_review_cache_row,
+    list_recent_flash_review_cache_rows,
+    record_flash_review_cache_hit,
+)
+from scan_worker.embedding_client import embed_text
+
+SIMILARITY_THRESHOLD = 0.92
+
+logger = logging.getLogger(__name__)
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def lookup_cached_result(
+    dsn: str, installation_id: int, repo_full_name: str, diff_text: str
+) -> list[dict] | None:
+    try:
+        vector = embed_text(diff_text)
+        if vector is None:
+            return None
+
+        rows = list_recent_flash_review_cache_rows(dsn, installation_id, repo_full_name)
+        if not rows:
+            return None
+
+        best_row = None
+        best_score = 0.0
+        for row in rows:
+            score = _cosine_similarity(vector, row["embedding"])
+            if score > best_score:
+                best_score = score
+                best_row = row
+
+        if best_row is None or best_score < SIMILARITY_THRESHOLD:
+            return None
+
+        record_flash_review_cache_hit(dsn, best_row["id"])
+        return best_row["findings"]
+    except Exception as exc:
+        logger.warning("flash review cache lookup failed (%s); treating as miss", type(exc).__name__)
+        return None
+
+
+def store_result(
+    dsn: str,
+    installation_id: int,
+    repo_full_name: str,
+    diff_text: str,
+    findings: list[dict],
+    model_used: str,
+) -> None:
+    try:
+        vector = embed_text(diff_text)
+        if vector is None:
+            logger.warning("embedding unavailable; skipping flash review cache write")
+            return
+
+        insert_flash_review_cache_row(
+            dsn,
+            installation_id,
+            repo_full_name,
+            _content_hash(diff_text),
+            vector,
+            diff_text,
+            findings,
+            model_used,
+        )
+    except Exception as exc:
+        logger.warning("flash review cache write failed (%s); continuing without cache", type(exc).__name__)

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -45,7 +45,16 @@ from scan_worker.db import (
     upsert_wiki_overview,
     upsert_wiki_subsystem,
 )
-from scan_worker.flash_review import build_code_evidence_context, gather_file_context, review_diff
+from scan_worker.flash_review import (
+    build_code_evidence_context,
+    gather_file_context,
+    is_non_substantive_diff,
+    review_diff,
+)
+from scan_worker.flash_review_cache import (
+    lookup_cached_result as lookup_cached_flash_review_result,
+    store_result as store_flash_review_result,
+)
 from scan_worker.github_api import create_check_run, fetch_pr_changed_files, fetch_pr_diff, upsert_pr_comment
 from scan_worker.managed_audit import run_managed_audit
 from scan_worker.model_tiers import model_for_plan, writing_adapter_for_plan
@@ -374,26 +383,47 @@ def run_flash_review_job(
         diff_base = last_reviewed_sha or base_sha
         diff_text = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha)
         changed_files = fetch_pr_changed_files(client, token, repo_full_name, diff_base, head_sha)
-        file_context = gather_file_context(client, token, repo_full_name, changed_files, head_sha)
-        evidence = _latest_evidence_or_none(settings.database_url, installation_id, repo_full_name)
-        code_evidence_context = build_code_evidence_context(evidence, changed_files)
 
         spend_accumulator = {"total": 0.0}
 
-        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            spend_accumulator["total"] += cost_for_usage(
-                "deepseek-v4-flash", prompt_tokens, completion_tokens
-            )
-
-        if code_evidence_context:
-            findings = review_diff(
-                diff_text,
-                file_context=file_context,
-                code_evidence_context=code_evidence_context,
-                on_usage=_on_usage,
-            )
+        if is_non_substantive_diff(changed_files):
+            findings: list[dict] = []
         else:
-            findings = review_diff(diff_text, file_context=file_context, on_usage=_on_usage)
+            file_context = gather_file_context(client, token, repo_full_name, changed_files, head_sha)
+            evidence = _latest_evidence_or_none(settings.database_url, installation_id, repo_full_name)
+            code_evidence_context = build_code_evidence_context(evidence, changed_files)
+            dsn = settings.database_url
+
+            def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+                spend_accumulator["total"] += cost_for_usage(
+                    "deepseek-v4-flash", prompt_tokens, completion_tokens
+                )
+
+            def _cache_lookup(diff: str) -> list[dict] | None:
+                return lookup_cached_flash_review_result(dsn, installation_id, repo_full_name, diff)
+
+            def _cache_write(diff: str, found: list[dict], used: str) -> None:
+                store_flash_review_result(dsn, installation_id, repo_full_name, diff, found, used)
+
+            if code_evidence_context:
+                findings = review_diff(
+                    diff_text,
+                    file_context=file_context,
+                    code_evidence_context=code_evidence_context,
+                    on_usage=_on_usage,
+                    cache_lookup=_cache_lookup,
+                    cache_write=_cache_write,
+                    model_used="deepseek-v4-flash",
+                )
+            else:
+                findings = review_diff(
+                    diff_text,
+                    file_context=file_context,
+                    on_usage=_on_usage,
+                    cache_lookup=_cache_lookup,
+                    cache_write=_cache_write,
+                    model_used="deepseek-v4-flash",
+                )
         record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
 
         if findings:

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -1,7 +1,74 @@
 import json
 from unittest.mock import MagicMock, patch
 
-from scan_worker.flash_review import FLASH_REVIEW_SYSTEM_PROMPT, build_code_evidence_context, review_diff
+from scan_worker.flash_review import (
+    FLASH_REVIEW_SYSTEM_PROMPT,
+    _diff_valid_lines,
+    _validate_findings,
+    build_code_evidence_context,
+    is_non_substantive_diff,
+    review_diff,
+)
+
+
+def test_diff_valid_lines_maps_added_and_context_lines_by_file():
+    diff_text = "--- a.py ---\n@@ -1,2 +1,3 @@\n context\n+added\n context2"
+
+    assert _diff_valid_lines(diff_text) == {"a.py": {1, 2, 3}}
+
+
+def test_diff_valid_lines_excludes_removed_lines():
+    diff_text = "--- a.py ---\n@@ -1,2 +1,1 @@\n-removed\n context"
+
+    assert _diff_valid_lines(diff_text) == {"a.py": {1}}
+
+
+def test_diff_valid_lines_tracks_multiple_files_separately():
+    diff_text = (
+        "--- a.py ---\n@@ -1,1 +5,1 @@\n+in a\n\n"
+        "--- b.py ---\n@@ -1,1 +10,1 @@\n+in b"
+    )
+
+    assert _diff_valid_lines(diff_text) == {"a.py": {5}, "b.py": {10}}
+
+
+def test_validate_findings_keeps_findings_inside_diff_hunks():
+    diff_text = "--- a.py ---\n@@ -1,1 +1,1 @@\n+only line"
+    findings = [{"file": "a.py", "line": 1, "issue": "valid"}]
+
+    assert _validate_findings(findings, diff_text) == findings
+
+
+def test_validate_findings_drops_finding_outside_diff_hunks():
+    diff_text = "--- a.py ---\n@@ -1,1 +1,1 @@\n+only line"
+    findings = [
+        {"file": "a.py", "line": 1, "issue": "valid"},
+        {"file": "a.py", "line": 99, "issue": "not in this diff"},
+        {"file": "b.py", "line": 1, "issue": "file not in this diff"},
+    ]
+
+    assert _validate_findings(findings, diff_text) == [{"file": "a.py", "line": 1, "issue": "valid"}]
+
+
+def test_is_non_substantive_diff_true_for_lockfile_only():
+    assert is_non_substantive_diff(["package-lock.json"]) is True
+    assert is_non_substantive_diff(["yarn.lock", "poetry.lock"]) is True
+
+
+def test_is_non_substantive_diff_true_for_generated_paths():
+    assert is_non_substantive_diff(["dist/bundle.js", "vendor/lib.min.js"]) is True
+
+
+def test_is_non_substantive_diff_false_when_any_file_is_substantive():
+    assert is_non_substantive_diff(["package-lock.json", "app.py"]) is False
+
+
+def test_is_non_substantive_diff_false_for_normal_source_files():
+    assert is_non_substantive_diff(["app.py", "tests/test_app.py"]) is False
+
+
+def test_is_non_substantive_diff_false_for_empty_list():
+    assert is_non_substantive_diff([]) is False
 
 
 def test_review_diff_returns_empty_list_for_empty_diff():
@@ -17,7 +84,7 @@ def test_review_diff_parses_valid_findings(mock_adapter_class):
     )
     mock_adapter_class.return_value = mock_adapter
 
-    findings = review_diff("--- app.py ---\n@@ ... @@\n+f = open('x')")
+    findings = review_diff("--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')")
 
     assert findings == [
         {"file": "app.py", "line": 42, "issue": "unclosed file handle, never calls .close()"}
@@ -30,7 +97,7 @@ def test_review_diff_treats_malformed_json_as_no_findings(mock_adapter_class):
     mock_adapter.simple_completion.return_value = "not valid json at all"
     mock_adapter_class.return_value = mock_adapter
 
-    assert review_diff("some diff text") == []
+    assert review_diff("--- app.py ---\n@@ -1,1 +1,1 @@\n+print(1)") == []
 
 
 @patch("scan_worker.flash_review.OpenAICompatibleAdapter")
@@ -42,9 +109,97 @@ def test_review_diff_drops_findings_missing_required_fields(mock_adapter_class):
     )
     mock_adapter_class.return_value = mock_adapter
 
-    findings = review_diff("some diff text")
+    findings = review_diff("--- b.py ---\n@@ -1,1 +3,1 @@\n+something")
 
     assert findings == [{"file": "b.py", "line": 3, "issue": "this one is valid"}]
+
+
+@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+def test_review_diff_drops_a_hallucinated_finding_outside_the_diff(mock_adapter_class):
+    mock_adapter = MagicMock()
+    mock_adapter.simple_completion.return_value = (
+        '[{"file": "app.py", "line": 42, "issue": "real, inside the diff"}, '
+        '{"file": "unrelated.py", "line": 9999, "issue": "hallucinated, not in this diff"}]'
+    )
+    mock_adapter_class.return_value = mock_adapter
+
+    findings = review_diff("--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')")
+
+    assert findings == [{"file": "app.py", "line": 42, "issue": "real, inside the diff"}]
+
+
+def test_review_diff_serves_validated_cache_hit_without_calling_the_model():
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    cached_findings = [{"file": "app.py", "line": 42, "issue": "cached finding"}]
+
+    with patch("scan_worker.flash_review.OpenAICompatibleAdapter") as mock_adapter_class:
+        findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
+
+    mock_adapter_class.assert_not_called()
+    assert findings == cached_findings
+
+
+def test_review_diff_revalidates_cache_hit_against_current_diff():
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    cached_findings = [
+        {"file": "app.py", "line": 42, "issue": "still valid"},
+        {"file": "app.py", "line": 9999, "issue": "stale - not in this diff anymore"},
+    ]
+
+    with patch("scan_worker.flash_review.OpenAICompatibleAdapter") as mock_adapter_class:
+        findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
+
+    mock_adapter_class.assert_not_called()
+    assert findings == [{"file": "app.py", "line": 42, "issue": "still valid"}]
+
+
+@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+def test_review_diff_falls_through_to_model_call_on_cache_miss(mock_adapter_class):
+    mock_adapter = MagicMock()
+    mock_adapter.simple_completion.return_value = (
+        '[{"file": "app.py", "line": 42, "issue": "fresh finding"}]'
+    )
+    mock_adapter_class.return_value = mock_adapter
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+
+    findings = review_diff(diff_text, cache_lookup=lambda diff: None)
+
+    assert findings == [{"file": "app.py", "line": 42, "issue": "fresh finding"}]
+
+
+@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+def test_review_diff_writes_to_cache_after_a_fresh_call(mock_adapter_class):
+    mock_adapter = MagicMock()
+    mock_adapter.simple_completion.return_value = (
+        '[{"file": "app.py", "line": 42, "issue": "fresh finding"}]'
+    )
+    mock_adapter_class.return_value = mock_adapter
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    written = []
+
+    review_diff(
+        diff_text,
+        cache_lookup=lambda diff: None,
+        cache_write=lambda diff, findings, model_used: written.append((diff, findings, model_used)),
+        model_used="deepseek-v4-flash",
+    )
+
+    assert written == [
+        (diff_text, [{"file": "app.py", "line": 42, "issue": "fresh finding"}], "deepseek-v4-flash")
+    ]
+
+
+@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+def test_review_diff_does_not_call_the_model_at_all_for_an_empty_diff_even_with_cache_lookup(
+    mock_adapter_class,
+):
+    cache_lookup_called = []
+
+    findings = review_diff("", cache_lookup=lambda diff: cache_lookup_called.append(True))
+
+    assert findings == []
+    assert cache_lookup_called == []
+    mock_adapter_class.assert_not_called()
 
 
 @patch("scan_worker.flash_review.OpenAICompatibleAdapter")
@@ -54,7 +209,7 @@ def test_review_diff_threads_on_usage_to_the_adapter(mock_adapter_class):
     mock_adapter_class.return_value = mock_adapter
 
     on_usage = lambda p, c: None
-    review_diff("some diff text", on_usage=on_usage)
+    review_diff("--- a.py ---\n@@ -1,1 +1,1 @@\n+x = 1", on_usage=on_usage)
 
     _, kwargs = mock_adapter_class.call_args
     assert kwargs["on_usage"] is on_usage
@@ -67,7 +222,7 @@ def test_review_diff_includes_file_context_in_prompt(mock_adapter_class):
     mock_adapter.simple_completion.return_value = "[]"
     mock_adapter_class.return_value = mock_adapter
 
-    review_diff("some diff", file_context="--- full content: a.py ---\nprint(1)")
+    review_diff("--- a.py ---\n@@ -1,1 +1,1 @@\n+print(1)", file_context="--- full content: a.py ---\nprint(1)")
 
     call_args = mock_adapter.simple_completion.call_args
     assert "print(1)" in call_args.args[1] or "print(1)" in call_args.kwargs.get("user_prompt", "")
@@ -80,7 +235,7 @@ def test_review_diff_includes_code_evidence_context_in_prompt(mock_adapter_class
     mock_adapter_class.return_value = mock_adapter
 
     review_diff(
-        "some diff",
+        "--- a.py ---\n@@ -1,1 +1,1 @@\n+foo()",
         code_evidence_context="--- code evidence ---\na.py:1 symbol=foo owner=@api",
     )
 
@@ -125,7 +280,7 @@ def test_review_diff_parses_optional_suggestion_field(mock_adapter_class):
     )
     mock_adapter_class.return_value = mock_adapter
 
-    findings = review_diff("some diff")
+    findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
     assert findings == [
         {"file": "a.py", "line": 3, "issue": "off-by-one", "suggestion": "for i in range(n):"}
@@ -140,7 +295,7 @@ def test_review_diff_suggestion_field_is_optional(mock_adapter_class):
     )
     mock_adapter_class.return_value = mock_adapter
 
-    findings = review_diff("some diff")
+    findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
     assert findings == [{"file": "a.py", "line": 3, "issue": "off-by-one"}]
 
@@ -171,7 +326,7 @@ def test_review_diff_drops_finding_whose_issue_smuggles_a_suggestion_fence(mock_
     )
     mock_adapter_class.return_value = mock_adapter
 
-    assert review_diff("some diff") == []
+    assert review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing") == []
 
 
 @patch("scan_worker.flash_review.OpenAICompatibleAdapter")
@@ -190,7 +345,7 @@ def test_review_diff_drops_only_the_suggestion_when_it_smuggles_a_fence(mock_ada
     )
     mock_adapter_class.return_value = mock_adapter
 
-    findings = review_diff("some diff")
+    findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
     assert findings == [{"file": "a.py", "line": 3, "issue": "real, benign issue text"}]
 
@@ -215,7 +370,7 @@ def test_review_diff_ignores_unexpected_fields_on_a_finding(mock_adapter_class):
     )
     mock_adapter_class.return_value = mock_adapter
 
-    findings = review_diff("some diff")
+    findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
     assert findings == [{"file": "a.py", "line": 3, "issue": "real issue"}]
 

--- a/github-app/tests/test_flash_review_cache.py
+++ b/github-app/tests/test_flash_review_cache.py
@@ -1,0 +1,159 @@
+import pytest
+
+from scan_worker.flash_review_cache import lookup_cached_result, store_result
+
+
+def test_lookup_returns_none_when_embedding_unavailable(monkeypatch):
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: None)
+
+    result = lookup_cached_result("postgresql://unused", 1, "org/repo", "some diff")
+
+    assert result is None
+
+
+def test_lookup_returns_none_when_no_rows_exist(monkeypatch):
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [1.0, 0.0])
+    monkeypatch.setattr(
+        "scan_worker.flash_review_cache.list_recent_flash_review_cache_rows", lambda *a, **k: []
+    )
+
+    result = lookup_cached_result("postgresql://unused", 1, "org/repo", "some diff")
+
+    assert result is None
+
+
+def test_lookup_returns_none_below_similarity_threshold(monkeypatch):
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [1.0, 0.0])
+    monkeypatch.setattr(
+        "scan_worker.flash_review_cache.list_recent_flash_review_cache_rows",
+        lambda *a, **k: [{"id": 1, "embedding": [0.0, 1.0], "findings": [], "model_used": "deepseek-v4-flash"}],
+    )
+
+    result = lookup_cached_result("postgresql://unused", 1, "org/repo", "some diff")
+
+    assert result is None
+
+
+def test_lookup_returns_findings_above_threshold_and_records_hit(monkeypatch):
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [1.0, 0.0])
+    monkeypatch.setattr(
+        "scan_worker.flash_review_cache.list_recent_flash_review_cache_rows",
+        lambda *a, **k: [
+            {
+                "id": 7,
+                "embedding": [1.0, 0.0001],
+                "findings": [{"file": "a.py", "line": 1, "issue": "cached finding"}],
+                "model_used": "deepseek-v4-flash",
+            }
+        ],
+    )
+    recorded = []
+    monkeypatch.setattr(
+        "scan_worker.flash_review_cache.record_flash_review_cache_hit",
+        lambda dsn, row_id: recorded.append(row_id),
+    )
+
+    result = lookup_cached_result("postgresql://unused", 1, "org/repo", "some diff")
+
+    assert result == [{"file": "a.py", "line": 1, "issue": "cached finding"}]
+    assert recorded == [7]
+
+
+def test_lookup_fails_open_when_db_lookup_raises(monkeypatch):
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [1.0, 0.0])
+
+    def _raise(*a, **k):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr("scan_worker.flash_review_cache.list_recent_flash_review_cache_rows", _raise)
+
+    result = lookup_cached_result("postgresql://unused", 1, "org/repo", "some diff")
+
+    assert result is None
+
+
+def test_store_result_writes_a_row(monkeypatch):
+    written = {}
+
+    def fake_insert(dsn, installation_id, repo_full_name, content_hash, embedding, diff_text, findings, model_used):
+        written.update(
+            installation_id=installation_id,
+            repo_full_name=repo_full_name,
+            content_hash=content_hash,
+            embedding=embedding,
+            diff_text=diff_text,
+            findings=findings,
+            model_used=model_used,
+        )
+
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [0.5, 0.5])
+    monkeypatch.setattr("scan_worker.flash_review_cache.insert_flash_review_cache_row", fake_insert)
+
+    store_result(
+        "postgresql://unused",
+        1,
+        "org/repo",
+        "--- a.py ---\n@@ -1,1 +1,1 @@\n+x = 1",
+        [{"file": "a.py", "line": 1, "issue": "fresh finding"}],
+        "deepseek-v4-flash",
+    )
+
+    assert written["installation_id"] == 1
+    assert written["repo_full_name"] == "org/repo"
+    assert written["embedding"] == [0.5, 0.5]
+    assert written["findings"] == [{"file": "a.py", "line": 1, "issue": "fresh finding"}]
+    assert written["model_used"] == "deepseek-v4-flash"
+
+
+def test_store_result_is_noop_when_embedding_unavailable(monkeypatch):
+    called = []
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: None)
+    monkeypatch.setattr(
+        "scan_worker.flash_review_cache.insert_flash_review_cache_row", lambda *a, **k: called.append(True)
+    )
+
+    store_result("postgresql://unused", 1, "org/repo", "diff", [], "deepseek-v4-flash")
+
+    assert called == []
+
+
+def test_store_result_fails_open_when_insert_raises(monkeypatch):
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [0.5, 0.5])
+
+    def _raise(*a, **k):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr("scan_worker.flash_review_cache.insert_flash_review_cache_row", _raise)
+
+    store_result("postgresql://unused", 1, "org/repo", "diff", [], "deepseek-v4-flash")
+
+
+@pytest.mark.asyncio
+async def test_lookup_never_returns_a_different_installations_row(pool, monkeypatch):
+    from conftest import TEST_DATABASE_URL
+
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login) VALUES ($1, $2)",
+        601,
+        "org-a",
+    )
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login) VALUES ($1, $2)",
+        602,
+        "org-b",
+    )
+
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [1.0, 0.0])
+
+    store_result(
+        TEST_DATABASE_URL,
+        601,
+        "org-a/repo",
+        "diff for org-a",
+        [{"file": "a.py", "line": 1, "issue": "org-a's cached finding"}],
+        "deepseek-v4-flash",
+    )
+
+    result = lookup_cached_result(TEST_DATABASE_URL, 602, "org-b/repo", "diff for org-a")
+
+    assert result is None

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -454,6 +454,41 @@ def test_flash_review_job_skips_when_spend_cap_reached(monkeypatch):
     assert llm_called == []
 
 
+def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
+    )
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- package-lock.json ---\n+huge lockfile diff"
+    )
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["package-lock.json"])
+    llm_called = []
+    monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
+    posted = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.upsert_pr_comment",
+        lambda client, token, repo_full_name, pr_number, body, **kwargs: posted.update(body=body),
+    )
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert llm_called == []
+    assert "no issues found" in posted["body"].lower()
+
+
 def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
@@ -473,7 +508,7 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
-        lambda diff_text, file_context="", on_usage=None: [
+        lambda diff_text, file_context="", **kwargs: [
             {"file": "app.py", "line": 1, "issue": "real problem"}
         ],
     )
@@ -523,7 +558,7 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
-        lambda diff_text, file_context="", on_usage=None: [
+        lambda diff_text, file_context="", **kwargs: [
             {"file": "app.py", "line": 1, "issue": "unclosed handle", "suggestion": "f.close()"}
         ],
     )
@@ -559,7 +594,7 @@ def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+fine")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", on_usage=None: [])
+    monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", **kwargs: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -1,6 +1,9 @@
+from datetime import date
+
 import pytest
 
-from app_server.llm_cost import cost_for_usage, monthly_cap_for_installation
+from app_server import llm_cost
+from app_server.llm_cost import cost_for_usage, monthly_cap_for_installation, stale_models
 
 
 def test_cost_for_usage_deepseek_v4_pro():
@@ -26,3 +29,53 @@ def test_monthly_cap_for_installation_base_only():
 
 def test_monthly_cap_for_installation_with_extra_seats():
     assert monthly_cap_for_installation(7.00, 3) == pytest.approx(13.00)
+
+
+def test_stale_models_returns_empty_when_all_recently_verified():
+    assert stale_models(as_of=date(2026, 7, 24)) == []
+
+
+def test_stale_models_flags_a_model_past_max_age(monkeypatch):
+    monkeypatch.setitem(
+        llm_cost.MODEL_RATES_PER_MILLION_USD,
+        "deepseek-v4-pro",
+        {"input": 0.435, "output": 0.87, "verified_at": "2026-01-01"},
+    )
+
+    assert stale_models(as_of=date(2026, 7, 23)) == ["deepseek-v4-pro"]
+
+
+def test_stale_models_respects_custom_max_age(monkeypatch):
+    monkeypatch.setitem(
+        llm_cost.MODEL_RATES_PER_MILLION_USD,
+        "deepseek-v4-pro",
+        {"input": 0.435, "output": 0.87, "verified_at": "2026-07-01"},
+    )
+
+    assert stale_models(as_of=date(2026, 7, 23), max_age_days=90) == []
+    assert stale_models(as_of=date(2026, 7, 23), max_age_days=10) == ["deepseek-v4-pro"]
+
+
+def test_cost_for_usage_warns_once_per_model_for_stale_pricing(monkeypatch, caplog):
+    monkeypatch.setitem(
+        llm_cost.MODEL_RATES_PER_MILLION_USD,
+        "deepseek-v4-pro",
+        {"input": 0.435, "output": 0.87, "verified_at": "2020-01-01"},
+    )
+    monkeypatch.setattr(llm_cost, "_warned_stale_models", set())
+
+    with caplog.at_level("WARNING"):
+        cost_for_usage("deepseek-v4-pro", 1000, 1000)
+        cost_for_usage("deepseek-v4-pro", 1000, 1000)
+
+    stale_warnings = [r for r in caplog.records if "deepseek-v4-pro" in r.message]
+    assert len(stale_warnings) == 1
+
+
+def test_cost_for_usage_does_not_warn_for_freshly_verified_model(monkeypatch, caplog):
+    monkeypatch.setattr(llm_cost, "_warned_stale_models", set())
+
+    with caplog.at_level("WARNING"):
+        cost_for_usage("deepseek-v4-flash", 1000, 1000)
+
+    assert caplog.records == []

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -151,6 +151,78 @@ async def test_list_evidence_packet_cache_rows_never_crosses_installations(pool)
 
 
 @pytest.mark.asyncio
+async def test_insert_and_list_flash_review_cache_rows(pool):
+    await _insert_installation(pool, 411, "flash-org")
+
+    from scan_worker.db import insert_flash_review_cache_row, list_recent_flash_review_cache_rows
+
+    insert_flash_review_cache_row(
+        TEST_DATABASE_URL,
+        411,
+        "flash-org/repo",
+        "hash-1",
+        [0.1, 0.2, 0.3],
+        "--- a.py ---\n@@ -1,1 +1,1 @@\n+x = 1",
+        [{"file": "a.py", "line": 1, "issue": "unused variable"}],
+        "deepseek-v4-flash",
+    )
+
+    rows = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 411, "flash-org/repo")
+
+    assert len(rows) == 1
+    assert rows[0]["content_hash"] == "hash-1"
+    assert rows[0]["embedding"] == [0.1, 0.2, 0.3]
+    assert rows[0]["diff_text"] == "--- a.py ---\n@@ -1,1 +1,1 @@\n+x = 1"
+    assert rows[0]["findings"] == [{"file": "a.py", "line": 1, "issue": "unused variable"}]
+    assert rows[0]["model_used"] == "deepseek-v4-flash"
+
+
+@pytest.mark.asyncio
+async def test_list_flash_review_cache_rows_never_crosses_installations(pool):
+    await _insert_installation(pool, 412, "org-a")
+    await _insert_installation(pool, 413, "org-b")
+
+    from scan_worker.db import insert_flash_review_cache_row, list_recent_flash_review_cache_rows
+
+    insert_flash_review_cache_row(
+        TEST_DATABASE_URL, 412, "org-a/repo", "hash-a", [1.0], "diff a", [], "deepseek-v4-flash"
+    )
+    insert_flash_review_cache_row(
+        TEST_DATABASE_URL, 413, "org-b/repo", "hash-b", [1.0], "diff b", [], "deepseek-v4-flash"
+    )
+
+    rows = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 412, "org-a/repo")
+
+    assert len(rows) == 1
+    assert rows[0]["content_hash"] == "hash-a"
+
+
+@pytest.mark.asyncio
+async def test_record_flash_review_cache_hit_updates_hit_count_and_last_hit_at(pool):
+    await _insert_installation(pool, 414, "hit-org")
+
+    from scan_worker.db import (
+        insert_flash_review_cache_row,
+        list_recent_flash_review_cache_rows,
+        record_flash_review_cache_hit,
+    )
+
+    insert_flash_review_cache_row(
+        TEST_DATABASE_URL, 414, "hit-org/repo", "hash-1", [1.0], "diff", [], "deepseek-v4-flash"
+    )
+    row_id = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 414, "hit-org/repo")[0]["id"]
+
+    record_flash_review_cache_hit(TEST_DATABASE_URL, row_id)
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT hit_count, last_hit_at FROM flash_review_cache WHERE id = $1", row_id
+        )
+    assert row["hit_count"] == 1
+    assert row["last_hit_at"] is not None
+
+
+@pytest.mark.asyncio
 async def test_insert_repo_history_rejects_oversized_evidence(pool):
     await _insert_installation(pool, 301, "a")
     oversized = {"padding": "x" * (MAX_EVIDENCE_BYTES + 1)}


### PR DESCRIPTION
Implements docs/superpowers/plans/2026-07-23-aletheore-model-routing-cost-control.md: pricing verified_at tracking + stale-price warnings, Flash review diff-hunk validation, lockfile/generated-only PR skip before model call, flash_review_cache migration + DB helpers + cache module, cache lookup/write wiring into Flash review. Managed audits untouched.