### PR TITLE
fix: O(1) first-commit lookup + patch js-yaml DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "veridion",
+  "name": "aletheore",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "veridion",
+      "name": "aletheore",
       "version": "0.0.0",
       "devDependencies": {
         "cspell": "8.17.5",
@@ -1471,9 +1471,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "cspell": "8.17.5",
     "markdownlint-cli2": "^0.23.1",
     "prettier": "3.3.3"
+  },
+  "overrides": {
+    "js-yaml": "^5.2.2"
   }
 }

--- a/src/aletheore/git_intel/analyzer.py
+++ b/src/aletheore/git_intel/analyzer.py
@@ -252,6 +252,23 @@ def compute_hotspots(repo_path: Path, modules: list[dict]) -> list[dict]:
     return sorted(hotspots, key=lambda item: (-item["churn_count"], item["path"]))[:HOTSPOT_LIMIT]
 
 
+def _first_commit_at(repo_path: Path) -> datetime:
+    # `git log --reverse HEAD` walks and formats the *entire* history just to
+    # read its first line - confirmed as the exact query that got OOM-killed
+    # scanning torvalds/linux's 1.46M commits under a 1GB limit. Root commits
+    # are directly enumerable without touching anything in between: normally
+    # there's exactly one, but a repo with merged unrelated histories can
+    # have several, so take the oldest of whichever `--max-parents=0` finds -
+    # still O(root commits), never O(total commits).
+    roots_result = _run_git_or_raise(repo_path, "rev-list", "--max-parents=0", "HEAD")
+    root_shas = [line for line in roots_result.stdout.strip().splitlines() if line]
+    dates = []
+    for sha in root_shas:
+        date_result = _run_git_or_raise(repo_path, "log", "-1", "--format=%ad", "--date=iso-strict", sha)
+        dates.append(datetime.fromisoformat(date_result.stdout.strip()))
+    return min(dates)
+
+
 def analyze_git(repo_path: Path, now: datetime | None = None) -> dict:
     if now is None:
         now = datetime.now(timezone.utc)
@@ -262,12 +279,7 @@ def analyze_git(repo_path: Path, now: datetime | None = None) -> dict:
     total_commits_result = _run_git_or_raise(repo_path, "rev-list", "--count", "HEAD")
     total_commits = int(total_commits_result.stdout.strip())
 
-    first_commit_result = _run_git_or_raise(
-        repo_path, "log", "--reverse", "--format=%ad", "--date=iso-strict", "HEAD"
-    )
-    first_commit_line = first_commit_result.stdout.strip().splitlines()[0]
-    first_commit_at = datetime.fromisoformat(first_commit_line)
-    repo_age_days = (now - first_commit_at).days
+    repo_age_days = (now - _first_commit_at(repo_path)).days
 
     return {
         "available": True,

--- a/src/tests/test_git_intel.py
+++ b/src/tests/test_git_intel.py
@@ -192,6 +192,8 @@ def _fail_only_on_git_log(returncode: int):
             return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout="abc123\n", stderr="")
         if args == ("rev-list", "--count", "HEAD"):
             return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout="5\n", stderr="")
+        if args == ("rev-list", "--max-parents=0", "HEAD"):
+            return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout="root123\n", stderr="")
         return subprocess.CompletedProcess(args=["git", *args], returncode=0, stdout="", stderr="")
 
     return side_effect
@@ -251,6 +253,57 @@ def test_analyze_git_totals(tmp_path):
     result = analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
     assert result["total_commits"] == 3
     assert result["repo_age_days"] == 43
+
+
+def test_first_commit_lookup_never_walks_full_history(tmp_path):
+    # Confirmed directly: `git log --reverse HEAD` (the old approach) was the
+    # exact query that got OOM-killed scanning torvalds/linux's 1.46M
+    # commits - it has to walk and format the entire history just to read
+    # its first line. The fix must never issue that call.
+    from aletheore.git_intel import analyzer
+
+    repo = make_git_repo(tmp_path)
+    real_run_git = analyzer._run_git
+    calls = []
+
+    def spy(repo_path, *args):
+        calls.append(args)
+        return real_run_git(repo_path, *args)
+
+    with patch("aletheore.git_intel.analyzer._run_git", side_effect=spy):
+        result = analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
+
+    assert result["repo_age_days"] == 43
+    assert not any("--reverse" in call for call in calls)
+
+
+def test_analyze_git_repo_age_uses_oldest_of_multiple_root_commits(tmp_path):
+    # A repo merging unrelated histories (git merge --allow-unrelated-histories)
+    # can have more than one root commit - repo age must reflect the oldest
+    # one, not whichever `rev-list --max-parents=0` happens to list first.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(repo, "init", "-b", "main")
+    run(repo, "config", "user.email", "a@example.com")
+    run(repo, "config", "user.name", "Alice")
+    (repo / "a.txt").write_text("1")
+    run(repo, "add", "a.txt")
+    commit(repo, "main root", "2026-06-01T00:00:00+00:00")
+
+    run(repo, "checkout", "--orphan", "grafted")
+    run(repo, "reset", "--hard")
+    (repo / "b.txt").write_text("1")
+    run(repo, "add", "b.txt")
+    commit(repo, "older independent root", "2026-01-01T00:00:00+00:00")
+
+    run(repo, "checkout", "main")
+    run(repo, "merge", "--allow-unrelated-histories", "-m", "merge", "grafted")
+
+    result = analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
+    # Age measured from the older (January) root, not the newer (June) one.
+    assert result["repo_age_days"] == (
+        datetime(2026, 7, 14, tzinfo=timezone.utc) - datetime(2026, 1, 1, tzinfo=timezone.utc)
+    ).days
 
 
 def test_analyze_git_ignores_remote_head_symbolic_ref(tmp_path):


### PR DESCRIPTION
## Summary
Two independent, low-risk fixes bundled together:

1. `analyze_git()`'s `repo_age_days` used `git log --reverse HEAD` (walks and formats the *entire* history) just to read its first line - this is the exact query that got OOM-killed scanning torvalds/linux's 1.46M commits. Replaced with `git rev-list --max-parents=0 HEAD` (root commits, normally just one) + a single `git log -1` per root. O(root commits), not O(total commits). First piece of the larger incremental-git-analysis work (rest is a separate architectural pass).
2. Dependabot flagged `js-yaml` (transitive via `markdownlint-cli2`, devDependency only) for a high-severity DoS vulnerability (GHSA-pm4m-ph32-ghv5). Pinned to the patched 5.2.2 via npm overrides.

## Test plan
- [x] New test proves the fix never issues a `--reverse` call (spies on `_run_git`)
- [x] New test proves correctness for repos with multiple root commits (merged unrelated histories) - takes the oldest
- [x] Existing `repo_age_days`/OOM-simulation tests still pass (fixed one test fixture that needed to know about the new call shape)
- [x] Full `src` suite: 693 passed
- [x] `npm ls js-yaml` confirms 5.2.2, `npx markdownlint-cli2` still lints correctly against it

🤖 Generated with [Claude Code](https://claude.com/claude-code)