### PR TITLE
fix: fail gracefully when git analysis is killed (likely OOM)

### DIFF
--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 DEMO_SCAN_QUEUE_NAME = "demo_scan"
 DEMO_SCAN_JOB_FUNCTION = "scan_worker.demo_scan.run_demo_scan_job"
 DEMO_SCAN_COOLDOWN_SECONDS = 20 * 60  # ~3 runs/hour per visitor
-DEMO_SCAN_MAX_QUEUE_DEPTH = 4  # queued + running, matches 2 dedicated workers
+DEMO_SCAN_MAX_QUEUE_DEPTH = 4  # queued + running, ahead of the single demo-scan-worker
 DEMO_SCAN_JOB_TIMEOUT_SECONDS = 120
 DEMO_SCAN_RESULT_TTL_SECONDS = 900
 
@@ -52,6 +52,31 @@ def _fetch_job(job_id: str, redis_url: str):
     from rq.job import Job
 
     return Job.fetch(job_id, connection=Redis.from_url(redis_url))
+
+
+_GENERIC_FAILURE_DETAIL = "scan failed - the repo may be invalid, private, or too large"
+
+
+def _failure_detail(exc_info: str | None) -> str:
+    # RQ only stores the failure as a formatted traceback string, no
+    # structured exception object - but that string's own last non-empty
+    # line is always "<ExceptionClassName>: <message>" (Python's own
+    # traceback format), so this reliably recovers just the message for our
+    # own deliberately-raised, user-facing DemoScanError. Anything else
+    # (a real bug, an unexpected exception type) falls back to the generic
+    # message rather than ever showing internal details to a public visitor.
+    if not exc_info:
+        return _GENERIC_FAILURE_DETAIL
+    lines = [line for line in exc_info.strip().splitlines() if line.strip()]
+    if not lines:
+        return _GENERIC_FAILURE_DETAIL
+    last_line = lines[-1]
+    prefix = "scan_worker.demo_scan.DemoScanError: "
+    if last_line.startswith(prefix):
+        return last_line[len(prefix):]
+    if last_line.startswith("DemoScanError: "):
+        return last_line[len("DemoScanError: "):]
+    return _GENERIC_FAILURE_DETAIL
 
 
 def _check_repo_size(owner: str, repo: str, token: str | None) -> None:
@@ -145,7 +170,7 @@ async def get_demo_scan_status(job_id: str):
         raise HTTPException(status_code=404, detail="job not found")
 
     if job.is_failed:
-        return {"status": "failed", "detail": "scan failed - the repo may be invalid, private, or too large"}
+        return {"status": "failed", "detail": _failure_detail(job.exc_info)}
     if job.is_finished:
         return {"status": "finished", "result": job.result}
     return {"status": job.get_status()}

--- a/github-app/scan_worker/demo_scan.py
+++ b/github-app/scan_worker/demo_scan.py
@@ -15,6 +15,8 @@ import logging
 import subprocess
 import uuid
 
+from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE
+
 logger = logging.getLogger(__name__)
 
 DEMO_SANDBOX_IMAGE = "aletheore-demo-sandbox:latest"
@@ -58,6 +60,19 @@ def _run_sandboxed_scan(repo_url: str) -> dict:
         # timeout using resources or holding the untrusted repo on disk.
         subprocess.run(["docker", "rm", "-f", container_name], capture_output=True)
         raise DemoScanError("scan timed out") from exc
