### PR TITLE
Add defensive infrastructure signals

### DIFF
--- a/github-app/app_server/audit_signing.py
+++ b/github-app/app_server/audit_signing.py
@@ -1,0 +1,30 @@
+import hashlib
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+def content_hash(report_text: str) -> str:
+    return hashlib.sha256(report_text.encode()).hexdigest()
+
+
+def sign_report(report_text: str, private_key_hex: str) -> str:
+    private_key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(private_key_hex))
+    return private_key.sign(content_hash(report_text).encode()).hex()
+
+
+def verify_report(report_text: str, signature_hex: str, public_key_hex: str) -> bool:
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key_hex))
+        public_key.verify(bytes.fromhex(signature_hex), content_hash(report_text).encode())
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+def public_key_hex_from_private(private_key_hex: str) -> str:
+    private_key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(private_key_hex))
+    return private_key.public_key().public_bytes_raw().hex()

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -14,6 +14,7 @@ class Settings:
     session_secret: str
     public_base_url: str
     internal_metrics_token: str | None
+    audit_signing_private_key: str
 
 
 def _required_env(name: str) -> str:
@@ -52,4 +53,5 @@ def get_settings() -> Settings:
         session_secret=_required_env("SESSION_SECRET"),
         public_base_url=os.environ.get("PUBLIC_BASE_URL", "https://aletheore.com"),
         internal_metrics_token=os.environ.get("INTERNAL_METRICS_TOKEN", "").strip() or None,
+        audit_signing_private_key=_required_env("AUDIT_SIGNING_PRIVATE_KEY"),
     )

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, HTTPException, Request, Response
 
 from aletheore.evidence_resolution import resolve_code_evidence
