### PR TITLE
Sign API-triggered managed audit reports

### DIFF
--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -87,6 +87,7 @@ async def start_managed_audit(request: Request, body: StartManagedAuditRequest):
         job_timeout=900,
         installation_id=installation["installation_id"],
         evidence=body.evidence,
+        repo_full_name=body.repo_full_name,
     )
     return JSONResponse(status_code=202, content={"job_id": job.id})
 
@@ -132,5 +133,9 @@ async def get_managed_audit_status(job_id: str, request: Request):
     if job.is_failed:
         return {"status": "failed"}
     if job.is_finished:
-        return {"status": "finished", "result": job.result}
+        return {
+            "status": "finished",
+            "result": job.result,
+            "verification_token": job.meta.get("verification_token"),
+        }
     return {"status": "pending"}

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -10,7 +10,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import httpx
+from rq import get_current_job
 
+from app_server.audit_signing import content_hash, sign_report
 from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from aletheore.evidence import write_evidence
@@ -19,7 +21,6 @@ from aletheore.history import compute_diff
 from aletheore.pr_comment import COMMENT_MARKER, format_diff_comment
 from aletheore.healthcheck import run_healthcheck
 from app_server.config import get_settings
-from app_server.audit_signing import content_hash, sign_report
 from app_server.github_auth import generate_app_jwt, get_installation_token
 from app_server.llm_cost import cost_for_usage, monthly_cap_for_installation
 from app_server.logging_config import log_job
@@ -344,6 +345,34 @@ def _clone_pr_head(url: str, pr_number: int, dest: Path) -> None:
     subprocess.run(["git", "checkout", "-q", "FETCH_HEAD"], cwd=dest, check=True)
 
 
+def _sign_and_persist_audit_report(
+    settings,
+    installation_id: int,
+    repo_full_name: str,
+    report_text: str,
+) -> str | None:
+    try:
+        verification_token = secrets.token_hex(32)
+        report_hash = content_hash(report_text)
+        signature = sign_report(report_text, settings.audit_signing_private_key)
+        insert_audit_report(
+            settings.database_url,
+            installation_id,
+            repo_full_name,
+            verification_token,
+            report_text,
+            report_hash,
+            signature,
+        )
+        return verification_token
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "audit report signing/persistence failed (%s); report still returned unsigned",
+            type(exc).__name__,
+        )
+        return None
+
+
 @log_job
 def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_number: int) -> None:
     settings = get_settings()
@@ -391,23 +420,20 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                     record_llm_spend(
                         settings.database_url, installation_id, spend_accumulator["total"]
                     )
