### PR TITLE
fix: AIRview incremental-update billing, dead-token 500s, and diagram zoom

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -109,6 +109,24 @@ async def _administered_installation_ids(github_token: str) -> set[int]:
     return {item["id"] for item in response.json().get("installations", [])}
 
 
+async def _administered_installation_ids_or_401(github_token: str) -> set[int]:
+    """Same as _administered_installation_ids, but for JSON API callers that
+    just want a clean 401/502 rather than handling httpx.HTTPStatusError
+    themselves - unlike /subscribe (frontend.py), which needs the raw
+    exception to redirect to sign-in and clear the dead session cookie, a
+    JSON endpoint's caller is the frontend's own apiGet() helper, which
+    already redirects to sign-in on any 401 response. Before this existed,
+    a revoked/expired GitHub token here surfaced as an unhandled 500 whose
+    non-JSON body then crashed the page trying to parse it as JSON.
+    """
+    try:
+        return await _administered_installation_ids(github_token)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            raise HTTPException(status_code=401, detail="GitHub session expired - please sign in again") from exc
+        raise HTTPException(status_code=502, detail="GitHub API unavailable") from exc
+
+
 def _bearer_github_token(request: Request) -> str:
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
@@ -149,7 +167,7 @@ async def _require_admin_installation(request: Request, org: str, repo: str) -> 
 
     pool = request.app.state.db_pool
     installation_id = await _repo_installation_id(pool, org, repo)
-    administered_ids = await _administered_installation_ids(session["github_access_token"])
+    administered_ids = await _administered_installation_ids_or_401(session["github_access_token"])
     if installation_id not in administered_ids:
         raise HTTPException(status_code=403, detail="you do not administer this installation")
 
