### PR TITLE
fix: cap managed-AI spend at 50% of tier price

### DIFF
--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -20,6 +20,22 @@ STALE_PRICE_MAX_AGE_DAYS = 90
 
 EXTRA_SEAT_MONTHLY_COST_USD = 2.00
 
+# Base monthly price per plan (github-app/../website/pricing.html) - the hard
+# LLM spend cap is set as a fraction of this, not a flat dollar figure, so it
+# scales with what each tier actually pays rather than penalizing cheaper
+# tiers or under-capping expensive ones.
+PLAN_MONTHLY_PRICE_USD = {
+    "indie": 29.00,
+    "team": 79.00,
+    "enterprise": 199.00,
+}
+
+# Deliberately generous: this is a worst-case abuse/runaway-cost ceiling, not
+# a target for typical spend. Normal usage is expected to land far below it -
+# if real usage routinely approaches this fraction, that's a signal to
+# investigate (a caching regression, a runaway loop), not to raise the cap.
+CAP_FRACTION_OF_PRICE = 0.5
+
 # Warn once per process per model, not once per call - cost_for_usage()
 # runs on every token-usage callback, and a real deploy could otherwise
 # emit thousands of identical warnings for one stale price.
@@ -48,6 +64,13 @@ def cost_for_usage(model: str, prompt_tokens: int, completion_tokens: int) -> fl
         )
         _warned_stale_models.add(model)
     return (prompt_tokens * rates["input"] + completion_tokens * rates["output"]) / 1_000_000
+
+
+def base_cap_for_plan(plan: str) -> float:
+    price = PLAN_MONTHLY_PRICE_USD.get(plan)
+    if price is None:
+        return 0.0
+    return price * CAP_FRACTION_OF_PRICE
 
 
 def monthly_cap_for_installation(base_cap_usd: float, extra_seats: int) -> float:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -28,7 +28,7 @@ from aletheore.pr_comment import COMMENT_MARKER, format_diff_comment
 from aletheore.healthcheck import run_healthcheck
 from app_server.config import get_settings
 from app_server.github_auth import generate_app_jwt, get_installation_token
-from app_server.llm_cost import cost_for_usage, monthly_cap_for_installation
+from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation
 from app_server.logging_config import log_job
 from app_server.rate_limit import cooldown_seconds_for_loc, total_loc_from_evidence
 from scan_worker import live_wiki
@@ -424,7 +424,7 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
         else:
             with installation_spend_lock(settings.database_url, installation_id):
                 extra_seats = get_extra_seats(settings.database_url, installation_id)
-                monthly_cap = monthly_cap_for_installation(7.00, extra_seats)
+                monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
                 current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
                 if current_spend >= monthly_cap:
                     body = (
@@ -486,7 +486,7 @@ def run_managed_audit_api_job(
     plan = installation["plan"] if installation is not None else "indie"
     with installation_spend_lock(settings.database_url, installation_id):
         extra_seats = get_extra_seats(settings.database_url, installation_id)
-        monthly_cap = monthly_cap_for_installation(7.00, extra_seats)
+        monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
         current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
         if current_spend >= monthly_cap:
             raise RuntimeError(
@@ -546,7 +546,7 @@ def run_flash_review_job(
 
     with installation_spend_lock(settings.database_url, installation_id):
         extra_seats = get_extra_seats(settings.database_url, installation_id)
-        monthly_cap = monthly_cap_for_installation(7.00, extra_seats)
+        monthly_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
         current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
         if current_spend >= monthly_cap:
             return

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -3,7 +3,7 @@ from datetime import date
 import pytest
 
 from app_server import llm_cost
-from app_server.llm_cost import cost_for_usage, monthly_cap_for_installation, stale_models
+from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation, stale_models
 
 
 def test_cost_for_usage_deepseek_v4_pro():
@@ -21,6 +21,17 @@ def test_cost_for_usage_deepseek_v4_flash():
 def test_cost_for_usage_small_real_call():
     expected = (2_000 * 0.14 + 300 * 0.28) / 1_000_000
     assert cost_for_usage("deepseek-v4-flash", 2_000, 300) == pytest.approx(expected)
+
+
+def test_base_cap_for_plan_is_half_of_tier_price():
+    assert base_cap_for_plan("indie") == pytest.approx(14.50)
+    assert base_cap_for_plan("team") == pytest.approx(39.50)
+    assert base_cap_for_plan("enterprise") == pytest.approx(99.50)
+
+
+def test_base_cap_for_plan_free_or_unknown_plan_has_no_budget():
+    assert base_cap_for_plan("free") == 0.0
+    assert base_cap_for_plan("not-a-real-plan") == 0.0
 
 
 def test_monthly_cap_for_installation_base_only():


### PR DESCRIPTION
## Summary
- The hard monthly LLM-spend cap was a flat $7/mo across every plan, left over from before the current Indie/Team/Enterprise pricing ($29/$79/$199). It no longer reflects what each tier actually pays.
- Replaces it with `base_cap_for_plan(plan)` = 50% of that tier's monthly price, used as a worst-case abuse/runaway-cost ceiling (not a target for typical spend): Indie $14.50, Team $39.50, Enterprise $99.50. Free plan gets no managed-AI budget (0.0), matching that free installations never run managed audits/AIRview at all.
- All three call sites in `scan_worker/jobs.py` (PR-triggered managed audit, API-triggered managed audit, Flash Review) updated; each already had `plan` in scope.

## Test plan
- [x] New unit tests in `test_llm_cost.py` for `base_cap_for_plan` (per-tier value, free/unknown plan = 0.0)
- [x] Full `test_llm_cost.py` suite passes (12/12)
- [x] `jobs.py` and `llm_cost.py` syntax-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)