### PR TITLE
Add MCP client config installer

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -375,6 +375,34 @@ by default, plus one optional answer tool when started with `--agent`:
 aletheore mcp .
 ```
 
+### `aletheore mcp-install [path]`
+
+Writes the MCP server registration into your coding tool's own config, so it launches
+`aletheore mcp` for you automatically instead of you running it by hand. By default writes for
+every scriptable target: Claude Code (`.mcp.json`), Cursor (`.cursor/mcp.json`), VS Code
+(`.vscode/mcp.json`), Kiro (`.kiro/settings/mcp.json`), Opencode (`opencode.json`), and OpenAI
+Codex CLI (`.codex/config.toml`). Use `--target` to restrict to one or more
+(e.g. `--target cursor --target vscode`). Safe to re-run - it merges into any existing config
+file rather than overwriting it, so other MCP servers you've already configured are left alone.
+
+```bash
+aletheore mcp-install .
+```
+
+**PyCharm / other JetBrains IDEs:** not auto-configured. There's no single stable, publicly
+documented file format to safely script against - the supported path is Settings | Tools | AI
+Assistant | Model Context Protocol, using "Import a Claude MCP config" against the `.mcp.json`
+this command already wrote.
+
+**vim, Neovim, Emacs, and other terminal editors:** none of these have a native MCP client -
+support depends entirely on whichever AI plugin you've installed (e.g. `avante.nvim`,
+`codecompanion.nvim`), each with its own config. Point that plugin at `aletheore mcp <path>`.
+
+**OpenAI Codex CLI:** writes `.codex/config.toml`, but Codex only reads project-scoped MCP
+config for projects it already trusts - check Codex's own trust prompt if the tools don't
+appear. Writing this file reformats it; hand-written comments in an existing `config.toml` are
+not preserved.
+
 ### `aletheore dashboard [path]`
 
 A live local web UI (Starlette + SSE, opens in your browser): repo overview, git activity,

--- a/prototype/aletheore/cli.py
+++ b/prototype/aletheore/cli.py
@@ -3,12 +3,14 @@ import socket
 import sys
 import threading
 import time
+import tomllib
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
 from typing import Optional
 
 import httpx
+import tomli_w
 import typer
 import uvicorn
 from rich.console import Console
@@ -114,6 +116,7 @@ _COMMAND_SUMMARIES = [
     ("query", "answer a targeted question from existing evidence"),
     ("diff", "compare two evidence snapshots"),
     ("mcp", "run an MCP server so an agent can query a repo directly"),
+    ("mcp-install", "write MCP client config for Claude Code, Cursor, VS Code, Kiro, Opencode, or Codex CLI"),
     ("dashboard", "a live local web UI over the same evidence"),
     ("healthcheck", "GET-only live check of mapped API endpoints"),
     ("init", "scaffold a repository-local .aletheore.json config file"),
@@ -604,6 +607,123 @@ def _mcp(repo_path: str, forced_agent: str | None = None) -> int:
     return 0
 
 
+def _stdio_entry(repo_path: Path, include_type: bool) -> dict:
+    entry: dict = {"command": "aletheore", "args": ["mcp", str(repo_path)]}
+    if include_type:
+        entry = {"type": "stdio", **entry}
+    return entry
+
+
+def _opencode_entry(repo_path: Path) -> dict:
+    return {"type": "local", "command": ["aletheore", "mcp", str(repo_path)], "enabled": True}
+
+
+_MCP_CLIENT_CONFIGS: dict[str, tuple[str, str, Callable[[Path], dict]]] = {
+    "claude-code": (".mcp.json", "mcpServers", lambda p: _stdio_entry(p, include_type=True)),
+    "cursor": (".cursor/mcp.json", "mcpServers", lambda p: _stdio_entry(p, include_type=False)),
+    "vscode": (".vscode/mcp.json", "servers", lambda p: _stdio_entry(p, include_type=True)),
+    "kiro": (".kiro/settings/mcp.json", "mcpServers", lambda p: _stdio_entry(p, include_type=False)),
+    "opencode": ("opencode.json", "mcp", _opencode_entry),
+}
+
+
+def _write_json_mcp_client_config(config_path: Path, top_level_key: str, entry: dict) -> str:
+    if config_path.exists():
+        try:
+            data = json.loads(config_path.read_text())
+        except json.JSONDecodeError:
+            return f"skipped (existing file is not valid JSON): {config_path}"
+        if not isinstance(data, dict):
+            return f"skipped (existing file's top level is not a JSON object): {config_path}"
+    else:
+        data = {}
+
+    servers = data.get(top_level_key, {})
+    if not isinstance(servers, dict):
+        return f"skipped (existing '{top_level_key}' is not a JSON object): {config_path}"
+
+    already_present = "aletheore" in servers
+    servers["aletheore"] = entry
+    data[top_level_key] = servers
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(data, indent=2) + "\n")
+    return f"{'updated' if already_present else 'wrote'} {config_path}"
+
+
+def _write_toml_mcp_client_config(config_path: Path, top_level_key: str, entry: dict) -> str:
+    if config_path.exists():
+        try:
+            data = tomllib.loads(config_path.read_text())
+        except tomllib.TOMLDecodeError:
+            return f"skipped (existing file is not valid TOML): {config_path}"
+        if not isinstance(data, dict):
+            return f"skipped (existing file's top level is not a TOML table): {config_path}"
+    else:
+        data = {}
+
+    servers = data.get(top_level_key, {})
+    if not isinstance(servers, dict):
+        return f"skipped (existing '{top_level_key}' is not a TOML table): {config_path}"
+
+    already_present = "aletheore" in servers
+    servers["aletheore"] = entry
+    data[top_level_key] = servers
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(tomli_w.dumps(data))
+    return f"{'updated' if already_present else 'wrote'} {config_path}"
+
+
+def _mcp_install(path: str, targets: list[str]) -> int:
+    repo_path = Path(path).resolve()
+    all_targets = [*_MCP_CLIENT_CONFIGS.keys(), "codex-cli"]
+    selected = targets or all_targets
+    unknown = [target for target in selected if target not in all_targets]
+    if unknown:
+        console.print(
+            f"[bold red]error:[/bold red] unknown target(s): {', '.join(unknown)}. "
+            f"Valid targets: {', '.join(all_targets)}"
+        )
+        return 1
+
+    for target in selected:
+        if target == "codex-cli":
+            config_path = repo_path / ".codex" / "config.toml"
+            entry = {"command": "aletheore", "args": ["mcp", str(repo_path)]}
+            message = _write_toml_mcp_client_config(config_path, "mcp_servers", entry)
+        else:
+            relative_path, top_level_key, entry_builder = _MCP_CLIENT_CONFIGS[target]
+            config_path = repo_path / relative_path
+            entry = entry_builder(repo_path)
+            message = _write_json_mcp_client_config(config_path, top_level_key, entry)
+        console.print(f"[bold green]{target}[/bold green]: {message}")
+
+    console.print(
+        "\nRestart or reload your coding tool so it picks up the new MCP server - "
+        "Aletheore's tools will then be available without running 'aletheore mcp' yourself."
+    )
+    console.print(
+        "\n[bold]PyCharm / other JetBrains IDEs:[/bold] not auto-configured - there's no single "
+        "stable, documented file format to script against yet. Instead: open Settings | Tools | "
+        "AI Assistant | Model Context Protocol, and use \"Import a Claude MCP config\", pointing "
+        "at the .mcp.json written above."
+    )
+    console.print(
+        "[bold]vim / Neovim / Emacs / other terminal editors:[/bold] no native MCP client exists "
+        "in any of them - support depends entirely on whichever AI plugin you have installed "
+        "(e.g. avante.nvim, codecompanion.nvim). Point that plugin's own MCP config at: "
+        f"aletheore mcp {repo_path}"
+    )
+    console.print(
+        "[bold]OpenAI Codex CLI:[/bold] wrote .codex/config.toml, but Codex only reads "
+        "project-scoped MCP config for projects it already trusts - if the tools don't show up, "
+        "check Codex's own trust prompt for this directory. Also note: writing this file "
+        "reformats it - any hand-written comments in an existing config.toml are not preserved."
+    )
+    return 0
+
+
 def _port_is_available(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -835,6 +955,21 @@ def mcp(
     agent: Optional[str] = typer.Option(None, "--agent", help="provider for the aletheore_answer tool"),
 ) -> None:
     raise typer.Exit(code=_mcp(path, agent))
+
+
+@app.command(
+    name="mcp-install",
+    help="write MCP client config so a coding agent auto-launches this repo's MCP server",
+)
+def mcp_install(
+    path: str = typer.Argument(".", help="repository path"),
+    target: list[str] = typer.Option(
+        [],
+        "--target",
+        help="which client(s) to configure (default: all)",
+    ),
+) -> None:
+    raise typer.Exit(code=_mcp_install(path, target))
 
 
 @app.command(help="run a live local dashboard scoped to a repository")

--- a/prototype/pyproject.toml
+++ b/prototype/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "pyyaml>=6.0,<7.0",
     "typer>=0.24,<0.25",
     "rich>=13.0",
+    "tomli-w>=1.0,<2.0",
 ]
 
 [project.optional-dependencies]

--- a/prototype/tests/test_cli.py
+++ b/prototype/tests/test_cli.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +10,16 @@ import httpx
 import pytest
 from typer.testing import CliRunner
 
-from aletheore.cli import _ElapsedTicker, _make_progress_printer, app
+from aletheore.cli import (
+    _ElapsedTicker,
+    _MCP_CLIENT_CONFIGS,
+    _make_progress_printer,
+    _opencode_entry,
+    _stdio_entry,
+    _write_json_mcp_client_config,
+    _write_toml_mcp_client_config,
+    app,
+)
 from aletheore.device_auth import DeviceFlowError
 from aletheore.report import (
     AmbiguousAdapterError,
@@ -153,6 +163,247 @@ def test_version_flag_prints_version_and_exits():
 def test_main_unknown_command_still_errors():
     result = runner.invoke(app, ["bogus-command"])
     assert result.exit_code != 0
+
+
+def test_mcp_client_configs_cover_the_five_json_targets():
+    assert set(_MCP_CLIENT_CONFIGS.keys()) == {"claude-code", "cursor", "vscode", "kiro", "opencode"}
+
+
+def test_stdio_entry_includes_type_only_when_asked():
+    entry_with_type = _stdio_entry(Path("/repo"), include_type=True)
+    entry_without_type = _stdio_entry(Path("/repo"), include_type=False)
+
+    assert entry_with_type == {"type": "stdio", "command": "aletheore", "args": ["mcp", "/repo"]}
+    assert entry_without_type == {"command": "aletheore", "args": ["mcp", "/repo"]}
+
+
+def test_opencode_entry_uses_single_command_array_not_command_plus_args():
+    entry = _opencode_entry(Path("/repo"))
+
+    assert entry == {"type": "local", "command": ["aletheore", "mcp", "/repo"], "enabled": True}
+
+
+def test_write_json_mcp_client_config_creates_new_file(tmp_path):
+    config_path = tmp_path / ".mcp.json"
+    entry = {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+
+    message = _write_json_mcp_client_config(config_path, "mcpServers", entry)
+
+    assert "wrote" in message
+    assert json.loads(config_path.read_text()) == {"mcpServers": {"aletheore": entry}}
+
+
+def test_write_json_mcp_client_config_creates_parent_directories(tmp_path):
+    config_path = tmp_path / ".vscode" / "mcp.json"
+    entry = {"type": "stdio", "command": "aletheore", "args": ["mcp", str(tmp_path)]}
+
+    _write_json_mcp_client_config(config_path, "servers", entry)
+
+    assert json.loads(config_path.read_text()) == {"servers": {"aletheore": entry}}
+
+
+def test_write_json_mcp_client_config_preserves_other_servers(tmp_path):
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text(
+        json.dumps({"mcpServers": {"other-tool": {"command": "npx", "args": ["-y", "other"]}}})
+    )
+    entry = {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+
+    _write_json_mcp_client_config(config_path, "mcpServers", entry)
+
+    data = json.loads(config_path.read_text())
+    assert data["mcpServers"]["other-tool"] == {"command": "npx", "args": ["-y", "other"]}
+    assert data["mcpServers"]["aletheore"] == entry
+
+
+def test_write_json_mcp_client_config_updates_existing_aletheore_entry(tmp_path):
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text(
+        json.dumps({"mcpServers": {"aletheore": {"command": "aletheore", "args": ["mcp", "/old"]}}})
+    )
+    new_entry = {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+
+    message = _write_json_mcp_client_config(config_path, "mcpServers", new_entry)
+
+    assert "updated" in message
+    data = json.loads(config_path.read_text())
+    assert data["mcpServers"]["aletheore"] == new_entry
+    assert len(data["mcpServers"]) == 1
+
+
+def test_write_json_mcp_client_config_skips_invalid_json_without_crashing(tmp_path):
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text("{not valid json")
+
+    message = _write_json_mcp_client_config(
+        config_path, "mcpServers", {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+    )
+
+    assert "skipped" in message
+    assert config_path.read_text() == "{not valid json"
+
+
+def test_write_json_mcp_client_config_skips_when_top_level_key_is_not_an_object(tmp_path):
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text(json.dumps({"mcpServers": "not-an-object"}))
+
+    message = _write_json_mcp_client_config(
+        config_path, "mcpServers", {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+    )
+
+    assert "skipped" in message
+    assert json.loads(config_path.read_text()) == {"mcpServers": "not-an-object"}
+
+
+def test_write_toml_mcp_client_config_creates_new_file(tmp_path):
+    config_path = tmp_path / ".codex" / "config.toml"
+    entry = {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+
+    message = _write_toml_mcp_client_config(config_path, "mcp_servers", entry)
+
+    assert "wrote" in message
+    data = tomllib.loads(config_path.read_text())
+    assert data == {"mcp_servers": {"aletheore": entry}}
+
+
+def test_write_toml_mcp_client_config_preserves_other_servers(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[mcp_servers.other-tool]\ncommand = "uvx"\nargs = ["other"]\n')
+    entry = {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+
+    _write_toml_mcp_client_config(config_path, "mcp_servers", entry)
+
+    data = tomllib.loads(config_path.read_text())
+    assert data["mcp_servers"]["other-tool"] == {"command": "uvx", "args": ["other"]}
+    assert data["mcp_servers"]["aletheore"] == entry
+
+
+def test_write_toml_mcp_client_config_updates_existing_aletheore_entry(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[mcp_servers.aletheore]\ncommand = "aletheore"\nargs = ["mcp", "/old"]\n')
+    new_entry = {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+
+    message = _write_toml_mcp_client_config(config_path, "mcp_servers", new_entry)
+
+    assert "updated" in message
+    data = tomllib.loads(config_path.read_text())
+    assert data["mcp_servers"]["aletheore"] == new_entry
+    assert len(data["mcp_servers"]) == 1
+
+
+def test_write_toml_mcp_client_config_skips_invalid_toml_without_crashing(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("not [ valid toml")
+
+    message = _write_toml_mcp_client_config(
+        config_path, "mcp_servers", {"command": "aletheore", "args": ["mcp", str(tmp_path)]}
+    )
+
+    assert "skipped" in message
+    assert config_path.read_text() == "not [ valid toml"
+
+
+def test_mcp_install_writes_all_json_targets_by_default(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".mcp.json").exists()
+    assert (tmp_path / ".cursor" / "mcp.json").exists()
+    assert (tmp_path / ".vscode" / "mcp.json").exists()
+    assert (tmp_path / ".kiro" / "settings" / "mcp.json").exists()
+    assert (tmp_path / "opencode.json").exists()
+
+
+def test_mcp_install_default_now_includes_codex_cli(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".codex" / "config.toml").exists()
+
+
+def test_mcp_install_respects_target_flag(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "cursor"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".cursor" / "mcp.json").exists()
+    assert not (tmp_path / ".mcp.json").exists()
+    assert not (tmp_path / "opencode.json").exists()
+
+
+def test_mcp_install_accepts_multiple_target_flags(tmp_path):
+    result = runner.invoke(
+        app, ["mcp-install", str(tmp_path), "--target", "cursor", "--target", "opencode"]
+    )
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".cursor" / "mcp.json").exists()
+    assert (tmp_path / "opencode.json").exists()
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+def test_mcp_install_rejects_unknown_target(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "notatool"])
+
+    assert result.exit_code == 1
+    assert "notatool" in result.stdout
+
+
+def test_mcp_install_written_entry_points_at_the_resolved_repo_path(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "claude-code"])
+
+    assert result.exit_code == 0
+    entry = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]["aletheore"]
+    assert entry["args"] == ["mcp", str(tmp_path.resolve())]
+
+
+def test_mcp_install_opencode_entry_uses_command_array(tmp_path):
+    runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "opencode"])
+
+    entry = json.loads((tmp_path / "opencode.json").read_text())["mcp"]["aletheore"]
+    assert entry["command"] == ["aletheore", "mcp", str(tmp_path.resolve())]
+    assert "args" not in entry
+
+
+def test_mcp_install_writes_codex_cli_target(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "codex-cli"])
+
+    assert result.exit_code == 0
+    config_path = tmp_path / ".codex" / "config.toml"
+    assert config_path.exists()
+    entry = tomllib.loads(config_path.read_text())["mcp_servers"]["aletheore"]
+    assert entry == {"command": "aletheore", "args": ["mcp", str(tmp_path.resolve())]}
+
+
+def test_mcp_install_is_idempotent_and_does_not_duplicate_entries(tmp_path):
+    runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "cursor"])
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "cursor"])
+
+    assert result.exit_code == 0
+    data = json.loads((tmp_path / ".cursor" / "mcp.json").read_text())
+    assert list(data["mcpServers"].keys()) == ["aletheore"]
+
+
+def test_mcp_install_preserves_other_servers_already_in_the_file(tmp_path):
+    cursor_dir = tmp_path / ".cursor"
+    cursor_dir.mkdir()
+    (cursor_dir / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"other-tool": {"command": "npx", "args": ["-y", "other"]}}})
+    )
+
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "cursor"])
+
+    assert result.exit_code == 0
+    data = json.loads((cursor_dir / "mcp.json").read_text())
+    assert "other-tool" in data["mcpServers"]
+    assert "aletheore" in data["mcpServers"]
+
+
+def test_mcp_install_prints_pycharm_and_terminal_editor_guidance(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path)])
+
+    assert "PyCharm" in result.stdout
+    assert "Import a Claude MCP config" in result.stdout
+    assert "avante.nvim" in result.stdout or "no native MCP" in result.stdout
 
 
 def test_progress_printer_prints_each_distinct_phase_on_its_own_line(capsys):


### PR DESCRIPTION
Implements docs/superpowers/plans/2026-07-24-aletheore-mcp-client-install.md: new `aletheore mcp-install [path]` command. Merge-safe JSON config writers for Claude Code, Cursor, VS Code, Kiro, and Opencode, plus TOML support for OpenAI Codex CLI (`.codex/config.toml`, new `tomli-w` dependency since stdlib `tomllib` only reads). PyCharm and the vim/Neovim/Emacs family get explicit printed guidance instead of an auto-write, since neither has a confirmed stable, safely-scriptable config format.