### PR TITLE
feat: tell demo-scan visitors when they're queued, not just "scanning"

### DIFF
--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -173,4 +173,13 @@ async def get_demo_scan_status(job_id: str):
         return {"status": "failed", "detail": _failure_detail(job.exc_info)}
     if job.is_finished:
         return {"status": "finished", "result": job.result}
-    return {"status": job.get_status()}
+
+    status = job.get_status()
+    if status == "queued":
+        # Only one worker consumes this queue (see demo_scan_worker.py), so
+        # without this a visitor waiting behind someone else's scan sees the
+        # same "scanning" message as the person actually being scanned, with
+        # no way to tell they're just waiting in line.
+        queue = _get_queue(settings.redis_url)
+        return {"status": "queued", "queue_position": queue.get_job_position(job.id)}
+    return {"status": status}

--- a/github-app/tests/test_demo_scan_api.py
+++ b/github-app/tests/test_demo_scan_api.py
@@ -296,3 +296,27 @@ async def test_get_status_returns_pending_status_while_running(pool, monkeypatch
         response = await client.get("/v1/demo-scan/demo-job-123")
     assert response.status_code == 200
     assert response.json() == {"status": "started"}
+
+
+@pytest.mark.asyncio
+async def test_get_status_includes_queue_position_while_queued(pool, monkeypatch):
+    # A visitor waiting behind someone else's scan must be told they're
+    # queued (and roughly how long the wait is), not shown the same message
+    # as the person actually being scanned.
+    fake_job = MagicMock(
+        origin="demo_scan",
+        func_name="scan_worker.demo_scan.run_demo_scan_job",
+        is_finished=False,
+        is_failed=False,
+    )
+    fake_job.get_status.return_value = "queued"
+    fake_queue = MagicMock()
+    fake_queue.get_job_position.return_value = 2
+    monkeypatch.setattr("app_server.demo_scan_api._fetch_job", lambda job_id, redis_url: fake_job)
+    monkeypatch.setattr("app_server.demo_scan_api._get_queue", lambda redis_url: fake_queue)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/v1/demo-scan/demo-job-123")
+    assert response.status_code == 200
+    assert response.json() == {"status": "queued", "queue_position": 2}
+    fake_queue.get_job_position.assert_called_once_with(fake_job.id)

--- a/website/live-demo.js
+++ b/website/live-demo.js
@@ -18,6 +18,21 @@ function setStatus(message, isError) {
   el.classList.toggle("is-error", Boolean(isError));
 }
 
+function queueStatusMessage(body) {
+  // Only one worker runs demo scans (see demo_scan_worker.py) - without
+  // this, a visitor waiting behind someone else's scan saw the exact same
+  // "scanning" message as the person actually being scanned, with no way
+  // to tell they were just waiting in line.
+  if (body.status === "queued") {
+    const position = body.queue_position;
+    if (position === null || position === undefined || position <= 0) {
+      return "You're next in line - starting shortly...";
+    }
+    return `Waiting in queue - ${position} request${position === 1 ? "" : "s"} ahead of you...`;
+  }
+  return "Scanning your repo in an isolated sandbox...";
+}
+
 function resetButton() {
   const button = document.getElementById("live-demo-submit");
   button.disabled = false;
@@ -81,7 +96,7 @@ async function pollJob(jobId) {
     resetButton();
     return;
   }
-  setStatus("Scanning your repo in an isolated sandbox...");
+  setStatus(queueStatusMessage(body));
   setTimeout(() => pollJob(jobId), POLL_INTERVAL_MS);
 }
 
@@ -117,7 +132,6 @@ async function handleSubmit(event) {
   }
 
   button.textContent = "Scanning...";
-  setStatus("Scanning your repo in an isolated sandbox...");
   pollJob(body.job_id);
 }
 


### PR DESCRIPTION
## Summary
Only one worker runs demo scans (confirmed while investigating a related question), so a visitor waiting behind someone else's request saw the exact same "Scanning your repo in an isolated sandbox..." message as the person actually being scanned - no way to tell they were just waiting in line.

The status API now includes the job's queue position (RQ's own `Queue.get_job_position`, 0-indexed) whenever status is `"queued"`. The frontend shows "You're next in line" at position 0, or "N requests ahead of you" otherwise, and only shows the "scanning" message once the job has actually started.

## Test plan
- [x] New API test confirms `queue_position` is included and correctly sourced from RQ when status is queued.
- [x] Verified `queueStatusMessage()` directly in the browser: correct singular/plural wording, correct "next in line" fallback when position is 0 or missing.
- [x] Full suite: 507 passed, 1 skipped.