### PR TITLE
fix: don't flag main-guarded scripts or HTML-loaded JS as dead code

### DIFF
--- a/prototype/aletheore/dead_code.py
+++ b/prototype/aletheore/dead_code.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 
+from aletheore.scanner.detect import IGNORED_DIRS
 from aletheore.vulnerabilities import _parse_npm_direct_pins, _parse_pip_pins
 
 ENTRY_POINT_FILENAMES = {
@@ -35,11 +36,57 @@ PACKAGE_IMPORT_ALIASES = {
     "scikit-learn": {"sklearn"},
 }
 
+# A file run directly (`python worker.py`, `python -m pkg.worker`) is never
+# imported by another module, so it always looks unreachable by that signal
+# alone - but a __main__ guard means it's deliberately invoked, not dead.
+# Confirmed on this repo: RQ worker processes and standalone scripts/*.py
+# CLI tools all follow this convention regardless of filename.
+_MAIN_GUARD_PATTERN = re.compile(r"if\s+__name__\s*==\s*[\'\"]__main__[\'\"]\s*:")
+
+_HTML_SCRIPT_SRC_PATTERN = re.compile(r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE)
+
 
 def _is_entry_point(path: str, custom_entry_points: set[str]) -> bool:
     if path in custom_entry_points:
         return True
     return path.rsplit("/", 1)[-1] in ENTRY_POINT_FILENAMES
+
+
+def _has_main_guard(repo_path: Path, path: str) -> bool:
+    if not path.endswith(".py"):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(_MAIN_GUARD_PATTERN.search(content))
+
+
+def _html_script_entry_points(repo_path: Path) -> set[str]:
+    # Plain <script src="..."> tags (no bundler, no ES module imports) are
+    # invisible to the JS import graph - confirmed on this repo's website/:
+    # every JS file loaded that way looked unreachable despite being the
+    # actual entry point a browser executes.
+    entry_points = set()
+    for html_file in repo_path.rglob("*.html"):
+        rel_parts = html_file.relative_to(repo_path).parts
+        if any(part in IGNORED_DIRS for part in rel_parts):
+            continue
+        try:
+            content = html_file.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for match in _HTML_SCRIPT_SRC_PATTERN.finditer(content):
+            src = match.group(1)
+            if src.startswith(("http://", "https://", "//")):
+                continue
+            resolved = (html_file.parent / src).resolve()
+            try:
+                rel = resolved.relative_to(repo_path.resolve())
+            except ValueError:
+                continue
+            entry_points.add(rel.as_posix())
+    return entry_points
 
 
 def _is_test_file(path: str) -> bool:
@@ -70,6 +117,8 @@ def find_dead_code(repo_path: Path, modules: list[dict], config: dict | None) ->
         if isinstance(raw_entry_points, list):
             custom_entry_points = {path for path in raw_entry_points if isinstance(path, str)}
 
+    html_script_entry_points = _html_script_entry_points(repo_path)
+
     unreachable_modules = []
     entry_points_detected = []
     for module in modules:
@@ -80,6 +129,9 @@ def find_dead_code(repo_path: Path, modules: list[dict], config: dict | None) ->
         if _is_test_file(path):
             continue
         if not module.get("imported_by", []):
+            if path in html_script_entry_points or _has_main_guard(repo_path, path):
+                entry_points_detected.append(path)
+                continue
             unreachable_modules.append(
                 {"path": path, "reason": "no other module imports this file"}
             )

--- a/prototype/tests/test_dead_code.py
+++ b/prototype/tests/test_dead_code.py
@@ -48,6 +48,54 @@ def test_unused_dependency_flagged_when_never_imported(tmp_path):
     assert ("PyPI", "flask") not in unused
 
 
+def test_script_with_main_guard_is_never_unreachable(tmp_path):
+    # Found on this repo: RQ worker processes and standalone CLI scripts are
+    # run directly (`python -m scan_worker.worker`, `python scripts/foo.py`),
+    # never imported by another module - a `__main__` guard is a strong
+    # signal that a file is meant to be invoked that way, filename aside.
+    (tmp_path / "worker.py").write_text(
+        "def main():\n    pass\n\nif __name__ == '__main__':\n    main()\n"
+    )
+    modules = [_module("worker.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "worker.py" in result["entry_points_detected"]
+
+
+def test_script_without_main_guard_is_still_unreachable(tmp_path):
+    # A __main__-guard file with no other references is a legitimate,
+    # deliberately-invoked entry point (see above) - a plain orphan module
+    # with no guard and no importer is not, and must still be flagged. This
+    # is the false-negative guard rail on the fix above.
+    (tmp_path / "orphan.py").write_text("def helper():\n    pass\n")
+    modules = [_module("orphan.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [module["path"] for module in result["unreachable_modules"]]
+    assert "orphan.py" in paths
+
+
+def test_js_referenced_by_html_script_tag_is_never_unreachable(tmp_path):
+    # Found on this repo: plain <script src="..."> tags (no bundler, no ES
+    # module imports) load website JS - the import graph never sees these
+    # references, so every one of these files looked unreachable.
+    (tmp_path / "index.html").write_text(
+        '<html><body><script src="script.js"></script></body></html>'
+    )
+    (tmp_path / "script.js").write_text("console.log('hi');")
+    modules = [_module("script.js")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "script.js" in result["entry_points_detected"]
+
+
+def test_js_not_referenced_by_any_html_is_still_unreachable(tmp_path):
+    (tmp_path / "index.html").write_text('<html><body>no scripts here</body></html>')
+    modules = [_module("orphan.js")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [module["path"] for module in result["unreachable_modules"]]
+    assert "orphan.js" in paths
+
+
 def test_npm_transitive_lockfile_dependencies_are_never_reported_as_unused(tmp_path):
     # Confirmed on this repo: a package-lock.json's "packages" map lists every
     # resolved transitive dependency, not just what's declared in package.json


### PR DESCRIPTION
## Summary
- Second real finding from running `aletheore scan .` on this repo: dead code's "unreachable module" check flagged 9 files that are actually legitimate entry points - RQ worker scripts (`python -m scan_worker.worker`), standalone CLI tools under `scripts/`, and website JS loaded via `<script src>` rather than ES imports.
- Added two narrowly-scoped signals, both gated to modules that already have zero importers, so nothing that's genuinely dead gets a new way to hide:
  - `__main__` guard detection for Python files
  - HTML `<script src>` parsing to seed additional JS entry points
- Re-ran the real scan after the fix: unreachable count went from 9 to 0.

## Test plan
- [x] 4 new tests (main-guard true/false case, HTML-script true/false case) - written failing first, confirmed they failed, then confirmed they pass
- [x] Full `prototype` suite: 691 passed
- [x] Re-ran `aletheore scan .` on this repo directly and confirmed 0 unreachable modules (was 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)