### PR TITLE
fix: detect_languages() was missing Rust/Java/Ruby/PHP/C/C++/C#

### DIFF
--- a/prototype/aletheore/scanner/detect.py
+++ b/prototype/aletheore/scanner/detect.py
@@ -18,15 +18,6 @@ IGNORED_DIRS = {
     "obj",
 }
 
-EXTENSION_TO_LANGUAGE = {
-    ".py": "python",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".ts": "typescript",
-    ".tsx": "typescript",
-    ".go": "go",
-}
-
 FRAMEWORK_MARKERS_PY = {
     "fastapi": "fastapi",
     "flask": "flask",
@@ -222,11 +213,21 @@ def _iter_source_files(repo_path: Path):
 
 
 def detect_languages(repo_path: Path) -> list[dict]:
+    # Local import: graph.py already imports IGNORED_DIRS from this module, so a
+    # module-level import here would be circular. LANGUAGE_BY_EXTENSION is the
+    # single source of truth for "which extensions we support" - this used to be
+    # a second, separately-maintained mapping here that fell out of sync (missing
+    # Rust/Java/Ruby/PHP/C/C++/C# entirely - confirmed on a real scan where a
+    # C/C++-heavy repo reported zero C or C++ in its language summary despite
+    # both being fully parsed into the module graph).
+    from aletheore.scanner.graph import LANGUAGE_BY_EXTENSION
+
     counts: dict[str, dict] = {}
     for path in _iter_source_files(repo_path):
-        language = EXTENSION_TO_LANGUAGE.get(path.suffix)
-        if language is None:
+        entry_spec = LANGUAGE_BY_EXTENSION.get(path.suffix)
+        if entry_spec is None:
             continue
+        language = entry_spec[0]
         entry = counts.setdefault(language, {"name": language, "file_count": 0, "loc": 0})
         entry["file_count"] += 1
         try:

--- a/prototype/tests/test_detect.py
+++ b/prototype/tests/test_detect.py
@@ -39,6 +39,36 @@ def test_detect_languages_counts_files_and_loc(tmp_path):
     assert by_name["javascript"]["file_count"] == 1
 
 
+def test_detect_languages_covers_every_module_graph_language(tmp_path):
+    # detect_languages() used to keep its own, separately-maintained extension
+    # mapping that fell out of sync with graph.py's - it silently reported zero
+    # files for Rust, Java, Ruby, PHP, C, C++, and C# despite all of them being
+    # fully supported by the module graph (found on a real scan: a C/C++-heavy
+    # repo reported zero C or C++ in its language summary). It now reuses
+    # graph.py's mapping directly, so anything the module graph supports must
+    # show up here too.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.rs").write_text("fn main() {}\n")
+    (repo / "Main.java").write_text("class Main {}\n")
+    (repo / "app.rb").write_text("puts 1\n")
+    (repo / "index.php").write_text("<?php echo 1; ?>\n")
+    (repo / "main.c").write_text("int main() { return 0; }\n")
+    (repo / "util.hpp").write_text("int add(int a, int b);\n")
+    (repo / "Program.cs").write_text("class Program {}\n")
+
+    languages = detect_languages(repo)
+    by_name = {entry["name"]: entry for entry in languages}
+
+    assert by_name["rust"]["file_count"] == 1
+    assert by_name["java"]["file_count"] == 1
+    assert by_name["ruby"]["file_count"] == 1
+    assert by_name["php"]["file_count"] == 1
+    assert by_name["c"]["file_count"] == 1
+    assert by_name["cpp"]["file_count"] == 1
+    assert by_name["csharp"]["file_count"] == 1
+
+
 def test_detect_frameworks_reads_requirements_txt(tmp_path):
     repo = make_repo(tmp_path)
     frameworks = detect_frameworks(repo)


### PR DESCRIPTION
## Summary
Found via the same real Linux kernel scan that surfaced the previous two fixes: the language summary ("Detecting languages, frameworks, and build tools" - the first thing a scan reports) came back showing only Python, despite 36,851 C files and 26,887 C++/header files being fully parsed into the module graph moments later.

`detect.py` kept its own extension-to-language mapping, entirely separate from `graph.py`'s `LANGUAGE_BY_EXTENSION`, and it was never updated when Rust, Java, Ruby, PHP, C, C++, and C# support was added to the module graph - it only ever had Python, JS, TS, and Go.

`detect_languages()` now imports `LANGUAGE_BY_EXTENSION` directly (a local import - `graph.py` already imports `IGNORED_DIRS` from `detect.py`, so a module-level import the other way would be circular), making it the single source of truth so this specific class of bug can't recur when a language is added later.

## Test plan
- [x] New regression test: one file per previously-missing language (Rust, Java, Ruby, PHP, C, C++, C#), asserts `detect_languages()` counts all of them.
- [x] Full `prototype` suite: 681 passed.
- [x] Full `github-app` suite: 503 passed, 1 skipped.