### PR TITLE
fix: handle a dead GitHub access token gracefully on the claim page

### DIFF
--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -17,11 +17,12 @@ competing for space with five other sections.
 from html import escape
 from urllib.parse import parse_qs
 
+import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app_server.admin import _administered_installation_ids
-from app_server.auth import get_current_session
+from app_server.auth import SESSION_COOKIE_NAME, get_current_session
 from app_server.db import (
     add_paddle_ids_to_installation,
     get_pending_subscription_claim_by_token,
@@ -1349,7 +1350,19 @@ async def subscribe_claim_page(request: Request):
     if claim["claimed_at"] is not None:
         return _no_store_html(_claim_already_claimed_page())
 
-    administered_ids = await _administered_installation_ids(session["github_access_token"])
+    try:
+        administered_ids = await _administered_installation_ids(session["github_access_token"])
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            # The stored GitHub token is dead (revoked, expired) - the signed
+            # session cookie itself is still valid, but GitHub no longer honors
+            # the access token inside it. Clear it and send them through a
+            # fresh sign-in rather than a raw 500.
+            response = RedirectResponse(url="/auth/login?next=%2Fsubscribe%2Fclaim", status_code=307)
+            response.delete_cookie(SESSION_COOKIE_NAME)
+            return response
+        raise
+
     installations = await list_installations_for_ids(pool, list(administered_ids))
     if not installations:
         return _no_store_html(_claim_install_prompt_page(claim["plan"]))
@@ -1372,7 +1385,14 @@ async def subscribe_claim_apply(request: Request):
         raise HTTPException(status_code=400, detail="invalid installation_id") from exc
 
     pool = request.app.state.db_pool
-    administered_ids = await _administered_installation_ids(session["github_access_token"])
+    try:
+        administered_ids = await _administered_installation_ids(session["github_access_token"])
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401:
+            raise HTTPException(
+                status_code=401, detail="your GitHub session has expired, sign in again"
+            ) from exc
+        raise
     if installation_id not in administered_ids:
         raise HTTPException(status_code=403, detail="you do not administer this installation")
 

--- a/github-app/tests/test_frontend_claim.py
+++ b/github-app/tests/test_frontend_claim.py
@@ -133,3 +133,55 @@ async def test_apply_rejects_installation_user_does_not_administer(pool, monkeyp
             headers={"content-type": "application/x-www-form-urlencoded"},
         )
     assert response.status_code == 403
+
+
+async def _logged_in_client_with_dead_token(pool, monkeypatch):
+    """A session whose stored GitHub access token GitHub itself now rejects
+    with 401 - simulates a revoked/expired token, distinct from having no
+    session cookie at all."""
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    await create_session(
+        pool,
+        "dead-token-sess",
+        43,
+        "octocat",
+        encrypt_access_token("gho_deadtoken", "test-session-secret"),
+        datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "Bad credentials"})
+
+    monkeypatch.setattr(
+        "app_server.admin._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    app.state.db_pool = pool
+    signed = sign_session_id("dead-token-sess", "test-session-secret")
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test", cookies={"session": signed})
+
+
+@pytest.mark.asyncio
+async def test_claim_page_dead_github_token_redirects_to_fresh_login_not_500(pool, monkeypatch):
+    await insert_pending_subscription_claim(pool, "tok_dead", "sub_6", "ctm_6", None, "indie")
+    client = await _logged_in_client_with_dead_token(pool, monkeypatch)
+    client.cookies.set("claim_token", "tok_dead")
+    async with client:
+        response = await client.get("/subscribe/claim", follow_redirects=False)
+    assert response.status_code == 307
+    assert "/auth/login" in response.headers["location"]
+    assert "next=%2Fsubscribe%2Fclaim" in response.headers["location"]
+    assert response.cookies.get("session") is None
+
+
+@pytest.mark.asyncio
+async def test_apply_dead_github_token_returns_401_not_500(pool, monkeypatch):
+    await insert_pending_subscription_claim(pool, "tok_dead2", "sub_7", "ctm_7", None, "team")
+    client = await _logged_in_client_with_dead_token(pool, monkeypatch)
+    async with client:
+        response = await client.post(
+            "/subscribe/claim/apply",
+            content="claim_token=tok_dead2&installation_id=1",
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        )
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- `_administered_installation_ids` raised an unhandled `httpx.HTTPStatusError` (401) straight to a 500 when a session's stored GitHub access token was revoked/expired - hit for real during production end-to-end testing of the Paddle claim flow.
- GET `/subscribe/claim` now clears the stale session and redirects to fresh sign-in; POST `/subscribe/claim/apply` now returns a clear 401 instead of crashing.

## Test plan
- [x] 2 new tests covering both call sites with a mocked 401 from GitHub
- [x] Full suite: 462 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)