### PR TITLE
feat: live "paste a repo" demo on the website, sandboxed with gVisor

### DIFF
--- a/github-app/Dockerfile.demo-sandbox
+++ b/github-app/Dockerfile.demo-sandbox
@@ -1,0 +1,27 @@
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+
+# This image runs untrusted, arbitrary public repos cloned by strangers on
+# the internet (the live "paste a repo" website demo) - it deliberately
+# contains nothing besides git and the aletheore CLI. No app_server, no
+# scan_worker, no DB credentials, no GitHub App private key, no LLM API
+# keys. It is run with --runtime=runsc and no network egress after clone.
+
+WORKDIR /app
+
+COPY prototype/pyproject.toml prototype/pyproject.toml
+COPY prototype/aletheore prototype/aletheore
+RUN pip install --no-cache-dir ./prototype
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY github-app/scripts/demo_sandbox_entrypoint.sh /app/demo_sandbox_entrypoint.sh
+RUN chmod +x /app/demo_sandbox_entrypoint.sh
+
+RUN groupadd --system sandbox \
+    && useradd --system --gid sandbox --home-dir /work --create-home sandbox
+USER sandbox
+WORKDIR /work
+
+ENTRYPOINT ["/app/demo_sandbox_entrypoint.sh"]

--- a/github-app/Dockerfile.demo-scan-worker
+++ b/github-app/Dockerfile.demo-scan-worker
@@ -1,0 +1,26 @@
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "redis>=5.0.0" "rq>=1.16.0"
+
+# Docker CLI only (talks to the host daemon via the mounted socket at
+# runtime) - no daemon, no docker-in-docker. This is the one service in
+# the whole stack with that socket mounted, so it deliberately carries
+# nothing else: no DB credentials, no GitHub App key, no LLM keys, and
+# none of the heavier scan_worker dependency tree (tree-sitter, lancedb,
+# model SDKs) that the trusted customer-scan path needs but this doesn't.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends docker-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY github-app/app_server/__init__.py app_server/__init__.py
+COPY github-app/app_server/logging_config.py app_server/logging_config.py
+COPY github-app/scan_worker/__init__.py scan_worker/__init__.py
+COPY github-app/scan_worker/demo_scan.py scan_worker/demo_scan.py
+COPY github-app/scan_worker/demo_scan_worker.py scan_worker/demo_scan_worker.py
+
+# Runs as root deliberately - needs group access to the mounted
+# /var/run/docker.sock, whose group ownership is host-specific and not
+# knowable at image-build time.
+CMD ["python", "-m", "scan_worker.demo_scan_worker"]

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -17,6 +17,7 @@ class Settings:
     audit_signing_private_key: str
     paddle_webhook_secret: str
     github_app_slug: str
+    github_demo_readonly_token: str | None
 
 
 def _required_env(name: str) -> str:
@@ -58,4 +59,9 @@ def get_settings() -> Settings:
         audit_signing_private_key=_required_env("AUDIT_SIGNING_PRIVATE_KEY"),
         paddle_webhook_secret=_required_env("PADDLE_WEBHOOK_SECRET"),
         github_app_slug=_required_env("GITHUB_APP_SLUG"),
