### PR TITLE
feat: single Pro tier foundation - repo/review caps + real model routing

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -121,6 +121,31 @@ async def insert_repo_history(
             )
 
 
+async def count_other_repos_audited_this_month(
+    pool: asyncpg.Pool, installation_id: int, repo_full_name: str
+) -> int:
+    """Distinct repos, other than repo_full_name, that have run a managed
+    audit for this installation since the start of the current calendar
+    month - repo_full_name is excluded so a repeat audit of an already-seen
+    repo never counts against the new-repo limit, only genuinely new repos
+    do. Protects against a single Pro subscription burst-connecting many
+    repos to front-load one-time audit cost, without capping total repos
+    an installation can ever connect.
+    """
+    row = await pool.fetchrow(
+        """
+        SELECT COUNT(DISTINCT repo_full_name) AS count
+        FROM managed_audit_rate_limits
+        WHERE installation_id = $1
+          AND repo_full_name != $2
+          AND last_run_at >= date_trunc('month', now())
+        """,
+        installation_id,
+        repo_full_name,
+    )
+    return row["count"]
+
+
 async def check_and_reserve_managed_audit(
     pool: asyncpg.Pool,
     installation_id: int,

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -9,6 +9,7 @@ from app_server.audit_signing import public_key_hex_from_private, verify_report
 from app_server.config import get_settings
 from app_server.db import (
     check_and_reserve_managed_audit,
+    count_other_repos_audited_this_month,
     get_audit_report_by_token,
     get_installation_by_token_hash,
     touch_api_token,
@@ -17,6 +18,12 @@ from app_server.evidence_limits import MAX_EVIDENCE_BYTES
 from app_server.rate_limit import cooldown_seconds_for_loc, total_loc_from_evidence
 
 managed_audit_router = APIRouter()
+
+# Protects against a single Pro subscription burst-connecting many repos to
+# front-load one-time audit cost onto one $34.99/mo install - total repos an
+# installation can connect stays unlimited, only how many *new* ones can
+# each run their first audit within a calendar month is bounded.
+MAX_NEW_REPOS_AUDITED_PER_MONTH = 10
 
 
 class StartManagedAuditRequest(BaseModel):
@@ -67,6 +74,19 @@ async def start_managed_audit(request: Request, body: StartManagedAuditRequest):
         decoded_evidence = toon.decode(body.evidence)
     except Exception as exc:
         raise HTTPException(status_code=400, detail="evidence could not be decoded") from exc
+
+    other_repos_this_month = await count_other_repos_audited_this_month(
+        pool, installation["installation_id"], body.repo_full_name
+    )
+    if other_repos_this_month >= MAX_NEW_REPOS_AUDITED_PER_MONTH:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"this installation has already run first-time audits on "
+                f"{MAX_NEW_REPOS_AUDITED_PER_MONTH} different repos this month - "
+                "try again next month, or re-run an audit on a repo you've already audited"
+            ),
+        )
 
     cooldown_seconds = cooldown_seconds_for_loc(total_loc_from_evidence(decoded_evidence))
     allowed = await check_and_reserve_managed_audit(

--- a/github-app/migrations/021_flash_review_monthly_count.sql
+++ b/github-app/migrations/021_flash_review_monthly_count.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS flash_review_monthly_count (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    month            DATE NOT NULL,
+    review_count     INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (installation_id, month)
+);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -106,6 +106,39 @@ def record_llm_spend(dsn: str, installation_id: int, cost_usd: float) -> None:
         conn.commit()
 
 
+def get_flash_review_count_this_month(dsn: str, installation_id: int) -> int:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT review_count FROM flash_review_monthly_count
+                WHERE installation_id = %s AND month = date_trunc('month', now())::date
+                """,
+                (installation_id,),
+            )
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+
+
+def increment_flash_review_count(dsn: str, installation_id: int) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO flash_review_monthly_count (installation_id, month, review_count)
+                VALUES (%s, date_trunc('month', now())::date, 1)
+                ON CONFLICT (installation_id, month) DO UPDATE
+                SET review_count = flash_review_monthly_count.review_count + 1
+                """,
+                (installation_id,),
+            )
+        conn.commit()
+
+
 def insert_audit_report(
     dsn: str,
     installation_id: int,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -40,11 +40,13 @@ from scan_worker.db import (
     delete_expired_sessions,
     delete_wiki_subsystems_not_in,
     get_extra_seats,
+    get_flash_review_count_this_month,
     get_installation as get_installation_row,
     get_last_endpoint_health,
     get_last_reviewed_sha,
     get_latest_evidence,
     get_llm_spend_this_month,
+    increment_flash_review_count,
     insert_audit_report,
     insert_endpoint_health,
     insert_repo_history,
@@ -128,6 +130,15 @@ GRAPH_COLD_SYNC_DEPTH_CAP = 50_000
 # whether it also OOMs. Capped separately and more conservatively than
 # GRAPH_COLD_SYNC_DEPTH_CAP for that reason.
 SECRETS_HISTORY_DEPTH_CAP = 20_000
+
+# The real, customer-facing promise for Pro ($34.99/mo): up to 300 PR
+# reviews/month. Worst-case cost at 300 reviews hitting the max context
+# caps each is well under $3 (deepseek-v4-flash, ~$0.14/M input +
+# $0.28/M output) - this is a usage ceiling for the promise itself, not a
+# cost-protection measure; the existing dollar-based monthly_cap_for_installation
+# check stays in place as a separate defense against a pathological
+# per-review cost blowing past what 300 reviews should ever cost.
+MAX_FLASH_REVIEWS_PER_MONTH = 300
 
 
 def _job_temp_dir() -> Path:
@@ -633,6 +644,8 @@ def run_flash_review_job(
         current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
         if current_spend >= monthly_cap:
             return
+        if get_flash_review_count_this_month(settings.database_url, installation_id) >= MAX_FLASH_REVIEWS_PER_MONTH:
+            return
 
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
         token = _token_sync(installation_id, app_jwt)
@@ -686,6 +699,7 @@ def run_flash_review_job(
                     model_used="deepseek-v4-flash",
                 )
         record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
+        increment_flash_review_count(settings.database_url, installation_id)
 
         if findings:
             lines = [f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n"]

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -1,50 +1,48 @@
-"""Which LLM each pricing tier actually uses to write managed audit
-reports and one-time AIRview builds - the pricing page's model claims are
-read from this file, not written separately, so they can never drift
-from what actually runs.
+"""Which LLM the single Pro plan actually uses for one-time managed audit
+reports, one-time AIRview builds, and the audit's LLM-based-suggestion
+section - the pricing page's model claims are read from this file, not
+written separately, so they can never drift from what actually runs.
 
-Falls back one rung at a time toward DeepSeek if a higher tier's
-provider key isn't configured yet, so a tier's builds never hard-fail on
-missing infra - logged, never silent, so this is never mistaken for the
-intended path.
+PR reviews and AIRview's incremental updates don't go through this module
+at all - they're hardcoded to deepseek-v4-flash directly in flash_review.py
+and live_wiki.py, since they fire on every push/PR and need to stay cheap
+regardless of which model the one-time work above uses.
+
+Falls back to DeepSeek Pro if OPENAI_API_KEY isn't configured yet, so a
+build never hard-fails on missing infra - logged, never silent, so this
+is never mistaken for the intended path.
 """
 
 import logging
 from typing import Callable
 
-from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from aletheore.credentials import has_api_key
 
-INDIE_MODEL = "deepseek-v4-pro"
-TEAM_MODEL = "gpt-4o"
-ENTERPRISE_MODEL = "claude-opus-4-8"
+TERRA_MODEL = "gpt-5.6-terra"
+PRO_FALLBACK_MODEL = "deepseek-v4-pro"
 
 
 def model_for_plan(plan: str) -> str:
     """The model name writing_adapter_for_plan() will actually construct
     for this plan right now - used for cost accounting, so a spend cap
-    never silently prices a tier's real tokens at DeepSeek's rate.
+    never silently prices Pro's real tokens at DeepSeek's rate.
     """
-    logger = logging.getLogger(__name__)
-    if plan == "enterprise":
-        if has_api_key("ANTHROPIC_API_KEY", "Anthropic"):
-            return ENTERPRISE_MODEL
-        logger.warning("ANTHROPIC_API_KEY not configured - enterprise tier falling back")
-    if plan in ("enterprise", "team"):
-        if has_api_key("OPENAI_API_KEY", "OpenAI"):
-            return TEAM_MODEL
-        logger.warning("OPENAI_API_KEY not configured - %s tier falling back to DeepSeek", plan)
-    return INDIE_MODEL
+    if plan != "pro":
+        return PRO_FALLBACK_MODEL
+    if has_api_key("OPENAI_API_KEY", "OpenAI"):
+        return TERRA_MODEL
+    logging.getLogger(__name__).warning(
+        "OPENAI_API_KEY not configured - Pro's one-time audit/AIRview build falling back to DeepSeek"
+    )
+    return PRO_FALLBACK_MODEL
 
 
 def writing_adapter_for_plan(
     plan: str, on_usage: Callable[[int, int], None] | None = None
-) -> OpenAICompatibleAdapter | AnthropicAdapter:
+) -> OpenAICompatibleAdapter:
     model = model_for_plan(plan)
-    if model == ENTERPRISE_MODEL:
-        return AnthropicAdapter(model=model, on_usage=on_usage)
-    if model == TEAM_MODEL:
+    if model == TERRA_MODEL:
         return OpenAICompatibleAdapter(
             name="OpenAI",
             base_url="https://api.openai.com/v1",

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from scan_worker.jobs import run_pr_scan_job
+from scan_worker.jobs import MAX_FLASH_REVIEWS_PER_MONTH, run_pr_scan_job
 
 
 @contextmanager
@@ -741,6 +741,30 @@ def test_flash_review_job_skips_when_spend_cap_reached(monkeypatch):
     assert llm_called == []
 
 
+def test_flash_review_job_skips_when_monthly_review_count_reached(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
+    )
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_flash_review_count_this_month",
+        lambda *a, **k: MAX_FLASH_REVIEWS_PER_MONTH,
+    )
+    llm_called = []
+    monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert llm_called == []
+
+
 def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
@@ -752,6 +776,7 @@ def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
@@ -762,6 +787,7 @@ def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
     llm_called = []
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -786,6 +812,7 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     )
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
@@ -803,6 +830,7 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.record_llm_spend", lambda dsn, iid, cost: recorded_spend.append(cost)
     )
+    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
     set_sha_calls = []
     monkeypatch.setattr(
         "scan_worker.jobs.set_last_reviewed_sha",
@@ -837,6 +865,7 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
@@ -850,6 +879,7 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
         ],
     )
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -874,6 +904,7 @@ def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch)
     )
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
@@ -883,6 +914,7 @@ def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch)
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", **kwargs: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -1622,9 +1654,9 @@ def test_full_build_writing_adapter_uses_the_tier_model_for_the_plan(monkeypatch
     from scan_worker.jobs import _live_wiki_full_build_writing_adapter
 
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
-    adapter = _live_wiki_full_build_writing_adapter("team")
+    adapter = _live_wiki_full_build_writing_adapter("pro")
     assert adapter.name == "OpenAI"
-    assert adapter._model == "gpt-4o"
+    assert adapter._model == "gpt-5.6-terra"
 
 
 def test_full_build_writing_adapter_indie_stays_on_deepseek(monkeypatch):

--- a/github-app/tests/test_managed_audit_api.py
+++ b/github-app/tests/test_managed_audit_api.py
@@ -241,6 +241,76 @@ async def test_managed_audit_rate_limit_is_independent_per_repo(pool, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_managed_audit_blocks_11th_new_repo_this_month(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await set_installation_plan(pool, 100, "indie")
+    token_hash = hashlib.sha256(b"real-token").hexdigest()
+    await create_api_token(pool, 100, token_hash, "laptop", "octocat")
+    for i in range(10):
+        await pool.execute(
+            """
+            INSERT INTO managed_audit_rate_limits (installation_id, repo_full_name, last_run_at)
+            VALUES (100, $1, now() - interval '1 day')
+            """,
+            f"octocat/repo-{i}",
+        )
+    fake_queue = MagicMock()
+    fake_queue.enqueue.return_value = MagicMock(id="job-123")
+    monkeypatch.setattr("app_server.managed_audit_api._get_queue", lambda redis_url: fake_queue)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/managed-audit",
+            json={"evidence": _evidence_toon(), "repo_full_name": "octocat/the-11th-repo"},
+            headers={"Authorization": "Bearer real-token"},
+        )
+
+    assert response.status_code == 429
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_managed_audit_new_repo_limit_does_not_block_repeat_audit(pool, monkeypatch):
+    # A repo that already ran its audit this month must not count against
+    # the new-repo limit on a repeat run - only genuinely new repos do.
+    await upsert_installation(pool, 100, "octocat")
+    await set_installation_plan(pool, 100, "indie")
+    token_hash = hashlib.sha256(b"real-token").hexdigest()
+    await create_api_token(pool, 100, token_hash, "laptop", "octocat")
+    for i in range(9):
+        await pool.execute(
+            """
+            INSERT INTO managed_audit_rate_limits (installation_id, repo_full_name, last_run_at)
+            VALUES (100, $1, now() - interval '1 day')
+            """,
+            f"octocat/repo-{i}",
+        )
+    # octocat/widgets already ran an audit this month, well outside its own cooldown.
+    await pool.execute(
+        """
+        INSERT INTO managed_audit_rate_limits (installation_id, repo_full_name, last_run_at)
+        VALUES (100, 'octocat/widgets', now() - interval '1 day')
+        """
+    )
+    fake_queue = MagicMock()
+    fake_queue.enqueue.return_value = MagicMock(id="job-123")
+    monkeypatch.setattr("app_server.managed_audit_api._get_queue", lambda redis_url: fake_queue)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/managed-audit",
+            json={"evidence": _evidence_toon(), "repo_full_name": "octocat/widgets"},
+            headers={"Authorization": "Bearer real-token"},
+        )
+
+    assert response.status_code == 202
+
+
+@pytest.mark.asyncio
 async def test_start_managed_audit_passes_repo_full_name_to_the_job(pool, monkeypatch):
     await upsert_installation(pool, 100, "octocat")
     await set_installation_plan(pool, 100, "indie")

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -1,9 +1,7 @@
-from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from scan_worker.model_tiers import (
-    ENTERPRISE_MODEL,
-    INDIE_MODEL,
-    TEAM_MODEL,
+    PRO_FALLBACK_MODEL,
+    TERRA_MODEL,
     model_for_plan,
     writing_adapter_for_plan,
 )
@@ -16,56 +14,37 @@ def _keys(monkeypatch, **available):
     )
 
 
-def test_indie_always_uses_deepseek_regardless_of_other_keys(monkeypatch):
-    _keys(monkeypatch, OpenAI=True, Anthropic=True)
-    adapter = writing_adapter_for_plan("indie")
+def test_pro_uses_terra_when_openai_key_present(monkeypatch):
+    _keys(monkeypatch, OpenAI=True)
+    adapter = writing_adapter_for_plan("pro")
     assert isinstance(adapter, OpenAICompatibleAdapter)
+    assert adapter.name == "OpenAI"
+    assert adapter._model == TERRA_MODEL
+
+
+def test_pro_falls_back_to_deepseek_when_openai_key_missing(monkeypatch):
+    _keys(monkeypatch)
+    adapter = writing_adapter_for_plan("pro")
     assert adapter.name == "DeepSeek"
-    assert adapter._model == INDIE_MODEL
+    assert adapter._model == PRO_FALLBACK_MODEL
     assert adapter._supports_tool_choice is False
 
 
-def test_team_uses_gpt4o_when_openai_key_present(monkeypatch):
+def test_non_pro_plan_always_falls_back_to_deepseek(monkeypatch):
+    # free (or any other non-"pro" value) should never reach Terra, even
+    # with a real OpenAI key configured - this path shouldn't be reachable
+    # in practice (managed audits already reject free plan earlier), but
+    # the fallback must be safe regardless.
     _keys(monkeypatch, OpenAI=True)
-    adapter = writing_adapter_for_plan("team")
-    assert isinstance(adapter, OpenAICompatibleAdapter)
-    assert adapter.name == "OpenAI"
-    assert adapter._model == TEAM_MODEL
-
-
-def test_team_falls_back_to_deepseek_when_openai_key_missing(monkeypatch):
-    _keys(monkeypatch)
-    adapter = writing_adapter_for_plan("team")
+    adapter = writing_adapter_for_plan("free")
     assert adapter.name == "DeepSeek"
-    assert adapter._model == INDIE_MODEL
-
-
-def test_enterprise_uses_claude_opus_when_anthropic_key_present(monkeypatch):
-    _keys(monkeypatch, Anthropic=True, OpenAI=True)
-    adapter = writing_adapter_for_plan("enterprise")
-    assert isinstance(adapter, AnthropicAdapter)
-    assert adapter._model == ENTERPRISE_MODEL
-
-
-def test_enterprise_falls_back_to_openai_when_only_openai_key_present(monkeypatch):
-    _keys(monkeypatch, OpenAI=True)
-    adapter = writing_adapter_for_plan("enterprise")
-    assert isinstance(adapter, OpenAICompatibleAdapter)
-    assert adapter.name == "OpenAI"
-    assert adapter._model == TEAM_MODEL
-
-
-def test_enterprise_falls_back_to_deepseek_when_no_keys_present(monkeypatch):
-    _keys(monkeypatch)
-    adapter = writing_adapter_for_plan("enterprise")
-    assert adapter.name == "DeepSeek"
-    assert adapter._model == INDIE_MODEL
+    assert adapter._model == PRO_FALLBACK_MODEL
 
 
 def test_on_usage_is_threaded_through_to_whichever_adapter_is_chosen(monkeypatch):
     _keys(monkeypatch)
     received = []
-    adapter = writing_adapter_for_plan("indie", on_usage=lambda p, c: received.append((p, c)))
+    adapter = writing_adapter_for_plan("pro", on_usage=lambda p, c: received.append((p, c)))
     adapter._on_usage(10, 20)
     assert received == [(10, 20)]
 
@@ -73,14 +52,9 @@ def test_on_usage_is_threaded_through_to_whichever_adapter_is_chosen(monkeypatch
 def test_model_for_plan_never_drifts_from_writing_adapter_for_plan(monkeypatch):
     # cost_for_usage() prices tokens by whatever model_for_plan() reports -
     # if it ever disagreed with the adapter writing_adapter_for_plan()
-    # actually built, a tier's spend would be silently mispriced.
-    for available in [
-        {},
-        {"OpenAI": True},
-        {"Anthropic": True},
-        {"OpenAI": True, "Anthropic": True},
-    ]:
-        for plan in ["indie", "team", "enterprise"]:
+    # actually built, Pro's spend would be silently mispriced.
+    for available in [{}, {"OpenAI": True}]:
+        for plan in ["pro", "free"]:
             _keys(monkeypatch, **available)
             adapter = writing_adapter_for_plan(plan)
             assert model_for_plan(plan) == adapter._model, (plan, available)


### PR DESCRIPTION
## Summary
First slice of the single-\$34.99-Pro-tier restructuring (replaces Indie/Team/Enterprise):
- New-repo audit cap: 10 distinct repos/month per installation, on top of the existing per-repo cooldown - stops burst-connecting many repos to front-load one-time audit cost, total repos stays unlimited.
- Real 300-review/month ceiling for Flash Review, alongside (not replacing) the existing dollar-based spend cap.
- `model_tiers.py` rewritten: Pro uses `gpt-5.6-terra` for the one-time audit + AIRview initial build, falls back to `deepseek-v4-pro` when `OPENAI_API_KEY` isn't configured. PR reviews and AIRview incrementals are unaffected (already hardcoded to `deepseek-v4-flash` outside this module).

## Test plan
- [x] New tests: 11th-new-repo-this-month block, repeat-audit doesn't count against the limit, 300-review cap skip, Terra/fallback routing
- [x] Full suite: 562 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)