-                    verification_token = secrets.token_hex(32)
-                    report_hash = content_hash(report_text)
-                    signature = sign_report(report_text, settings.audit_signing_private_key)
-                    insert_audit_report(
-                        settings.database_url,
+                    verification_token = _sign_and_persist_audit_report(
+                        settings,
                         installation_id,
                         repo_full_name,
-                        verification_token,
                         report_text,
-                        report_hash,
-                        signature,
                     )
-                    verify_url = f"{settings.public_base_url}/v1/audit/{verification_token}/verify"
-                    body = (
-                        f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
-                        f"{report_text}\n\n[Verify this report]({verify_url})"
-                    )
+                    if verification_token is not None:
+                        verify_url = f"{settings.public_base_url}/v1/audit/{verification_token}/verify"
+                        body = (
+                            f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
+                            f"{report_text}\n\n[Verify this report]({verify_url})"
+                        )
+                    else:
+                        body = f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n{report_text}"
         upsert_pr_comment(
             client,
             token,
@@ -426,7 +452,11 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
 
 
 @log_job
-def run_managed_audit_api_job(installation_id: int, evidence: dict | str) -> str:
+def run_managed_audit_api_job(
+    installation_id: int,
+    evidence: dict | str,
+    repo_full_name: str,
+) -> str:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
     plan = installation["plan"] if installation is not None else "indie"
@@ -457,6 +487,16 @@ def run_managed_audit_api_job(installation_id: int, evidence: dict | str) -> str
 
             result = run_managed_audit(job_dir, on_usage=_on_usage, plan=plan)
             record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
+            verification_token = _sign_and_persist_audit_report(
+                settings,
+                installation_id,
+                repo_full_name,
+                result,
+            )
+            job = get_current_job()
+            if job is not None:
+                job.meta["verification_token"] = verification_token
+                job.save_meta()
             return result
         finally:
             shutil.rmtree(job_dir, ignore_errors=True)

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -308,7 +308,74 @@ def test_managed_audit_api_job_returns_report_text(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     from scan_worker.jobs import run_managed_audit_api_job
 
-    result = run_managed_audit_api_job(installation_id=100, evidence={"scanned_at": "2026-01-01"})
+    result = run_managed_audit_api_job(
+        installation_id=100,
+        evidence={"scanned_at": "2026-01-01"},
+        repo_full_name="octocat/widgets",
+    )
+
+    assert "API Report" in result
+
+
+def test_managed_audit_api_job_signs_and_persists_the_report(monkeypatch):
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+    )
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.run_managed_audit", lambda *a, **k: "# API Report")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    stored = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.insert_audit_report",
+        lambda dsn, iid, repo, token, text, chash, sig: stored.update(
+            installation_id=iid,
+            repo_full_name=repo,
+            token=token,
+            text=text,
+        ),
+    )
+
+    from scan_worker.jobs import run_managed_audit_api_job
+
+    result = run_managed_audit_api_job(
+        installation_id=100,
+        evidence={"scanned_at": "2026-01-01"},
+        repo_full_name="octocat/widgets",
+    )
+
+    assert "API Report" in result
+    assert stored["installation_id"] == 100
+    assert stored["repo_full_name"] == "octocat/widgets"
+    assert stored["text"] == "# API Report"
+    assert len(stored["token"]) == 64
+
+
+def test_managed_audit_api_job_still_returns_report_when_signing_fails(monkeypatch):
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+    )
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.run_managed_audit", lambda *a, **k: "# API Report")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+
+    def _raise(*a, **k):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr("scan_worker.jobs.insert_audit_report", _raise)
+
+    from scan_worker.jobs import run_managed_audit_api_job
+
+    result = run_managed_audit_api_job(
+        installation_id=100,
+        evidence={"scanned_at": "2026-01-01"},
+        repo_full_name="octocat/widgets",
+    )
 
     assert "API Report" in result
 
@@ -328,7 +395,11 @@ def test_managed_audit_api_job_raises_when_spend_cap_reached(monkeypatch):
     from scan_worker.jobs import run_managed_audit_api_job
 
     with pytest.raises(Exception, match="spend cap"):
-        run_managed_audit_api_job(installation_id=100, evidence={"scanned_at": "2026-01-01"})
+        run_managed_audit_api_job(
+            installation_id=100,
+            evidence={"scanned_at": "2026-01-01"},
+            repo_full_name="octocat/widgets",
+        )
     assert llm_called == []
 
 
@@ -451,6 +522,63 @@ def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_pat
     assert stored["text"] == "the audit findings"
     assert len(stored["token"]) == 64
     assert stored["token"] in posted["body"]
+
+
+def test_managed_audit_pr_job_still_posts_report_when_signing_fails(monkeypatch, tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=work, check=True)
+    (work / "app.py").write_text("print('hello')\n")
+    subprocess.run(["git", "add", "."], cwd=work, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "commit"], cwd=work, check=True)
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(work), str(bare)], check=True)
+    subprocess.run(
+        ["git", "--git-dir", str(bare), "update-ref", "refs/pull/42/head", head_sha],
+        check=True,
+    )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.run_managed_audit", lambda *a, **k: "the audit findings")
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_managed_audit", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+
+    def _raise(*a, **k):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr("scan_worker.jobs.insert_audit_report", _raise)
+    posted = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.upsert_pr_comment",
+        lambda client, token, repo_full_name, pr_number, body, **kwargs: posted.update(
+            body=body,
+            marker=kwargs.get("marker"),
+        ),
+    )
+
+    from scan_worker.jobs import AUDIT_COMMENT_MARKER, run_managed_audit_pr_job
+
+    run_managed_audit_pr_job(1, "octocat/hello-world", 42)
+
+    assert "the audit findings" in posted["body"]
+    assert posted["marker"] == AUDIT_COMMENT_MARKER
+    assert "Verify this report" not in posted["body"]
 
 
 def test_managed_audit_pr_job_skips_llm_call_when_spend_cap_reached(monkeypatch, tmp_path):