+
+    if result.returncode == GIT_ANALYSIS_RESOURCE_EXIT_CODE:
+        # Confirmed directly: a full scan of the Linux kernel got OOM-killed
+        # under this same 1GB container limit. The demo's own 400MB repo-size
+        # cap makes this rare (400MB needs a small fraction of the memory
+        # Linux's 8.2GB needed), but a pathologically dense repo could still
+        # hit it - when it does, say so plainly instead of a generic failure.
+        logger.info("demo scan hit the memory limit for %s", repo_url)
+        raise DemoScanError(
+            "this repo needs more memory to scan than the live demo allows - install the "
+            "free CLI (`pip install aletheore`) and run `aletheore scan` locally, or "
+            "connect via MCP, with no size limit"
+        )
 
     if result.returncode != 0:
         logger.warning(

--- a/github-app/tests/test_demo_scan.py
+++ b/github-app/tests/test_demo_scan.py
@@ -96,6 +96,21 @@ def test_run_sandboxed_scan_raises_on_nonzero_exit(monkeypatch):
         _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
 
 
+def test_run_sandboxed_scan_gives_a_specific_message_when_memory_limited(monkeypatch):
+    # Confirmed directly: a full scan of the Linux kernel got OOM-killed
+    # under this same 1GB container limit, and the CLI (via GitAnalysisError)
+    # exits with GIT_ANALYSIS_RESOURCE_EXIT_CODE for exactly this case -
+    # the demo should say so plainly rather than a generic failure message.
+    from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE
+
+    def fake_run(cmd, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=GIT_ANALYSIS_RESOURCE_EXIT_CODE, stdout="", stderr="")
+
+    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    with pytest.raises(DemoScanError, match="pip install aletheore"):
+        _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+
+
 def test_run_sandboxed_scan_raises_on_non_json_stdout(monkeypatch):
     def fake_run(cmd, capture_output, text, timeout):
         return subprocess.CompletedProcess(cmd, returncode=0, stdout="not json", stderr="")

--- a/github-app/tests/test_demo_scan_api.py
+++ b/github-app/tests/test_demo_scan_api.py
@@ -210,13 +210,75 @@ async def test_get_status_returns_failed(pool, monkeypatch):
         func_name="scan_worker.demo_scan.run_demo_scan_job",
         is_finished=False,
         is_failed=True,
+        exc_info=None,
     )
     monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
     app.state.db_pool = pool
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/v1/demo-scan/demo-job-123")
     assert response.status_code == 200
-    assert response.json()["status"] == "failed"
+    body = response.json()
+    assert body["status"] == "failed"
+    assert body["detail"] == "scan failed - the repo may be invalid, private, or too large"
+
+
+@pytest.mark.asyncio
+async def test_get_status_surfaces_the_demo_scan_error_message(pool, monkeypatch):
+    # A public visitor should see WHY their scan failed when it's our own
+    # deliberate, user-facing DemoScanError (e.g. "too large for the live
+    # demo, install the CLI") - not the generic catch-all message.
+    exc_info = (
+        "Traceback (most recent call last):\n"
+        '  File "job.py", line 1, in run\n'
+        "    raise DemoScanError(msg)\n"
+        "scan_worker.demo_scan.DemoScanError: this repo needs more memory to scan "
+        "than the live demo allows - install the free CLI (`pip install aletheore`)\n"
+    )
+    fake_job = MagicMock(
+        origin="demo_scan",
+        func_name="scan_worker.demo_scan.run_demo_scan_job",
+        is_finished=False,
+        is_failed=True,
+        exc_info=exc_info,
+    )
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/demo-job-123")
+    assert response.status_code == 200
+    detail = response.json()["detail"]
+    assert "pip install aletheore" in detail
+    assert "Traceback" not in detail
+
+
+@pytest.mark.asyncio
+async def test_get_status_never_leaks_an_unexpected_exception_to_the_visitor(pool, monkeypatch):
+    # Any OTHER exception type (a real bug, not our own deliberate
+    # DemoScanError) must fall back to the generic message - never show
+    # internal implementation details on a public, unauthenticated endpoint.
+    exc_info = (
+        "Traceback (most recent call last):\n"
+        '  File "job.py", line 42, in run\n'
+        "    conn.execute(query)\n"
+        "psycopg.OperationalError: connection to server failed: FATAL: password "
+        "authentication failed for user \"internal_svc\"\n"
+    )
+    fake_job = MagicMock(
+        origin="demo_scan",
+        func_name="scan_worker.demo_scan.run_demo_scan_job",
+        is_finished=False,
+        is_failed=True,
+        exc_info=exc_info,
+    )
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/demo-job-123")
+    assert response.status_code == 200
+    detail = response.json()["detail"]
+    assert detail == "scan failed - the repo may be invalid, private, or too large"
+    assert "internal_svc" not in detail
+    assert "psycopg" not in detail
 
 
 @pytest.mark.asyncio

