### PR TITLE
Correlate runtime health checks to code

### DIFF
--- a/github-app/migrations/014_endpoint_health_response_shape.sql
+++ b/github-app/migrations/014_endpoint_health_response_shape.sql
@@ -1,0 +1,1 @@
+ALTER TABLE endpoint_health ADD COLUMN IF NOT EXISTS response_shape TEXT[];

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -294,7 +294,7 @@ def get_last_endpoint_health(
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT reachable, status_code, latency_ms, checked_at
+                SELECT reachable, status_code, latency_ms, response_shape, checked_at
                 FROM endpoint_health
                 WHERE installation_id = %s
                   AND repo_full_name = %s
@@ -325,6 +325,7 @@ def insert_endpoint_health(
     reachable: bool,
     status_code: int | None,
     latency_ms: float | None,
+    response_shape: list[str] | None = None,
     target_id: int | None = None,
     keep: int = 20,
 ) -> None:
@@ -336,10 +337,20 @@ def insert_endpoint_health(
                 """
                 INSERT INTO endpoint_health
                     (installation_id, repo_full_name, endpoint_method, endpoint_path,
-                     reachable, status_code, latency_ms, target_id)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                     reachable, status_code, latency_ms, response_shape, target_id)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
-                (installation_id, repo_full_name, method, path, reachable, status_code, latency_ms, target_id),
+                (
+                    installation_id,
+                    repo_full_name,
+                    method,
+                    path,
+                    reachable,
+                    status_code,
+                    latency_ms,
+                    response_shape,
+                    target_id,
+                ),
             )
             cur.execute(
                 """

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -135,3 +135,38 @@ def fetch_file_content(
         return base64.b64decode(data["content"]).decode("utf-8")
     except (ValueError, UnicodeDecodeError):
         return None
+
+
+def fetch_recent_commits_for_path(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    path: str,
+    limit: int = 1,
+) -> list[dict]:
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    response = client.get(
+        f"/repos/{repo_full_name}/commits",
+        headers=headers,
+        params={"path": path, "per_page": limit},
+    )
+    if response.status_code == 404:
+        return []
+    response.raise_for_status()
+    commits = []
+    for item in response.json():
+        commit = item.get("commit", {})
+        author = commit.get("author", {}) or {}
+        message = commit.get("message") or ""
+        commits.append(
+            {
+                "sha": item.get("sha"),
+                "author": author.get("name"),
+                "date": author.get("date"),
+                "subject": message.split("\n", 1)[0],
+            }
+        )
+    return commits

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -4,6 +4,7 @@ import json
 import logging
 import shutil
 import subprocess
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,7 +14,12 @@ import httpx
 from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from aletheore.evidence import write_evidence
-from aletheore.evidence_resolution import resolve_code_evidence
+from aletheore.evidence_resolution import (
+    empty_resolution,
+    merge_resolution,
+    normalize_resolution,
+    resolve_code_evidence,
+)
 from aletheore.history import compute_diff
 from aletheore.pr_comment import COMMENT_MARKER, format_diff_comment
 from aletheore.healthcheck import run_healthcheck
@@ -46,13 +52,20 @@ from scan_worker.db import (
     upsert_wiki_subsystem,
 )
 from scan_worker.flash_review import build_code_evidence_context, gather_file_context, review_diff
-from scan_worker.github_api import create_check_run, fetch_pr_changed_files, fetch_pr_diff, upsert_pr_comment
+from scan_worker.github_api import (
+    create_check_run,
+    fetch_pr_changed_files,
+    fetch_pr_diff,
+    fetch_recent_commits_for_path,
+    upsert_pr_comment,
+)
 from scan_worker.managed_audit import run_managed_audit
 from scan_worker.model_tiers import model_for_plan, writing_adapter_for_plan
 from scan_worker.packet_cache import lookup_cached_result, store_result
 from scan_worker.slack import (
     format_latency_alert,
     format_reachability_alert,
+    format_shape_change_alert,
     send_health_alert,
     send_slack_alert,
 )
@@ -65,6 +78,8 @@ FLASH_REVIEW_MARKER = "<!-- aletheore-flash-review -->"
 # the whole Live Wiki pipeline - see scan_worker/live_wiki.py.
 LIVE_WIKI_FULL_BUILD_JOB_TIMEOUT_SECONDS = 1800
 LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS = 300
+HEALTH_CHECK_DOWN_RETRY_ATTEMPTS = 2
+HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS = 2.0
 
 
 def _job_temp_dir() -> Path:
@@ -466,6 +481,57 @@ def _latency_flipped(
     return (prior["latency_ms"] > threshold_ms) != now_over
 
 
+def _recheck_single_endpoint(entry: dict, base_url: str) -> dict:
+    minimal_endpoint = {"method": entry.get("method"), "path": entry["path"]}
+    results = run_healthcheck([minimal_endpoint], base_url).get("results", [])
+    if not results:
+        return {
+            "reachable": False,
+            "status_code": None,
+            "latency_ms": None,
+            "response_shape": None,
+        }
+    return results[0]
+
+
+def _attach_recent_commit_for_failure(
+    settings,
+    installation_id: int,
+    repo_full_name: str,
+    source_file: str,
+    evidence_resolution: dict | None,
+) -> dict | None:
+    try:
+        app_jwt = generate_app_jwt(
+            settings.github_app_id,
+            settings.github_app_private_key,
+        )
+        token = _token_sync(installation_id, app_jwt)
+        with httpx.Client(base_url="https://api.github.com") as client:
+            commits = fetch_recent_commits_for_path(
+                client,
+                token,
+                repo_full_name,
+                source_file,
+                limit=1,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "commit correlation failed (%s); alerting without it",
+            type(exc).__name__,
+        )
+        return evidence_resolution
+    if not commits:
+        return evidence_resolution
+    commit_attachment = normalize_resolution(
+        kind="commit",
+        commit=commits[0],
+        confidence="weak",
+    )
+    base = evidence_resolution or empty_resolution("endpoint")
+    return merge_resolution(base, commit_attachment)
+
+
 @log_job
 def run_health_check_sweep_job() -> None:
     settings = get_settings()
@@ -493,6 +559,7 @@ def run_health_check_sweep_job() -> None:
             reachable = entry["reachable"]
             status_code = entry.get("status_code")
             latency_ms = entry.get("latency_ms")
+            response_shape = entry.get("response_shape")
             prior = get_last_endpoint_health(
                 dsn,
                 installation_id,
@@ -505,7 +572,30 @@ def run_health_check_sweep_job() -> None:
             reachability_flipped = (prior is None and not reachable) or (
                 prior is not None and prior.get("reachable") != reachable
             )
+
+            if reachability_flipped and not reachable:
+                for _ in range(HEALTH_CHECK_DOWN_RETRY_ATTEMPTS):
+                    time.sleep(HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS)
+                    retry_result = _recheck_single_endpoint(entry, base_url)
+                    if retry_result.get("reachable"):
+                        reachable = True
+                        status_code = retry_result.get("status_code")
+                        latency_ms = retry_result.get("latency_ms")
+                        response_shape = retry_result.get("response_shape")
+                        break
+                reachability_flipped = (prior is None and not reachable) or (
+                    prior is not None and prior.get("reachable") != reachable
+                )
+
             if reachability_flipped:
+                if not reachable and source_file:
+                    evidence_resolution = _attach_recent_commit_for_failure(
+                        settings,
+                        installation_id,
+                        repo_full_name,
+                        source_file,
+                        evidence_resolution,
+                    )
                 _send_if_webhook_configured(
                     target,
                     format_reachability_alert(
@@ -535,6 +625,30 @@ def run_health_check_sweep_job() -> None:
                     ),
                 )
 
+            shape_changed = (
+                reachable
+                and not reachability_flipped
+                and prior is not None
+                and prior.get("reachable") is True
+                and prior.get("response_shape") is not None
+                and response_shape is not None
+                and prior["response_shape"] != response_shape
+            )
+            if shape_changed:
+                _send_if_webhook_configured(
+                    target,
+                    format_shape_change_alert(
+                        repo_full_name,
+                        method,
+                        path,
+                        source_file,
+                        source_line,
+                        prior["response_shape"],
+                        response_shape,
+                        evidence_resolution=evidence_resolution,
+                    ),
+                )
+
             insert_endpoint_health(
                 dsn,
                 installation_id,
@@ -544,6 +658,7 @@ def run_health_check_sweep_job() -> None:
                 reachable,
                 status_code,
                 latency_ms,
+                response_shape=response_shape,
                 target_id=target_id,
             )
 

--- a/github-app/scan_worker/slack.py
+++ b/github-app/scan_worker/slack.py
@@ -141,6 +141,37 @@ def format_latency_alert(
     return {"text": text}
 
 
+def format_shape_change_alert(
+    repo_full_name: str,
+    method: str,
+    path: str,
+    source_file: str | None,
+    source_line: int | None,
+    prior_shape: list[str],
+    current_shape: list[str],
+    evidence_resolution: dict | None = None,
+) -> dict:
+    location = (
+        f" - handled by {source_file}:{source_line}"
+        if source_file and source_line is not None
+        else ""
+    )
+    added = sorted(set(current_shape) - set(prior_shape))
+    dropped = sorted(set(prior_shape) - set(current_shape))
+    changes = []
+    if added:
+        changes.append(f"added keys: {', '.join(added)}")
+    if dropped:
+        changes.append(f"dropped keys: {', '.join(dropped)}")
+    change_summary = "; ".join(changes) if changes else "key order changed"
+    text = (
+        f"*Aletheore*: response shape changed on `{repo_full_name}`\n"
+        f"`{method} {path}` {change_summary}{location}"
+        f"{_format_evidence_context(evidence_resolution)}"
+    )
+    return {"text": text}
+
+
 def send_health_alert(
     webhook_url: str,
     message: dict,

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -3,7 +3,13 @@ import base64
 import httpx
 
 from aletheore.pr_comment import COMMENT_MARKER
-from scan_worker.github_api import fetch_file_content, fetch_pr_changed_files, fetch_pr_diff, upsert_pr_comment
+from scan_worker.github_api import (
+    fetch_file_content,
+    fetch_pr_changed_files,
+    fetch_pr_diff,
+    fetch_recent_commits_for_path,
+    upsert_pr_comment,
+)
 
 
 def test_creates_comment_when_none_exists():
@@ -159,3 +165,90 @@ def test_fetch_file_content_returns_none_for_binary():
     result = fetch_file_content(client, "tok", "octocat/hello-world", "image.png", "bbb")
 
     assert result is None
+
+
+def test_fetch_recent_commits_for_path_returns_shaped_commits():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/repos/octocat/hello-world/commits"
+        assert dict(request.url.params) == {
+            "path": "controllers/user.controller.ts",
+            "per_page": "1",
+        }
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "sha": "abc123def456",
+                    "commit": {
+                        "author": {
+                            "name": "Ada Lovelace",
+                            "date": "2026-07-23T10:00:00Z",
+                        },
+                        "message": "fix: guard against null user id\n\nlonger body here",
+                    },
+                }
+            ],
+        )
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://api.github.com",
+    )
+    commits = fetch_recent_commits_for_path(
+        client,
+        "token",
+        "octocat/hello-world",
+        "controllers/user.controller.ts",
+    )
+
+    assert commits == [
+        {
+            "sha": "abc123def456",
+            "author": "Ada Lovelace",
+            "date": "2026-07-23T10:00:00Z",
+            "subject": "fix: guard against null user id",
+        }
+    ]
+
+
+def test_fetch_recent_commits_for_path_respects_limit():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert dict(request.url.params)["per_page"] == "3"
+        return httpx.Response(200, json=[])
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://api.github.com",
+    )
+    fetch_recent_commits_for_path(client, "token", "octocat/hello-world", "app.py", limit=3)
+
+
+def test_fetch_recent_commits_for_path_returns_empty_list_for_404():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"message": "Not Found"})
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://api.github.com",
+    )
+    commits = fetch_recent_commits_for_path(
+        client,
+        "token",
+        "octocat/hello-world",
+        "deleted_file.py",
+    )
+
+    assert commits == []
+
+
+def test_fetch_recent_commits_for_path_returns_empty_list_when_no_commits():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://api.github.com",
+    )
+    commits = fetch_recent_commits_for_path(client, "token", "octocat/hello-world", "app.py")
+
+    assert commits == []

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -638,8 +638,10 @@ def _patch_sweep(
     prior=None,
     result_entry=None,
     evidence=None,
+    retry_result_entry=None,
 ):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.time.sleep", lambda *a, **k: None)
     monkeypatch.setattr(
         "scan_worker.jobs.list_health_check_targets_all",
         lambda dsn: [
@@ -659,15 +661,23 @@ def _patch_sweep(
         lambda dsn, iid, repo: evidence
         or {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
     )
-    monkeypatch.setattr(
-        "scan_worker.jobs.run_healthcheck",
-        lambda endpoints, base_url: {
-            "results": [
-                result_entry
-                or {"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 90.0}
-            ]
-        },
-    )
+    default_first = result_entry or {
+        "method": "GET",
+        "path": "/x",
+        "reachable": True,
+        "status_code": 200,
+        "latency_ms": 90.0,
+        "response_shape": None,
+    }
+    calls = {"count": 0}
+
+    def fake_healthcheck(endpoints, base_url):
+        calls["count"] += 1
+        if calls["count"] == 1 or retry_result_entry is None:
+            return {"results": [default_first]}
+        return {"results": [retry_result_entry]}
+
+    monkeypatch.setattr("scan_worker.jobs.run_healthcheck", fake_healthcheck)
     monkeypatch.setattr(
         "scan_worker.jobs.get_last_endpoint_health", lambda dsn, iid, repo, method, path, target_id=None: prior
     )
@@ -690,6 +700,239 @@ def test_sweep_sends_reachability_down_alert(monkeypatch):
 
     assert len(sent) == 1
     assert "down" in sent[0]["text"]
+
+
+def test_sweep_retries_before_confirming_down_and_recovers_silently(monkeypatch):
+    sent = _patch_sweep(
+        monkeypatch,
+        prior={"reachable": True, "latency_ms": 100.0},
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": False,
+            "status_code": None,
+            "latency_ms": 10.0,
+            "response_shape": None,
+        },
+        retry_result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": True,
+            "status_code": 200,
+            "latency_ms": 95.0,
+            "response_shape": None,
+        },
+    )
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert sent == []
+
+
+def test_sweep_confirms_down_after_retries_all_fail(monkeypatch):
+    sent = _patch_sweep(
+        monkeypatch,
+        prior={"reachable": True, "latency_ms": 100.0},
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": False,
+            "status_code": None,
+            "latency_ms": 10.0,
+            "response_shape": None,
+        },
+    )
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert len(sent) == 1
+    assert "down" in sent[0]["text"]
+
+
+def test_sweep_does_not_retry_a_recovery_flip(monkeypatch):
+    healthcheck_calls = []
+    sent = _patch_sweep(
+        monkeypatch,
+        prior={"reachable": False, "latency_ms": None},
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": True,
+            "status_code": 200,
+            "latency_ms": 80.0,
+            "response_shape": None,
+        },
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.run_healthcheck",
+        lambda endpoints, base_url: healthcheck_calls.append(True)
+        or {
+            "results": [
+                {
+                    "method": "GET",
+                    "path": "/x",
+                    "reachable": True,
+                    "status_code": 200,
+                    "latency_ms": 80.0,
+                    "response_shape": None,
+                }
+            ]
+        },
+    )
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert len(healthcheck_calls) == 1
+    assert len(sent) == 1
+    assert "recovered" in sent[0]["text"]
+
+
+def test_sweep_attaches_recent_commit_on_confirmed_down(monkeypatch):
+    sent = _patch_sweep(
+        monkeypatch,
+        prior={"reachable": True, "latency_ms": 100.0},
+        evidence={
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {
+                            "method": "GET",
+                            "path": "/x",
+                            "file": "controllers/user.controller.ts",
+                            "line": 42,
+                        }
+                    ]
+                }
+            }
+        },
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": False,
+            "status_code": None,
+            "latency_ms": 10.0,
+            "response_shape": None,
+        },
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_recent_commits_for_path",
+        lambda client, token, repo, path, limit=1: [
+            {
+                "sha": "abc123def456",
+                "author": "Ada",
+                "date": "2026-07-23T10:00:00Z",
+                "subject": "touched the handler",
+            }
+        ],
+    )
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert len(sent) == 1
+    assert "Recent commit: `abc123de`" in sent[0]["text"]
+    assert "touched the handler" in sent[0]["text"]
+
+
+def test_sweep_alerts_without_commit_when_correlation_fails(monkeypatch):
+    sent = _patch_sweep(
+        monkeypatch,
+        prior={"reachable": True, "latency_ms": 100.0},
+        evidence={
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {
+                            "method": "GET",
+                            "path": "/x",
+                            "file": "controllers/user.controller.ts",
+                            "line": 42,
+                        }
+                    ]
+                }
+            }
+        },
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": False,
+            "status_code": None,
+            "latency_ms": 10.0,
+            "response_shape": None,
+        },
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+
+    def _raise(*a, **k):
+        raise RuntimeError("github api unavailable")
+
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", _raise)
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert len(sent) == 1
+    assert "down" in sent[0]["text"]
+    assert "Recent commit" not in sent[0]["text"]
+
+
+def test_sweep_sends_shape_change_alert_while_still_reachable(monkeypatch):
+    sent = _patch_sweep(
+        monkeypatch,
+        prior={
+            "reachable": True,
+            "latency_ms": 100.0,
+            "response_shape": ["email", "id", "name"],
+        },
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": True,
+            "status_code": 200,
+            "latency_ms": 90.0,
+            "response_shape": ["id", "name"],
+        },
+    )
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert len(sent) == 1
+    assert "response shape changed" in sent[0]["text"]
+    assert "dropped keys: email" in sent[0]["text"]
+
+
+def test_sweep_skips_shape_alert_when_prior_shape_unknown(monkeypatch):
+    sent = _patch_sweep(
+        monkeypatch,
+        prior={"reachable": True, "latency_ms": 100.0, "response_shape": None},
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": True,
+            "status_code": 200,
+            "latency_ms": 90.0,
+            "response_shape": ["id"],
+        },
+    )
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert sent == []
 
 
 def test_sweep_sends_nothing_when_reachable_stays_same(monkeypatch):
