### PR TITLE
feat: implement Paddle subscription claim flow

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,10 @@
 {
   "version": "0.2",
   "language": "en",
+  "ignoreRegExpList": [
+    "pri_[0-9a-z]+",
+    "pro_[0-9a-z]+"
+  ],
   "ignorePaths": [
     ".git",
     "**/__pycache__/**",

--- a/github-app/.env.example
+++ b/github-app/.env.example
@@ -12,11 +12,13 @@ GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
 
 GITHUB_WEBHOOK_SECRET=
+GITHUB_APP_SLUG=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 SESSION_SECRET=
 PUBLIC_BASE_URL=https://aletheore.com
 ANTHROPIC_API_KEY=
+PADDLE_WEBHOOK_SECRET=
 
 # Optional. Set to enable GET /v1/internal/queue-stats (RQ queue depth,
 # started/failed/finished counts, worker count) for ops monitoring. The

--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -17,6 +17,7 @@ SESSION_COOKIE_NAME = "session"
 SESSION_TTL = timedelta(days=30)
 OAUTH_STATE_COOKIE_NAME = "oauth_state"
 OAUTH_STATE_TTL = timedelta(minutes=10)
+NEXT_COOKIE_NAME = "aletheore_oauth_next"
 
 auth_router = APIRouter()
 
@@ -86,10 +87,17 @@ async def get_current_session(request: Request) -> dict | None:
     return row
 
 
+def _is_safe_next_path(next_path: str | None) -> str:
+    if not next_path or not next_path.startswith("/") or next_path.startswith("//"):
+        return "/dashboard"
+    return next_path
+
+
 @auth_router.get("/auth/login")
-async def login():
+async def login(next: str | None = None):
     settings = get_settings()
     state = secrets.token_urlsafe(32)
+    safe_next = _is_safe_next_path(next)
     url = (
         "https://github.com/login/oauth/authorize"
         f"?client_id={settings.github_client_id}"
@@ -100,6 +108,14 @@ async def login():
     response.set_cookie(
         OAUTH_STATE_COOKIE_NAME,
         sign_oauth_state(state, settings.session_secret),
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=int(OAUTH_STATE_TTL.total_seconds()),
+    )
+    response.set_cookie(
+        NEXT_COOKIE_NAME,
+        safe_next,
         httponly=True,
         secure=True,
         samesite="lax",
@@ -155,7 +171,8 @@ async def callback(code: str, request: Request, state: str | None = None):
         datetime.now(timezone.utc) + SESSION_TTL,
     )
 
-    response = RedirectResponse(url="/dashboard", status_code=307)
+    next_path = _is_safe_next_path(request.cookies.get(NEXT_COOKIE_NAME))
+    response = RedirectResponse(url=next_path, status_code=307)
     response.set_cookie(
         SESSION_COOKIE_NAME,
         sign_session_id(session_id, settings.session_secret),
@@ -165,6 +182,7 @@ async def callback(code: str, request: Request, state: str | None = None):
         max_age=int(SESSION_TTL.total_seconds()),
     )
     response.delete_cookie(OAUTH_STATE_COOKIE_NAME)
+    response.delete_cookie(NEXT_COOKIE_NAME)
     return response
 
 

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -15,6 +15,8 @@ class Settings:
     public_base_url: str
     internal_metrics_token: str | None
     audit_signing_private_key: str
+    paddle_webhook_secret: str
+    github_app_slug: str
 
 
 def _required_env(name: str) -> str:
@@ -54,4 +56,6 @@ def get_settings() -> Settings:
         public_base_url=os.environ.get("PUBLIC_BASE_URL", "https://aletheore.com"),
         internal_metrics_token=os.environ.get("INTERNAL_METRICS_TOKEN", "").strip() or None,
         audit_signing_private_key=_required_env("AUDIT_SIGNING_PRIVATE_KEY"),
+        paddle_webhook_secret=_required_env("PADDLE_WEBHOOK_SECRET"),
+        github_app_slug=_required_env("GITHUB_APP_SLUG"),
     )

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -27,7 +27,8 @@ async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | N
     row = await pool.fetchrow(
         """
         SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
-               health_check_base_url, health_check_latency_threshold_ms
+               health_check_base_url, health_check_latency_threshold_ms,
+               paddle_subscription_id, paddle_customer_id
         FROM installations
         WHERE installation_id = $1
         """,
@@ -42,6 +43,107 @@ async def set_installation_plan(pool: asyncpg.Pool, installation_id: int, plan: 
         installation_id,
         plan,
     )
+
+
+async def insert_pending_subscription_claim(
+    pool: asyncpg.Pool,
+    claim_token: str,
+    paddle_subscription_id: str,
+    paddle_customer_id: str,
+    paddle_customer_email: str | None,
+    plan: str,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO pending_subscription_claims
+            (claim_token, paddle_subscription_id, paddle_customer_id, paddle_customer_email, plan)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (paddle_subscription_id) DO UPDATE SET
+            claim_token = EXCLUDED.claim_token,
+            paddle_customer_id = EXCLUDED.paddle_customer_id,
+            paddle_customer_email = EXCLUDED.paddle_customer_email,
+            plan = EXCLUDED.plan
+        """,
+        claim_token,
+        paddle_subscription_id,
+        paddle_customer_id,
+        paddle_customer_email,
+        plan,
+    )
+
+
+async def get_pending_subscription_claim_by_token(pool: asyncpg.Pool, claim_token: str) -> dict | None:
+    row = await pool.fetchrow(
+        """
+        SELECT id, claim_token, paddle_subscription_id, paddle_customer_id, paddle_customer_email,
+               plan, created_at, claimed_at, claimed_by_installation_id
+        FROM pending_subscription_claims
+        WHERE claim_token = $1
+        """,
+        claim_token,
+    )
+    return dict(row) if row else None
+
+
+async def mark_subscription_claim_claimed(pool: asyncpg.Pool, claim_token: str, installation_id: int) -> None:
+    await pool.execute(
+        """
+        UPDATE pending_subscription_claims
+        SET claimed_at = now(), claimed_by_installation_id = $2
+        WHERE claim_token = $1
+        """,
+        claim_token,
+        installation_id,
+    )
+
+
+async def add_paddle_ids_to_installation(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    paddle_subscription_id: str,
+    paddle_customer_id: str,
+) -> None:
+    await pool.execute(
+        """
+        UPDATE installations
+        SET paddle_subscription_id = $2, paddle_customer_id = $3, updated_at = now()
+        WHERE installation_id = $1
+        """,
+        installation_id,
+        paddle_subscription_id,
+        paddle_customer_id,
+    )
+
+
+async def backfill_customer_email_for_claims(
+    pool: asyncpg.Pool,
+    paddle_customer_id: str,
+    email: str,
+) -> None:
+    await pool.execute(
+        """
+        UPDATE pending_subscription_claims
+        SET paddle_customer_email = $2
+        WHERE paddle_customer_id = $1 AND paddle_customer_email IS NULL
+        """,
+        paddle_customer_id,
+        email,
+    )
+
+
+async def list_installations_for_ids(pool: asyncpg.Pool, installation_ids: list[int]) -> list[dict]:
+    if not installation_ids:
+        return []
+    rows = await pool.fetch(
+        """
+        SELECT installation_id, account_login, plan
+        FROM installations
+        WHERE installation_id = ANY($1::bigint[])
+        ORDER BY account_login ASC
+        """,
+        installation_ids,
+    )
+    return [dict(row) for row in rows]
 
 
 async def delete_installation(pool: asyncpg.Pool, installation_id: int) -> None:

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -14,10 +14,21 @@ each fetches only the data it needs and can show full detail without
 competing for space with five other sections.
 """
 
-from fastapi import APIRouter, Request
+from html import escape
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from app_server.admin import _administered_installation_ids
 from app_server.auth import get_current_session
+from app_server.db import (
+    add_paddle_ids_to_installation,
+    get_pending_subscription_claim_by_token,
+    list_installations_for_ids,
+    mark_subscription_claim_claimed,
+    set_installation_plan,
+)
 
 frontend_router = APIRouter()
 
@@ -248,6 +259,14 @@ table.findings tr:last-child td { border-bottom: none; }
 .token-row:last-child { border-bottom: none; }
 .token-label { font-weight: 500; }
 .token-meta { font-size: 11px; color: var(--slate-600); }
+.claim-page { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 3rem 1.5rem;
+  background-image: radial-gradient(var(--border-strong) 1px, transparent 1px); background-size: 22px 22px; }
+.claim-card { width: 100%; max-width: 520px; background: var(--paper); border: 1px solid var(--border); border-radius: 14px; padding: 2rem; box-shadow: var(--shadow-card); }
+.claim-card h1 { margin: 0 0 0.7rem; font-size: 24px; font-weight: 550; }
+.claim-card p { color: var(--slate-600); line-height: 1.6; font-size: 14px; margin: 0 0 1.2rem; }
+.claim-options { display: flex; flex-direction: column; gap: 8px; margin: 1rem 0; }
+.claim-option { display: flex; align-items: center; gap: 9px; padding: 10px 12px; border: 1px solid var(--border); border-radius: 9px; }
+.claim-option input { accent-color: var(--accent); }
 
 @media (max-width: 720px) {
   .shell { grid-template-columns: 1fr; }
@@ -1241,6 +1260,138 @@ def _no_store_html(content: str) -> HTMLResponse:
     # request ever reaching the server. no-store excludes the page from
     # bfcache entirely, forcing a real reload that re-checks the session.
     return HTMLResponse(content, headers={"Cache-Control": "no-store"})
+
+
+CLAIM_TOKEN_COOKIE_NAME = "claim_token"
+
+
+def _claim_page(title: str, body: str) -> str:
+    return _page_head(f"{title} — Aletheore") + f"""
+<div class="claim-page">
+  <div class="claim-card">
+    {body}
+  </div>
+</div>
+"""
+
+
+def _claim_polling_page() -> str:
+    return _claim_page(
+        "Confirming your subscription",
+        """
+        <h1>Confirming your payment</h1>
+        <p>This usually takes a few seconds. We are waiting for Paddle to confirm the subscription.</p>
+        <script>setTimeout(() => location.reload(), 2000);</script>
+        """,
+    )
+
+
+def _claim_already_claimed_page() -> str:
+    return _claim_page(
+        "Subscription active",
+        """
+        <h1>Already activated</h1>
+        <p>This subscription is already active for an Aletheore installation.</p>
+        <a class="btn btn-accent" href="/dashboard">Go to dashboard</a>
+        """,
+    )
+
+
+def _claim_install_prompt_page(plan: str) -> str:
+    return _claim_page(
+        "Install the GitHub App",
+        f"""
+        <h1>Install the Aletheore GitHub App</h1>
+        <p>Install the app to activate your {escape(plan.title())} plan on a GitHub organization.</p>
+        <a class="btn btn-accent" href="/auth/login?next=%2Fsubscribe%2Fclaim">Install the Aletheore GitHub App</a>
+        """,
+    )
+
+
+def _claim_selection_page(plan: str, installations: list[dict], claim_token: str) -> str:
+    options = "\n".join(
+        (
+            '<label class="claim-option">'
+            f'<input type="radio" name="installation_id" value="{installation["installation_id"]}" required> '
+            f'{escape(installation["account_login"])}'
+            "</label>"
+        )
+        for installation in installations
+    )
+    return _claim_page(
+        "Apply your plan",
+        f"""
+        <h1>Apply your {escape(plan.title())} plan</h1>
+        <p>Choose the GitHub installation this subscription should activate.</p>
+        <form method="post" action="/subscribe/claim/apply">
+          <input type="hidden" name="claim_token" value="{escape(claim_token)}">
+          <div class="claim-options">{options}</div>
+          <button class="btn btn-accent" type="submit">Apply</button>
+        </form>
+        """,
+    )
+
+
+@frontend_router.get("/subscribe/claim", response_class=HTMLResponse)
+async def subscribe_claim_page(request: Request):
+    session = await get_current_session(request)
+    if session is None:
+        return RedirectResponse(url="/auth/login?next=%2Fsubscribe%2Fclaim", status_code=307)
+
+    claim_token = request.cookies.get(CLAIM_TOKEN_COOKIE_NAME)
+    if not claim_token:
+        return _no_store_html(_claim_polling_page())
+
+    pool = request.app.state.db_pool
+    claim = await get_pending_subscription_claim_by_token(pool, claim_token)
+    if claim is None:
+        return _no_store_html(_claim_polling_page())
+    if claim["claimed_at"] is not None:
+        return _no_store_html(_claim_already_claimed_page())
+
+    administered_ids = await _administered_installation_ids(session["github_access_token"])
+    installations = await list_installations_for_ids(pool, list(administered_ids))
+    if not installations:
+        return _no_store_html(_claim_install_prompt_page(claim["plan"]))
+
+    return _no_store_html(_claim_selection_page(claim["plan"], installations, claim_token))
+
+
+@frontend_router.post("/subscribe/claim/apply")
+async def subscribe_claim_apply(request: Request):
+    session = await get_current_session(request)
+    if session is None:
+        raise HTTPException(status_code=401, detail="login required")
+
+    form = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
+    claim_token = (form.get("claim_token") or [""])[0]
+    installation_id_raw = (form.get("installation_id") or [""])[0]
+    try:
+        installation_id = int(installation_id_raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid installation_id") from exc
+
+    pool = request.app.state.db_pool
+    administered_ids = await _administered_installation_ids(session["github_access_token"])
+    if installation_id not in administered_ids:
+        raise HTTPException(status_code=403, detail="you do not administer this installation")
+
+    claim = await get_pending_subscription_claim_by_token(pool, claim_token)
+    if claim is None or claim["claimed_at"] is not None:
+        raise HTTPException(status_code=409, detail="claim is not available")
+
+    await set_installation_plan(pool, installation_id, claim["plan"])
+    await add_paddle_ids_to_installation(
+        pool,
+        installation_id,
+        claim["paddle_subscription_id"],
+        claim["paddle_customer_id"],
+    )
+    await mark_subscription_claim_claimed(pool, claim_token, installation_id)
+
+    response = _no_store_html(_claim_already_claimed_page())
+    response.delete_cookie(CLAIM_TOKEN_COOKIE_NAME)
+    return response
 
 
 @frontend_router.get("/", response_class=HTMLResponse)

--- a/github-app/app_server/github_install.py
+++ b/github-app/app_server/github_install.py
@@ -1,0 +1,8 @@
+from urllib.parse import quote
+
+from app_server.config import get_settings
+
+
+def github_app_install_url(next_path: str) -> str:
+    settings = get_settings()
+    return f"https://github.com/apps/{settings.github_app_slug}/installations/new?state={quote(next_path)}"

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -18,6 +18,7 @@ from app_server.managed_audit_api import managed_audit_router
 from app_server.metrics import metrics_router
 from app_server.signature import verify_signature
 from app_server.webhooks.installation import handle_installation_event
+from app_server.webhooks.paddle import paddle_webhook_router
 
 configure_json_logging()
 access_logger = logging.getLogger("app_server.access")
@@ -39,6 +40,7 @@ app.include_router(admin_router)
 app.include_router(managed_audit_router)
 app.include_router(metrics_router)
 app.include_router(frontend_router)
+app.include_router(paddle_webhook_router)
 
 
 @app.middleware("http")

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -1,0 +1,14 @@
+"""Paddle price ID to Aletheore plan mapping."""
+
+PADDLE_PRICE_TO_PLAN: dict[str, str] = {
+    "pri_01ky9jwz35hvj5xs6f8xqw6htt": "indie",
+    "pri_01ky9jwzd6k9rhmnj8b4drbygg": "indie",
+    "pri_01ky9jx0gbx02mnn4d166yp3vc": "team",
+    "pri_01ky9jx0rkkkz75atfb29me9mn": "team",
+    "pri_01ky9jx1bkbbkfd9zspcgzd7p8": "enterprise",
+    "pri_01ky9jx1pbbpsexbmtbk1wfej1": "enterprise",
+}
+
+
+def resolve_plan_for_price_id(price_id: str) -> str | None:
+    return PADDLE_PRICE_TO_PLAN.get(price_id)

--- a/github-app/app_server/paddle_webhook_verify.py
+++ b/github-app/app_server/paddle_webhook_verify.py
@@ -1,0 +1,31 @@
+"""Paddle webhook signature verification."""
+
+import hashlib
+import hmac
+import time
+
+
+def verify_paddle_signature(
+    raw_body: bytes,
+    signature_header: str,
+    secret: str,
+    tolerance_seconds: int = 5,
+) -> bool:
+    try:
+        parts = dict(part.split("=", 1) for part in signature_header.split(";") if "=" in part)
+    except ValueError:
+        return False
+    ts_str = parts.get("ts")
+    h1 = parts.get("h1")
+    if ts_str is None or h1 is None:
+        return False
+    try:
+        ts = int(ts_str)
+    except ValueError:
+        return False
+    if abs(time.time() - ts) > tolerance_seconds:
+        return False
+
+    signed_payload = f"{ts}:{raw_body.decode('utf-8')}"
+    expected = hmac.new(secret.encode("utf-8"), signed_payload.encode("utf-8"), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, h1)

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -1,0 +1,46 @@
+import logging
+
+from fastapi import APIRouter, Request, Response
+
+from app_server.config import get_settings
+from app_server.db import backfill_customer_email_for_claims, insert_pending_subscription_claim
+from app_server.paddle_pricing import resolve_plan_for_price_id
+from app_server.paddle_webhook_verify import verify_paddle_signature
+
+paddle_webhook_router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+@paddle_webhook_router.post("/webhooks/paddle")
+async def handle_paddle_webhook(request: Request) -> Response:
+    raw_body = await request.body()
+    signature = request.headers.get("paddle-signature", "")
+    settings = get_settings()
+    if not signature or not verify_paddle_signature(raw_body, signature, settings.paddle_webhook_secret):
+        return Response(status_code=401)
+
+    payload = await request.json()
+    event_type = payload.get("event_type")
+    data = payload.get("data") or {}
+    if event_type == "subscription.created":
+        claim_token = (data.get("custom_data") or {}).get("claim_token")
+        items = data.get("items") or []
+        price_id = items[0].get("price", {}).get("id") if items else None
+        plan = resolve_plan_for_price_id(price_id) if price_id else None
+        if claim_token and plan:
+            await insert_pending_subscription_claim(
+                request.app.state.db_pool,
+                claim_token,
+                data["id"],
+                data["customer_id"],
+                None,
+                plan,
+            )
+        else:
+            logger.warning("subscription.created missing claim token or known price id: price_id=%s", price_id)
+    elif event_type in ("customer.created", "customer.updated"):
+        email = data.get("email")
+        if data.get("id") and email:
+            await backfill_customer_email_for_claims(request.app.state.db_pool, data["id"], email)
+
+    return Response(status_code=200)

--- a/github-app/migrations/018_pending_subscription_claims.sql
+++ b/github-app/migrations/018_pending_subscription_claims.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS pending_subscription_claims (
+    id BIGSERIAL PRIMARY KEY,
+    claim_token TEXT NOT NULL UNIQUE,
+    paddle_subscription_id TEXT NOT NULL UNIQUE,
+    paddle_customer_id TEXT NOT NULL,
+    paddle_customer_email TEXT,
+    plan TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    claimed_at TIMESTAMPTZ,
+    claimed_by_installation_id BIGINT REFERENCES installations(installation_id)
+);
+
+CREATE INDEX IF NOT EXISTS pending_subscription_claims_token
+ON pending_subscription_claims (claim_token);
+
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS paddle_subscription_id TEXT;
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS paddle_customer_id TEXT;

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -16,10 +16,12 @@ os.environ.setdefault("DATABASE_URL", TEST_DATABASE_URL)
 os.environ.setdefault("GITHUB_APP_ID", "12345")
 os.environ.setdefault("GITHUB_APP_PRIVATE_KEY", "test-private-key")
 os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-webhook-secret")
+os.environ.setdefault("GITHUB_APP_SLUG", "aletheore")
 os.environ.setdefault("GITHUB_CLIENT_ID", "test-client-id")
 os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-client-secret")
 os.environ.setdefault("SESSION_SECRET", "test-session-secret")
 os.environ.setdefault("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
+os.environ.setdefault("PADDLE_WEBHOOK_SECRET", "pdl_ntfset_test_secret")
 os.environ.setdefault("PUBLIC_BASE_URL", "http://test")
 
 

--- a/github-app/tests/test_app_server_db.py
+++ b/github-app/tests/test_app_server_db.py
@@ -1,0 +1,46 @@
+import pytest
+
+from app_server.db import (
+    add_paddle_ids_to_installation,
+    get_installation,
+    get_pending_subscription_claim_by_token,
+    insert_pending_subscription_claim,
+    mark_subscription_claim_claimed,
+)
+
+
+@pytest.mark.asyncio
+async def test_insert_pending_subscription_claim_upserts_on_subscription_id(pool):
+    await insert_pending_subscription_claim(pool, "tok_a", "sub_123", "ctm_1", "buyer@example.com", "team")
+    row = await get_pending_subscription_claim_by_token(pool, "tok_a")
+    assert row["plan"] == "team"
+    assert row["claimed_at"] is None
+
+    await insert_pending_subscription_claim(pool, "tok_a", "sub_123", "ctm_1", "buyer@example.com", "team")
+    row_again = await get_pending_subscription_claim_by_token(pool, "tok_a")
+    assert row_again["id"] == row["id"]
+
+
+@pytest.mark.asyncio
+async def test_mark_subscription_claim_claimed(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (1, 'acme', 'free')"
+    )
+    await insert_pending_subscription_claim(pool, "tok_b", "sub_456", "ctm_2", None, "indie")
+
+    await mark_subscription_claim_claimed(pool, "tok_b", 1)
+
+    row = await get_pending_subscription_claim_by_token(pool, "tok_b")
+    assert row["claimed_at"] is not None
+    assert row["claimed_by_installation_id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_add_paddle_ids_to_installation(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (2, 'acme', 'free')"
+    )
+    await add_paddle_ids_to_installation(pool, 2, "sub_789", "ctm_3")
+    row = await get_installation(pool, 2)
+    assert row["paddle_subscription_id"] == "sub_789"
+    assert row["paddle_customer_id"] == "ctm_3"

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -9,6 +9,7 @@ from app_server.auth import (
     get_current_session,
     sign_session_id,
     unsign_session_id,
+    _is_safe_next_path,
 )
 from app_server.db import create_session, get_session
 from app_server.main import app
@@ -75,6 +76,26 @@ def test_unsign_rejects_tampered_value():
     assert unsign_session_id(tampered, "test-secret") is None
 
 
+def test_safe_relative_next_path_accepted():
+    assert _is_safe_next_path("/subscribe/claim") == "/subscribe/claim"
+
+
+def test_missing_next_defaults_to_dashboard():
+    assert _is_safe_next_path(None) == "/dashboard"
+
+
+def test_absolute_next_url_rejected():
+    assert _is_safe_next_path("https://evil.example.com/phish") == "/dashboard"
+
+
+def test_protocol_relative_next_url_rejected():
+    assert _is_safe_next_path("//evil.example.com/phish") == "/dashboard"
+
+
+def test_next_path_not_starting_with_slash_rejected():
+    assert _is_safe_next_path("evil.example.com") == "/dashboard"
+
+
 @pytest.mark.asyncio
 async def test_login_redirects_to_github_authorize(pool, monkeypatch):
     monkeypatch.setenv("GITHUB_CLIENT_ID", "test-client-id")
@@ -86,6 +107,18 @@ async def test_login_redirects_to_github_authorize(pool, monkeypatch):
     assert response.status_code == 307
     assert "github.com/login/oauth/authorize" in response.headers["location"]
     assert "client_id=test-client-id" in response.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_login_sets_next_cookie(pool, monkeypatch):
+    monkeypatch.setenv("GITHUB_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "http://test")
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/auth/login?next=/subscribe/claim", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.cookies.get("aletheore_oauth_next").strip('"') == "/subscribe/claim"
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_config.py
+++ b/github-app/tests/test_config.py
@@ -14,19 +14,23 @@ def _clean_env(monkeypatch):
         "GITHUB_CLIENT_ID",
         "GITHUB_CLIENT_SECRET",
         "GITHUB_WEBHOOK_SECRET",
+        "GITHUB_APP_SLUG",
         "SESSION_SECRET",
         "PUBLIC_BASE_URL",
         "AUDIT_SIGNING_PRIVATE_KEY",
+        "PADDLE_WEBHOOK_SECRET",
     ):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost/db")
     # Required secrets get a baseline value so tests that aren't specifically
     # exercising fail-closed behavior don't have to restate them.
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "webhook-secret")
+    monkeypatch.setenv("GITHUB_APP_SLUG", "aletheore")
     monkeypatch.setenv("GITHUB_CLIENT_SECRET", "client-secret")
     monkeypatch.setenv("SESSION_SECRET", "session-secret")
     monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "raw-key-value")
     monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", "pdl_ntfset_test_secret")
 
 
 def test_reads_private_key_from_path_when_set(tmp_path, monkeypatch):
@@ -70,10 +74,12 @@ def test_reads_paid_tier_settings(monkeypatch):
     "missing_var",
     [
         "GITHUB_WEBHOOK_SECRET",
+        "GITHUB_APP_SLUG",
         "GITHUB_CLIENT_SECRET",
         "SESSION_SECRET",
         "GITHUB_APP_PRIVATE_KEY",
         "AUDIT_SIGNING_PRIVATE_KEY",
+        "PADDLE_WEBHOOK_SECRET",
     ],
 )
 def test_raises_when_required_secret_is_missing(missing_var, monkeypatch):
@@ -86,10 +92,12 @@ def test_raises_when_required_secret_is_missing(missing_var, monkeypatch):
     "missing_var",
     [
         "GITHUB_WEBHOOK_SECRET",
+        "GITHUB_APP_SLUG",
         "GITHUB_CLIENT_SECRET",
         "SESSION_SECRET",
         "GITHUB_APP_PRIVATE_KEY",
         "AUDIT_SIGNING_PRIVATE_KEY",
+        "PADDLE_WEBHOOK_SECRET",
     ],
 )
 def test_raises_when_required_secret_is_blank(missing_var, monkeypatch):

--- a/github-app/tests/test_frontend_claim.py
+++ b/github-app/tests/test_frontend_claim.py
@@ -1,0 +1,135 @@
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.auth import encrypt_access_token, sign_session_id
+from app_server.db import (
+    create_session,
+    get_installation,
+    get_pending_subscription_claim_by_token,
+    insert_pending_subscription_claim,
+    mark_subscription_claim_claimed,
+    upsert_installation,
+)
+from app_server.main import app
+
+
+async def _logged_in_client(pool, monkeypatch, administered_ids):
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    await create_session(
+        pool,
+        "claim-sess",
+        42,
+        "octocat",
+        encrypt_access_token("gho_faketoken", "test-session-secret"),
+        datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "total_count": len(administered_ids),
+                "installations": [{"id": installation_id} for installation_id in administered_ids],
+            },
+        )
+
+    monkeypatch.setattr(
+        "app_server.admin._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    app.state.db_pool = pool
+    signed = sign_session_id("claim-sess", "test-session-secret")
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test", cookies={"session": signed})
+
+
+@pytest.mark.asyncio
+async def test_claim_page_redirects_to_login_when_not_signed_in(pool):
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/subscribe/claim", follow_redirects=False)
+    assert response.status_code == 307
+    assert "/auth/login" in response.headers["location"]
+    assert "next=%2Fsubscribe%2Fclaim" in response.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_claim_page_shows_polling_state_when_claim_not_found_yet(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, [])
+    client.cookies.set("claim_token", "tok_not_found_yet")
+    async with client:
+        response = await client.get("/subscribe/claim")
+    assert response.status_code == 200
+    assert "Confirming your payment" in response.text
+
+
+@pytest.mark.asyncio
+async def test_claim_page_shows_already_claimed_state(pool, monkeypatch):
+    await upsert_installation(pool, 1001, "acme")
+    await insert_pending_subscription_claim(pool, "tok_claimed", "sub_1", "ctm_1", None, "team")
+    await mark_subscription_claim_claimed(pool, "tok_claimed", 1001)
+    client = await _logged_in_client(pool, monkeypatch, [1001])
+    client.cookies.set("claim_token", "tok_claimed")
+    async with client:
+        response = await client.get("/subscribe/claim")
+    assert response.status_code == 200
+    assert "already activated" in response.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_claim_page_zero_installations_prompts_install(pool, monkeypatch):
+    await insert_pending_subscription_claim(pool, "tok_zero", "sub_2", "ctm_2", None, "indie")
+    client = await _logged_in_client(pool, monkeypatch, [])
+    client.cookies.set("claim_token", "tok_zero")
+    async with client:
+        response = await client.get("/subscribe/claim")
+    assert response.status_code == 200
+    assert "Install the Aletheore GitHub App" in response.text
+
+
+@pytest.mark.asyncio
+async def test_claim_page_one_installation_shows_confirm(pool, monkeypatch):
+    await upsert_installation(pool, 1002, "acme")
+    await insert_pending_subscription_claim(pool, "tok_one", "sub_3", "ctm_3", None, "team")
+    client = await _logged_in_client(pool, monkeypatch, [1002])
+    client.cookies.set("claim_token", "tok_one")
+    async with client:
+        response = await client.get("/subscribe/claim")
+    assert response.status_code == 200
+    assert "Apply" in response.text
+    assert "acme" in response.text
+
+
+@pytest.mark.asyncio
+async def test_apply_updates_installation_plan_and_marks_claimed(pool, monkeypatch):
+    await upsert_installation(pool, 1003, "acme")
+    await insert_pending_subscription_claim(pool, "tok_apply", "sub_4", "ctm_4", None, "enterprise")
+    client = await _logged_in_client(pool, monkeypatch, [1003])
+    async with client:
+        response = await client.post(
+            "/subscribe/claim/apply",
+            content="claim_token=tok_apply&installation_id=1003",
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+    assert response.status_code == 200
+    installation = await get_installation(pool, 1003)
+    assert installation["plan"] == "enterprise"
+    assert installation["paddle_subscription_id"] == "sub_4"
+    claim = await get_pending_subscription_claim_by_token(pool, "tok_apply")
+    assert claim["claimed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_installation_user_does_not_administer(pool, monkeypatch):
+    await upsert_installation(pool, 1004, "someone-else")
+    await insert_pending_subscription_claim(pool, "tok_forbidden", "sub_5", "ctm_5", None, "team")
+    client = await _logged_in_client(pool, monkeypatch, [])
+    async with client:
+        response = await client.post(
+            "/subscribe/claim/apply",
+            content="claim_token=tok_forbidden&installation_id=1004",
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+    assert response.status_code == 403

--- a/github-app/tests/test_github_install.py
+++ b/github-app/tests/test_github_install.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+from app_server.github_install import github_app_install_url
+
+
+def test_install_url_includes_slug_and_state():
+    with patch("app_server.github_install.get_settings") as mock_settings:
+        mock_settings.return_value.github_app_slug = "aletheore"
+        url = github_app_install_url("/subscribe/claim")
+    assert url.startswith("https://github.com/apps/aletheore/installations/new")
+    assert "state=" in url

--- a/github-app/tests/test_paddle_pricing.py
+++ b/github-app/tests/test_paddle_pricing.py
@@ -1,0 +1,14 @@
+from app_server.paddle_pricing import resolve_plan_for_price_id
+
+
+def test_resolves_all_six_real_price_ids():
+    assert resolve_plan_for_price_id("pri_01ky9jwz35hvj5xs6f8xqw6htt") == "indie"
+    assert resolve_plan_for_price_id("pri_01ky9jwzd6k9rhmnj8b4drbygg") == "indie"
+    assert resolve_plan_for_price_id("pri_01ky9jx0gbx02mnn4d166yp3vc") == "team"
+    assert resolve_plan_for_price_id("pri_01ky9jx0rkkkz75atfb29me9mn") == "team"
+    assert resolve_plan_for_price_id("pri_01ky9jx1bkbbkfd9zspcgzd7p8") == "enterprise"
+    assert resolve_plan_for_price_id("pri_01ky9jx1pbbpsexbmtbk1wfej1") == "enterprise"
+
+
+def test_unknown_price_id_returns_none():
+    assert resolve_plan_for_price_id("pri_totally_unknown") is None

--- a/github-app/tests/test_paddle_webhook_verify.py
+++ b/github-app/tests/test_paddle_webhook_verify.py
@@ -1,0 +1,42 @@
+import hashlib
+import hmac
+import time
+
+from app_server.paddle_webhook_verify import verify_paddle_signature
+
+SECRET = "pdl_ntfset_test_secret"
+
+
+def _sign(raw_body: bytes, ts: int, secret: str = SECRET) -> str:
+    signed_payload = f"{ts}:{raw_body.decode()}"
+    digest = hmac.new(secret.encode(), signed_payload.encode(), hashlib.sha256).hexdigest()
+    return f"ts={ts};h1={digest}"
+
+
+def test_valid_signature_accepted():
+    body = b'{"event_type": "subscription.created"}'
+    assert verify_paddle_signature(body, _sign(body, int(time.time())), SECRET) is True
+
+
+def test_tampered_body_rejected():
+    body = b'{"event_type": "subscription.created"}'
+    header = _sign(body, int(time.time()))
+    tampered_body = b'{"event_type": "subscription.created", "extra": "injected"}'
+    assert verify_paddle_signature(tampered_body, header, SECRET) is False
+
+
+def test_wrong_secret_rejected():
+    body = b'{"event_type": "subscription.created"}'
+    header = _sign(body, int(time.time()), secret="wrong_secret")
+    assert verify_paddle_signature(body, header, SECRET) is False
+
+
+def test_expired_timestamp_rejected():
+    body = b'{"event_type": "subscription.created"}'
+    assert verify_paddle_signature(body, _sign(body, int(time.time()) - 3600), SECRET) is False
+
+
+def test_malformed_header_rejected():
+    body = b'{"event_type": "subscription.created"}'
+    assert verify_paddle_signature(body, "not-a-valid-header", SECRET) is False
+    assert verify_paddle_signature(body, "", SECRET) is False

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -1,0 +1,102 @@
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.db import get_pending_subscription_claim_by_token, insert_pending_subscription_claim
+from app_server.main import app
+
+WEBHOOK_SECRET = "pdl_ntfset_test_secret"
+
+
+def _sign(raw_body: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    ts = int(time.time())
+    signed_payload = f"{ts}:{raw_body.decode()}"
+    digest = hmac.new(secret.encode(), signed_payload.encode(), hashlib.sha256).hexdigest()
+    return f"ts={ts};h1={digest}"
+
+
+def _subscription_created_payload(price_id: str, claim_token: str) -> dict:
+    return {
+        "event_type": "subscription.created",
+        "data": {
+            "id": "sub_test_123",
+            "customer_id": "ctm_test_456",
+            "custom_data": {"claim_token": claim_token},
+            "items": [{"price": {"id": price_id}}],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_valid_subscription_created_creates_pending_claim(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    body = json.dumps(_subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", "claim_abc")).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
+    assert response.status_code == 200
+    claim = await get_pending_subscription_claim_by_token(pool, "claim_abc")
+    assert claim["plan"] == "indie"
+    assert claim["paddle_subscription_id"] == "sub_test_123"
+
+
+@pytest.mark.asyncio
+async def test_invalid_signature_rejected_with_no_write(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    body = json.dumps(_subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", "claim_xyz")).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": "ts=1;h1=deadbeef"})
+    assert response.status_code == 401
+    assert await get_pending_subscription_claim_by_token(pool, "claim_xyz") is None
+
+
+@pytest.mark.asyncio
+async def test_missing_signature_header_rejected(pool):
+    app.state.db_pool = pool
+    body = json.dumps(_subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", "claim_none")).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/webhooks/paddle", content=body)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_unknown_price_id_returns_200_but_writes_no_claim(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    body = json.dumps(_subscription_created_payload("pri_totally_unknown", "claim_unknown")).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
+    assert response.status_code == 200
+    assert await get_pending_subscription_claim_by_token(pool, "claim_unknown") is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_delivery_is_idempotent(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    body = json.dumps(_subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", "claim_dup")).encode()
+    headers = {"paddle-signature": _sign(body)}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r1 = await client.post("/webhooks/paddle", content=body, headers=headers)
+        r2 = await client.post("/webhooks/paddle", content=body, headers=headers)
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert await get_pending_subscription_claim_by_token(pool, "claim_dup") is not None
+
+
+@pytest.mark.asyncio
+async def test_customer_updated_backfills_pending_claim_email(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    await insert_pending_subscription_claim(pool, "claim_email", "sub_999", "ctm_email", None, "team")
+    body = json.dumps({"event_type": "customer.updated", "data": {"id": "ctm_email", "email": "buyer@example.com"}}).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
+    assert response.status_code == 200
+    claim = await get_pending_subscription_claim_by_token(pool, "claim_email")
+    assert claim["paddle_customer_email"] == "buyer@example.com"

--- a/website/paddle-checkout.js
+++ b/website/paddle-checkout.js
@@ -1,0 +1,100 @@
+// Paddle checkout wiring for the pricing page.
+const PADDLE_ENVIRONMENT = "sandbox";
+const PADDLE_CLIENT_TOKEN = "test_4c86268368fd75d088763f49248";
+
+const TIERS = {
+  indie: {
+    name: "Indie",
+    priceId: { month: "pri_01ky9jwz35hvj5xs6f8xqw6htt", year: "pri_01ky9jwzd6k9rhmnj8b4drbygg" },
+  },
+  team: {
+    name: "Team",
+    priceId: { month: "pri_01ky9jx0gbx02mnn4d166yp3vc", year: "pri_01ky9jx0rkkkz75atfb29me9mn" },
+  },
+  enterprise: {
+    name: "Enterprise",
+    priceId: { month: "pri_01ky9jx1bkbbkfd9zspcgzd7p8", year: "pri_01ky9jx1pbbpsexbmtbk1wfej1" },
+  },
+};
+
+let billingInterval = "month";
+let paddleReady = null;
+
+function initPaddle() {
+  if (paddleReady) return paddleReady;
+  paddleReady = new Promise((resolve, reject) => {
+    if (typeof Paddle === "undefined") {
+      reject(new Error("Paddle.js failed to load"));
+      return;
+    }
+    Paddle.Environment.set(PADDLE_ENVIRONMENT);
+    Paddle.Initialize({ token: PADDLE_CLIENT_TOKEN });
+    resolve(Paddle);
+  });
+  return paddleReady;
+}
+
+function generateClaimToken() {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function refreshPrices() {
+  const paddle = await initPaddle();
+  const items = Object.values(TIERS).map((tier) => ({ priceId: tier.priceId[billingInterval], quantity: 1 }));
+
+  let preview;
+  try {
+    preview = await paddle.PricePreview({ items });
+  } catch (err) {
+    console.error("Paddle price preview failed", err);
+    return;
+  }
+
+  const lineItems = preview.data.details.lineItems;
+  Object.keys(TIERS).forEach((key, index) => {
+    const card = document.querySelector(`[data-tier="${key}"]`);
+    if (!card) return;
+    const lineItem = lineItems[index];
+    card.querySelector(".price-now").textContent = lineItem.formattedTotals.total;
+    const subEl = card.querySelector(".price-sub-interval");
+    if (subEl) subEl.textContent = billingInterval === "month" ? "/month" : "/year";
+  });
+}
+
+function setBillingInterval(interval) {
+  billingInterval = interval;
+  document.querySelectorAll(".billing-toggle button").forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.interval === interval);
+  });
+  refreshPrices();
+}
+
+async function subscribe(tierKey) {
+  const paddle = await initPaddle();
+  const tier = TIERS[tierKey];
+  const claimToken = generateClaimToken();
+
+  document.cookie = `claim_token=${claimToken}; domain=.aletheore.com; path=/; max-age=3600; secure; samesite=lax`;
+
+  paddle.Checkout.open({
+    items: [{ priceId: tier.priceId[billingInterval], quantity: 1 }],
+    customData: { claim_token: claimToken },
+    settings: {
+      displayMode: "overlay",
+      variant: "one-page",
+      successUrl: "https://app.aletheore.com/subscribe/claim",
+    },
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".billing-toggle button").forEach((btn) => {
+    btn.addEventListener("click", () => setBillingInterval(btn.dataset.interval));
+  });
+  document.querySelectorAll("[data-subscribe]").forEach((btn) => {
+    btn.addEventListener("click", () => subscribe(btn.dataset.subscribe));
+  });
+  refreshPrices();
+});

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -37,6 +37,11 @@
       <h1>Simple, honest pricing.</h1>
       <p class="section-intro">The deterministic scanner is free forever. Indie, Team, and Enterprise add managed AI audits and AIRview - the model writing them, and the seats included, scale with plan.</p>
 
+      <div class="billing-toggle" role="group" aria-label="Billing interval">
+        <button type="button" data-interval="month" class="active">Monthly</button>
+        <button type="button" data-interval="year">Yearly <span class="billing-toggle-badge">2 months free</span></button>
+      </div>
+
       <div class="pricing-grid">
         <article class="price-card">
           <h3>Free</h3>
@@ -50,10 +55,10 @@
           </ul>
         </article>
 
-        <article class="price-card">
+        <article class="price-card" data-tier="indie">
           <h3>Indie</h3>
           <div class="price-now">$29</div>
-          <div class="price-sub">/month, up to 3 team members</div>
+          <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 3 team members</div>
           <ul>
             <li>Everything in Free.</li>
             <li>Managed audits and AIRview, written by DeepSeek.</li>
@@ -63,28 +68,31 @@
             <li>Endpoint health monitoring across multiple targets, with a public status API.</li>
             <li>+$3.99/mo per additional team member.</li>
           </ul>
+          <button type="button" class="btn btn-primary" data-subscribe="indie">Subscribe</button>
         </article>
 
-        <article class="price-card pro">
+        <article class="price-card pro" data-tier="team">
           <h3>Team</h3>
           <div class="price-now">$79</div>
-          <div class="price-sub">/month, up to 10 team members</div>
+          <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 10 team members</div>
           <ul>
             <li>Everything in Indie.</li>
             <li>Managed audits and AIRview, written by GPT-4o.</li>
             <li>+$3.99/mo per additional team member.</li>
           </ul>
+          <button type="button" class="btn btn-primary" data-subscribe="team">Subscribe</button>
         </article>
 
-        <article class="price-card">
+        <article class="price-card" data-tier="enterprise">
           <h3>Enterprise</h3>
           <div class="price-now">$199</div>
-          <div class="price-sub">/month, up to 25 team members</div>
+          <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 25 team members</div>
           <ul>
             <li>Everything in Team.</li>
             <li>Managed audits and AIRview, written by Claude Opus.</li>
             <li>+$3.99/mo per additional team member.</li>
           </ul>
+          <button type="button" class="btn btn-primary" data-subscribe="enterprise">Subscribe</button>
         </article>
       </div>
       <p class="section-intro" style="margin-top: 28px;">
@@ -121,5 +129,7 @@
     </div>
   </footer>
   <script src="vendor/motion.js"></script>
+  <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
+  <script src="paddle-checkout.js" defer></script>
 </body>
 </html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1088,6 +1088,48 @@ pre {
   font-weight: 700;
 }
 
+.price-card button.btn {
+  width: 100%;
+  margin-top: 20px;
+  border: 1px solid var(--accent);
+  font-family: inherit;
+  appearance: none;
+}
+
+.billing-toggle {
+  display: inline-flex;
+  gap: 4px;
+  margin-bottom: 28px;
+  padding: 4px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 100px;
+  background: var(--card-bg);
+}
+
+.billing-toggle button {
+  padding: 8px 18px;
+  border: none;
+  border-radius: 100px;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.billing-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.billing-toggle-badge {
+  margin-left: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  opacity: 0.85;
+}
+
 .legal-body {
   max-width: 720px;
   padding: 48px 0 80px;


### PR DESCRIPTION
## Summary
- Implements the Paddle subscription claim flow per the design spec (#28) and implementation plan (#29).
- Webhook endpoint with raw HMAC-SHA256 signature verification, idempotent subscription.created handling, customer email backfill for the abandoned-claim recovery path.
- Open-redirect-safe `next` support added to the existing GitHub sign-in flow.
- Four-state claim page (`/subscribe/claim`) and apply endpoint, with a real-time GitHub-admin authorization check before ever applying a plan.
- Marketing-site checkout wiring: claim token cookie + Paddle `customData`.

## Test plan
- [x] Full `github-app` suite: 460 passed, 1 skipped (verified independently, not just Codex's self-report)
- [x] Full `prototype` suite: 678 passed
- [x] Reviewed webhook signature verification, claim-apply authorization check, and next-path open-redirect guard by hand against the design spec
- [ ] Real end-to-end sandbox checkout → webhook → claim → apply, once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)