@@ -10,6 +12,7 @@ from app_server.admin import (
 from app_server.auth import get_current_session
 from app_server.db import (
     get_installation,
+    get_endpoint_health_summary_since,
     get_latest_evidence,
     get_recent_endpoint_health,
     get_recent_history,
@@ -20,6 +23,31 @@ from app_server.db import (
 )
 
 dashboard_router = APIRouter()
+MIN_CHECKS_FOR_STALE_CONFIDENCE = 5
+STALE_ENDPOINT_WINDOW_DAYS = 30
+
+
+def find_stale_endpoints(
+    endpoints: list[dict], health_summary: dict[tuple[str, str], dict]
+) -> list[dict]:
+    stale = []
+    for endpoint in endpoints:
+        key = (endpoint.get("method"), endpoint.get("path"))
+        summary = health_summary.get(key)
+        if summary is None:
+            continue
+        if summary["ever_reachable"] or summary["check_count"] < MIN_CHECKS_FOR_STALE_CONFIDENCE:
+            continue
+        stale.append(
+            {
+                "method": endpoint.get("method"),
+                "path": endpoint.get("path"),
+                "file": endpoint.get("file"),
+                "line": endpoint.get("line"),
+                "check_count": summary["check_count"],
+            }
+        )
+    return stale
 
 
 @dashboard_router.get("/app/repos")
@@ -108,7 +136,26 @@ async def get_dashboard_health(org: str, repo: str, request: Request):
             )
         endpoints.append(entry)
 
-    return {"repo_full_name": repo_full_name, "endpoints": endpoints}
+    since = datetime.now(timezone.utc) - timedelta(days=STALE_ENDPOINT_WINDOW_DAYS)
+    health_summary = await get_endpoint_health_summary_since(
+        pool,
+        installation_id,
+        repo_full_name,
+        since,
+    )
+    api_endpoints = (
+        (evidence or {})
+        .get("repository", {})
+        .get("api_endpoints", {})
+        .get("endpoints", [])
+    )
+    stale_endpoints = find_stale_endpoints(api_endpoints, health_summary)
+
+    return {
+        "repo_full_name": repo_full_name,
+        "endpoints": endpoints,
+        "stale_endpoints": stale_endpoints,
+    }
 
 
 @dashboard_router.get("/app/{org}/{repo}/wiki")

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -342,6 +342,32 @@ async def get_recent_endpoint_health(
     return [dict(row) for row in rows]
 
 
+async def get_endpoint_health_summary_since(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    repo_full_name: str,
+    since: datetime,
+) -> dict[tuple[str, str], dict]:
+    rows = await pool.fetch(
+        """
+        SELECT endpoint_method, endpoint_path, bool_or(reachable) AS ever_reachable, count(*) AS check_count
+        FROM endpoint_health
+        WHERE installation_id = $1 AND repo_full_name = $2 AND checked_at >= $3
+        GROUP BY endpoint_method, endpoint_path
+        """,
+        installation_id,
+        repo_full_name,
+        since,
+    )
+    return {
+        (row["endpoint_method"], row["endpoint_path"]): {
+            "ever_reachable": row["ever_reachable"],
+            "check_count": row["check_count"],
+        }
+        for row in rows
+    }
+
+
 async def create_session(
     pool: asyncpg.Pool,
     session_id: str,
@@ -472,6 +498,21 @@ async def touch_api_token(pool: asyncpg.Pool, token_hash: str) -> None:
         "UPDATE api_tokens SET last_used_at = now() WHERE token_hash = $1",
         token_hash,
     )
+
+
+async def get_audit_report_by_token(
+    pool: asyncpg.Pool,
+    verification_token: str,
+) -> dict | None:
+    row = await pool.fetchrow(
+        """
+        SELECT repo_full_name, report_text, content_hash, signature, created_at
+        FROM audit_reports
+        WHERE verification_token = $1
+        """,
+        verification_token,
+    )
+    return dict(row) if row else None
 
 
 async def list_repos_for_installations(pool: asyncpg.Pool, installation_ids: list[int]) -> list[dict]:

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -5,8 +5,14 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from app_server.audit_signing import public_key_hex_from_private, verify_report
 from app_server.config import get_settings
-from app_server.db import check_and_reserve_managed_audit, get_installation_by_token_hash, touch_api_token
+from app_server.db import (
+    check_and_reserve_managed_audit,
+    get_audit_report_by_token,
+    get_installation_by_token_hash,
+    touch_api_token,
+)
 from app_server.evidence_limits import MAX_EVIDENCE_BYTES
 from app_server.rate_limit import cooldown_seconds_for_loc, total_loc_from_evidence
 
@@ -89,6 +95,24 @@ async def start_managed_audit(request: Request, body: StartManagedAuditRequest):
 async def whoami(request: Request):
     installation, _ = await _authenticate_token(request)
     return {"account_login": installation["account_login"], "plan": installation["plan"]}
+
+
+@managed_audit_router.get("/v1/audit/{verification_token}/verify")
+async def verify_audit_report(verification_token: str, request: Request):
+    report = await get_audit_report_by_token(request.app.state.db_pool, verification_token)
+    if report is None:
+        raise HTTPException(status_code=404, detail="report not found")
+
+    settings = get_settings()
+    public_key_hex = public_key_hex_from_private(settings.audit_signing_private_key)
+    verified = verify_report(report["report_text"], report["signature"], public_key_hex)
+
+    return {
+        "repo_full_name": report["repo_full_name"],
+        "content_hash": report["content_hash"],
+        "signed_at": report["created_at"].isoformat(),
+        "verified": verified,
+    }
 
 
 @managed_audit_router.get("/v1/managed-audit/{job_id}")

--- a/github-app/migrations/015_audit_reports.sql
+++ b/github-app/migrations/015_audit_reports.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS audit_reports (
+    id                  BIGSERIAL PRIMARY KEY,
+    installation_id     BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name      TEXT NOT NULL,
+    verification_token  TEXT NOT NULL UNIQUE,
+    report_text         TEXT NOT NULL,
+    content_hash        TEXT NOT NULL,
+    signature           TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS audit_reports_token_lookup ON audit_reports (verification_token);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -106,6 +106,37 @@ def record_llm_spend(dsn: str, installation_id: int, cost_usd: float) -> None:
         conn.commit()
 
 
+def insert_audit_report(
+    dsn: str,
+    installation_id: int,
+    repo_full_name: str,
+    verification_token: str,
+    report_text: str,
+    content_hash: str,
+    signature: str,
+) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO audit_reports
+                    (installation_id, repo_full_name, verification_token, report_text, content_hash, signature)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    installation_id,
+                    repo_full_name,
+                    verification_token,
+                    report_text,
+                    content_hash,
+                    signature,
+                ),
+            )
+        conn.commit()
+
+
 def get_extra_seats(dsn: str, installation_id: int) -> int:
     import psycopg
 
@@ -314,6 +345,29 @@ def get_last_endpoint_health(
             if result["latency_ms"] is not None:
                 result["latency_ms"] = float(result["latency_ms"])
             return result
+
+
+def list_recent_endpoint_incidents(
+    dsn: str,
+    installation_id: int,
+    repo_full_name: str,
+    since: datetime,
+) -> list[dict]:
+    import psycopg
+    import psycopg.rows
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT endpoint_method, endpoint_path, count(*) AS incident_count, max(checked_at) AS last_incident_at
+                FROM endpoint_health
+                WHERE installation_id = %s AND repo_full_name = %s AND reachable = false AND checked_at >= %s
+                GROUP BY endpoint_method, endpoint_path
+                """,
+                (installation_id, repo_full_name, since),
+            )
+            return cur.fetchall()
 
 
 def insert_endpoint_health(

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -47,6 +47,7 @@ def create_check_run(
     head_sha: str,
     conclusion: str,
     summary: str,
+    name: str = "Aletheore secrets check",
 ) -> None:
     headers = {
         "Authorization": f"token {token}",
@@ -56,11 +57,11 @@ def create_check_run(
         f"/repos/{repo_full_name}/check-runs",
         headers=headers,
         json={
-            "name": "Aletheore secrets check",
+            "name": name,
             "head_sha": head_sha,
             "status": "completed",
             "conclusion": conclusion,
-            "output": {"title": "Aletheore secrets check", "summary": summary},
+            "output": {"title": name, "summary": summary},
         },
     )
     response.raise_for_status()

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2,10 +2,11 @@ import asyncio
 import inspect
 import json
 import logging
+import secrets
 import shutil
 import subprocess
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import httpx
@@ -18,6 +19,7 @@ from aletheore.history import compute_diff
 from aletheore.pr_comment import COMMENT_MARKER, format_diff_comment
 from aletheore.healthcheck import run_healthcheck
 from app_server.config import get_settings
+from app_server.audit_signing import content_hash, sign_report
 from app_server.github_auth import generate_app_jwt, get_installation_token
 from app_server.llm_cost import cost_for_usage, monthly_cap_for_installation
 from app_server.logging_config import log_job
@@ -34,10 +36,12 @@ from scan_worker.db import (
     get_last_reviewed_sha,
     get_latest_evidence,
     get_llm_spend_this_month,
+    insert_audit_report,
     insert_endpoint_health,
     insert_repo_history,
     installation_spend_lock,
     list_health_check_targets_all,
+    list_recent_endpoint_incidents,
     list_repos_for_installation,
     list_wiki_subsystems,
     record_llm_spend,
@@ -119,6 +123,38 @@ def _real_new_secrets(diff: dict) -> list[dict]:
     ]
 
 
+REGRESSION_FENCE_WINDOW_DAYS = 7
+
+
+def find_touched_incident_endpoints(
+    changed_files: list[str],
+    evidence: dict,
+    incidents: list[dict],
+) -> list[dict]:
+    incident_by_key = {(i["endpoint_method"], i["endpoint_path"]): i for i in incidents}
+    endpoints = evidence.get("repository", {}).get("api_endpoints", {}).get("endpoints", [])
+    changed = set(changed_files)
+    touched = []
+    for endpoint in endpoints:
+        if endpoint.get("file") not in changed:
+            continue
+        key = (endpoint.get("method"), endpoint.get("path"))
+        incident = incident_by_key.get(key)
+        if incident is None:
+            continue
+        touched.append(
+            {
+                "method": endpoint.get("method"),
+                "path": endpoint.get("path"),
+                "file": endpoint.get("file"),
+                "line": endpoint.get("line"),
+                "incident_count": incident["incident_count"],
+                "last_incident_at": incident["last_incident_at"],
+            }
+        )
+    return touched
+
+
 def _maybe_create_check_run(
     client: httpx.Client,
     token: str,
@@ -141,6 +177,61 @@ def _maybe_create_check_run(
         create_check_run(client, token, repo_full_name, head_sha, "failure", summary)
     else:
         create_check_run(client, token, repo_full_name, head_sha, "success", "No new secrets found.")
+
+
+def _maybe_create_regression_risk_check_run(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    head_sha: str,
+    installation_id: int,
+    evidence: dict,
+    changed_files: list[str],
+) -> None:
+    settings = get_settings()
+    installation = get_installation_row(settings.database_url, installation_id)
+    if installation is None or installation["plan"] == "free":
+        return
+
+    since = datetime.now(timezone.utc) - timedelta(days=REGRESSION_FENCE_WINDOW_DAYS)
+    incidents = list_recent_endpoint_incidents(
+        settings.database_url,
+        installation_id,
+        repo_full_name,
+        since,
+    )
+    if not incidents:
+        return
+
+    touched = find_touched_incident_endpoints(changed_files, evidence, incidents)
+    if not touched:
+        return
+
+    lines = []
+    for item in touched:
+        location = (
+            f" - handled by {item['file']}:{item['line']}"
+            if item.get("file") and item.get("line") is not None
+            else ""
+        )
+        lines.append(
+            f"- `{item['method']} {item['path']}`{location}: "
+            f"{item['incident_count']} reachability incident(s) in the last "
+            f"{REGRESSION_FENCE_WINDOW_DAYS} days"
+        )
+    summary = (
+        "This PR touches a handler with recent production reachability incidents:\n"
+        + "\n".join(lines)
+    )
+    create_check_run(
+        client,
+        token,
+        repo_full_name,
+        head_sha,
+        "neutral",
+        summary,
+        name="Aletheore regression risk",
+    )
 
 
 async def _resolve_token(installation_id: int, app_jwt: str) -> str:
@@ -215,9 +306,25 @@ def run_pr_scan_job(
             pass
         try:
             changed_files = fetch_pr_changed_files(client, token, repo_full_name, base_sha, head_sha)
-            _maybe_update_live_wiki(installation_id, repo_full_name, new, changed_files, head_sha)
         except Exception:  # noqa: BLE001
-            pass
+            changed_files = None
+        if changed_files is not None:
+            try:
+                _maybe_update_live_wiki(installation_id, repo_full_name, new, changed_files, head_sha)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                _maybe_create_regression_risk_check_run(
+                    client,
+                    token,
+                    repo_full_name,
+                    head_sha,
+                    installation_id,
+                    new,
+                    changed_files,
+                )
+            except Exception:  # noqa: BLE001
+                pass
     except Exception as exc:  # noqa: BLE001
         try:
             _post_failure_comment(settings, installation_id, repo_full_name, pr_number, exc)
@@ -284,7 +391,23 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                     record_llm_spend(
                         settings.database_url, installation_id, spend_accumulator["total"]
                     )
-                    body = f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n{report_text}"
+                    verification_token = secrets.token_hex(32)
+                    report_hash = content_hash(report_text)
+                    signature = sign_report(report_text, settings.audit_signing_private_key)
+                    insert_audit_report(
+                        settings.database_url,
+                        installation_id,
+                        repo_full_name,
+                        verification_token,
+                        report_text,
+                        report_hash,
+                        signature,
+                    )
+                    verify_url = f"{settings.public_base_url}/v1/audit/{verification_token}/verify"
+                    body = (
+                        f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
+                        f"{report_text}\n\n[Verify this report]({verify_url})"
+                    )
         upsert_pr_comment(
             client,
             token,

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -19,6 +19,7 @@ os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-webhook-secret")
 os.environ.setdefault("GITHUB_CLIENT_ID", "test-client-id")
 os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-client-secret")
 os.environ.setdefault("SESSION_SECRET", "test-session-secret")
+os.environ.setdefault("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
 os.environ.setdefault("PUBLIC_BASE_URL", "http://test")
 
 

--- a/github-app/tests/test_audit_signing.py
+++ b/github-app/tests/test_audit_signing.py
@@ -1,0 +1,48 @@
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from app_server.audit_signing import (
+    content_hash,
+    public_key_hex_from_private,
+    sign_report,
+    verify_report,
+)
+
+
+def _fresh_private_key_hex() -> str:
+    return Ed25519PrivateKey.generate().private_bytes_raw().hex()
+
+
+def test_content_hash_is_deterministic_sha256():
+    assert content_hash("report body") == content_hash("report body")
+    assert content_hash("report body") != content_hash("different body")
+    assert len(content_hash("report body")) == 64
+
+
+def test_sign_and_verify_round_trip():
+    private_key_hex = _fresh_private_key_hex()
+    public_key_hex = public_key_hex_from_private(private_key_hex)
+    signature = sign_report("the report text", private_key_hex)
+
+    assert verify_report("the report text", signature, public_key_hex) is True
+
+
+def test_verify_fails_for_tampered_text():
+    private_key_hex = _fresh_private_key_hex()
+    public_key_hex = public_key_hex_from_private(private_key_hex)
+    signature = sign_report("the original report", private_key_hex)
+
+    assert verify_report("a tampered report", signature, public_key_hex) is False
+
+
+def test_verify_fails_for_wrong_public_key():
+    private_key_hex = _fresh_private_key_hex()
+    other_public_key_hex = public_key_hex_from_private(_fresh_private_key_hex())
+    signature = sign_report("the report text", private_key_hex)
+
+    assert verify_report("the report text", signature, other_public_key_hex) is False
+
+
+def test_verify_fails_for_malformed_signature():
+    public_key_hex = public_key_hex_from_private(_fresh_private_key_hex())
+
+    assert verify_report("the report text", "not-hex-at-all", public_key_hex) is False

--- a/github-app/tests/test_config.py
+++ b/github-app/tests/test_config.py
@@ -16,6 +16,7 @@ def _clean_env(monkeypatch):
         "GITHUB_WEBHOOK_SECRET",
         "SESSION_SECRET",
         "PUBLIC_BASE_URL",
+        "AUDIT_SIGNING_PRIVATE_KEY",
     ):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost/db")
@@ -25,6 +26,7 @@ def _clean_env(monkeypatch):
     monkeypatch.setenv("GITHUB_CLIENT_SECRET", "client-secret")
     monkeypatch.setenv("SESSION_SECRET", "session-secret")
     monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "raw-key-value")
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
 
 
 def test_reads_private_key_from_path_when_set(tmp_path, monkeypatch):
@@ -66,7 +68,13 @@ def test_reads_paid_tier_settings(monkeypatch):
 
 @pytest.mark.parametrize(
     "missing_var",
-    ["GITHUB_WEBHOOK_SECRET", "GITHUB_CLIENT_SECRET", "SESSION_SECRET", "GITHUB_APP_PRIVATE_KEY"],
+    [
+        "GITHUB_WEBHOOK_SECRET",
+        "GITHUB_CLIENT_SECRET",
+        "SESSION_SECRET",
+        "GITHUB_APP_PRIVATE_KEY",
+        "AUDIT_SIGNING_PRIVATE_KEY",
+    ],
 )
 def test_raises_when_required_secret_is_missing(missing_var, monkeypatch):
     monkeypatch.delenv(missing_var, raising=False)
@@ -76,7 +84,13 @@ def test_raises_when_required_secret_is_missing(missing_var, monkeypatch):
 
 @pytest.mark.parametrize(
     "missing_var",
-    ["GITHUB_WEBHOOK_SECRET", "GITHUB_CLIENT_SECRET", "SESSION_SECRET", "GITHUB_APP_PRIVATE_KEY"],
+    [
+        "GITHUB_WEBHOOK_SECRET",
+        "GITHUB_CLIENT_SECRET",
+        "SESSION_SECRET",
+        "GITHUB_APP_PRIVATE_KEY",
+        "AUDIT_SIGNING_PRIVATE_KEY",
+    ],
 )
 def test_raises_when_required_secret_is_blank(missing_var, monkeypatch):
     monkeypatch.setenv(missing_var, "   ")

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -365,6 +365,101 @@ async def test_dashboard_health_includes_evidence_resolution(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
+    await upsert_installation(pool, 504, "octocat")
+    await insert_repo_history(
+        pool,
+        504,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {
+                            "method": "GET",
+                            "path": "/api/legacy",
+                            "file": "routes.py",
+                            "line": 5,
+                            "handler": "legacy",
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    async with pool.acquire() as conn:
+        for _ in range(5):
+            await conn.execute(
+                """
+                INSERT INTO endpoint_health
+                    (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+                VALUES (504, 'octocat/hello-world', 'GET', '/api/legacy', false)
+                """
+            )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[504])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/health")
+
+    assert response.status_code == 200
+    stale = response.json()["stale_endpoints"]
+    assert stale == [
+        {
+            "method": "GET",
+            "path": "/api/legacy",
+            "file": "routes.py",
+            "line": 5,
+            "check_count": 5,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_health_omits_stale_endpoints_with_recent_success(pool, monkeypatch):
+    await upsert_installation(pool, 505, "octocat")
+    await insert_repo_history(
+        pool,
+        505,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {
+                            "method": "GET",
+                            "path": "/api/active",
+                            "file": "routes.py",
+                            "line": 5,
+                            "handler": "active",
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES
+                (505, 'octocat/hello-world', 'GET', '/api/active', true),
+                (505, 'octocat/hello-world', 'GET', '/api/active', false),
+                (505, 'octocat/hello-world', 'GET', '/api/active', false),
+                (505, 'octocat/hello-world', 'GET', '/api/active', false),
+                (505, 'octocat/hello-world', 'GET', '/api/active', false)
+            """
+        )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[505])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/health")
+
+    assert response.status_code == 200
+    assert response.json()["stale_endpoints"] == []
+
+
+@pytest.mark.asyncio
 async def test_dashboard_wiki_requires_login(pool):
     app.state.db_pool = pool
     transport = ASGITransport(app=app)

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -3,7 +3,13 @@ import base64
 import httpx
 
 from aletheore.pr_comment import COMMENT_MARKER
-from scan_worker.github_api import fetch_file_content, fetch_pr_changed_files, fetch_pr_diff, upsert_pr_comment
+from scan_worker.github_api import (
+    create_check_run,
+    fetch_file_content,
+    fetch_pr_changed_files,
+    fetch_pr_diff,
+    upsert_pr_comment,
+)
 
 
 def test_creates_comment_when_none_exists():
@@ -63,8 +69,6 @@ def test_create_check_run_posts_expected_payload():
         return httpx.Response(201, json={"id": 1})
 
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
-    from scan_worker.github_api import create_check_run
-
     create_check_run(client, "token", "octocat/hello-world", "abc123", "failure", "New secret found")
 
     assert len(calls) == 1
@@ -78,6 +82,34 @@ def test_create_check_run_posts_expected_payload():
     assert body["status"] == "completed"
     assert body["conclusion"] == "failure"
     assert body["name"] == "Aletheore secrets check"
+
+
+def test_create_check_run_uses_custom_name_when_given():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.content)
+        return httpx.Response(201, json={"id": 1})
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        base_url="https://api.github.com",
+    )
+    create_check_run(
+        client,
+        "token",
+        "octocat/hello-world",
+        "abc123",
+        "neutral",
+        "summary text",
+        name="Aletheore regression risk",
+    )
+
+    import json as _json
+
+    payload = _json.loads(calls[0])
+    assert payload["name"] == "Aletheore regression risk"
+    assert payload["conclusion"] == "neutral"
 
 
 def test_fetch_pr_diff_concatenates_real_patches():

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -203,6 +203,99 @@ def test_check_run_failure_on_new_secret(bare_repo_with_two_commits, monkeypatch
     assert created["head_sha"] == head_sha
 
 
+def test_maybe_create_regression_risk_check_run_creates_neutral_check_run(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_recent_endpoint_incidents",
+        lambda *a, **k: [
+            {
+                "endpoint_method": "GET",
+                "endpoint_path": "/x",
+                "incident_count": 3,
+                "last_incident_at": "2026-07-20T00:00:00Z",
+            }
+        ],
+    )
+    created = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_check_run",
+        lambda client, token, repo, sha, conclusion, summary, name="Aletheore secrets check": created.append(
+            (conclusion, name, summary)
+        ),
+    )
+    evidence = {
+        "repository": {
+            "api_endpoints": {
+                "endpoints": [{"method": "GET", "path": "/x", "file": "app.py", "line": 10}]
+            }
+        }
+    }
+
+    from scan_worker.jobs import _maybe_create_regression_risk_check_run
+
+    _maybe_create_regression_risk_check_run(
+        client=None,
+        token="tok",
+        repo_full_name="octocat/hello-world",
+        head_sha="sha1",
+        installation_id=1,
+        evidence=evidence,
+        changed_files=["app.py"],
+    )
+
+    assert len(created) == 1
+    assert created[0][0] == "neutral"
+    assert created[0][1] == "Aletheore regression risk"
+    assert "GET /x" in created[0][2]
+
+
+def test_maybe_create_regression_risk_check_run_skips_when_no_incidents(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.list_recent_endpoint_incidents", lambda *a, **k: [])
+    created = []
+    monkeypatch.setattr("scan_worker.jobs.create_check_run", lambda *a, **k: created.append(True))
+
+    from scan_worker.jobs import _maybe_create_regression_risk_check_run
+
+    _maybe_create_regression_risk_check_run(
+        client=None,
+        token="tok",
+        repo_full_name="octocat/hello-world",
+        head_sha="sha1",
+        installation_id=1,
+        evidence={"repository": {"api_endpoints": {"endpoints": []}}},
+        changed_files=["app.py"],
+    )
+
+    assert created == []
+
+
+def test_maybe_create_regression_risk_check_run_skips_free_plan(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"})
+    touched_incidents = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_recent_endpoint_incidents",
+        lambda *a, **k: touched_incidents.append(True),
+    )
+
+    from scan_worker.jobs import _maybe_create_regression_risk_check_run
+
+    _maybe_create_regression_risk_check_run(
+        client=None,
+        token="tok",
+        repo_full_name="octocat/hello-world",
+        head_sha="sha1",
+        installation_id=1,
+        evidence={"repository": {}},
+        changed_files=[],
+    )
+
+    assert touched_incidents == []
+
+
 def test_managed_audit_api_job_returns_report_text(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
@@ -275,6 +368,7 @@ def test_managed_audit_pr_job_clones_pr_head_runs_audit_and_replies(monkeypatch,
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.insert_audit_report", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
         "scan_worker.jobs.upsert_pr_comment",
@@ -292,6 +386,71 @@ def test_managed_audit_pr_job_clones_pr_head_runs_audit_and_replies(monkeypatch,
     assert "Managed Audit" in posted["body"]
     assert posted["repo_full_name"] == "octocat/hello-world"
     assert posted["marker"] == AUDIT_COMMENT_MARKER
+
+
+def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=work, check=True)
+    (work / "app.py").write_text("print('hello')\n")
+    subprocess.run(["git", "add", "."], cwd=work, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "commit"], cwd=work, check=True)
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(work), str(bare)], check=True)
+    subprocess.run(
+        ["git", "--git-dir", str(bare), "update-ref", "refs/pull/42/head", head_sha],
+        check=True,
+    )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+    )
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.run_managed_audit", lambda *a, **k: "the audit findings")
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_managed_audit", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    posted = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.upsert_pr_comment",
+        lambda client, token, repo_full_name, pr_number, body, **kwargs: posted.update(body=body),
+    )
+    stored = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.insert_audit_report",
+        lambda dsn, iid, repo, token, text, chash, sig: stored.update(
+            installation_id=iid,
+            repo_full_name=repo,
+            token=token,
+            text=text,
+            hash=chash,
+            sig=sig,
+        ),
+    )
+
+    from scan_worker.jobs import run_managed_audit_pr_job
+
+    run_managed_audit_pr_job(1, "octocat/hello-world", 42)
+
+    assert stored["installation_id"] == 1
+    assert stored["repo_full_name"] == "octocat/hello-world"
+    assert stored["text"] == "the audit findings"
+    assert len(stored["token"]) == 64
+    assert stored["token"] in posted["body"]
 
 
 def test_managed_audit_pr_job_skips_llm_call_when_spend_cap_reached(monkeypatch, tmp_path):

