### PR TITLE
fix: don't crash git log parsing on non-UTF-8 commit metadata

### DIFF
--- a/prototype/aletheore/evidence_resolution.py
+++ b/prototype/aletheore/evidence_resolution.py
@@ -188,6 +188,7 @@ def resolve_recent_commit(repo_path: Path, file_path: str, line: int | None = No
             check=False,
             capture_output=True,
             text=True,
+            errors="ignore",
             timeout=2,
         )
     except (OSError, subprocess.SubprocessError):

--- a/prototype/aletheore/git_intel/analyzer.py
+++ b/prototype/aletheore/git_intel/analyzer.py
@@ -7,11 +7,18 @@ HOTSPOT_LIMIT = 30
 
 
 def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess:
+    # errors="ignore" (matching secrets.py's git-log subprocess) - real commit
+    # history, especially anything spanning many years/contributors, isn't
+    # guaranteed to be valid UTF-8 (confirmed on Linux's own history: strict
+    # decoding crashed with UnicodeDecodeError on a non-UTF-8 byte in an old
+    # commit's author name). A handful of unparseable bytes in one field
+    # shouldn't take down the whole git analysis.
     return subprocess.run(
         ["git", *args],
         cwd=repo_path,
         capture_output=True,
         text=True,
+        errors="ignore",
     )
 
 

--- a/prototype/tests/test_git_intel.py
+++ b/prototype/tests/test_git_intel.py
@@ -132,6 +132,49 @@ def test_analyze_git_ownership_merges_same_email_different_case(tmp_path):
     assert result["ownership"][0]["commit_count"] == 2
 
 
+def test_analyze_git_survives_non_utf8_author_name(tmp_path):
+    # Found on a real scan of the Linux kernel's 20-year, 1.46M-commit
+    # history: git doesn't require commit metadata to be valid UTF-8, and an
+    # old commit's author name had a raw byte that isn't. Strict UTF-8
+    # decoding crashed the whole scan with UnicodeDecodeError.
+    #
+    # Setting GIT_AUTHOR_NAME to a raw invalid byte doesn't reproduce this -
+    # git itself repairs it (reinterprets as Latin-1, re-encodes to valid
+    # UTF-8) before storing the commit, confirmed directly. hash-object
+    # --stdin stores whatever bytes it's given with no such validation,
+    # which is the only reliable way to get a genuinely invalid byte into a
+    # real commit object for this test.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(repo, "init", "-b", "main")
+    (repo / "a.txt").write_text("1")
+    run(repo, "add", "a.txt")
+    tree_sha = subprocess.run(
+        ["git", "write-tree"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    timestamp = b"1748736000 +0000"
+    commit_bytes = (
+        b"tree " + tree_sha.encode() + b"\n"
+        b"author Weird" + bytes([0xE9]) + b"Name <old@example.com> " + timestamp + b"\n"
+        b"committer Weird" + bytes([0xE9]) + b"Name <old@example.com> " + timestamp + b"\n"
+        b"\nold commit\n"
+    )
+    commit_sha = subprocess.run(
+        ["git", "hash-object", "-w", "-t", "commit", "--stdin"],
+        cwd=repo,
+        input=commit_bytes,
+        check=True,
+        capture_output=True,
+    ).stdout.decode().strip()
+    run(repo, "update-ref", "refs/heads/main", commit_sha)
+
+    result = analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
+    assert result["available"] is True
+    assert result["ownership"][0]["email"] == "old@example.com"
+    assert result["ownership"][0]["commit_count"] == 1
+
+
 def test_analyze_git_ahead_behind_main(tmp_path):
     repo = make_git_repo(tmp_path)
     result = analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))


### PR DESCRIPTION
## Summary
Found immediately after the previous recursion fix, on the same real scan: the Linux kernel's 20-year, 1.46M-commit history has at least one old commit with a non-UTF-8 byte in its author name. Git itself never required commit metadata to be valid UTF-8, but every `git log` subprocess call in `git_intel/analyzer.py` decoded stdout with strict UTF-8, crashing the whole scan with `UnicodeDecodeError`.

`_run_git` (the single chokepoint for every git-log call in that file) now uses `errors="ignore"`, matching the pattern `secrets.py` already uses for its own git-log subprocess. Also applied the same fix to `evidence_resolution.py`'s per-file "most recent commit" lookup (used by flash review), which has the same lower-probability but real exposure.

## Test plan
- [x] New regression test: constructs a commit with a genuinely invalid byte via `git hash-object --stdin` (setting `GIT_AUTHOR_NAME` to a raw invalid byte doesn't reproduce this - confirmed git repairs it via Latin-1 reinterpretation before storing the commit; `hash-object` stores whatever bytes it's given, no validation).
- [x] Confirmed the test fails with the exact real crash (`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9`) when the fix is reverted, and passes with it restored.
- [x] Full suite: 680 passed.