### PR TITLE
Runtime correlation: owner + dependency context on failure alerts

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -731,12 +731,59 @@ def _recheck_single_endpoint(entry: dict, base_url: str) -> dict:
     return results[0]
 
 
+def _owner_attachment_from_graph(installation_id: int, repo_full_name: str, source_file: str) -> dict | None:
+    # Prefers the persisted graph over a live API call: no extra GitHub
+    # round-trip, and it still answers if GitHub itself is degraded. Only
+    # ever supplements the commit attachment below (which stays the
+    # existing, already-proven live lookup) - never the sole source, since
+    # a repo with no PR-triggered scan since this shipped has no graph data
+    # yet and this simply finds nothing to attach.
+    try:
+        settings = get_settings()
+        store = PostgresRepoGraphStore(settings.database_url, installation_id, repo_full_name)
+        snapshot = store.load("unused", GRAPH_BRANCH)
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "owner correlation from graph failed (%s); alerting without it", type(exc).__name__
+        )
+        return None
+    churn = snapshot.file_churn.get(source_file)
+    if churn is None or not churn.recent_commits:
+        return None
+    top_author_email = churn.recent_commits[0].author_email.lower()
+    owner = snapshot.ownership.get(top_author_email)
+    owner_name = sorted(owner.names)[0] if owner and owner.names else churn.recent_commits[0].author_name
+    return normalize_resolution(kind="owner", owner=owner_name, confidence="inferred")
+
+
+def _dependency_context_attachment(evidence: dict | None, source_file: str) -> dict | None:
+    # Upstream/downstream modules for the failing file - already computed
+    # by the scan itself (module.imports / module.imported_by), so this is
+    # a lookup against data already in hand, not a new analysis pass.
+    if not evidence:
+        return None
+    modules_by_path = {m["path"]: m for m in evidence.get("repository", {}).get("modules", [])}
+    module = modules_by_path.get(source_file)
+    if module is None:
+        return None
+    upstream = sorted(module.get("imports", []))[:5]
+    downstream = sorted(module.get("imported_by", []))[:5]
+    if not upstream and not downstream:
+        return None
+    return normalize_resolution(
+        kind="dependency",
+        dependency={"upstream": upstream, "downstream": downstream},
+        confidence="exact",
+    )
+
+
 def _attach_recent_commit_for_failure(
     settings,
     installation_id: int,
     repo_full_name: str,
     source_file: str,
     evidence_resolution: dict | None,
+    evidence: dict | None = None,
 ) -> dict | None:
     try:
         app_jwt = generate_app_jwt(
@@ -757,16 +804,22 @@ def _attach_recent_commit_for_failure(
             "commit correlation failed (%s); alerting without it",
             type(exc).__name__,
         )
+        commits = []
+
+    attachments = []
+    if commits:
+        attachments.append(normalize_resolution(kind="commit", commit=commits[0], confidence="weak"))
+    owner_attachment = _owner_attachment_from_graph(installation_id, repo_full_name, source_file)
+    if owner_attachment is not None:
+        attachments.append(owner_attachment)
+    dependency_attachment = _dependency_context_attachment(evidence, source_file)
+    if dependency_attachment is not None:
+        attachments.append(dependency_attachment)
+
+    if not attachments:
         return evidence_resolution
-    if not commits:
-        return evidence_resolution
-    commit_attachment = normalize_resolution(
-        kind="commit",
-        commit=commits[0],
-        confidence="weak",
-    )
     base = evidence_resolution or empty_resolution("endpoint")
-    return merge_resolution(base, commit_attachment)
+    return merge_resolution(base, *attachments)
 
 
 @log_job
@@ -832,6 +885,7 @@ def run_health_check_sweep_job() -> None:
                         repo_full_name,
                         source_file,
                         evidence_resolution,
+                        evidence,
                     )
                 _send_if_webhook_configured(
                     target,

--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -1,0 +1,193 @@
+import os
+from datetime import datetime
+
+import pytest
+
+from scan_worker.jobs import (
+    GRAPH_BRANCH,
+    _attach_recent_commit_for_failure,
+    _dependency_context_attachment,
+    _owner_attachment_from_graph,
+)
+from scan_worker.postgres_graph_store import PostgresRepoGraphStore
+
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://postgres:test@localhost:55433/aletheore_test",
+)
+
+
+async def _insert_installation(pool, installation_id: int, account_login: str, **values) -> None:
+    columns = ["installation_id", "account_login", *values.keys()]
+    params = [installation_id, account_login, *values.values()]
+    placeholders = ", ".join(f"${i}" for i in range(1, len(params) + 1))
+    await pool.execute(
+        f"INSERT INTO installations ({', '.join(columns)}) VALUES ({placeholders})",
+        *params,
+    )
+
+
+def _fake_evidence_with_modules() -> dict:
+    return {
+        "repository": {
+            "modules": [
+                {
+                    "path": "app/handler.py",
+                    "imports": ["app/db.py", "app/config.py"],
+                    "imported_by": ["app/main.py"],
+                },
+                {"path": "app/db.py", "imports": [], "imported_by": ["app/handler.py"]},
+            ]
+        }
+    }
+
+
+def test_dependency_context_attachment_finds_upstream_and_downstream():
+    attachment = _dependency_context_attachment(_fake_evidence_with_modules(), "app/handler.py")
+
+    assert attachment is not None
+    assert attachment["kind"] == "dependency"
+    assert attachment["dependency"]["upstream"] == ["app/config.py", "app/db.py"]
+    assert attachment["dependency"]["downstream"] == ["app/main.py"]
+    assert attachment["confidence"] == "exact"
+
+
+def test_dependency_context_attachment_returns_none_for_unknown_file():
+    assert _dependency_context_attachment(_fake_evidence_with_modules(), "nonexistent.py") is None
+
+
+def test_dependency_context_attachment_returns_none_without_evidence():
+    assert _dependency_context_attachment(None, "app/handler.py") is None
+
+
+@pytest.mark.asyncio
+async def test_owner_attachment_from_graph_uses_most_recent_committer(pool, monkeypatch):
+    await _insert_installation(pool, 801, "org")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    store = PostgresRepoGraphStore(TEST_DATABASE_URL, 801, "org/repo")
+
+    from aletheore.git_intel.graph_store import CommitTouch
+
+    store.apply_commits(
+        "unused",
+        GRAPH_BRANCH,
+        [
+            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",)),
+            CommitTouch("s2", "Bob", "b@example.com", datetime(2026, 6, 8), ("app/handler.py",)),
+        ],
+        new_sync_sha="s2",
+        new_sync_at=datetime(2026, 6, 8),
+        reset=True,
+    )
+
+    attachment = _owner_attachment_from_graph(801, "org/repo", "app/handler.py")
+
+    assert attachment is not None
+    assert attachment["kind"] == "owner"
+    assert attachment["owner"] == "Bob"  # most recent committer, not most prolific
+
+
+@pytest.mark.asyncio
+async def test_owner_attachment_from_graph_returns_none_when_no_data(pool, monkeypatch):
+    await _insert_installation(pool, 802, "org")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+
+    assert _owner_attachment_from_graph(802, "org/repo", "never/scanned.py") is None
+
+
+def test_owner_attachment_from_graph_degrades_gracefully_on_db_failure(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://nonexistent-host-for-this-test/db")
+
+    assert _owner_attachment_from_graph(803, "org/repo", "app/handler.py") is None
+
+
+def test_attach_recent_commit_for_failure_combines_commit_owner_and_dependency_attachments(monkeypatch):
+    # Proves all three sources merge into one resolution without any of
+    # them depending on the others being present - the live commit lookup
+    # keeps working exactly as before, and the two new attachments are
+    # purely additive.
+    class FakeSettings:
+        github_app_id = "x"
+        github_app_private_key = "y"
+
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_recent_commits_for_path",
+        lambda client, token, repo, path, limit=1: [
+            {"sha": "abc123", "author": "Carol", "date": "2026-07-20T00:00:00Z", "subject": "fix"}
+        ],
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._owner_attachment_from_graph",
+        lambda installation_id, repo_full_name, source_file: {
+            "kind": "owner",
+            "file": None,
+            "line": None,
+            "end_line": None,
+            "symbol": None,
+            "owner": "Dave",
+            "owner_status": "available",
+            "commit": None,
+            "commit_status": "unavailable",
+            "dependency": None,
+            "dependency_status": "unavailable",
+            "risk": [],
+            "risk_status": "unavailable",
+            "confidence": "inferred",
+            "evidence_path": None,
+            "evidence_status": "unavailable",
+        },
+    )
+
+    result = _attach_recent_commit_for_failure(
+        FakeSettings(),
+        901,
+        "org/repo",
+        "app/handler.py",
+        None,
+        _fake_evidence_with_modules(),
+    )
+
+    assert result["commit"]["sha"] == "abc123"
+    assert result["owner"] == "Dave"
+    assert result["dependency"]["upstream"] == ["app/config.py", "app/db.py"]
+
+
+def test_attach_recent_commit_for_failure_still_returns_something_when_only_commit_available(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_recent_commits_for_path",
+        lambda client, token, repo, path, limit=1: [
+            {"sha": "abc123", "author": "Carol", "date": "2026-07-20T00:00:00Z", "subject": "fix"}
+        ],
+    )
+    monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
+
+    class FakeSettings:
+        github_app_id = "x"
+        github_app_private_key = "y"
+
+    result = _attach_recent_commit_for_failure(
+        FakeSettings(), 901, "org/repo", "unknown-file.py", None, None
+    )
+
+    assert result["commit"]["sha"] == "abc123"
+    assert result["owner"] is None
+
+
+def test_attach_recent_commit_for_failure_returns_original_resolution_when_nothing_found(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    monkeypatch.setattr("scan_worker.jobs.fetch_recent_commits_for_path", lambda *a, **k: [])
+    monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
+
+    class FakeSettings:
+        github_app_id = "x"
+        github_app_private_key = "y"
+
+    original = {"kind": "endpoint"}
+    result = _attach_recent_commit_for_failure(FakeSettings(), 901, "org/repo", "x.py", original, None)
+
+    assert result is original


### PR DESCRIPTION
## Summary
- Extends the existing live-commit correlation in health-check alerts with two additive attachment sources: most-recent-owner (from the persisted Postgres git graph) and upstream/downstream dependency context (from already-resolved module evidence).
- Answers more of due-diligence review item #6 (owner, upstream/downstream modules) without touching the proven live-API commit lookup.
- Both new sources degrade to `None` on any failure (unknown file, no graph data, DB outage) - a correlation gap never blocks the health-check sweep.

## Test plan
- [x] `tests/test_correlation.py` (9 new tests, real Postgres): dependency lookup, owner-uses-most-recent-committer (not most-prolific), graceful degradation on bad DSN, full three-source merge, commit-only fallback, unchanged-when-nothing-found
- [x] Full github-app suite: 522 passed, 7 skipped

MCP tool / dashboard surfacing for this data is deferred as a fast-follow, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)