### PR TITLE
fix: close install-then-subscribe race on the GitHub App callback

### DIFF
--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 
@@ -11,7 +12,8 @@ from fastapi.responses import RedirectResponse
 from itsdangerous import BadSignature, URLSafeTimedSerializer
 
 from app_server.config import get_settings
-from app_server.db import create_session, delete_session, get_session
+from app_server.db import create_session, delete_session, get_session, upsert_installation
+from app_server.github_auth import generate_app_jwt, get_installation_details
 
 SESSION_COOKIE_NAME = "session"
 SESSION_TTL = timedelta(days=30)
@@ -20,6 +22,7 @@ OAUTH_STATE_TTL = timedelta(minutes=10)
 NEXT_COOKIE_NAME = "aletheore_oauth_next"
 
 auth_router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _fernet_key(session_secret: str) -> bytes:
@@ -125,7 +128,7 @@ async def login(next: str | None = None):
 
 
 @auth_router.get("/auth/callback")
-async def callback(code: str, request: Request, state: str | None = None):
+async def callback(code: str, request: Request, state: str | None = None, installation_id: int | None = None):
     settings = get_settings()
 
     # GitHub redirects here from two different entry points: our own
@@ -170,6 +173,23 @@ async def callback(code: str, request: Request, state: str | None = None):
         encrypt_access_token(access_token, settings.session_secret),
         datetime.now(timezone.utc) + SESSION_TTL,
     )
+
+    if installation_id is not None:
+        # A direct "Install" click lands here with installation_id already in
+        # hand, but the `installations` row it powers /subscribe's checkout
+        # page from is normally only written by the async `installation`
+        # webhook - which can arrive after this redirect. Upsert it here too
+        # so /subscribe never races that webhook. Best-effort: the webhook
+        # remains the source of truth, so a failure here just falls back to
+        # the normal (slightly delayed) path instead of breaking sign-in.
+        try:
+            app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+            installation = get_installation_details(installation_id, app_jwt, _github_http_client())
+            await upsert_installation(
+                request.app.state.db_pool, installation_id, installation["account"]["login"]
+            )
+        except Exception:
+            logger.warning("failed to synchronously upsert installation %s", installation_id, exc_info=True)
 
     if signed_state is None and state:
         # A direct "Install" click on GitHub's own App page never goes through

--- a/github-app/app_server/github_auth.py
+++ b/github-app/app_server/github_auth.py
@@ -29,3 +29,20 @@ async def get_installation_token(
     )
     response.raise_for_status()
     return response.json()["token"]
+
+
+def get_installation_details(
+    installation_id: int,
+    app_jwt: str,
+    http_client: httpx.Client | None = None,
+) -> dict:
+    client = http_client or httpx.Client(base_url="https://api.github.com")
+    response = client.get(
+        f"/app/installations/{installation_id}",
+        headers={
+            "Authorization": f"Bearer {app_jwt}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response.raise_for_status()
+    return response.json()

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -11,7 +11,7 @@ from app_server.auth import (
     unsign_session_id,
     _is_safe_next_path,
 )
-from app_server.db import create_session, get_session
+from app_server.db import create_session, get_installation, get_session
 from app_server.main import app
 
 
@@ -242,6 +242,83 @@ async def test_callback_direct_install_honors_state_as_next_path(pool, monkeypat
 
     assert response.status_code == 307
     assert response.headers["location"] == "/subscribe?plan=team&interval=month"
+
+
+@pytest.mark.asyncio
+async def test_callback_with_installation_id_upserts_installation_synchronously(pool, monkeypatch):
+    # /subscribe reads installations from our DB, which is normally populated
+    # by the async `installation` webhook - a browser redirect straight back
+    # from GitHub's install flow can land here before that webhook arrives.
+    # The callback must upsert the row itself so /subscribe never sees a gap.
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    monkeypatch.setattr("app_server.auth.generate_app_jwt", lambda app_id, key: "fake-app-jwt")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/login/oauth/access_token":
+            return httpx.Response(200, json={"access_token": "gho_faketoken"})
+        if request.url.path == "/user":
+            return httpx.Response(200, json={"id": 42, "login": "octocat"})
+        if request.url.path == "/app/installations/999":
+            return httpx.Response(200, json={"id": 999, "account": {"login": "acme-corp"}})
+        return httpx.Response(404)
+
+    monkeypatch.setattr(
+        "app_server.auth._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    monkeypatch.setattr(
+        "app_server.auth._github_oauth_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://github.com"),
+    )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        response = await client.get(
+            "/auth/callback?code=fake-code&installation_id=999&setup_action=install",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 307
+    installation = await get_installation(pool, 999)
+    assert installation is not None
+    assert installation["account_login"] == "acme-corp"
+
+
+@pytest.mark.asyncio
+async def test_callback_installation_upsert_failure_does_not_break_signin(pool, monkeypatch):
+    # The synchronous upsert is best-effort - the webhook is still the
+    # source of truth. If GitHub's /app/installations/{id} call fails (or
+    # the JWT can't be generated), sign-in must still succeed.
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/login/oauth/access_token":
+            return httpx.Response(200, json={"access_token": "gho_faketoken"})
+        if request.url.path == "/user":
+            return httpx.Response(200, json={"id": 42, "login": "octocat"})
+        return httpx.Response(404)
+
+    monkeypatch.setattr(
+        "app_server.auth._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    monkeypatch.setattr(
+        "app_server.auth._github_oauth_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://github.com"),
+    )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        response = await client.get(
+            "/auth/callback?code=fake-code&installation_id=998&setup_action=install",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 307
+    assert "session" in response.cookies
+    assert await get_installation(pool, 998) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `/subscribe` decides install-prompt vs. checkout using two different sources: GitHub's live API (which orgs the user administers) and our `installations` table (account/plan details), the latter populated only by the async `installation` webhook.
- A user who clicks "Install the Aletheore GitHub App" from `/subscribe` is redirected back to `/auth/callback` by GitHub before that webhook is guaranteed to have landed. In that window, checkout would render with zero installations, and if clicked through, Paddle would receive `customData.installation_id: undefined` — a real payment with no way to apply the plan.
- `/auth/callback` already receives `installation_id` directly from GitHub on this entry point. It now fetches the installation's account login via the app's own JWT and upserts it synchronously, closing the race. Best-effort: the webhook stays the source of truth, and a failure here just falls back to the normal (slightly delayed) path instead of breaking sign-in.

## Test plan
- [x] New test proves the row exists immediately after the callback, before any webhook fires.
- [x] New test proves a failed upsert (bad JWT / GitHub API error) doesn't break sign-in.
- [x] Full suite: 461 passed, 1 skipped.