@@ -292,7 +310,7 @@ async def remove_health_check_target_route(org: str, repo: str, target_id: int, 
 @admin_router.get("/v1/my-installations")
 async def my_installations(request: Request):
     github_token = _bearer_github_token(request)
-    administered_ids = await _administered_installation_ids(github_token)
+    administered_ids = await _administered_installation_ids_or_401(github_token)
     rows = await request.app.state.db_pool.fetch(
         """
         SELECT installation_id, account_login
@@ -310,7 +328,7 @@ async def create_cli_token(request: Request, body: CreateCliTokenRequest):
     github_token = _bearer_github_token(request)
     installation_id = body.installation_id
 
-    administered_ids = await _administered_installation_ids(github_token)
+    administered_ids = await _administered_installation_ids_or_401(github_token)
     if installation_id not in administered_ids:
         raise HTTPException(status_code=403, detail="you do not administer this installation")
 

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException, Request, Response
 
 from aletheore.evidence_resolution import resolve_code_evidence
 from app_server.admin import (
-    _administered_installation_ids,
+    _administered_installation_ids_or_401,
     _repo_installation_id,
     _require_admin_installation,
     _require_seat_if_paid,
@@ -56,7 +56,7 @@ async def list_my_repos(request: Request):
     if session is None:
         raise HTTPException(status_code=401, detail="login required")
 
-    administered_ids = await _administered_installation_ids(session["github_access_token"])
+    administered_ids = await _administered_installation_ids_or_401(session["github_access_token"])
     pool = request.app.state.db_pool
     repos = await list_repos_for_installations(pool, list(administered_ids))
     result = []
@@ -86,7 +86,7 @@ async def _require_dashboard_installation(request: Request, org: str, repo: str)
     pool = request.app.state.db_pool
     installation_id = await _repo_installation_id(pool, org, repo)
 
-    administered_ids = await _administered_installation_ids(session["github_access_token"])
+    administered_ids = await _administered_installation_ids_or_401(session["github_access_token"])
     if installation_id not in administered_ids:
         raise HTTPException(status_code=403, detail="you do not administer this installation")
 

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -232,14 +232,14 @@ table.findings tr:last-child td { border-bottom: none; }
 .diagram-wrap.diagram-zoomable { cursor: zoom-in; }
 .diagram-zoom-overlay { position: fixed; inset: 0; z-index: 1000; background: rgba(10, 8, 4, 0.82);
   overflow: auto; padding: 100px 40px; cursor: zoom-out; }
-.diagram-zoom-content { cursor: default; display: table; margin: 0 auto; }
+.diagram-zoom-content { cursor: default; display: inline-block; }
 .diagram-zoom-content svg { max-width: none; display: block; }
 .diagram-zoom-hint { position: fixed; top: 18px; left: 50%; transform: translateX(-50%); z-index: 1001;
   font-size: 12px; color: #F5F0E6; background: rgba(0, 0, 0, 0.45); padding: 6px 13px; border-radius: 99px; pointer-events: none; }
 .subsystem-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
 .subsystem-card { border: 1px solid var(--border); border-radius: 9px; padding: 11px 12px; text-align: left; background: var(--paper); cursor: pointer; font-family: var(--font-sans); }
 .subsystem-card:hover { border-color: var(--border-strong); }
-.subsystem-name { font-size: 13px; font-weight: 500; margin-bottom: 3px; }
+.subsystem-name { font-size: 13px; font-weight: 500; margin-bottom: 3px; color: var(--accent-strong); }
 .subsystem-desc { font-size: 12px; color: var(--slate-600); line-height: 1.55; }
 .subsystem-files { font-family: var(--font-mono); font-size: 10.5px; color: var(--slate-400); margin-top: 8px; }
 .subsystem-detail { border-top: 1px solid var(--border); margin-top: 14px; padding-top: 14px; }
@@ -279,6 +279,10 @@ FETCH_HELPERS = """
 async function apiGet(url) {
   const res = await fetch(url);
   if (res.status === 401) { window.location.href = '/'; return null; }
+  if (!res.ok) {
+    console.error('apiGet failed: ' + url + ' -> ' + res.status);
+    return null;
+  }
   return res;
 }
 function relativeTime(iso) {
@@ -973,6 +977,14 @@ function openDiagramZoom(svgHtml) {{
   document.body.appendChild(overlay);
   document.body.style.overflow = 'hidden';
   document.addEventListener('keydown', onDiagramZoomKeydown);
+  // Centering via margin:auto (the previous approach) leaves half of a
+  // diagram wider than the viewport permanently unreachable by scroll in
+  // most browsers - overflow past a centered element's near edge doesn't
+  // register as scrollable range. Centering the scroll position instead,
+  // on an unadorned top-left-anchored content box, keeps every part of
+  // the diagram reachable in both directions regardless of its size.
+  overlay.scrollLeft = (content.scrollWidth - overlay.clientWidth) / 2;
+  overlay.scrollTop = (content.scrollHeight - overlay.clientHeight) / 2;
 }}
 
 function onDiagramZoomKeydown(e) {{

--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -4,10 +4,10 @@ the deterministic briefs/diagrams in aletheore.wiki_mapping/wiki_diagrams.
 Naming always uses Flash - cheap, fast, low-stakes (just picking a
 readable label for a cluster the scanner already found). Writing uses
 the pricing tier's model (see scan_worker/model_tiers.py) for the
-one-time initial build, and Flash/DeepSeek for every incremental update
-after that regardless of tier - frequent, on every push, so it stays
-cheap even for higher tiers. Both use this module's same functions -
-which adapter to pass in is the caller's decision (see jobs.py).
+one-time initial build, and Flash for every incremental update after
+that regardless of tier - frequent, on every push, so it stays cheap
+even for higher tiers. Both use this module's same functions - which
+adapter to pass in is the caller's decision (see jobs.py).
 
 Every model response is validated against the deterministic brief it was
 given before being trusted: a file, function, or line number the model
@@ -27,7 +27,7 @@ from aletheore.wiki_diagrams import build_overview_diagram, build_subsystem_diag
 from aletheore.wiki_mapping import build_cluster_briefs
 
 FLASH_MODEL = "deepseek-v4-flash"
-UPDATE_MODEL = "deepseek-v4-pro"
+UPDATE_MODEL = "deepseek-v4-flash"
 
 logger = logging.getLogger(__name__)
 

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -124,6 +124,51 @@ async def test_app_repos_response_is_not_cacheable(pool, monkeypatch):
     assert response.headers["cache-control"] == "no-store"
 
 
+async def _logged_in_client_with_github_failure(pool, monkeypatch, status_code: int):
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    await create_session(
+        pool,
+        "sess-1",
+        42,
+        "octocat",
+        encrypt_access_token("gho_faketoken", "test-session-secret"),
+        datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, text="not json")
+
+    monkeypatch.setattr(
+        "app_server.admin._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+
+    app.state.db_pool = pool
+    signed = sign_session_id("sess-1", "test-session-secret")
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test", cookies={"session": signed})
+
+
+@pytest.mark.asyncio
+async def test_list_my_repos_returns_401_when_github_token_expired(pool, monkeypatch):
+    # A stored GitHub token can be revoked or expire after the local
+    # session was created - this must surface as a clean 401 (which every
+    # frontend page's apiGet() already redirects to sign-in on), not an
+    # unhandled 500 whose non-JSON body then crashes the page's res.json().
+    client = await _logged_in_client_with_github_failure(pool, monkeypatch, status_code=401)
+    async with client:
+        response = await client.get("/app/repos")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_my_repos_returns_502_on_github_outage(pool, monkeypatch):
+    client = await _logged_in_client_with_github_failure(pool, monkeypatch, status_code=503)
+    async with client:
+        response = await client.get("/app/repos")
+    assert response.status_code == 502
+
+
 @pytest.mark.asyncio
 async def test_list_my_repos_empty_for_no_administered_installations(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[])

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -2,11 +2,23 @@ import json
 from unittest.mock import MagicMock
 
 from scan_worker.live_wiki import (
+    FLASH_MODEL,
+    UPDATE_MODEL,
     build_subsystem_record,
     generate_overview,
     generate_subsystems,
     propose_cluster_names,
 )
+
+
+def test_incremental_update_model_stays_on_flash():
+    # Regression guard: incremental updates fire on every push, for every
+    # paid tier, per this module's own docstring ("so it stays cheap even
+    # for higher tiers"). UPDATE_MODEL was accidentally set to the Pro
+    # model from the very first commit - this went undetected until real
+    # billing data surfaced it, since nothing asserted the constant's
+    # actual value.
+    assert UPDATE_MODEL == FLASH_MODEL
 
 
 def make_evidence() -> dict:


### PR DESCRIPTION
## Summary
- **Billing bug**: AIRview's incremental wiki updates (fire on every push, every paid tier) were hardcoded to `deepseek-v4-pro` instead of `deepseek-v4-flash` since the very first commit - the module's own docstring says these should stay on Flash for cost reasons, but the constant was wrong. Fixed, with a regression test.
- **Dead-token 500s**: a revoked/expired GitHub token in a session caused `/app/repos` and other JSON API routes to 500 with a non-JSON body, which the frontend's `apiGet()` then tried to `res.json()`, throwing an unhandled `SyntaxError`. Added a wrapper that converts a GitHub 401/403 into a clean 401 (which `apiGet()` already redirects to sign-in on) for every JSON API caller; `/subscribe` keeps its own better-suited redirect+cookie-clear handling.
- **`apiGet()` hardening**: now treats any non-ok response as null, not just 401, matching the `if (!res) return;` pattern already used by every caller.
- **Diagram zoom**: fixed a classic CSS trap (`margin: 0 auto` centering inside a scrollable container leaves one side of wider-than-viewport content unreachable by scroll) by switching to JS-computed initial scroll centering on an unadorned content box.
- Subsystem card heading now uses the accent color already used elsewhere for emphasis, instead of plain near-black body text.

## Test plan
- [x] `test_live_wiki.py::test_incremental_update_model_stays_on_flash` - new regression guard
- [x] `test_dashboard.py` - two new tests for the 401/502 dead-token handling
- [x] Full `github-app` suite: 562 passed, 7 skipped
- [x] Verified `frontend.py` still renders/imports cleanly after the CSS/JS changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)