--- a/github-app/tests/test_managed_audit_api.py
+++ b/github-app/tests/test_managed_audit_api.py
@@ -7,11 +7,75 @@ from httpx import ASGITransport, AsyncClient
 from app_server.db import create_api_token, set_installation_plan, upsert_installation
 from app_server.evidence_limits import MAX_EVIDENCE_BYTES
 from app_server.main import app
+from app_server.audit_signing import content_hash, sign_report
 from aletheore.toon_encoding import to_toon
 
 
 def _evidence_toon(total_loc: int = 100) -> str:
     return to_toon({"repository": {"languages": [{"name": "Python", "files": 1, "lines": total_loc}]}})
+
+
+@pytest.mark.asyncio
+async def test_verify_audit_report_returns_verified_true_for_untampered_report(pool, monkeypatch):
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
+    await upsert_installation(pool, 601, "octocat")
+    report_text = "the audit findings"
+    signature = sign_report(report_text, "11" * 32)
+    await pool.execute(
+        """
+        INSERT INTO audit_reports
+            (installation_id, repo_full_name, verification_token, report_text, content_hash, signature)
+        VALUES (601, 'octocat/hello-world', 'tok-real', $1, $2, $3)
+        """,
+        report_text,
+        content_hash(report_text),
+        signature,
+    )
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/audit/tok-real/verify")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["verified"] is True
+    assert body["repo_full_name"] == "octocat/hello-world"
+    assert body["content_hash"] == content_hash(report_text)
+    assert "report_text" not in body
+
+
+@pytest.mark.asyncio
+async def test_verify_audit_report_returns_verified_false_for_tampered_report(pool, monkeypatch):
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
+    await upsert_installation(pool, 602, "octocat")
+    real_signature = sign_report("the original report", "11" * 32)
+    await pool.execute(
+        """
+        INSERT INTO audit_reports
+            (installation_id, repo_full_name, verification_token, report_text, content_hash, signature)
+        VALUES (602, 'octocat/hello-world', 'tok-tampered', 'a tampered report', $1, $2)
+        """,
+        content_hash("the original report"),
+        real_signature,
+    )
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/audit/tok-tampered/verify")
+
+    assert response.status_code == 200
+    assert response.json()["verified"] is False
+
+
+@pytest.mark.asyncio
+async def test_verify_audit_report_404s_for_unknown_token(pool, monkeypatch):
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/audit/does-not-exist/verify")
+
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_regression_risk.py
+++ b/github-app/tests/test_regression_risk.py
@@ -1,0 +1,45 @@
+from scan_worker.jobs import find_touched_incident_endpoints
+
+
+def _endpoint(method="GET", path="/api/users", file="routes/users.py", line=10):
+    return {"method": method, "path": path, "file": file, "line": line}
+
+
+def _incident(method="GET", path="/api/users", count=3):
+    return {
+        "endpoint_method": method,
+        "endpoint_path": path,
+        "incident_count": count,
+        "last_incident_at": "2026-07-20T00:00:00Z",
+    }
+
+
+def test_flags_endpoint_touched_by_changed_files_with_an_incident():
+    evidence = {"repository": {"api_endpoints": {"endpoints": [_endpoint()]}}}
+    incidents = [_incident()]
+
+    result = find_touched_incident_endpoints(["routes/users.py"], evidence, incidents)
+
+    assert result == [
+        {
+            "method": "GET",
+            "path": "/api/users",
+            "file": "routes/users.py",
+            "line": 10,
+            "incident_count": 3,
+            "last_incident_at": "2026-07-20T00:00:00Z",
+        }
+    ]
+
+
+def test_ignores_endpoint_in_a_file_not_in_the_diff():
+    evidence = {"repository": {"api_endpoints": {"endpoints": [_endpoint()]}}}
+    incidents = [_incident()]
+
+    assert find_touched_incident_endpoints(["some/other/file.py"], evidence, incidents) == []
+
+
+def test_ignores_touched_endpoint_with_no_incident_history():
+    evidence = {"repository": {"api_endpoints": {"endpoints": [_endpoint()]}}}
+
+    assert find_touched_incident_endpoints(["routes/users.py"], evidence, []) == []

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -214,6 +214,90 @@ async def test_insert_and_get_last_endpoint_health(pool):
 
 
 @pytest.mark.asyncio
