### PR TITLE
fix: address real bugs surfaced by Aletheore's own Flash review

### DIFF
--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -43,6 +44,33 @@ def _github_oauth_http_client() -> httpx.Client:
 
 def _github_http_client() -> httpx.Client:
     return httpx.Client(base_url="https://api.github.com")
+
+
+def _exchange_code_and_fetch_user(code: str, client_id: str, client_secret: str) -> tuple[str, dict]:
+    # Synchronous httpx.Client calls, run off the event loop via
+    # asyncio.to_thread by the caller - this whole function otherwise blocks
+    # every other request the server is handling for its duration.
+    token_response = _github_oauth_http_client().post(
+        "/login/oauth/access_token",
+        headers={"Accept": "application/json"},
+        data={"client_id": client_id, "client_secret": client_secret, "code": code},
+    )
+    token_response.raise_for_status()
+    access_token = token_response.json()["access_token"]
+
+    user_response = _github_http_client().get(
+        "/user",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    user_response.raise_for_status()
+    return access_token, user_response.json()
+
+
+def _fetch_installation_details(installation_id: int, app_jwt: str) -> dict:
+    return get_installation_details(installation_id, app_jwt, _github_http_client())
 
 
 def sign_session_id(session_id: str, secret: str) -> str:
@@ -142,27 +170,9 @@ async def callback(code: str, request: Request, state: str | None = None, instal
         if not expected_state or not state or not hmac.compare_digest(expected_state, state):
             raise HTTPException(status_code=400, detail="invalid oauth state")
 
-    token_response = _github_oauth_http_client().post(
-        "/login/oauth/access_token",
-        headers={"Accept": "application/json"},
-        data={
-            "client_id": settings.github_client_id,
-            "client_secret": settings.github_client_secret,
-            "code": code,
-        },
+    access_token, user = await asyncio.to_thread(
+        _exchange_code_and_fetch_user, code, settings.github_client_id, settings.github_client_secret
     )
-    token_response.raise_for_status()
-    access_token = token_response.json()["access_token"]
-
-    user_response = _github_http_client().get(
-        "/user",
-        headers={
-            "Authorization": f"Bearer {access_token}",
-            "Accept": "application/vnd.github+json",
-        },
-    )
-    user_response.raise_for_status()
-    user = user_response.json()
 
     session_id = secrets.token_urlsafe(32)
     await create_session(
@@ -184,7 +194,7 @@ async def callback(code: str, request: Request, state: str | None = None, instal
         # the normal (slightly delayed) path instead of breaking sign-in.
         try:
             app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
-            installation = get_installation_details(installation_id, app_jwt, _github_http_client())
+            installation = await asyncio.to_thread(_fetch_installation_details, installation_id, app_jwt)
             await upsert_installation(
                 request.app.state.db_pool, installation_id, installation["account"]["login"]
             )

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -16,6 +16,8 @@ class Settings:
     internal_metrics_token: str | None
     audit_signing_private_key: str
     paddle_webhook_secret: str
+    paddle_client_token: str
+    paddle_environment: str
     github_app_slug: str
     github_demo_readonly_token: str | None
 
@@ -44,7 +46,31 @@ def _load_private_key() -> str:
     return _required_env("GITHUB_APP_PRIVATE_KEY")
 
 
+def _paddle_environment() -> str:
+    # Flash review (PR #32) correctly flagged hardcoded sandbox Paddle
+    # credentials in frontend.py: a deploy that silently forgot to swap them
+    # would take real payments in sandbox mode forever, or reject them
+    # outright. Failing loudly here beats a live checkout that quietly never
+    # charges anyone.
+    value = os.environ.get("PADDLE_ENVIRONMENT", "sandbox").strip() or "sandbox"
+    if value not in ("sandbox", "production"):
+        raise RuntimeError(f"PADDLE_ENVIRONMENT must be 'sandbox' or 'production', got {value!r}")
+    return value
+
+
+def _paddle_client_token(environment: str) -> str:
+    token = _required_env("PADDLE_CLIENT_TOKEN")
+    if environment == "production" and token.startswith("test_"):
+        raise RuntimeError(
+            "PADDLE_ENVIRONMENT is 'production' but PADDLE_CLIENT_TOKEN looks like a sandbox "
+            "token (starts with 'test_') - refusing to start with a config that would silently "
+            "process live checkouts against the sandbox"
+        )
+    return token
+
+
 def get_settings() -> Settings:
+    paddle_environment = _paddle_environment()
     return Settings(
         database_url=os.environ["DATABASE_URL"],
         redis_url=os.environ.get("REDIS_URL", "redis://localhost:6379/0"),
@@ -58,6 +84,8 @@ def get_settings() -> Settings:
         internal_metrics_token=os.environ.get("INTERNAL_METRICS_TOKEN", "").strip() or None,
         audit_signing_private_key=_required_env("AUDIT_SIGNING_PRIVATE_KEY"),
         paddle_webhook_secret=_required_env("PADDLE_WEBHOOK_SECRET"),
+        paddle_client_token=_paddle_client_token(paddle_environment),
+        paddle_environment=paddle_environment,
         github_app_slug=_required_env("GITHUB_APP_SLUG"),
         # Only used to raise the rate limit on the pre-clone repo-size check
         # for the public demo (60/hr unauthenticated vs 5000/hr with a

--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -79,14 +79,15 @@ def _failure_detail(exc_info: str | None) -> str:
     return _GENERIC_FAILURE_DETAIL
 
 
-def _check_repo_size(owner: str, repo: str, token: str | None) -> None:
+async def _check_repo_size(owner: str, repo: str, token: str | None) -> None:
     headers = {"Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
     try:
-        response = httpx.get(
-            f"https://api.github.com/repos/{owner}/{repo}", headers=headers, timeout=10.0
-        )
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"https://api.github.com/repos/{owner}/{repo}", headers=headers, timeout=10.0
+            )
     except httpx.HTTPError as exc:
         raise HTTPException(status_code=502, detail="could not reach GitHub - try again shortly") from exc
 
@@ -127,7 +128,7 @@ async def start_demo_scan(request: Request, body: StartDemoScanRequest):
     # reserved - a repo that gets rejected here never reaches a worker, so
     # it shouldn't cost the visitor their one scan every 20 minutes. Only a
     # request that's actually eligible to run consumes the cooldown.
-    _check_repo_size(owner, repo, settings.github_demo_readonly_token)
+    await _check_repo_size(owner, repo, settings.github_demo_readonly_token)
 
     allowed = await check_and_reserve_demo_scan(pool, _client_ip(request), DEMO_SCAN_COOLDOWN_SECONDS)
     if not allowed:

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -23,6 +23,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app_server.admin import _administered_installation_ids
 from app_server.auth import SESSION_COOKIE_NAME, get_current_session
+from app_server.config import get_settings
 from app_server.db import list_installations_for_ids
 from app_server.github_install import github_app_install_url
 from app_server.paddle_pricing import resolve_price_id_for_plan
@@ -1259,9 +1260,6 @@ def _no_store_html(content: str) -> HTMLResponse:
     return HTMLResponse(content, headers={"Cache-Control": "no-store"})
 
 
-PADDLE_CLIENT_TOKEN = "test_4c86268368fd75d088763f49248"
-PADDLE_ENVIRONMENT = "sandbox"
-
 _VALID_PLANS = ("indie", "team", "enterprise")
 _VALID_INTERVALS = ("month", "year")
 
@@ -1319,11 +1317,12 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
         <p><a href="/dashboard">Cancel</a></p>
         """
 
+    settings = get_settings()
     return _subscribe_page("Subscribe", body) + f"""
 <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
 <script>
-Paddle.Environment.set("{PADDLE_ENVIRONMENT}");
-Paddle.Initialize({{ token: "{PADDLE_CLIENT_TOKEN}" }});
+Paddle.Environment.set("{settings.paddle_environment}");
+Paddle.Initialize({{ token: "{settings.paddle_client_token}" }});
 document.getElementById("continue-checkout").addEventListener("click", (event) => {{
   const btn = event.currentTarget;
   const selected = document.querySelector('input[name="installation_id"]:checked');

--- a/github-app/scan_worker/demo_scan.py
+++ b/github-app/scan_worker/demo_scan.py
@@ -15,13 +15,19 @@ import logging
 import subprocess
 import uuid
 
-from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE
-
 logger = logging.getLogger(__name__)
 
 DEMO_SANDBOX_IMAGE = "aletheore-demo-sandbox:latest"
 CONTAINER_TIMEOUT_SECONDS = 90
 MAX_LISTED_ITEMS = 5
+
+# Mirrors aletheore.git_intel.analyzer.GIT_ANALYSIS_RESOURCE_EXIT_CODE.
+# Inlined rather than imported: this container deliberately excludes the
+# aletheore package and its dependency tree (see Dockerfile.demo-scan-worker)
+# - importing it here would crash this worker on startup with no aletheore
+# installed. The scan runs inside aletheore-demo-sandbox, which does have the
+# real package; only its exit code crosses the container boundary.
+GIT_ANALYSIS_RESOURCE_EXIT_CODE = 2
 
 
 class DemoScanError(RuntimeError):

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -22,6 +22,7 @@ os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-client-secret")
 os.environ.setdefault("SESSION_SECRET", "test-session-secret")
 os.environ.setdefault("AUDIT_SIGNING_PRIVATE_KEY", "11" * 32)
 os.environ.setdefault("PADDLE_WEBHOOK_SECRET", "pdl_ntfset_test_secret")
+os.environ.setdefault("PADDLE_CLIENT_TOKEN", "test_conftest_client_token")
 os.environ.setdefault("PUBLIC_BASE_URL", "http://test")
 
 

--- a/github-app/tests/test_demo_scan_api.py
+++ b/github-app/tests/test_demo_scan_api.py
@@ -8,10 +8,10 @@ from app_server.main import app
 
 
 def _mock_github_response(monkeypatch, status_code: int, size_kb: int = 100):
-    def fake_get(url, headers=None, timeout=None):
+    async def fake_get(self, url, headers=None, timeout=None):
         return httpx.Response(status_code, json={"size": size_kb}, request=httpx.Request("GET", url))
 
-    monkeypatch.setattr("app_server.demo_scan_api.httpx.get", fake_get)
+    monkeypatch.setattr("app_server.demo_scan_api.httpx.AsyncClient.get", fake_get)
 
 
 def _mock_queue(monkeypatch, count: int = 0, started_count: int = 0, job_id: str = "demo-job-123"):

--- a/prototype/aletheore/dead_code.py
+++ b/prototype/aletheore/dead_code.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
 
-from aletheore.vulnerabilities import _parse_npm_pins, _parse_pip_pins
+from aletheore.vulnerabilities import _parse_npm_direct_pins, _parse_pip_pins
 
 ENTRY_POINT_FILENAMES = {
     "__init__.py",
@@ -86,7 +86,7 @@ def find_dead_code(repo_path: Path, modules: list[dict], config: dict | None) ->
 
     imported_roots = _import_roots(modules)
     unused_dependencies = []
-    for name, _version, ecosystem in _parse_pip_pins(repo_path) + _parse_npm_pins(repo_path):
+    for name, _version, ecosystem in _parse_pip_pins(repo_path) + _parse_npm_direct_pins(repo_path):
         # Static import-name matching is intentionally conservative. Some packages expose
         # different import roots than their package names; known common aliases live above.
         if imported_roots.isdisjoint(_package_import_names(name)):

--- a/prototype/aletheore/vulnerabilities.py
+++ b/prototype/aletheore/vulnerabilities.py
@@ -93,7 +93,35 @@ def _parse_pip_pins(repo_path: Path) -> list[tuple[str, str, str]]:
     return pins
 
 
+def _parse_npm_direct_pins(repo_path: Path) -> list[tuple[str, str, str]]:
+    # package.json only, deliberately never package-lock.json: this is used
+    # for checks that ask "is a *declared* dependency unused", where a lock
+    # file's full transitive tree would be wrong - a transitive package was
+    # never something your own code could import directly, so it would
+    # always look "unused" and drown every real finding in noise (confirmed
+    # on this repo: cspell's ~200 transitive packages, 0 of them actually
+    # unused - only cspell/markdownlint-cli2/prettier are real candidates).
+    package_json = repo_path / "package.json"
+    if not package_json.exists():
+        return []
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8", errors="ignore"))
+    except json.JSONDecodeError:
+        return []
+    deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
+    pins = []
+    for name, version in deps.items():
+        cleaned = _clean_range_version(version)
+        if cleaned:
+            pins.append((name, cleaned, "npm"))
+    return pins
+
+
 def _parse_npm_pins(repo_path: Path) -> list[tuple[str, str, str]]:
+    # package-lock.json preferred here: vulnerability scanning wants the
+    # full resolved transitive tree, since a vulnerable indirect dependency
+    # is still a real risk. See _parse_npm_direct_pins for the opposite
+    # need (dead-code's unused-dependency check).
     package_lock = repo_path / "package-lock.json"
     if package_lock.exists():
         try:
@@ -111,20 +139,7 @@ def _parse_npm_pins(repo_path: Path) -> list[tuple[str, str, str]]:
         if pins:
             return pins
 
-    package_json = repo_path / "package.json"
-    if not package_json.exists():
-        return []
-    try:
-        data = json.loads(package_json.read_text(encoding="utf-8", errors="ignore"))
-    except json.JSONDecodeError:
-        return []
-    deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
-    pins = []
-    for name, version in deps.items():
-        cleaned = _clean_range_version(version)
-        if cleaned:
-            pins.append((name, cleaned, "npm"))
-    return pins
+    return _parse_npm_direct_pins(repo_path)
 
 
 def _parse_go_pins(repo_path: Path) -> list[tuple[str, str, str]]:

--- a/prototype/tests/test_dead_code.py
+++ b/prototype/tests/test_dead_code.py
@@ -46,3 +46,33 @@ def test_unused_dependency_flagged_when_never_imported(tmp_path):
     unused = {(dependency["ecosystem"], dependency["package"]) for dependency in result["unused_dependencies"]}
     assert ("PyPI", "requests") in unused
     assert ("PyPI", "flask") not in unused
+
+
+def test_npm_transitive_lockfile_dependencies_are_never_reported_as_unused(tmp_path):
+    # Confirmed on this repo: a package-lock.json's "packages" map lists every
+    # resolved transitive dependency, not just what's declared in package.json
+    # - checking all of them against import statements flagged ~200 of
+    # cspell's own transitive packages as "unused" even though only cspell
+    # itself is a real, directly-declared dependency your code could ever
+    # import. Only package.json's direct dependencies are valid candidates.
+    import json
+
+    (tmp_path / "package.json").write_text(json.dumps({"devDependencies": {"cspell": "^8.17.5"}}))
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "": {"devDependencies": {"cspell": "^8.17.5"}},
+                    "node_modules/cspell": {"version": "8.17.5"},
+                    "node_modules/cspell-lib": {"version": "8.17.5"},
+                    "node_modules/chalk": {"version": "5.3.0"},
+                }
+            }
+        )
+    )
+    modules = [_module("app/index.js")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    unused = {dependency["package"] for dependency in result["unused_dependencies"]}
+    assert "cspell-lib" not in unused
+    assert "chalk" not in unused
+    assert "cspell" in unused


### PR DESCRIPTION
## Summary
- `demo-scan-worker` imported from the `aletheore` package at module level, but its Dockerfile deliberately never installs it - the next rebuild would have crash-looped the entire demo queue. Inlined the one constant it needed instead (Flash finding on #41).
- `_check_repo_size` and `auth.py`'s OAuth callback made blocking sync `httpx` calls inside async routes, serializing the event loop on every demo scan request and every sign-in (Flash findings on #36 and #34).
- `frontend.py` hardcoded a sandbox Paddle client token and environment directly in source (Flash finding on #32, never fixed) - moved to env-driven config that refuses to start in production with a sandbox-looking token.

## Test plan
- [x] `github-app` suite: 508 passed
- [x] `prototype` suite: 686 passed
- [x] Manually traced each finding against current code before fixing (not just applying Flash's suggestion blindly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)