+        # Only used to raise the rate limit on the pre-clone repo-size check
+        # for the public demo (60/hr unauthenticated vs 5000/hr with a
+        # token) - a public_repo-scoped read-only PAT is enough, and the
+        # demo works without one, just at a much lower shared ceiling.
+        github_demo_readonly_token=os.environ.get("GITHUB_DEMO_READONLY_TOKEN", "").strip() or None,
     )

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -149,6 +149,29 @@ async def check_and_reserve_managed_audit(
     return row is not None
 
 
+async def check_and_reserve_demo_scan(
+    pool: asyncpg.Pool,
+    client_ip: str,
+    cooldown_seconds: int,
+) -> bool:
+    # Same atomic INSERT .. ON CONFLICT .. WHERE pattern as
+    # check_and_reserve_managed_audit, keyed on IP instead of installation -
+    # the public demo has no installation, only an anonymous caller.
+    row = await pool.fetchrow(
+        """
+        INSERT INTO demo_scan_rate_limits (client_ip, last_run_at)
+        VALUES ($1, now())
+        ON CONFLICT (client_ip) DO UPDATE
+        SET last_run_at = EXCLUDED.last_run_at
+        WHERE demo_scan_rate_limits.last_run_at <= now() - make_interval(secs => $2)
+        RETURNING last_run_at
+        """,
+        client_ip,
+        cooldown_seconds,
+    )
+    return row is not None
+
+
 async def get_llm_spend_this_month(pool: asyncpg.Pool, installation_id: int) -> float:
     row = await pool.fetchrow(
         """

--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -1,0 +1,146 @@
+"""Public, unauthenticated "paste a repo" live demo on the marketing
+website. Visitors get the deterministic scan only (dead code, secrets
+existence, license issues, endpoint mapping) - no LLM calls, no OSV.dev
+lookup, and the cloned source is never persisted (see scan_worker.demo_scan).
+"""
+
+import logging
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from app_server.config import get_settings
+from app_server.db import check_and_reserve_demo_scan
+from app_server.demo_scan_validation import MAX_REPO_SIZE_KB, normalized_clone_url, parse_github_repo_url
+
+demo_scan_router = APIRouter()
+logger = logging.getLogger(__name__)
+
+DEMO_SCAN_QUEUE_NAME = "demo_scan"
+DEMO_SCAN_JOB_FUNCTION = "scan_worker.demo_scan.run_demo_scan_job"
+DEMO_SCAN_COOLDOWN_SECONDS = 20 * 60  # ~3 runs/hour per visitor
+DEMO_SCAN_MAX_QUEUE_DEPTH = 4  # queued + running, matches 2 dedicated workers
+DEMO_SCAN_JOB_TIMEOUT_SECONDS = 120
+DEMO_SCAN_RESULT_TTL_SECONDS = 900
+
+
+class StartDemoScanRequest(BaseModel):
+    repo_url: str
+
+
+def _client_ip(request: Request) -> str:
+    # app-server is only reachable via Caddy's reverse_proxy inside the
+    # docker network (bound to 127.0.0.1:8000 on the host) - Caddy is the
+    # only thing that can set this header, so trusting it here is safe.
+    forwarded_for = request.headers.get("x-forwarded-for")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _get_queue(redis_url: str):
+    from redis import Redis
+    from rq import Queue
+
+    return Queue(DEMO_SCAN_QUEUE_NAME, connection=Redis.from_url(redis_url))
+
+
+def _fetch_job(job_id: str, redis_url: str):
+    from redis import Redis
+    from rq.job import Job
+
+    return Job.fetch(job_id, connection=Redis.from_url(redis_url))
+
+
+def _check_repo_size(owner: str, repo: str, token: str | None) -> None:
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        response = httpx.get(
+            f"https://api.github.com/repos/{owner}/{repo}", headers=headers, timeout=10.0
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail="could not reach GitHub - try again shortly") from exc
+
+    if response.status_code == 404:
+        raise HTTPException(status_code=404, detail="repo not found - must be a public GitHub repo")
+    if response.status_code == 403:
+        # Almost certainly our own GitHub API rate limit, not the caller's fault.
+        logger.warning("GitHub API returned 403 checking repo size for %s/%s", owner, repo)
+        raise HTTPException(status_code=503, detail="demo is busy right now - try again shortly")
+    response.raise_for_status()
+
+    size_kb = response.json().get("size", 0)
+    if size_kb > MAX_REPO_SIZE_KB:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"repo is too large for the live demo ({size_kb // 1024}MB, limit "
+                f"{MAX_REPO_SIZE_KB // 1024}MB) - install the Aletheore CLI and run "
+                "`aletheore scan` locally, or connect via MCP, to see the full report"
+            ),
+        )
+
+
+@demo_scan_router.post("/v1/demo-scan")
+async def start_demo_scan(request: Request, body: StartDemoScanRequest):
+    parsed = parse_github_repo_url(body.repo_url)
+    if parsed is None:
+        raise HTTPException(
+            status_code=400,
+            detail="must be a public GitHub repo URL, e.g. https://github.com/owner/repo",
+        )
+    owner, repo = parsed
+
+    settings = get_settings()
+    pool = request.app.state.db_pool
+    allowed = await check_and_reserve_demo_scan(pool, _client_ip(request), DEMO_SCAN_COOLDOWN_SECONDS)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"one live demo every {DEMO_SCAN_COOLDOWN_SECONDS // 60} minutes per visitor - "
+                "try again shortly"
+            ),
+        )
+
+    _check_repo_size(owner, repo, settings.github_demo_readonly_token)
+
+    queue = _get_queue(settings.redis_url)
+    in_flight = queue.count + queue.started_job_registry.count
+    if in_flight >= DEMO_SCAN_MAX_QUEUE_DEPTH:
+        raise HTTPException(status_code=503, detail="demo is busy right now - try again shortly")
+
+    job = queue.enqueue(
+        DEMO_SCAN_JOB_FUNCTION,
+        job_timeout=DEMO_SCAN_JOB_TIMEOUT_SECONDS,
+        result_ttl=DEMO_SCAN_RESULT_TTL_SECONDS,
+        repo_url=normalized_clone_url(owner, repo),
+    )
+    return JSONResponse(status_code=202, content={"job_id": job.id})
+
+
+@demo_scan_router.get("/v1/demo-scan/{job_id}")
+async def get_demo_scan_status(job_id: str):
+    from rq.exceptions import NoSuchJobError
+
+    settings = get_settings()
+    try:
+        job = _fetch_job(job_id, settings.redis_url)
+    except NoSuchJobError as exc:
+        raise HTTPException(status_code=404, detail="job not found") from exc
+
+    # This Redis instance backs every RQ queue in the app, not just demo
+    # scans - without this check, a public unauthenticated endpoint could be
+    # used to probe the status/result of unrelated jobs by guessing job ids.
+    if job.origin != DEMO_SCAN_QUEUE_NAME or job.func_name != DEMO_SCAN_JOB_FUNCTION:
+        raise HTTPException(status_code=404, detail="job not found")
+
+    if job.is_failed:
+        return {"status": "failed", "detail": "scan failed - the repo may be invalid, private, or too large"}
+    if job.is_finished:
+        return {"status": "finished", "result": job.result}
+    return {"status": job.get_status()}

--- a/github-app/app_server/demo_scan_validation.py
+++ b/github-app/app_server/demo_scan_validation.py
@@ -1,0 +1,32 @@
+"""Shared repo-URL validation for the public, unauthenticated "paste a
+repo" website demo. Used both by the API route (fast 400 before anything
+is queued) and again by the worker right before it shells out to Docker -
+never trust a single choke point for something that ends up as an argv
+element passed to `git clone` inside a container we spun up ourselves.
+"""
+
+import re
+
+# GitHub username/org rules: alphanumeric or single hyphens, 1-39 chars,
+# can't start/end with a hyphen. Repo name: alphanumeric, ., -, _, 1-100
+# chars. Anchored, https-only, github.com only - this is the only thing
+# standing between a pasted string and a `git clone` argument.
+_REPO_URL_RE = re.compile(
+    r"^https://github\.com/"
+    r"(?P<owner>[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))/"
+    r"(?P<repo>[A-Za-z0-9._-]{1,100}?)"
+    r"(?:\.git)?/?$"
+)
+
+MAX_REPO_SIZE_KB = 400 * 1024
+
+
+def parse_github_repo_url(url: str) -> tuple[str, str] | None:
+    match = _REPO_URL_RE.match(url.strip())
+    if match is None:
+        return None
+    return match.group("owner"), match.group("repo")
+
+
+def normalized_clone_url(owner: str, repo: str) -> str:
+    return f"https://github.com/{owner}/{repo}.git"

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -5,6 +5,7 @@ import uuid
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app_server.admin import admin_router
@@ -12,6 +13,7 @@ from app_server.auth import auth_router
 from app_server.config import get_settings
 from app_server.dashboard import dashboard_router
 from app_server.db import create_pool
+from app_server.demo_scan_api import demo_scan_router
 from app_server.frontend import frontend_router
 from app_server.logging_config import configure_json_logging
 from app_server.managed_audit_api import managed_audit_router
@@ -34,6 +36,17 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+app.add_middleware(
+    CORSMiddleware,
+    # Only the public demo (/v1/demo-scan) is meant to be called from
+    # browser JS on a different origin - the marketing site. Everything
+    # else here is same-site cookie auth or a Bearer-token API not
+    # normally called from a browser, so this stays narrowly scoped
+    # rather than a wildcard.
+    allow_origins=["https://aletheore.com", "https://www.aletheore.com"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type"],
+)
 app.include_router(dashboard_router)
 app.include_router(auth_router)
 app.include_router(admin_router)
@@ -41,6 +54,7 @@ app.include_router(managed_audit_router)
 app.include_router(metrics_router)
 app.include_router(frontend_router)
 app.include_router(paddle_webhook_router)
+app.include_router(demo_scan_router)
 
 
 @app.middleware("http")

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -44,6 +44,38 @@ services:
     cpus: "1.0"
     mem_limit: 1g
 
+  # Never started via `up` - this service exists purely so `docker compose
+  # build demo-sandbox` produces the aletheore-demo-sandbox:latest image on
+  # the host daemon for demo-scan-worker (which has docker socket access)
+  # to `docker run --runtime=runsc` on demand, one ephemeral container per
+  # live website demo request.
+  demo-sandbox:
+    build:
+      context: ..
+      dockerfile: github-app/Dockerfile.demo-sandbox
+    image: aletheore-demo-sandbox:latest
+    profiles: ["build-only"]
+
+  demo-scan-worker:
+    build:
+      context: ..
+      dockerfile: github-app/Dockerfile.demo-scan-worker
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    # The only service with the host's Docker socket - deliberately gets
+    # no DB credentials, no GitHub App key, no LLM keys (see
+    # Dockerfile.demo-scan-worker). Only consumes the demo_scan queue,
+    # completely separate from paying customers' real scan/audit jobs.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      redis:
+        condition: service_started
+    cpus: "1.0"
+    mem_limit: 512m
+
   postgres:
     image: postgres:16
     restart: unless-stopped

--- a/github-app/migrations/019_demo_scan_rate_limits.sql
+++ b/github-app/migrations/019_demo_scan_rate_limits.sql
@@ -1,0 +1,7 @@
+-- Per-IP cooldown for the public, unauthenticated "paste a repo" website
+-- demo. Unlike managed_audit_rate_limits, this has no installation to key
+-- on - the caller is an anonymous visitor identified only by IP.
+CREATE TABLE IF NOT EXISTS demo_scan_rate_limits (
+    client_ip    TEXT NOT NULL PRIMARY KEY,
+    last_run_at  TIMESTAMPTZ NOT NULL
+);

--- a/github-app/scan_worker/demo_scan.py
+++ b/github-app/scan_worker/demo_scan.py
@@ -1,0 +1,134 @@
+"""RQ job for the public, unauthenticated "paste a repo" website demo.
+
+Runs on the dedicated `demo_scan` queue, consumed only by the
+demo-scan-worker compose service - the one component with access to the
+host's Docker socket, deliberately kept separate from the trusted
+scan_worker.jobs path, which only ever touches repos from installed
+GitHub Apps. Every run is a single ephemeral gVisor-sandboxed container:
+the clone and the deterministic scan happen entirely inside it, and only
+a curated, public-safe summary of the results ever leaves - never the
+cloned source, never raw secret matches, never the full evidence.
+"""
+
+import json
+import logging
+import subprocess
+import uuid
+
+logger = logging.getLogger(__name__)
+
+DEMO_SANDBOX_IMAGE = "aletheore-demo-sandbox:latest"
+CONTAINER_TIMEOUT_SECONDS = 90
+MAX_LISTED_ITEMS = 5
+
+
+class DemoScanError(RuntimeError):
+    pass
+
+
+def _run_sandboxed_scan(repo_url: str) -> dict:
+    container_name = f"demo-scan-{uuid.uuid4().hex}"
+    cmd = [
+        "docker",
+        "run",
+        "--name",
+        container_name,
+        "--rm",
+        "--runtime=runsc",
+        "--cpus=1",
+        "--memory=1g",
+        "--pids-limit=256",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        DEMO_SANDBOX_IMAGE,
+        repo_url,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CONTAINER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Killing the `docker run` CLI process (what subprocess's own
+        # timeout does) does not guarantee the container it started stops -
+        # the container is managed by the daemon, not the CLI. Force it
+        # explicitly so a slow/stuck clone can never linger past the
+        # timeout using resources or holding the untrusted repo on disk.
+        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True)
+        raise DemoScanError("scan timed out") from exc
+
+    if result.returncode != 0:
+        logger.warning(
+            "demo scan container exited %s for %s: %s",
+            result.returncode,
+            repo_url,
+            result.stderr[-2000:],
+        )
+        raise DemoScanError("scan failed - the repo may be invalid, private, or unparseable")
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        logger.warning("demo scan produced non-JSON stdout for %s", repo_url)
+        raise DemoScanError("scan failed") from exc
+
+
+def _summarize_for_public_display(evidence: dict) -> dict:
+    repository = evidence.get("repository", {})
+    security = evidence.get("security", {})
+    architecture = evidence.get("architecture", {})
+
+    languages = repository.get("languages", [])
+    dead_code = repository.get("dead_code", {})
+    unreachable_modules = dead_code.get("unreachable_modules", [])
+    unused_dependencies = dead_code.get("unused_dependencies", [])
+    secrets_findings = security.get("secrets", {}).get("findings", [])
+    license_findings = security.get("dependency_licenses", {}).get("findings", [])
+    endpoints = repository.get("api_endpoints", {}).get("endpoints", [])
+    clusters = architecture.get("clusters", [])
+
+    return {
+        "languages": [
+            {"name": lang.get("name"), "lines": lang.get("lines")} for lang in languages[:MAX_LISTED_ITEMS]
+        ],
+        "dead_code": {
+            "unreachable_module_count": len(unreachable_modules),
+            "unused_dependency_count": len(unused_dependencies),
+            "sample": unreachable_modules[:MAX_LISTED_ITEMS],
+        },
+        "secrets": {
+            "finding_count": len(secrets_findings),
+            # Never the matched value or its preview - path, line, and
+            # which pattern matched is enough to prove the scanner found
+            # something real without republishing anyone's leaked secret
+            # on a public web page.
+            "sample": [
+                {"path": f.get("path"), "line": f.get("line"), "pattern": f.get("pattern")}
+                for f in secrets_findings[:MAX_LISTED_ITEMS]
+            ],
+        },
+        "dependency_licenses": {
+            "issue_count": len(license_findings),
+        },
+        "api_endpoints": {
+            "count": len(endpoints),
+        },
+        "architecture": {
+            "cluster_count": len(clusters),
+        },
+        "held_back": {
+            "vulnerabilities": "dependency vulnerability check (OSV.dev) skipped in the live demo",
+            "message": (
+                "This is a preview of what Aletheore finds - install the CLI and run "
+                "`aletheore scan` locally, or connect via MCP, for the full report "
+                "including OSV.dev vulnerability checks and every finding."
+            ),
+        },
+    }
+
+
+def run_demo_scan_job(repo_url: str) -> dict:
+    evidence = _run_sandboxed_scan(repo_url)
+    return _summarize_for_public_display(evidence)

--- a/github-app/scan_worker/demo_scan_worker.py
+++ b/github-app/scan_worker/demo_scan_worker.py
@@ -1,0 +1,15 @@
+import os
+
+from redis import Redis
+from rq import Worker
+
+from app_server.logging_config import configure_json_logging
+
+# Deliberately does not import app_server.config.get_settings() - that
+# pulls in every secret the app has (DB credentials, GitHub App key, LLM
+# keys) via one required-env dataclass construction. This worker only
+# ever needs REDIS_URL, so it reads that directly and nothing else.
+if __name__ == "__main__":
+    configure_json_logging()
+    redis_conn = Redis.from_url(os.environ.get("REDIS_URL", "redis://localhost:6379/0"))
+    Worker(["demo_scan"], connection=redis_conn).work()

--- a/github-app/scripts/demo_sandbox_entrypoint.sh
+++ b/github-app/scripts/demo_sandbox_entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Entrypoint for the gVisor-sandboxed demo-scan container (Dockerfile.demo-sandbox).
+# Clones exactly one repo (URL already validated by the caller before this
+# container is even started) and runs only the deterministic scan phase -
+# no LLM calls, no OSV.dev lookup. stdout carries nothing but the final
+# air.json evidence so the orchestrator can read it straight from the
+# container's captured output; everything else goes to stderr.
+set -eu
+
+REPO_URL="$1"
+
+git clone -q --depth 1 --single-branch "$REPO_URL" /work/repo 1>&2
+aletheore scan /work/repo --no-check-vulnerabilities 1>&2
+cat /work/repo/.aletheore/air.json

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -39,7 +39,7 @@ async def pool():
         migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
         for migration in sorted(migrations_dir.glob("*.sql")):
             await conn.execute(migration.read_text())
-        await conn.execute("TRUNCATE installations, sessions CASCADE")
+        await conn.execute("TRUNCATE installations, sessions, demo_scan_rate_limits CASCADE")
     yield p
     await p.close()
 

--- a/github-app/tests/test_app_server_db.py
+++ b/github-app/tests/test_app_server_db.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app_server.db import add_paddle_ids_to_installation, get_installation
+from app_server.db import add_paddle_ids_to_installation, check_and_reserve_demo_scan, get_installation
 
 
 @pytest.mark.asyncio
@@ -12,3 +12,21 @@ async def test_add_paddle_ids_to_installation(pool):
     row = await get_installation(pool, 2)
     assert row["paddle_subscription_id"] == "sub_789"
     assert row["paddle_customer_id"] == "ctm_3"
+
+
+@pytest.mark.asyncio
+async def test_check_and_reserve_demo_scan_allows_first_then_blocks_within_cooldown(pool):
+    assert await check_and_reserve_demo_scan(pool, "203.0.113.5", cooldown_seconds=1200) is True
+    assert await check_and_reserve_demo_scan(pool, "203.0.113.5", cooldown_seconds=1200) is False
+
+
+@pytest.mark.asyncio
+async def test_check_and_reserve_demo_scan_different_ips_are_independent(pool):
+    assert await check_and_reserve_demo_scan(pool, "203.0.113.10", cooldown_seconds=1200) is True
+    assert await check_and_reserve_demo_scan(pool, "203.0.113.11", cooldown_seconds=1200) is True
+
+
+@pytest.mark.asyncio
+async def test_check_and_reserve_demo_scan_allows_again_after_cooldown_elapses(pool):
+    assert await check_and_reserve_demo_scan(pool, "203.0.113.20", cooldown_seconds=0) is True
+    assert await check_and_reserve_demo_scan(pool, "203.0.113.20", cooldown_seconds=0) is True

--- a/github-app/tests/test_demo_scan.py
+++ b/github-app/tests/test_demo_scan.py
@@ -1,0 +1,139 @@
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from scan_worker.demo_scan import (
+    DemoScanError,
+    _run_sandboxed_scan,
+    _summarize_for_public_display,
+    run_demo_scan_job,
+)
+
+
+def _fake_evidence(**overrides) -> dict:
+    base = {
+        "repository": {
+            "languages": [{"name": "Python", "lines": 1000}],
+            "dead_code": {
+                "unreachable_modules": [f"module_{i}.py" for i in range(8)],
+                "unused_dependencies": ["requests"],
+            },
+            "api_endpoints": {"endpoints": [{"path": "/a"}, {"path": "/b"}]},
+        },
+        "security": {
+            "secrets": {
+                "findings": [
+                    {
+                        "path": "config.py",
+                        "line": 12,
+                        "pattern": "aws_access_key_id",
+                        "match_preview": "AKIA-super-secret-do-not-leak",
+                    }
+                ]
+            },
+            "dependency_licenses": {"findings": [{"package": "left-pad", "category": "permissive"}]},
+        },
+        "architecture": {"clusters": [{"id": 1}, {"id": 2}]},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_summarize_never_includes_secret_match_preview():
+    summary = _summarize_for_public_display(_fake_evidence())
+    assert "AKIA-super-secret-do-not-leak" not in json.dumps(summary)
+    assert summary["secrets"]["finding_count"] == 1
+    assert summary["secrets"]["sample"][0] == {"path": "config.py", "line": 12, "pattern": "aws_access_key_id"}
+
+
+def test_summarize_caps_sample_list_size_but_keeps_true_count():
+    summary = _summarize_for_public_display(_fake_evidence())
+    assert summary["dead_code"]["unreachable_module_count"] == 8
+    assert len(summary["dead_code"]["sample"]) == 5
+
+
+def test_summarize_handles_empty_evidence_gracefully():
+    summary = _summarize_for_public_display({})
+    assert summary["languages"] == []
+    assert summary["dead_code"]["unreachable_module_count"] == 0
+    assert summary["secrets"]["finding_count"] == 0
+
+
+def test_summarize_notes_osv_is_held_back():
+    summary = _summarize_for_public_display(_fake_evidence())
+    assert "OSV" in summary["held_back"]["vulnerabilities"]
+
+
+def test_run_sandboxed_scan_invokes_docker_with_gvisor_runtime(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, timeout):
+        captured["cmd"] = cmd
+        captured["timeout"] = timeout
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout=json.dumps({"ok": True}), stderr="")
+
+    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    result = _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+
+    assert result == {"ok": True}
+    cmd = captured["cmd"]
+    assert cmd[0:2] == ["docker", "run"]
+    assert "--runtime=runsc" in cmd
+    assert "--rm" in cmd
+    assert cmd[-2] == "aletheore-demo-sandbox:latest"
+    assert cmd[-1] == "https://github.com/octocat/Hello-World.git"
+    assert captured["timeout"] == 90
+
+
+def test_run_sandboxed_scan_raises_on_nonzero_exit(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="clone failed")
+
+    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    with pytest.raises(DemoScanError):
+        _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+
+
+def test_run_sandboxed_scan_raises_on_non_json_stdout(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="not json", stderr="")
+
+    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    with pytest.raises(DemoScanError):
+        _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+
+
+def test_run_sandboxed_scan_force_removes_container_on_timeout(monkeypatch):
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        if args and args[0][0:2] == ["docker", "run"]:
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=90)
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    with pytest.raises(DemoScanError, match="timed out"):
+        _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+
+    # First call was the (timed-out) docker run, second must be the forced
+    # cleanup - the container name from the failed call is what gets removed.
+    assert len(calls) == 2
+    run_cmd = calls[0][0][0]
+    cleanup_cmd = calls[1][0][0]
+    assert cleanup_cmd[:3] == ["docker", "rm", "-f"]
+    container_name_index = run_cmd.index("--name") + 1
+    assert cleanup_cmd[3] == run_cmd[container_name_index]
+
+
+def test_run_demo_scan_job_returns_summarized_result(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout=json.dumps(_fake_evidence()), stderr="")
+
+    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    result = run_demo_scan_job("https://github.com/octocat/Hello-World.git")
+
+    assert result["secrets"]["finding_count"] == 1
+    assert "AKIA-super-secret-do-not-leak" not in json.dumps(result)

--- a/github-app/tests/test_demo_scan_api.py
+++ b/github-app/tests/test_demo_scan_api.py
@@ -1,0 +1,210 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.main import app
+
+
+def _mock_github_response(monkeypatch, status_code: int, size_kb: int = 100):
+    def fake_get(url, headers=None, timeout=None):
+        return httpx.Response(status_code, json={"size": size_kb}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr("app_server.demo_scan_api.httpx.get", fake_get)
+
+
+def _mock_queue(monkeypatch, count: int = 0, started_count: int = 0, job_id: str = "demo-job-123"):
+    fake_queue = MagicMock()
+    fake_queue.count = count
+    fake_queue.started_job_registry.count = started_count
+    fake_queue.enqueue.return_value = MagicMock(id=job_id)
+    monkeypatch.setattr("app_server.demo_scan_api._get_queue", lambda redis_url: fake_queue)
+    return fake_queue
+
+
+@pytest.mark.asyncio
+async def test_invalid_repo_url_returns_400(pool):
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/v1/demo-scan", json={"repo_url": "not a url"})
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_unknown_repo_returns_404(pool, monkeypatch):
+    _mock_github_response(monkeypatch, 404)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/does-not-exist"}
+        )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_repo_too_large_returns_413(pool, monkeypatch):
+    _mock_github_response(monkeypatch, 200, size_kb=(400 * 1024) + 1)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/torvalds/linux"}
+        )
+    assert response.status_code == 413
+    assert "install the aletheore cli" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_github_rate_limited_returns_503(pool, monkeypatch):
+    _mock_github_response(monkeypatch, 403)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Hello-World"}
+        )
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_valid_request_enqueues_job_and_returns_202(pool, monkeypatch):
+    _mock_github_response(monkeypatch, 200, size_kb=100)
+    fake_queue = _mock_queue(monkeypatch)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Hello-World"}
+        )
+    assert response.status_code == 202
+    assert response.json()["job_id"] == "demo-job-123"
+    args, kwargs = fake_queue.enqueue.call_args
+    assert args[0] == "scan_worker.demo_scan.run_demo_scan_job"
+    assert kwargs["repo_url"] == "https://github.com/octocat/Hello-World.git"
+
+
+@pytest.mark.asyncio
+async def test_second_request_from_same_ip_within_cooldown_returns_429(pool, monkeypatch):
+    _mock_github_response(monkeypatch, 200, size_kb=100)
+    _mock_queue(monkeypatch)
+    app.state.db_pool = pool
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"x-forwarded-for": "203.0.113.99"},
+    ) as client:
+        first = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Hello-World"}
+        )
+        second = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Spoon-Knife"}
+        )
+    assert first.status_code == 202
+    assert second.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_different_ips_are_not_rate_limited_together(pool, monkeypatch):
+    _mock_github_response(monkeypatch, 200, size_kb=100)
+    _mock_queue(monkeypatch)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        first = await client.post(
+            "/v1/demo-scan",
+            json={"repo_url": "https://github.com/octocat/Hello-World"},
+            headers={"x-forwarded-for": "203.0.113.1"},
+        )
+        second = await client.post(
+            "/v1/demo-scan",
+            json={"repo_url": "https://github.com/octocat/Hello-World"},
+            headers={"x-forwarded-for": "203.0.113.2"},
+        )
+    assert first.status_code == 202
+    assert second.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_queue_at_max_depth_returns_503(pool, monkeypatch):
+    _mock_github_response(monkeypatch, 200, size_kb=100)
+    _mock_queue(monkeypatch, count=3, started_count=1)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Hello-World"}
+        )
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_get_status_404s_for_unknown_job(pool, monkeypatch):
+    from rq.exceptions import NoSuchJobError
+
+    def _raise(job_id, redis_url):
+        raise NoSuchJobError()
+
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", _raise)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/does-not-exist")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_status_404s_for_job_from_a_different_queue(pool, monkeypatch):
+    # A public unauthenticated endpoint must not become a way to probe the
+    # status/result of unrelated jobs (e.g. managed-audit jobs) sharing the
+    # same Redis instance, just by guessing/reusing a job id.
+    fake_job = MagicMock(origin="scans", func_name="scan_worker.jobs.run_managed_audit_api_job")
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/some-other-job")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_result_when_finished(pool, monkeypatch):
+    fake_job = MagicMock(
+        origin="demo_scan",
+        func_name="scan_worker.demo_scan.run_demo_scan_job",
+        is_finished=True,
+        is_failed=False,
+        result={"summary": {"dead_code_count": 3}},
+    )
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/demo-job-123")
+    assert response.status_code == 200
+    assert response.json() == {"status": "finished", "result": {"summary": {"dead_code_count": 3}}}
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_failed(pool, monkeypatch):
+    fake_job = MagicMock(
+        origin="demo_scan",
+        func_name="scan_worker.demo_scan.run_demo_scan_job",
+        is_finished=False,
+        is_failed=True,
+    )
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/demo-job-123")
+    assert response.status_code == 200
+    assert response.json()["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_pending_status_while_running(pool, monkeypatch):
+    fake_job = MagicMock(
+        origin="demo_scan",
+        func_name="scan_worker.demo_scan.run_demo_scan_job",
+        is_finished=False,
+        is_failed=False,
+    )
+    fake_job.get_status.return_value = "started"
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/demo-job-123")
+    assert response.status_code == 200
+    assert response.json() == {"status": "started"}

--- a/github-app/tests/test_demo_scan_validation.py
+++ b/github-app/tests/test_demo_scan_validation.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app_server.demo_scan_validation import normalized_clone_url, parse_github_repo_url
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/octocat/Hello-World", ("octocat", "Hello-World")),
+        ("https://github.com/octocat/Hello-World.git", ("octocat", "Hello-World")),
+        ("https://github.com/octocat/Hello-World/", ("octocat", "Hello-World")),
+        ("https://github.com/some-org/some_repo.name", ("some-org", "some_repo.name")),
+    ],
+)
+def test_valid_urls_parse(url, expected):
+    assert parse_github_repo_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://github.com/octocat/Hello-World",  # not https
+        "https://gitlab.com/octocat/Hello-World",  # not github.com
+        "https://github.com/octocat/Hello-World/extra",  # extra path segment
+        "https://github.com/octocat/Hello-World?x=1",  # query string
+        "https://github.com@evil.com/octocat/Hello-World",  # host confusion
+        "https://github.com/-octocat/Hello-World",  # owner starts with hyphen
+        "https://github.com/octocat",  # missing repo
+        "git@github.com:octocat/Hello-World.git",  # ssh form
+        "file:///etc/passwd",
+        "https://169.254.169.254/latest/meta-data/",  # SSRF attempt
+        "",
+    ],
+)
+def test_invalid_urls_rejected(url):
+    assert parse_github_repo_url(url) is None
+
+
+def test_normalized_clone_url_always_has_git_suffix():
+    assert normalized_clone_url("octocat", "Hello-World") == "https://github.com/octocat/Hello-World.git"

--- a/website/index.html
+++ b/website/index.html
@@ -297,6 +297,17 @@
             </div>
           </div>
         </div>
+
+        <div class="live-demo">
+          <h3>Now try it on your own repo.</h3>
+          <p class="section-intro">Paste a public GitHub repo below. It runs the real deterministic scanner in an isolated sandbox - no signup, nothing installed on your machine, and the clone is destroyed the moment the scan finishes. One free run every 20 minutes; repos over 400MB need the CLI instead.</p>
+          <form id="live-demo-form" class="live-demo-form">
+            <input type="url" id="live-demo-url" class="live-demo-input" placeholder="https://github.com/owner/repo" required>
+            <button type="submit" class="btn btn-primary" id="live-demo-submit">Scan it</button>
+          </form>
+          <p id="live-demo-status" class="live-demo-status" hidden></p>
+          <div id="live-demo-results" class="live-demo-results" hidden></div>
+        </div>
       </div>
     </section>
 
@@ -354,5 +365,6 @@
   <script src="vendor/motion.js"></script>
   <script src="showcase-data.js"></script>
   <script src="script.js"></script>
+  <script src="live-demo.js"></script>
 </body>
 </html>

--- a/website/live-demo.js
+++ b/website/live-demo.js
@@ -1,0 +1,127 @@
+// Live "paste a repo" demo (index.html #live-demo). Calls the isolated,
+// unauthenticated /v1/demo-scan API on app.aletheore.com - deterministic
+// scan only, no LLM calls, cloned source destroyed server-side after the
+// scan. See github-app/app_server/demo_scan_api.py.
+const DEMO_API_BASE = "https://app.aletheore.com";
+const POLL_INTERVAL_MS = 2000;
+
+function escapeHtml(value) {
+  const div = document.createElement("div");
+  div.textContent = value == null ? "" : String(value);
+  return div.innerHTML;
+}
+
+function setStatus(message, isError) {
+  const el = document.getElementById("live-demo-status");
+  el.textContent = message;
+  el.hidden = !message;
+  el.classList.toggle("is-error", Boolean(isError));
+}
+
+function resetButton() {
+  const button = document.getElementById("live-demo-submit");
+  button.disabled = false;
+  button.textContent = "Scan it";
+}
+
+function renderResults(result) {
+  const el = document.getElementById("live-demo-results");
+  const languages =
+    (result.languages || []).map((lang) => `${lang.name} (${Number(lang.lines || 0).toLocaleString()} lines)`).join(", ") ||
+    "none detected";
+
+  const deadCodeSample = (result.dead_code?.sample || [])
+    .map((path) => `<li>${escapeHtml(path)}</li>`)
+    .join("");
+  const secretsSample = (result.secrets?.sample || [])
+    .map((f) => `<li>${escapeHtml(f.path)}:${escapeHtml(f.line)} — ${escapeHtml(f.pattern)}</li>`)
+    .join("");
+
+  el.innerHTML = `
+    <dl>
+      <div><dt>Dead code found</dt><dd>${result.dead_code?.unreachable_module_count ?? 0}</dd></div>
+      <div><dt>Secret patterns matched</dt><dd>${result.secrets?.finding_count ?? 0}</dd></div>
+      <div><dt>License issues</dt><dd>${result.dependency_licenses?.issue_count ?? 0}</dd></div>
+      <div><dt>API endpoints mapped</dt><dd>${result.api_endpoints?.count ?? 0}</dd></div>
+      <div><dt>Architecture clusters</dt><dd>${result.architecture?.cluster_count ?? 0}</dd></div>
+    </dl>
+    <p class="live-demo-status" style="margin-top:16px;">Languages: ${escapeHtml(languages)}</p>
+    ${deadCodeSample ? `<ul class="live-demo-sample">${deadCodeSample}</ul>` : ""}
+    ${secretsSample ? `<ul class="live-demo-sample">${secretsSample}</ul>` : ""}
+    <p class="live-demo-held-back">${escapeHtml(result.held_back?.message)}</p>
+  `;
+  el.hidden = false;
+}
+
+async function pollJob(jobId) {
+  let response;
+  try {
+    response = await fetch(`${DEMO_API_BASE}/v1/demo-scan/${jobId}`);
+  } catch (err) {
+    setStatus("Lost connection checking the scan status - try again shortly.", true);
+    resetButton();
+    return;
+  }
+
+  if (!response.ok) {
+    setStatus("Something went wrong checking the scan status.", true);
+    resetButton();
+    return;
+  }
+
+  const body = await response.json();
+  if (body.status === "finished") {
+    setStatus("");
+    renderResults(body.result);
+    resetButton();
+    return;
+  }
+  if (body.status === "failed") {
+    setStatus(body.detail || "Scan failed.", true);
+    resetButton();
+    return;
+  }
+  setStatus("Scanning your repo in an isolated sandbox...");
+  setTimeout(() => pollJob(jobId), POLL_INTERVAL_MS);
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  const input = document.getElementById("live-demo-url");
+  const button = document.getElementById("live-demo-submit");
+  const resultsEl = document.getElementById("live-demo-results");
+  resultsEl.hidden = true;
+  resultsEl.innerHTML = "";
+  button.disabled = true;
+  button.textContent = "Starting...";
+  setStatus("Starting scan...");
+
+  let response;
+  try {
+    response = await fetch(`${DEMO_API_BASE}/v1/demo-scan`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo_url: input.value.trim() }),
+    });
+  } catch (err) {
+    setStatus("Could not reach the demo service - try again shortly.", true);
+    resetButton();
+    return;
+  }
+
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    setStatus(body.detail || "That didn't work - check the URL and try again.", true);
+    resetButton();
+    return;
+  }
+
+  button.textContent = "Scanning...";
+  setStatus("Scanning your repo in an isolated sandbox...");
+  pollJob(body.job_id);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const form = document.getElementById("live-demo-form");
+  if (form) form.addEventListener("submit", handleSubmit);
+});

--- a/website/styles.css
+++ b/website/styles.css
@@ -1006,6 +1006,7 @@ pre {
 .live-demo h3 {
   margin-bottom: 12px;
   color: #fff;
+  text-align: center;
 }
 
 .live-demo .section-intro {

--- a/website/styles.css
+++ b/website/styles.css
@@ -996,6 +996,116 @@ pre {
   font-size: 13px;
 }
 
+.live-demo {
+  margin-top: 64px;
+  padding-top: 56px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: center;
+}
+
+.live-demo h3 {
+  margin-bottom: 12px;
+  color: #fff;
+}
+
+.live-demo .section-intro {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.live-demo-form {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  max-width: 560px;
+  margin: 28px auto 0;
+}
+
+.live-demo-input {
+  flex: 1;
+  min-width: 0;
+  padding: 11px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #fff;
+  font-size: 15px;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+}
+
+.live-demo-input::placeholder {
+  color: #7d7568;
+}
+
+.live-demo-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.live-demo-status {
+  margin-top: 20px;
+  color: #b9b1a4;
+  font-size: 14px;
+}
+
+.live-demo-status.is-error {
+  color: #e08a8a;
+}
+
+.live-demo-results {
+  max-width: 640px;
+  margin: 28px auto 0;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.2);
+  text-align: left;
+}
+
+.live-demo-results dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.live-demo-results dt {
+  color: #b9b1a4;
+  font-size: 13px;
+}
+
+.live-demo-results dd {
+  font-variant-numeric: tabular-nums;
+  color: #fff;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.live-demo-sample {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  list-style: none;
+  color: #b9b1a4;
+  font-family: "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+.live-demo-sample li {
+  padding: 4px 0;
+}
+
+.live-demo-held-back {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #b9b1a4;
+  font-size: 13px;
+}
+
+.live-demo-held-back a {
+  color: var(--accent);
+}
+
 .pricing-hero {
   padding-top: 40px;
   text-align: center;


### PR DESCRIPTION
## Summary
- Public, unauthenticated live demo on the marketing site: paste a public GitHub repo, get a real deterministic scan (dead code, secret patterns, license issues, endpoint mapping) back in ~seconds - no LLM calls, no OSV.dev lookup, nothing installed, nothing kept.
- Every run is a single ephemeral gVisor-sandboxed container. Only `demo-scan-worker` has Docker socket access, and it deliberately carries no DB credentials, GitHub App key, or LLM keys.
- Separate `demo_scan` RQ queue/worker pool from paying customers' real jobs.
- Abuse controls: per-IP 20-min cooldown, 400MB repo size cap (checked via GitHub API before enqueueing), queue-depth cap with a clear "busy" response, and job-ownership checks so the public status endpoint can't be used to probe unrelated jobs.
- Secret findings are shown as count + file:line + pattern name only - the match preview is never included in public output.

## Infra (already done on prod, not part of this PR's CI)
- gVisor (`runsc`) installed as an additional (non-default) Docker runtime - verified existing services untouched.
- New `Dockerfile.demo-sandbox` (git + aletheore CLI only, no secrets) and `Dockerfile.demo-scan-worker` (docker CLI only, no scan_worker's heavier deps) built and smoke-tested locally.

## Test plan
- [x] Full suite: 502 passed, 1 skipped.
- [x] New tests: URL validation (16), rate-limit DB helper (3), API routes incl. size/rate/queue-depth caps and cross-queue job isolation (17), sandboxed-scan orchestration incl. timeout force-cleanup (9).
- [x] Sandbox image built and run locally end-to-end against a real public repo (octocat/Hello-World) - clean JSON evidence on stdout, progress noise isolated to stderr.
- [x] demo-scan-worker image built and verified: docker CLI works against a mounted socket, Redis connectivity works, `scan_worker.demo_scan` imports without the heavy scan_worker dependency tree.
- [x] `docker compose config` confirms `demo-sandbox` is build-only (excluded from default `up`) and `demo-scan-worker` is a normal service.
- [ ] Real end-to-end browser test against the deployed site (after merge + deploy).