### PR TITLE
fix: bound git-graph cold-sync memory for oversized repos

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import json
 import logging
+import os
 import secrets
 import shutil
 import subprocess
@@ -103,6 +104,22 @@ HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS = 2.0
 # of one) a given clone happens to be on.
 GRAPH_BRANCH = "default"
 
+# Bounds the very first (cold) sync of a repo's history to its most recent
+# N commits, rather than walking the entire history in one pass. Needed
+# independent of the fold()-level memory caps (incremental.py's
+# MAX_CO_CHANGE_PARTNERS_TRACKED): reproduced directly against
+# torvalds/linux (1.46M commits, ~174K files) in a container capped at the
+# same 1GB limit as this worker - even with zero co-change/recent-commit
+# tracking, just the base per-file bookkeeping for that many distinct
+# files was already at the memory limit. A depth cap keeps a cold sync's
+# file count proportional to a bounded recent window instead of a repo's
+# entire lifetime, whatever that repo's total size turns out to be. Later
+# scans extend coverage incrementally (each only processes commits landed
+# since last sync) but never backfill older history beyond the original
+# cap - an accepted trade-off, surfaced via `history_depth_limited` in the
+# git evidence.
+GRAPH_COLD_SYNC_DEPTH_CAP = 50_000
+
 
 def _job_temp_dir() -> Path:
     path = JOBS_ROOT / str(uuid.uuid4())
@@ -120,7 +137,13 @@ def _clone_ref(url: str, ref: str, dest: Path) -> None:
 
 
 def _run_scan(repo_dir: Path) -> Path:
-    subprocess.run(["aletheore", "scan", str(repo_dir)], check=True)
+    # See GRAPH_COLD_SYNC_DEPTH_CAP - the CLI's own analyze_git call (inside
+    # this subprocess) hits the exact same cold-sync memory ceiling as the
+    # Postgres sync below, and runs first, so it needs the same cap. Left
+    # unset for a developer running `aletheore scan` directly on their own
+    # machine (see evidence.py's ALETHEORE_GIT_HISTORY_DEPTH_CAP handling).
+    env = {**os.environ, "ALETHEORE_GIT_HISTORY_DEPTH_CAP": str(GRAPH_COLD_SYNC_DEPTH_CAP)}
+    subprocess.run(["aletheore", "scan", str(repo_dir)], check=True, env=env)
     return repo_dir / ".aletheore" / "air.json"
 
 
@@ -143,9 +166,11 @@ def _sync_persistent_git_graph(installation_id: int, repo_full_name: str, repo_d
         settings = get_settings()
         store = PostgresRepoGraphStore(settings.database_url, installation_id, repo_full_name)
         modules = evidence.get("repository", {}).get("modules", [])
-        git_data = analyze_git(repo_dir, store=store, branch=GRAPH_BRANCH)
+        git_data = analyze_git(repo_dir, store=store, depth_cap=GRAPH_COLD_SYNC_DEPTH_CAP, branch=GRAPH_BRANCH)
         if git_data.get("available"):
-            git_data["hotspots"] = compute_hotspots(repo_dir, modules, store=store, branch=GRAPH_BRANCH)
+            git_data["hotspots"] = compute_hotspots(
+                repo_dir, modules, store=store, depth_cap=GRAPH_COLD_SYNC_DEPTH_CAP, branch=GRAPH_BRANCH
+            )
             evidence["git"] = git_data
     except Exception as exc:  # noqa: BLE001
         # Broad by design: a GitAnalysisError (bad history state) and a

--- a/github-app/scan_worker/postgres_graph_store.py
+++ b/github-app/scan_worker/postgres_graph_store.py
@@ -147,7 +147,7 @@ class PostgresRepoGraphStore:
                         "INSERT INTO evidence_git_ownership "
                         "(installation_id, repo_full_name, branch, email, names, commit_count) "
                         "VALUES (%s, %s, %s, %s, %s::jsonb, %s)",
-                        [
+                        (
                             (
                                 self._installation_id,
                                 self._repo_full_name,
@@ -157,7 +157,7 @@ class PostgresRepoGraphStore:
                                 total.commit_count,
                             )
                             for email, total in merged.ownership.items()
-                        ],
+                        ),
                     )
 
                 if merged.cadence_weekly_counts:
@@ -165,10 +165,10 @@ class PostgresRepoGraphStore:
                         "INSERT INTO evidence_git_cadence "
                         "(installation_id, repo_full_name, branch, week_start, commit_count) "
                         "VALUES (%s, %s, %s, %s, %s)",
-                        [
+                        (
                             (self._installation_id, self._repo_full_name, branch, week_start, count)
                             for week_start, count in merged.cadence_weekly_counts.items()
-                        ],
+                        ),
                     )
 
                 if merged.file_churn:
@@ -176,7 +176,7 @@ class PostgresRepoGraphStore:
                         "INSERT INTO evidence_git_file_churn "
                         "(installation_id, repo_full_name, branch, path, churn_count, recent_commits, "
                         "co_change_counts) VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb)",
-                        [
+                        (
                             (
                                 self._installation_id,
                                 self._repo_full_name,
@@ -197,6 +197,6 @@ class PostgresRepoGraphStore:
                                 json.dumps(churn.co_change_counts),
                             )
                             for path, churn in merged.file_churn.items()
-                        ],
+                        ),
                     )
             conn.commit()

--- a/github-app/tests/test_jobs_git_graph_sync.py
+++ b/github-app/tests/test_jobs_git_graph_sync.py
@@ -1,10 +1,11 @@
 import os
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from scan_worker.jobs import GRAPH_BRANCH, _sync_persistent_git_graph
+from scan_worker.jobs import GRAPH_BRANCH, GRAPH_COLD_SYNC_DEPTH_CAP, _run_scan, _sync_persistent_git_graph
 from scan_worker.postgres_graph_store import PostgresRepoGraphStore
 
 TEST_DATABASE_URL = os.environ.get(
@@ -37,6 +38,20 @@ def _init_repo(tmp_path: Path) -> Path:
     _run(repo, "add", "a.py")
     _run(repo, "commit", "-q", "-m", "initial")
     return repo
+
+
+def test_run_scan_sets_git_history_depth_cap_env_var(tmp_path):
+    # This subprocess call runs `aletheore scan`, which hits the exact same
+    # cold-sync memory ceiling as the Postgres persistence sync - and runs
+    # first, before that sync code ever executes - so it needs the same
+    # depth cap passed through as an env var (see evidence.py's
+    # ALETHEORE_GIT_HISTORY_DEPTH_CAP handling).
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    with patch("scan_worker.jobs.subprocess.run") as mock_run:
+        _run_scan(repo_dir)
+    _, kwargs = mock_run.call_args
+    assert kwargs["env"]["ALETHEORE_GIT_HISTORY_DEPTH_CAP"] == str(GRAPH_COLD_SYNC_DEPTH_CAP)
 
 
 def _fake_evidence() -> dict:

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -1,4 +1,5 @@
 import json
+import os
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,6 +26,26 @@ from aletheore.toon_encoding import to_toon
 from aletheore.vulnerabilities import check_vulnerabilities as check_dependency_vulnerabilities
 
 EVIDENCE_VERSION = "0.1.0"
+
+# Unset by default - a developer scanning their own repo locally wants full
+# history, and isn't running inside a memory-constrained container. The
+# hosted scan-worker sets this (see scan_worker/jobs.py's
+# GRAPH_COLD_SYNC_DEPTH_CAP) before invoking `aletheore scan` as a
+# subprocess, so a customer's very first scan of an oversized repo (e.g.
+# torvalds/linux scale) can't OOM this call before persistence-layer code
+# even runs - reproduced directly in a container at the same 1GB limit as
+# that worker.
+_GIT_HISTORY_DEPTH_CAP_ENV = "ALETHEORE_GIT_HISTORY_DEPTH_CAP"
+
+
+def _git_history_depth_cap() -> int | None:
+    raw = os.environ.get(_GIT_HISTORY_DEPTH_CAP_ENV)
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
 
 
 def _noop_progress(_message: str) -> None:
@@ -66,7 +87,7 @@ def scan_repository(
     modules, dependency_graph, unparseable_files = build_module_graph(repo_path)
 
     report("Analyzing git history and ownership")
-    git_data = analyze_git(repo_path)
+    git_data = analyze_git(repo_path, depth_cap=_git_history_depth_cap())
 
     report("Scanning working tree for secrets")
     secrets_baseline = load_secrets_baseline(repo_path)

--- a/src/aletheore/git_intel/incremental.py
+++ b/src/aletheore/git_intel/incremental.py
@@ -8,6 +8,14 @@ as a single buffered string or a full in-memory list. Confirmed directly:
 the old approach (`subprocess.run(capture_output=True)`) buffering the
 entire formatted output was what got OOM-killed scanning torvalds/linux's
 1.46M commits under a 1GB memory limit.
+
+A second, independent bound matters just as much for large repos: without
+MAX_CO_CHANGE_PARTNERS_TRACKED, the *aggregate* itself (not the raw log
+text) is what OOM-kills a cold sync of a repo like torvalds/linux under a
+1GB limit - confirmed by reproducing the OOM in a container capped at the
+same limit as the production scan-worker, then tracing it to "hub" files
+(MAINTAINERS, top-level Kconfig) whose co_change_counts dict grows one
+entry per distinct file ever touched alongside them.
 """
 
 from __future__ import annotations
@@ -28,6 +36,16 @@ from aletheore.git_intel.graph_store import (
 MASS_COMMIT_FILE_THRESHOLD = 50
 RECENT_COMMITS_PER_FILE = 10
 CO_CHANGE_PARTNERS_RETURNED = 5
+# "Hub" files (MAINTAINERS, top-level Kconfig/Makefile) get touched
+# alongside nearly every other file over a long enough history - without a
+# cap, one file's co_change_counts dict grows without bound as history
+# grows. Confirmed directly: on torvalds/linux (1.46M commits), MAINTAINERS'
+# co-change JSON alone was ~780KB, and the aggregate across all files was
+# the dominant cost behind a cold sync OOM-killing under a 1GB limit. Far
+# above CO_CHANGE_PARTNERS_RETURNED so real (non-hub) files are never
+# affected - only pathological hub files get their least-frequent, least
+# useful partners evicted to stay bounded.
+MAX_CO_CHANGE_PARTNERS_TRACKED = 200
 
 # A commit header line in the streamed format below always starts with this
 # byte - real file paths never do, so it unambiguously marks "new commit"
@@ -160,6 +178,22 @@ def _week_start(at: datetime) -> date:
     return d - timedelta(days=d.weekday())
 
 
+def _bump_co_change(counts: dict[str, int], partner: str) -> None:
+    if partner in counts:
+        counts[partner] += 1
+        return
+    if len(counts) >= MAX_CO_CHANGE_PARTNERS_TRACKED:
+        # Evict the current weakest partner to make room, rather than let
+        # a hub file's dict grow without bound. This trades exact history
+        # for a hard memory ceiling: once a file is at capacity, a rare new
+        # partner may bump out a still-rarer existing one instead of both
+        # being tracked - only files with more than
+        # MAX_CO_CHANGE_PARTNERS_TRACKED distinct partners are affected.
+        weakest = min(counts, key=counts.get)
+        del counts[weakest]
+    counts[partner] = 1
+
+
 def fold(snapshot: GraphSnapshot, commits: list[CommitTouch]) -> GraphSnapshot:
     """Pure aggregation: merges `commits` into `snapshot`, returning a new
     snapshot. Both store backends call this internally so the aggregation
@@ -200,8 +234,8 @@ def fold(snapshot: GraphSnapshot, commits: list[CommitTouch]) -> GraphSnapshot:
         if len(unique_files) <= MASS_COMMIT_FILE_THRESHOLD:
             for i, first in enumerate(unique_files):
                 for second in unique_files[i + 1 :]:
-                    file_churn[first].co_change_counts[second] = file_churn[first].co_change_counts.get(second, 0) + 1
-                    file_churn[second].co_change_counts[first] = file_churn[second].co_change_counts.get(first, 0) + 1
+                    _bump_co_change(file_churn[first].co_change_counts, second)
+                    _bump_co_change(file_churn[second].co_change_counts, first)
 
     return GraphSnapshot(
         last_synced_sha=snapshot.last_synced_sha,

--- a/src/aletheore/git_intel/sqlite_store.py
+++ b/src/aletheore/git_intel/sqlite_store.py
@@ -155,22 +155,22 @@ class SQLiteRepoGraphStore:
             )
             self._conn.executemany(
                 "INSERT INTO ownership (repo_key, branch, email, names, commit_count) VALUES (?, ?, ?, ?, ?)",
-                [
+                (
                     (repo_key, branch, email, json.dumps(sorted(total.names)), total.commit_count)
                     for email, total in merged.ownership.items()
-                ],
+                ),
             )
             self._conn.executemany(
                 "INSERT INTO cadence (repo_key, branch, week_start, commit_count) VALUES (?, ?, ?, ?)",
-                [
+                (
                     (repo_key, branch, week_start.isoformat(), count)
                     for week_start, count in merged.cadence_weekly_counts.items()
-                ],
+                ),
             )
             self._conn.executemany(
                 "INSERT INTO file_churn (repo_key, branch, path, churn_count, recent_commits, co_change_counts) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                [
+                (
                     (
                         repo_key,
                         branch,
@@ -190,5 +190,5 @@ class SQLiteRepoGraphStore:
                         json.dumps(churn.co_change_counts),
                     )
                     for path, churn in merged.file_churn.items()
-                ],
+                ),
             )

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -75,6 +75,28 @@ def test_scan_repository_includes_dead_code_and_hotspots(tmp_path):
     assert evidence["git"]["hotspots"][0]["path"] == "main.py"
 
 
+def test_scan_repository_honors_git_history_depth_cap_env_var(tmp_path, monkeypatch):
+    # Proves the hosted scan-worker's ALETHEORE_GIT_HISTORY_DEPTH_CAP env
+    # var (set before invoking `aletheore scan` as a subprocess, see
+    # scan_worker/jobs.py's _run_scan) actually reaches analyze_git - this
+    # is what keeps a cold sync of an oversized repo from OOMing before any
+    # persistence-layer code even runs. Unset by default for a developer
+    # scanning their own repo directly.
+    repo = make_repo(tmp_path)
+    for i in range(4):
+        (repo / "main.py").write_text(f"def hello():\n    return {i}\n")
+        run(repo, "add", "-A")
+        run(repo, "commit", "-q", "-m", f"change {i}")
+
+    monkeypatch.setenv("ALETHEORE_GIT_HISTORY_DEPTH_CAP", "2")
+    with patch("aletheore.evidence.check_dependency_vulnerabilities") as mock_check:
+        mock_check.return_value = {"checked": True, "reason": None, "findings": []}
+        evidence = scan_repository(repo, check_licenses=False)
+
+    assert evidence["git"]["total_commits"] == 5
+    assert evidence["git"]["history_depth_limited"] is True
+
+
 def test_write_evidence_creates_aletheore_dir(tmp_path):
     repo = make_repo(tmp_path)
     evidence = scan_repository(repo, check_vulnerabilities=False, check_licenses=False)

--- a/src/tests/test_incremental.py
+++ b/src/tests/test_incremental.py
@@ -7,6 +7,7 @@ import pytest
 
 from aletheore.git_intel.graph_store import CommitTouch, GraphSnapshot
 from aletheore.git_intel.incremental import (
+    MAX_CO_CHANGE_PARTNERS_TRACKED,
     RECENT_COMMITS_PER_FILE,
     GitLogStreamError,
     compute_repo_key,
@@ -168,6 +169,37 @@ def test_fold_skips_co_change_for_mass_commits():
     result = fold(GraphSnapshot.empty(), commits)
     assert result.file_churn["f0.txt"].churn_count == 1
     assert result.file_churn["f0.txt"].co_change_counts == {}
+
+
+def test_fold_caps_co_change_partners_tracked_per_file():
+    # A "hub" file (e.g. MAINTAINERS) touched alongside a different partner
+    # in every commit must not grow its co_change_counts dict without bound
+    # - that unbounded growth is what OOM-killed a cold sync of
+    # torvalds/linux under the production 1GB memory limit.
+    commits = [
+        _touch(f"s{i}", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", ("hub.txt", f"partner{i}.txt"))
+        for i in range(MAX_CO_CHANGE_PARTNERS_TRACKED + 50)
+    ]
+    result = fold(GraphSnapshot.empty(), commits)
+    assert len(result.file_churn["hub.txt"].co_change_counts) == MAX_CO_CHANGE_PARTNERS_TRACKED
+    # churn_count itself is never capped - only the co-change partner dict.
+    assert result.file_churn["hub.txt"].churn_count == MAX_CO_CHANGE_PARTNERS_TRACKED + 50
+
+
+def test_fold_bumping_an_already_tracked_partner_never_evicts():
+    commits = [_touch("s0", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", ("hub.txt", "steady.txt"))]
+    for i in range(MAX_CO_CHANGE_PARTNERS_TRACKED - 1):
+        commits.append(
+            _touch(f"s{i + 1}", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", ("hub.txt", f"p{i}.txt"))
+        )
+    # hub.txt is now exactly at capacity, with "steady.txt" at count 1 like
+    # everything else. Bumping it again should never be at risk of eviction
+    # just because the dict happens to be full.
+    commits.append(_touch("sN", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", ("hub.txt", "steady.txt")))
+    result = fold(GraphSnapshot.empty(), commits)
+    counts = result.file_churn["hub.txt"].co_change_counts
+    assert len(counts) == MAX_CO_CHANGE_PARTNERS_TRACKED
+    assert counts["steady.txt"] == 2
 
 
 def test_fold_caps_recent_commits_per_file_newest_first():


### PR DESCRIPTION
## Summary
- Real, container-based reproduction (1GB memory cap matching the production scan-worker) found the incremental git-graph engine's cold sync still OOM-killed on a repo at torvalds/linux's scale, even after the earlier O(1) first-commit fix.
- Root-caused and fixed three real contributors: unbounded `co_change_counts` per "hub" file, a redundant fully-serialized snapshot copy held in memory at write time (`executemany` given a list instead of a generator), and the missing `depth_cap` wiring on the hosted cold-sync path (in both the new Postgres sync AND the `aletheore scan` subprocess itself, which runs first).
- Verified end-to-end: git-graph cold sync of torvalds/linux now completes in 229MB / 40s (was OOM-killed under 1GB uncapped).
- Separately discovered (not fixed here): the full `aletheore scan` pipeline still OOMs on the same repo even with this fix, likely due to `find_secrets_in_history`'s unrelated unbounded `git log -p` full-history walk. Flagged as a distinct follow-up task.

## Test plan
- [x] `src/tests/test_incremental.py` - new tests for the co-change cap (bounded, eviction doesn't affect already-tracked partners)
- [x] `src/tests/test_evidence.py` - new test for `ALETHEORE_GIT_HISTORY_DEPTH_CAP` env var reaching `analyze_git`
- [x] `github-app/tests/test_jobs_git_graph_sync.py` - new test for `_run_scan` setting the env var on the subprocess
- [x] Full `src` suite: 1443 passed
- [x] Full `github-app` suite: 559 passed, 7 skipped
- [x] Real Docker reproduction at the actual 1GB scan-worker limit against a bare clone of torvalds/linux: OOM-killed before this fix, clean (229MB peak) after, for the git-graph engine specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)