+async def test_insert_audit_report(pool):
+    await _insert_installation(pool, 421, "audit-org")
+
+    from scan_worker.db import insert_audit_report
+
+    insert_audit_report(
+        TEST_DATABASE_URL,
+        421,
+        "audit-org/repo",
+        "tok-abc123",
+        "the report text",
+        "hash-1",
+        "sig-1",
+    )
+
+    row = await pool.fetchrow(
+        "SELECT * FROM audit_reports WHERE verification_token = 'tok-abc123'"
+    )
+    assert row["installation_id"] == 421
+    assert row["repo_full_name"] == "audit-org/repo"
+    assert row["report_text"] == "the report text"
+    assert row["content_hash"] == "hash-1"
+    assert row["signature"] == "sig-1"
+
+
+@pytest.mark.asyncio
+async def test_list_recent_endpoint_incidents_groups_by_endpoint(pool):
+    await _insert_installation(pool, 431, "incident-org")
+
+    from scan_worker.db import list_recent_endpoint_incidents
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES
+                (431, 'incident-org/repo', 'GET', '/api/users', false),
+                (431, 'incident-org/repo', 'GET', '/api/users', false),
+                (431, 'incident-org/repo', 'GET', '/api/orders', true)
+            """
+        )
+
+    since = datetime.now(timezone.utc) - timedelta(days=7)
+    incidents = list_recent_endpoint_incidents(
+        TEST_DATABASE_URL,
+        431,
+        "incident-org/repo",
+        since,
+    )
+
+    assert len(incidents) == 1
+    assert incidents[0]["endpoint_method"] == "GET"
+    assert incidents[0]["endpoint_path"] == "/api/users"
+    assert incidents[0]["incident_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_recent_endpoint_incidents_excludes_old_incidents(pool):
+    await _insert_installation(pool, 432, "incident-org")
+
+    from scan_worker.db import list_recent_endpoint_incidents
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, checked_at)
+            VALUES (432, 'incident-org/repo', 'GET', '/api/stale', false, now() - interval '30 days')
+            """
+        )
+
+    since = datetime.now(timezone.utc) - timedelta(days=7)
+    incidents = list_recent_endpoint_incidents(
+        TEST_DATABASE_URL,
+        432,
+        "incident-org/repo",
+        since,
+    )
+
+    assert incidents == []
+
+
+@pytest.mark.asyncio
 async def test_endpoint_health_rotation_keeps_20(pool):
     await _insert_installation(pool, 301, "a")
     for _ in range(21):

