### PR TITLE
fix: don't consume the demo-scan rate limit slot on a rejected repo

### DIFF
--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -97,6 +97,13 @@ async def start_demo_scan(request: Request, body: StartDemoScanRequest):
 
     settings = get_settings()
     pool = request.app.state.db_pool
+
+    # Size (and existence) is checked before the rate-limit slot is
+    # reserved - a repo that gets rejected here never reaches a worker, so
+    # it shouldn't cost the visitor their one scan every 20 minutes. Only a
+    # request that's actually eligible to run consumes the cooldown.
+    _check_repo_size(owner, repo, settings.github_demo_readonly_token)
+
     allowed = await check_and_reserve_demo_scan(pool, _client_ip(request), DEMO_SCAN_COOLDOWN_SECONDS)
     if not allowed:
         raise HTTPException(
@@ -106,8 +113,6 @@ async def start_demo_scan(request: Request, body: StartDemoScanRequest):
                 "try again shortly"
             ),
         )
-
-    _check_repo_size(owner, repo, settings.github_demo_readonly_token)
 
     queue = _get_queue(settings.redis_url)
     in_flight = queue.count + queue.started_job_registry.count

--- a/github-app/tests/test_demo_scan_api.py
+++ b/github-app/tests/test_demo_scan_api.py
@@ -82,6 +82,32 @@ async def test_valid_request_enqueues_job_and_returns_202(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_rejected_oversized_repo_does_not_consume_rate_limit_slot(pool, monkeypatch):
+    # A repo that's too large never reaches a worker - it shouldn't cost
+    # the visitor their one scan every 20 minutes either. The next request
+    # from the same IP, for a repo that fits, must still be allowed.
+    _mock_github_response(monkeypatch, 200, size_kb=(400 * 1024) + 1)
+    fake_queue = _mock_queue(monkeypatch)
+    app.state.db_pool = pool
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"x-forwarded-for": "203.0.113.55"},
+    ) as client:
+        too_big = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/torvalds/linux"}
+        )
+        assert too_big.status_code == 413
+
+        _mock_github_response(monkeypatch, 200, size_kb=100)
+        fits = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Hello-World"}
+        )
+    assert fits.status_code == 202
+    assert fake_queue.enqueue.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_second_request_from_same_ip_within_cooldown_returns_429(pool, monkeypatch):
     _mock_github_response(monkeypatch, 200, size_kb=100)
     _mock_queue(monkeypatch)


### PR DESCRIPTION
## Summary
Found via a real production test against `torvalds/linux`: it correctly hit the 413 size cap (6148MB > 400MB), but the rate-limit reservation happened *before* the size check, so the visitor's one scan every 20 minutes was burned on a request that never reached a worker at all.

Size (and existence) is now checked before the cooldown is reserved - only a request that's actually eligible to run costs the visitor their slot.

## Test plan
- [x] New test: an oversized-repo rejection followed immediately by a valid-sized request from the same IP - the second one must still succeed (previously would 429).
- [x] Full suite: 503 passed, 1 skipped.