### PR TITLE
fix: add cancel link to /subscribe pages

### DIFF
--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1284,6 +1284,7 @@ def _subscribe_install_prompt_page(plan: str, next_path: str) -> str:
         <h1>Install the Aletheore GitHub App</h1>
         <p>Install the app on a GitHub organization to activate your {escape(plan.title())} plan.</p>
         <a class="btn btn-accent" href="{escape(install_url)}">Install the Aletheore GitHub App</a>
+        <p><a href="/dashboard">Cancel</a></p>
         """,
     )
 
@@ -1296,6 +1297,7 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
         <h1>Subscribe to {escape(plan.title())}</h1>
         <p>{escape(installation["account_login"])} is currently on {escape(installation["plan"].title())}.</p>
         <button class="btn btn-accent" id="continue-checkout" {continue_attrs}>Continue to checkout</button>
+        <p><a href="/dashboard">Cancel</a></p>
         """
     else:
         options = "\n".join(
@@ -1314,6 +1316,7 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
         <p>Choose which installation this subscription applies to.</p>
         <div class="claim-options">{options}</div>
         <button class="btn btn-accent" id="continue-checkout">Continue to checkout</button>
+        <p><a href="/dashboard">Cancel</a></p>
         """
 
     return _subscribe_page("Subscribe", body) + f"""

--- a/github-app/tests/test_frontend_subscribe.py
+++ b/github-app/tests/test_frontend_subscribe.py
@@ -110,6 +110,7 @@ async def test_zero_installations_shows_install_prompt(pool, monkeypatch):
     assert response.status_code == 200
     assert "Install the Aletheore GitHub App" in response.text
     assert "github.com/apps/aletheore/installations/new" in response.text
+    assert 'href="/dashboard"' in response.text
 
 
 @pytest.mark.asyncio
@@ -125,6 +126,7 @@ async def test_one_installation_shows_checkout_with_current_plan(pool, monkeypat
     assert "pri_01ky9jx0gbx02mnn4d166yp3vc" in response.text  # team monthly price id
     assert "customData" in response.text
     assert "successUrl" in response.text and "dashboard" in response.text
+    assert 'href="/dashboard"' in response.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- The new `/subscribe` pre-payment flow (install-prompt and checkout pages) had no way back to the dashboard other than the browser back button.
- Adds a "Cancel" link to `/dashboard` on both pages.

## Test plan
- [x] `pytest tests/test_frontend_subscribe.py tests/test_auth.py tests/test_webhooks_paddle.py tests/test_app_server_db.py` — 31 passed