@@ -821,6 +1064,7 @@ def test_sweep_checks_every_target_independently(monkeypatch):
             },
         ],
     )
+    monkeypatch.setattr("scan_worker.jobs.time.sleep", lambda *a, **k: None)
     monkeypatch.setattr(
         "scan_worker.jobs.get_latest_evidence",
         lambda dsn, iid, repo: {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
@@ -828,7 +1072,18 @@ def test_sweep_checks_every_target_independently(monkeypatch):
 
     def fake_healthcheck(endpoints, base_url):
         reachable = base_url == "https://staging.example.com"
-        return {"results": [{"method": "GET", "path": "/x", "reachable": reachable, "status_code": 200 if reachable else None, "latency_ms": 50.0}]}
+        return {
+            "results": [
+                {
+                    "method": "GET",
+                    "path": "/x",
+                    "reachable": reachable,
+                    "status_code": 200 if reachable else None,
+                    "latency_ms": 50.0,
+                    "response_shape": None,
+                }
+            ]
+        }
 
     monkeypatch.setattr("scan_worker.jobs.run_healthcheck", fake_healthcheck)
     monkeypatch.setattr(
@@ -838,7 +1093,7 @@ def test_sweep_checks_every_target_independently(monkeypatch):
     recorded = []
     monkeypatch.setattr(
         "scan_worker.jobs.insert_endpoint_health",
-        lambda dsn, iid, repo, method, path, reachable, status_code, latency_ms, target_id=None, keep=20: recorded.append(
+        lambda dsn, iid, repo, method, path, reachable, status_code, latency_ms, response_shape=None, target_id=None, keep=20: recorded.append(
             (target_id, reachable)
         ),
     )

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -214,6 +214,36 @@ async def test_insert_and_get_last_endpoint_health(pool):
 
 
 @pytest.mark.asyncio
+async def test_insert_and_get_last_endpoint_health_with_response_shape(pool):
+    await _insert_installation(pool, 301, "a")
+
+    insert_endpoint_health(
+        TEST_DATABASE_URL,
+        301,
+        "a/repo1",
+        "GET",
+        "/x",
+        True,
+        200,
+        120.5,
+        response_shape=["email", "id", "name"],
+    )
+    last = get_last_endpoint_health(TEST_DATABASE_URL, 301, "a/repo1", "GET", "/x")
+
+    assert last["response_shape"] == ["email", "id", "name"]
+
+
+@pytest.mark.asyncio
+async def test_insert_endpoint_health_defaults_response_shape_to_none(pool):
+    await _insert_installation(pool, 301, "a")
+
+    insert_endpoint_health(TEST_DATABASE_URL, 301, "a/repo1", "GET", "/x", True, 200, 120.5)
+    last = get_last_endpoint_health(TEST_DATABASE_URL, 301, "a/repo1", "GET", "/x")
+
+    assert last["response_shape"] is None
+
+
+@pytest.mark.asyncio
 async def test_endpoint_health_rotation_keeps_20(pool):
     await _insert_installation(pool, 301, "a")
     for _ in range(21):

--- a/github-app/tests/test_slack.py
+++ b/github-app/tests/test_slack.py
@@ -3,6 +3,7 @@ import httpx
 from scan_worker.slack import (
     format_latency_alert,
     format_reachability_alert,
+    format_shape_change_alert,
     format_slack_message,
     send_health_alert,
     send_slack_alert,
@@ -126,6 +127,41 @@ def test_format_latency_alert_under():
     )
     assert "under threshold" in body["text"]
     assert "controllers/user.controller.ts:42" in body["text"]
+
+
+def test_format_shape_change_alert_reports_added_and_dropped_keys():
+    body = format_shape_change_alert(
+        "octocat/hello-world",
+        "GET",
+        "/api/users",
+        "controllers/user.controller.ts",
+        42,
+        prior_shape=["email", "id", "name"],
+        current_shape=["id", "name", "role"],
+    )
+
+    assert "response shape changed" in body["text"]
+    assert "added keys: role" in body["text"]
+    assert "dropped keys: email" in body["text"]
+    assert "controllers/user.controller.ts:42" in body["text"]
+
+
+def test_format_shape_change_alert_includes_evidence_context():
+    evidence_resolution = {
+        "commit": {"sha": "abcdef123456", "subject": "drop email from response"},
+    }
+    body = format_shape_change_alert(
+        "octocat/hello-world",
+        "GET",
+        "/api/users",
+        None,
+        None,
+        prior_shape=["email", "id"],
+        current_shape=["id"],
+        evidence_resolution=evidence_resolution,
+    )
+
+    assert "Recent commit: `abcdef12`" in body["text"]
 
 
 def test_send_health_alert_posts_message():

--- a/prototype/aletheore/healthcheck.py
+++ b/prototype/aletheore/healthcheck.py
@@ -1,3 +1,4 @@
+import json
 import re
 import ssl
 import time
@@ -17,6 +18,7 @@ _PATH_PARAM_PATTERNS = (
     re.compile(r"\{[^}]+\}"),
     re.compile(r":[A-Za-z_][A-Za-z0-9_]*"),
 )
+MAX_BODY_BYTES_FOR_SHAPE = 65_536
 
 
 def _substitute_path_params(path: str) -> tuple[str, bool]:
@@ -27,6 +29,22 @@ def _substitute_path_params(path: str) -> tuple[str, bool]:
             had_params = True
             substituted = pattern.sub("1", substituted)
     return substituted, had_params
+
+
+def _response_shape(response) -> list[str] | None:
+    content_type = response.headers.get("Content-Type", "")
+    if "application/json" not in content_type:
+        return None
+    try:
+        raw = response.read(MAX_BODY_BYTES_FOR_SHAPE)
+        data = json.loads(raw)
+    except (ValueError, TypeError, UnicodeDecodeError):
+        return None
+    if isinstance(data, dict):
+        return sorted(data.keys())
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        return sorted(data[0].keys())
+    return None
 
 
 def run_healthcheck(endpoints: list[dict], base_url: str, timeout: float = 5.0) -> dict:
@@ -76,12 +94,15 @@ def run_healthcheck(endpoints: list[dict], base_url: str, timeout: float = 5.0) 
             ) as response:
                 entry["status_code"] = response.status
                 entry["reachable"] = True
+                entry["response_shape"] = _response_shape(response)
         except urllib.error.HTTPError as exc:
             entry["status_code"] = exc.code
             entry["reachable"] = True
+            entry["response_shape"] = None
         except (urllib.error.URLError, TimeoutError, OSError):
             entry["status_code"] = None
             entry["reachable"] = False
+            entry["response_shape"] = None
         entry["latency_ms"] = round((time.monotonic() - start) * 1000, 1)
         results.append(entry)
 

--- a/prototype/tests/test_healthcheck.py
+++ b/prototype/tests/test_healthcheck.py
@@ -4,9 +4,11 @@ from unittest.mock import MagicMock, patch
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
 
 
-def _mock_response(status: int):
+def _mock_response(status: int, headers: dict | None = None, body: bytes = b""):
     mock = MagicMock()
     mock.status = status
+    mock.headers = headers or {}
+    mock.read.return_value = body
     mock.__enter__.return_value = mock
     mock.__exit__.return_value = False
     return mock
@@ -167,6 +169,124 @@ def test_run_healthcheck_reports_unreachable_on_connection_error():
 
     assert result["results"][0]["reachable"] is False
     assert result["results"][0]["status_code"] is None
+
+
+def test_run_healthcheck_captures_response_shape_for_json_object():
+    endpoints = [
+        {
+            "method": "GET",
+            "path": "/users/1",
+            "framework": "flask",
+            "file": "app.py",
+            "line": 1,
+            "handler": "get_user",
+            "unresolved": False,
+        }
+    ]
+
+    response = _mock_response(
+        200,
+        headers={"Content-Type": "application/json"},
+        body=b'{"id": 1, "name": "Ada", "email": "ada@example.com"}',
+    )
+
+    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+        result = run_healthcheck(endpoints, "http://localhost:5000")
+
+    assert result["results"][0]["response_shape"] == ["email", "id", "name"]
+
+
+def test_run_healthcheck_captures_response_shape_for_json_list_of_objects():
+    endpoints = [
+        {
+            "method": "GET",
+            "path": "/users",
+            "framework": "flask",
+            "file": "app.py",
+            "line": 1,
+            "handler": "x",
+            "unresolved": False,
+        }
+    ]
+
+    response = _mock_response(
+        200,
+        headers={"Content-Type": "application/json"},
+        body=b'[{"id": 1, "name": "Ada"}, {"id": 2, "name": "Bea"}]',
+    )
+
+    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+        result = run_healthcheck(endpoints, "http://localhost:5000")
+
+    assert result["results"][0]["response_shape"] == ["id", "name"]
+
+
+def test_run_healthcheck_response_shape_is_none_for_non_json_content_type():
+    endpoints = [
+        {
+            "method": "GET",
+            "path": "/health",
+            "framework": "flask",
+            "file": "app.py",
+            "line": 1,
+            "handler": "x",
+            "unresolved": False,
+        }
+    ]
+
+    response = _mock_response(200, headers={"Content-Type": "text/plain"}, body=b"OK")
+
+    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+        result = run_healthcheck(endpoints, "http://localhost:5000")
+
+    assert result["results"][0]["response_shape"] is None
+
+
+def test_run_healthcheck_response_shape_is_none_for_malformed_json():
+    endpoints = [
+        {
+            "method": "GET",
+            "path": "/broken",
+            "framework": "flask",
+            "file": "app.py",
+            "line": 1,
+            "handler": "x",
+            "unresolved": False,
+        }
+    ]
+
+    response = _mock_response(
+        200,
+        headers={"Content-Type": "application/json"},
+        body=b"not actually json",
+    )
+
+    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+        result = run_healthcheck(endpoints, "http://localhost:5000")
+
+    assert result["results"][0]["response_shape"] is None
+
+
+def test_run_healthcheck_response_shape_is_none_on_unreachable():
+    endpoints = [
+        {
+            "method": "GET",
+            "path": "/x",
+            "framework": "flask",
+            "file": "app.py",
+            "line": 1,
+            "handler": "x",
+            "unresolved": False,
+        }
+    ]
+
+    with patch(
+        "aletheore.healthcheck.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        result = run_healthcheck(endpoints, "http://localhost:9999")
+
+    assert result["results"][0]["response_shape"] is None
 
 
 def test_save_healthcheck_rotates_at_21st_save_keeping_20_newest(tmp_path):


### PR DESCRIPTION
Implements docs/superpowers/plans/2026-07-23-aletheore-runtime-code-correlation.md: response-shape (keys only, never values) capture on health checks, retry-hydration before confirming an endpoint down, commit correlation on confirmed failures (fails open), Slack alert on reachable-but-shape-changed.