--- a/github-app/tests/test_managed_audit_api.py
+++ b/github-app/tests/test_managed_audit_api.py
@@ -241,6 +241,29 @@ async def test_managed_audit_rate_limit_is_independent_per_repo(pool, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_start_managed_audit_passes_repo_full_name_to_the_job(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await set_installation_plan(pool, 100, "indie")
+    token_hash = hashlib.sha256(b"real-token").hexdigest()
+    await create_api_token(pool, 100, token_hash, "laptop", "octocat")
+    fake_queue = MagicMock()
+    fake_queue.enqueue.return_value = MagicMock(id="job-123")
+    monkeypatch.setattr("app_server.managed_audit_api._get_queue", lambda redis_url: fake_queue)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post(
+            "/v1/managed-audit",
+            json={"evidence": _evidence_toon(), "repo_full_name": "octocat/widgets"},
+            headers={"Authorization": "Bearer real-token"},
+        )
+
+    _, kwargs = fake_queue.enqueue.call_args
+    assert kwargs["repo_full_name"] == "octocat/widgets"
+
+
+@pytest.mark.asyncio
 async def test_get_job_status_requires_bearer_token(pool):
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
@@ -256,7 +279,13 @@ async def test_get_job_status_returns_result_when_finished(pool, monkeypatch):
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
 
-    fake_job = MagicMock(is_finished=True, is_failed=False, result="# Report", kwargs={"installation_id": 100})
+    fake_job = MagicMock(
+        is_finished=True,
+        is_failed=False,
+        result="# Report",
+        kwargs={"installation_id": 100},
+        meta={},
+    )
     monkeypatch.setattr("app_server.managed_audit_api._fetch_job", lambda job_id, redis_url: fake_job)
 
     app.state.db_pool = pool
@@ -267,7 +296,43 @@ async def test_get_job_status_returns_result_when_finished(pool, monkeypatch):
         )
 
     assert response.status_code == 200
-    assert response.json() == {"status": "finished", "result": "# Report"}
+    assert response.json() == {
+        "status": "finished",
+        "result": "# Report",
+        "verification_token": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_job_status_includes_verification_token_when_present(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await set_installation_plan(pool, 100, "indie")
+    token_hash = hashlib.sha256(b"real-token").hexdigest()
+    await create_api_token(pool, 100, token_hash, "laptop", "octocat")
+
+    fake_job = MagicMock(
+        is_finished=True,
+        is_failed=False,
+        result="# Report",
+        kwargs={"installation_id": 100},
+        meta={"verification_token": "abc123"},
+    )
+    monkeypatch.setattr("app_server.managed_audit_api._fetch_job", lambda job_id, redis_url: fake_job)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/v1/managed-audit/job-123",
+            headers={"Authorization": "Bearer real-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "finished",
+        "result": "# Report",
+        "verification_token": "abc123",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Implements docs/superpowers/plans/2026-07-24-aletheore-audit-api-signing.md: extracts a shared, fail-open `_sign_and_persist_audit_report(...)` helper used by both the PR-triggered and API-triggered managed audit paths. Fixes a real bug where a signing/persistence failure previously replaced the whole PR-audit comment with a generic error. API-triggered audits are now signed and persisted too, with the verification token surfaced via RQ job.meta and returned from job-status polling as `verification_token` - `run_managed_audit_api_job`'s return type (plain report text) is unchanged, so the CLI client's contract never breaks.