### PR TITLE
fix: correct nomic-embed-text's real context limit (2048, not 8192)

### DIFF
--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -112,6 +112,14 @@ services:
   ollama:
     image: ollama/ollama:latest
     restart: unless-stopped
+    # Tried OLLAMA_CONTEXT_LENGTH=8192 here first, assuming nomic-embed-text
+    # supports an 8192-token context - it doesn't, not on the GGUF this
+    # pulls: confirmed directly against the running server that the model's
+    # own trained context is a hard 2048, and requesting more just logged
+    # "requested context size too large for model" and got silently
+    # clamped back down. The real fix is keeping input within that limit
+    # (see MAX_EMBEDDING_CHARS in scan_worker/embedding_client.py), not a
+    # server setting that can't raise a ceiling the model itself doesn't have.
     volumes:
       - aletheore_ollama_data:/root/.ollama
     entrypoint: ["/bin/sh", "-c"]

--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -7,22 +7,27 @@ import httpx
 
 EMBEDDING_MODEL = "nomic-embed-text"
 
-# nomic-embed-text supports an 8192-token context, but Ollama's own default
-# (2048) is much smaller and silently truncates/errors past it - confirmed
-# in production: every real embedding call failed with "input (N tokens) is
-# too large to process" against the 2048 default, so the cache never
-# recorded a single hit despite running for 38 hours. num_ctx below asks
-# Ollama to actually use the model's real capacity.
-EMBEDDING_NUM_CTX = 8192
+# The pulled nomic-embed-text GGUF's own metadata caps it at a real,
+# hard 2048-token training context (confirmed directly against the running
+# server: `nomic-bert.context_length = 2048`, and requesting num_ctx=8192
+# just produced "requested context size too large for model" and got
+# silently clamped back to 2048 - the model was never going to accept more,
+# regardless of server or per-request settings). Every real embedding call
+# failed until input was kept under this real limit; the cache had a 0%
+# hit rate for the 38 hours it ran before this was caught.
+EMBEDDING_NUM_CTX = 2048
 
-# A conservative ~3 chars/token estimate for TOON-encoded evidence (denser
-# than prose - lots of short identifiers and punctuation) keeps even the
-# largest real packets seen in production (52k+ tokens) under the model's
-# context window, rather than sending something guaranteed to fail. A
-# truncated embedding is still useful for similarity matching; the exact
-# text match isn't needed, and a cache hit is always re-verified against
-# current evidence regardless of how it was found.
-MAX_EMBEDDING_CHARS = EMBEDDING_NUM_CTX * 3
+# Empirically calibrated against the real running model with text shaped
+# like actual evidence packets (file paths, symbol names, short identifiers
+# - not plain prose, and not a pathological single repeated character
+# either): 6600 chars succeeded, 6990 failed. 5000 chars keeps a real
+# margin below that boundary for token-density variance in different
+# packets and the single-CPU container being busier under real concurrent
+# load than this manual test. A truncated embedding is still useful for
+# similarity matching; the exact text match isn't needed, and a cache hit
+# is always re-verified against current evidence regardless of how it was
+# found.
+MAX_EMBEDDING_CHARS = 5000
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +36,12 @@ def _client(base_url: str | None = None) -> httpx.Client:
     return httpx.Client(base_url=base_url or os.environ.get("OLLAMA_BASE_URL", "http://ollama:11434"))
 
 
-def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 5.0) -> list[float] | None:
+def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 10.0) -> list[float] | None:
+    # A 7000-char prompt (above the truncation budget below) measured 3.6s
+    # against the real server - 5.0 left too little margin under real
+    # concurrent load on a single-CPU container; this is a degrade-to-miss
+    # timeout, not a build-blocking one, so erring toward more patience
+    # costs nothing but a slightly slower cache lookup.
     if len(text) > MAX_EMBEDDING_CHARS:
         text = text[:MAX_EMBEDDING_CHARS]
     try:

--- a/github-app/tests/test_embedding_client.py
+++ b/github-app/tests/test_embedding_client.py
@@ -20,11 +20,12 @@ def test_embed_text_returns_vector_on_success(monkeypatch):
     assert result == [0.1, 0.2, 0.3]
 
 
-def test_embed_text_requests_the_models_real_context_window(monkeypatch):
-    # Confirmed in production: Ollama's own default (2048) is far smaller
-    # than nomic-embed-text's real 8192-token context, and every real
-    # embedding call failed against that default - the cache never recorded
-    # a single hit despite running for 38 hours.
+def test_embed_text_sends_the_models_real_context_window(monkeypatch):
+    # Confirmed directly against the running production model: the pulled
+    # nomic-embed-text GGUF has a hard 2048-token trained context (not 8192,
+    # which was a first, wrong assumption - requesting more just got
+    # silently clamped by Ollama with a warning). Sending it explicitly
+    # keeps this self-documenting even though it now matches the default.
     seen = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -38,16 +39,15 @@ def test_embed_text_requests_the_models_real_context_window(monkeypatch):
 
     embed_text("some evidence text")
 
-    assert seen["body"]["options"] == {"num_ctx": 8192}
+    assert seen["body"]["options"] == {"num_ctx": 2048}
 
 
 def test_embed_text_truncates_oversized_input(monkeypatch):
-    # A real production packet hit 52k+ tokens - even with num_ctx raised to
-    # the model's real max, that's still too large for a single embedding
-    # call. Truncating keeps the call from failing outright; the exact text
-    # match isn't needed for similarity matching, and any cache hit found
-    # this way is still re-verified against current evidence before being
-    # served.
+    # A real production packet hit 52k+ tokens - nowhere close to fitting
+    # the model's real 2048-token context. Truncating keeps the call from
+    # failing outright; the exact text match isn't needed for similarity
+    # matching, and any cache hit found this way is still re-verified
+    # against current evidence before being served.
     seen = {}
 
     def handler(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
## Summary
Follow-up to #45. That fix assumed nomic-embed-text supports an 8192-token context and tried raising Ollama's context length to match - verified directly against the running production server that this was wrong. The pulled GGUF's own metadata caps it at a hard, trained 2048-token context, and requesting more just got silently clamped back down with a warning. No server or per-request setting can raise a ceiling the model weights themselves don't have.

- Corrected `EMBEDDING_NUM_CTX` to the real, confirmed 2048.
- Removed the ineffective `OLLAMA_CONTEXT_LENGTH=8192` from docker-compose.yml.
- Recalibrated `MAX_EMBEDDING_CHARS` empirically against the real running model using text shaped like actual evidence packets (paths, identifiers, short tokens), not prose or a pathological single-character stress test.
- Verified end-to-end against production directly: packets from 500 to 60,000 characters (matching the real 52k-token packet seen in logs) all return a real embedding vector now.

## Test plan
- [x] Updated unit tests, full `github-app` suite: 503 passed, 7 skipped (pre-existing local-fixture skip, unrelated)
- [x] Verified directly against the real production Ollama container before and after, at multiple realistic packet sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)