### PR TITLE
fix: evidence-packet cache never worked - Ollama context too small

### DIFF
--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -7,6 +7,23 @@ import httpx
 
 EMBEDDING_MODEL = "nomic-embed-text"
 
+# nomic-embed-text supports an 8192-token context, but Ollama's own default
+# (2048) is much smaller and silently truncates/errors past it - confirmed
+# in production: every real embedding call failed with "input (N tokens) is
+# too large to process" against the 2048 default, so the cache never
+# recorded a single hit despite running for 38 hours. num_ctx below asks
+# Ollama to actually use the model's real capacity.
+EMBEDDING_NUM_CTX = 8192
+
+# A conservative ~3 chars/token estimate for TOON-encoded evidence (denser
+# than prose - lots of short identifiers and punctuation) keeps even the
+# largest real packets seen in production (52k+ tokens) under the model's
+# context window, rather than sending something guaranteed to fail. A
+# truncated embedding is still useful for similarity matching; the exact
+# text match isn't needed, and a cache hit is always re-verified against
+# current evidence regardless of how it was found.
+MAX_EMBEDDING_CHARS = EMBEDDING_NUM_CTX * 3
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,11 +32,17 @@ def _client(base_url: str | None = None) -> httpx.Client:
 
 
 def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 5.0) -> list[float] | None:
+    if len(text) > MAX_EMBEDDING_CHARS:
+        text = text[:MAX_EMBEDDING_CHARS]
     try:
         with _client(base_url) as client:
             response = client.post(
                 "/api/embeddings",
-                json={"model": EMBEDDING_MODEL, "prompt": text},
+                json={
+                    "model": EMBEDDING_MODEL,
+                    "prompt": text,
+                    "options": {"num_ctx": EMBEDDING_NUM_CTX},
+                },
                 timeout=timeout_seconds,
             )
             response.raise_for_status()

--- a/github-app/tests/test_embedding_client.py
+++ b/github-app/tests/test_embedding_client.py
@@ -1,6 +1,8 @@
+import json
+
 import httpx
 
-from scan_worker.embedding_client import embed_text
+from scan_worker.embedding_client import MAX_EMBEDDING_CHARS, embed_text
 
 
 def test_embed_text_returns_vector_on_success(monkeypatch):
@@ -16,6 +18,50 @@ def test_embed_text_returns_vector_on_success(monkeypatch):
     result = embed_text("some evidence text")
 
     assert result == [0.1, 0.2, 0.3]
+
+
+def test_embed_text_requests_the_models_real_context_window(monkeypatch):
+    # Confirmed in production: Ollama's own default (2048) is far smaller
+    # than nomic-embed-text's real 8192-token context, and every real
+    # embedding call failed against that default - the cache never recorded
+    # a single hit despite running for 38 hours.
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"embedding": [0.1]})
+
+    monkeypatch.setattr(
+        "scan_worker.embedding_client._client",
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+    )
+
+    embed_text("some evidence text")
+
+    assert seen["body"]["options"] == {"num_ctx": 8192}
+
+
+def test_embed_text_truncates_oversized_input(monkeypatch):
+    # A real production packet hit 52k+ tokens - even with num_ctx raised to
+    # the model's real max, that's still too large for a single embedding
+    # call. Truncating keeps the call from failing outright; the exact text
+    # match isn't needed for similarity matching, and any cache hit found
+    # this way is still re-verified against current evidence before being
+    # served.
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["prompt"] = json.loads(request.content)["prompt"]
+        return httpx.Response(200, json={"embedding": [0.1]})
+
+    monkeypatch.setattr(
+        "scan_worker.embedding_client._client",
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+    )
+
+    embed_text("x" * (MAX_EMBEDDING_CHARS + 5000))
+
+    assert len(seen["prompt"]) == MAX_EMBEDDING_CHARS
 
 
 def test_embed_text_uses_explicit_base_url(monkeypatch):


### PR DESCRIPTION
## Summary
Caught while checking prod logs during an unrelated deploy: AIRview's evidence-packet similarity cache has been live for 38 hours and has never recorded a single successful embedding call. Ollama's default context window (2048 tokens) is far smaller than `nomic-embed-text`'s real 8192-token capacity - even the smallest real packet in production logs (2137 tokens) exceeded it, and the largest (52k+ tokens) badly so.

The failure path is exactly as designed - it degrades to a fresh model call, never breaks a build - which is also why this was silent: a warning log, no errors, just a permanently 0% hit rate.

- Pass `options.num_ctx: 8192` so Ollama actually uses the model's real context instead of its conservative default.
- Truncate input text to a safe character budget for packets too large even for that (a truncated embedding is still useful for similarity matching, and any hit is re-verified against current evidence regardless of how it was found).

## Test plan
- [x] 2 new tests proving `num_ctx` is sent and oversized input is truncated
- [x] Full `github-app` suite: 503 passed, 7 skipped (skips are a pre-existing, gitignored local-fixture self-check unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)