--- a/github-app/tests/test_stale_endpoints.py
+++ b/github-app/tests/test_stale_endpoints.py
@@ -1,0 +1,74 @@
+from app_server.dashboard import MIN_CHECKS_FOR_STALE_CONFIDENCE, find_stale_endpoints
+
+
+def _endpoint(method="GET", path="/api/legacy", file="routes.py", line=10):
+    return {"method": method, "path": path, "file": file, "line": line}
+
+
+def test_flags_endpoint_with_zero_successes_over_min_checks():
+    endpoints = [_endpoint()]
+    health_summary = {
+        ("GET", "/api/legacy"): {
+            "ever_reachable": False,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+        }
+    }
+
+    result = find_stale_endpoints(endpoints, health_summary)
+
+    assert result == [
+        {
+            "method": "GET",
+            "path": "/api/legacy",
+            "file": "routes.py",
+            "line": 10,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+        }
+    ]
+
+
+def test_does_not_flag_endpoint_that_has_ever_been_reachable():
+    endpoints = [_endpoint()]
+    health_summary = {("GET", "/api/legacy"): {"ever_reachable": True, "check_count": 10}}
+
+    assert find_stale_endpoints(endpoints, health_summary) == []
+
+
+def test_does_not_flag_endpoint_below_min_check_count():
+    endpoints = [_endpoint()]
+    health_summary = {
+        ("GET", "/api/legacy"): {
+            "ever_reachable": False,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE - 1,
+        }
+    }
+
+    assert find_stale_endpoints(endpoints, health_summary) == []
+
+
+def test_does_not_flag_endpoint_with_no_health_history_at_all():
+    endpoints = [_endpoint()]
+
+    assert find_stale_endpoints(endpoints, {}) == []
+
+
+def test_ignores_endpoints_missing_file_or_line():
+    endpoints = [{"method": "GET", "path": "/api/legacy"}]
+    health_summary = {
+        ("GET", "/api/legacy"): {
+            "ever_reachable": False,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+        }
+    }
+
+    result = find_stale_endpoints(endpoints, health_summary)
+
+    assert result == [
+        {
+            "method": "GET",
+            "path": "/api/legacy",
+            "file": None,
+            "line": None,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+        }
+    ]


### PR DESCRIPTION
Implements docs/superpowers/plans/2026-07-23-aletheore-defensive-infrastructure.md: stale-endpoint detection from endpoint_health history, signed+persisted managed-audit reports (Ed25519, random verification token, never re-serves report text), advisory-only (neutral, non-blocking) regression-risk check run for PRs touching handlers with recent incidents.