--- a/prototype/aletheore/cli.py
+++ b/prototype/aletheore/cli.py
@@ -28,6 +28,7 @@ from aletheore.adapters.opencode import OpenCodeAdapter
 from aletheore.credentials import get_api_key
 from aletheore.device_auth import infer_repo_full_name_from_cwd_git_remote
 from aletheore.evidence import scan_repository, write_evidence
+from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE, GitAnalysisError
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
 from aletheore.history import compute_diff, list_snapshots, save_snapshot
 from aletheore.managed_audit_client import ManagedAuditError, run_managed_audit_request
@@ -221,14 +222,18 @@ def _scan(
 ) -> tuple[int, dict, Path]:
     repo = Path(repo_path).resolve()
     console.print(f"Scanning {repo}...")
-    evidence = scan_repository(
-        repo,
-        check_vulnerabilities=check_vulnerabilities,
-        scan_git_history=scan_git_history,
-        check_licenses=check_licenses,
-        map_endpoints=map_endpoints,
-        progress=_make_progress_printer(),
-    )
+    try:
+        evidence = scan_repository(
+            repo,
+            check_vulnerabilities=check_vulnerabilities,
+            scan_git_history=scan_git_history,
+            check_licenses=check_licenses,
+            map_endpoints=map_endpoints,
+            progress=_make_progress_printer(),
+        )
+    except GitAnalysisError as exc:
+        console.print(f"[bold red]error:[/bold red] {exc}")
+        return GIT_ANALYSIS_RESOURCE_EXIT_CODE, {}, repo
     evidence_path = write_evidence(evidence, repo)
     console.print(f"[green]Evidence written to[/green] {evidence_path}")
     snapshot_path = save_snapshot(evidence, repo)
@@ -244,9 +249,11 @@ def _audit(
     check_licenses: bool = True,
     map_endpoints: bool = True,
 ) -> int:
-    _exit_code, _evidence, evidence_path = _scan(
+    scan_exit_code, _evidence, evidence_path = _scan(
         repo_path, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints
     )
+    if scan_exit_code != 0:
+        return scan_exit_code
     repo = Path(repo_path).resolve()
 
     try:
@@ -296,13 +303,15 @@ def _managed_audit(
         console.print("[bold red]error:[/bold red] no managed-audit token available")
         return 1
 
-    _exit_code, evidence, evidence_path = _scan(
+    scan_exit_code, evidence, evidence_path = _scan(
         repo_path,
         check_vulnerabilities,
         scan_git_history,
         check_licenses,
         map_endpoints,
     )
+    if scan_exit_code != 0:
+        return scan_exit_code
     repo = Path(repo_path).resolve()
     repo_full_name = infer_repo_full_name_from_cwd_git_remote(cwd=str(repo))
 

--- a/prototype/aletheore/git_intel/analyzer.py
+++ b/prototype/aletheore/git_intel/analyzer.py
@@ -5,6 +5,23 @@ from pathlib import Path
 MASS_COMMIT_FILE_THRESHOLD = 50
 HOTSPOT_LIMIT = 30
 
+# Distinct from the generic exit code 1 other scan failures use, so callers
+# that only see a subprocess exit code (scan_worker/jobs.py, demo_scan.py)
+# can tell "the repo is likely too large for the memory available" apart
+# from "something else went wrong" without parsing stderr text.
+GIT_ANALYSIS_RESOURCE_EXIT_CODE = 2
+
+
+class GitAnalysisError(RuntimeError):
+    """A git subprocess this module depends on failed or was killed - most
+    commonly the OS OOM killer on a repository whose history is too large
+    to walk in the memory available (confirmed directly: a full scan of
+    torvalds/linux under a 1GB cgroup limit got OOM-killed here). Raised
+    instead of letting execution continue with truncated/empty output,
+    which previously surfaced many call sites downstream as a confusing,
+    unrelated IndexError/ValueError instead of one clear signal.
+    """
+
 
 def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess:
     # errors="ignore" (matching secrets.py's git-log subprocess) - real commit
@@ -20,6 +37,23 @@ def _run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess:
         text=True,
         errors="ignore",
     )
+
+
+def _run_git_or_raise(repo_path: Path, *args: str) -> subprocess.CompletedProcess:
+    # For call sites past _has_commits() that assume success and parse the
+    # output unconditionally - a negative returncode means the process was
+    # killed by a signal (subprocess.run's documented convention), which for
+    # a `git log` over a huge history is almost always the OOM killer.
+    result = _run_git(repo_path, *args)
+    if result.returncode != 0:
+        command = " ".join(args)
+        if result.returncode < 0:
+            raise GitAnalysisError(
+                f"git {command} was killed (likely out of memory) - this repository's "
+                "history may be too large to analyze with the memory available"
+            )
+        raise GitAnalysisError(f"git {command} failed with exit code {result.returncode}")
+    return result
 
 
 def _has_commits(repo_path: Path) -> bool:
@@ -98,7 +132,7 @@ def _parse_branches(repo_path: Path, now: datetime) -> list[dict]:
 
 
 def _commit_cadence(repo_path: Path, now: datetime) -> dict:
-    result = _run_git(repo_path, "log", "--format=%ad", "--date=iso-strict", "HEAD")
+    result = _run_git_or_raise(repo_path, "log", "--format=%ad", "--date=iso-strict", "HEAD")
     dates = [datetime.fromisoformat(line) for line in result.stdout.strip().splitlines() if line]
     if not dates:
         return {"weekly_counts": [], "trend": "flat", "most_recent_week_partial": False}
@@ -137,7 +171,7 @@ def _commit_cadence(repo_path: Path, now: datetime) -> dict:
 
 
 def _ownership(repo_path: Path) -> list[dict]:
-    result = _run_git(repo_path, "log", "--format=%an\x1f%ae", "HEAD")
+    result = _run_git_or_raise(repo_path, "log", "--format=%an\x1f%ae", "HEAD")
     entries = [
         line.split("\x1f") for line in result.stdout.strip().splitlines() if line
     ]
@@ -160,8 +194,8 @@ def _ownership(repo_path: Path) -> list[dict]:
 
 
 def _commit_file_lists(repo_path: Path) -> list[list[str]]:
-    result = _run_git(repo_path, "log", "--format=%x00", "--name-only", "HEAD")
-    prefix_result = _run_git(repo_path, "rev-parse", "--show-prefix")
+    result = _run_git_or_raise(repo_path, "log", "--format=%x00", "--name-only", "HEAD")
+    prefix_result = _run_git_or_raise(repo_path, "rev-parse", "--show-prefix")
     prefix = prefix_result.stdout.strip()
     commits: list[list[str]] = []
     current: list[str] = []
@@ -225,10 +259,10 @@ def analyze_git(repo_path: Path, now: datetime | None = None) -> dict:
     if not _has_commits(repo_path):
         return {"available": False}
 
-    total_commits_result = _run_git(repo_path, "rev-list", "--count", "HEAD")
+    total_commits_result = _run_git_or_raise(repo_path, "rev-list", "--count", "HEAD")
     total_commits = int(total_commits_result.stdout.strip())
 
-    first_commit_result = _run_git(
+    first_commit_result = _run_git_or_raise(
         repo_path, "log", "--reverse", "--format=%ad", "--date=iso-strict", "HEAD"
     )
     first_commit_line = first_commit_result.stdout.strip().splitlines()[0]

--- a/prototype/tests/test_cli.py
+++ b/prototype/tests/test_cli.py
@@ -21,6 +21,7 @@ from aletheore.cli import (
     app,
 )
 from aletheore.device_auth import DeviceFlowError
+from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE, GitAnalysisError
 from aletheore.report import (
     AmbiguousAdapterError,
     NoAdapterAvailableError,
@@ -472,6 +473,35 @@ def test_main_audit_invokes_audit_flow(tmp_path):
 
     assert result.exit_code == 0
     mock_audit.assert_called_once_with(str(tmp_path), "claude", True, True, True, True)
+
+
+def test_scan_command_reports_git_analysis_error_cleanly(tmp_path):
+    # Found on a real scan of the Linux kernel under a memory-constrained
+    # container: a git subprocess getting OOM-killed used to surface as a
+    # raw, unrelated IndexError traceback instead of a clear message.
+    with patch(
+        "aletheore.cli.scan_repository",
+        side_effect=GitAnalysisError("git log was killed (likely out of memory)"),
+    ):
+        result = runner.invoke(app, ["scan", str(tmp_path)])
+
+    assert result.exit_code == GIT_ANALYSIS_RESOURCE_EXIT_CODE
+    assert "killed" in result.output
+    assert "Traceback" not in result.output
+    assert not isinstance(result.exception, GitAnalysisError)
+
+
+def test_audit_command_bails_out_cleanly_when_scan_hits_git_analysis_error(tmp_path):
+    with patch(
+        "aletheore.cli.scan_repository",
+        side_effect=GitAnalysisError("git log was killed (likely out of memory)"),
+    ):
+        with patch("aletheore.cli.select_adapter") as mock_select_adapter:
+            result = runner.invoke(app, ["audit", str(tmp_path)])
+
+    assert result.exit_code == GIT_ANALYSIS_RESOURCE_EXIT_CODE
+    assert "killed" in result.output
+    mock_select_adapter.assert_not_called()
 
 
 def test_known_adapters_includes_every_provider():

--- a/prototype/tests/test_git_intel.py
+++ b/prototype/tests/test_git_intel.py
@@ -3,7 +3,11 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
-from aletheore.git_intel.analyzer import analyze_git, compute_hotspots
+from unittest.mock import patch
+
+import pytest
+
+from aletheore.git_intel.analyzer import GitAnalysisError, analyze_git, compute_hotspots
 
 
 def run(repo: Path, *args: str):
@@ -173,6 +177,54 @@ def test_analyze_git_survives_non_utf8_author_name(tmp_path):
     assert result["available"] is True
     assert result["ownership"][0]["email"] == "old@example.com"
     assert result["ownership"][0]["commit_count"] == 1
+
+
+def _fail_only_on_git_log(returncode: int):
+    # _has_commits() (rev-parse/rev-list) must keep succeeding so analyze_git
+    # actually reaches the code path under test, rather than short-circuiting
+    # to {"available": False} the moment _run_git is patched to fail broadly.
+    def side_effect(repo_path, *args):
+        if args and args[0] == "log":
+            return subprocess.CompletedProcess(args=["git", *args], returncode=returncode, stdout="", stderr="")
+        if args == ("rev-parse", "--git-dir"):
+            return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout=".git\n", stderr="")
+        if args == ("rev-list", "-1", "HEAD"):
+            return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout="abc123\n", stderr="")
+        if args == ("rev-list", "--count", "HEAD"):
+            return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout="5\n", stderr="")
+        return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout="", stderr="")
+
+    return side_effect
+
+
+def test_analyze_git_raises_clear_error_when_git_log_is_killed(tmp_path):
+    # Confirmed directly: a full scan of torvalds/linux under a 1GB memory
+    # cgroup got OOM-killed here, and the OS reports a signal-killed process
+    # via a negative returncode (Python's documented convention) - this used
+    # to surface downstream as an unrelated, confusing IndexError instead of
+    # a clear "this failed, likely out of memory" signal.
+    repo = make_git_repo(tmp_path)
+
+    with patch("aletheore.git_intel.analyzer._run_git", side_effect=_fail_only_on_git_log(-9)):
+        with pytest.raises(GitAnalysisError, match="killed"):
+            analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
+
+
+def test_compute_hotspots_raises_clear_error_when_git_log_is_killed(tmp_path):
+    repo = make_git_repo(tmp_path)
+    killed = subprocess.CompletedProcess(args=["git", "log"], returncode=-9, stdout="", stderr="")
+
+    with patch("aletheore.git_intel.analyzer._run_git", return_value=killed):
+        with pytest.raises(GitAnalysisError, match="killed"):
+            compute_hotspots(repo, modules=[])
+
+
+def test_analyze_git_raises_clear_error_on_non_signal_git_failure(tmp_path):
+    repo = make_git_repo(tmp_path)
+
+    with patch("aletheore.git_intel.analyzer._run_git", side_effect=_fail_only_on_git_log(128)):
+        with pytest.raises(GitAnalysisError, match="exit code 128"):
+            analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
 
 
 def test_analyze_git_ahead_behind_main(tmp_path):


### PR DESCRIPTION
## Summary
Confirmed directly: a full scan of the Linux kernel under a memory-constrained (1GB) container - matching production's real `scan-worker` and `demo-sandbox` limits - was OOM-killed. The visible symptom was a raw, confusing `IndexError` deep inside `analyze_git()`, because a killed `git log` subprocess returns empty stdout and nothing downstream checked the subprocess's return code before parsing it.

- New `GitAnalysisError`, raised by the `analyzer.py` call sites that assume success (the ones `_has_commits()` already gates as normal control flow are untouched). Distinguishes "process was killed by a signal" (`returncode < 0` - almost always the OOM killer) from other git failures, both now clear, catchable errors instead of an unrelated crash several frames downstream.
- The CLI's `scan`/`audit`/`managed-audit` commands now catch this and print a clean message with a distinct exit code (`GIT_ANALYSIS_RESOURCE_EXIT_CODE`) instead of a raw traceback - also fixed two call sites (`_audit`, `_managed_audit`) that were silently discarding `_scan()`'s exit code entirely and would have proceeded with empty evidence.
- The public demo (`demo_scan.py`) recognizes this exact exit code and tells the visitor plainly: install the free CLI (`pip install aletheore`) for repos too large for the live demo's memory limit, rather than a generic failure. The status API surfaces this specific message (parsed from RQ's own `exc_info`) while still falling back to a generic message for any other, unexpected exception type - never leaking internal details to a public, unauthenticated visitor.
- Fixed a stale comment claiming `demo-scan-worker` runs "2 dedicated workers" - it's one (confirmed against `docker-compose.yml` and the worker code).

**Deliberately out of scope**: does not change the 1GB memory limit itself, and does not add customer-facing PR comments on the (separate, untouched) `scan_worker/jobs.py` customer-scan path - this is a "make the failure graceful" fix, not an infra or product-notification change.

## Test plan
- [x] New unit tests confirm the exact real failure (a signal-killed git subprocess) now raises a clear `GitAnalysisError` instead of crashing, for both `analyze_git` and `compute_hotspots`.
- [x] New CLI tests confirm `scan`/`audit` exit cleanly with the distinct exit code and no raw traceback.
- [x] New API tests confirm the public status endpoint surfaces the specific message for our own `DemoScanError`, but never leaks details from any other exception type.
- [x] Full `prototype` suite: 686 passed.
- [x] Full `github-app` suite: 506 passed, 1 skipped.