### PR TITLE
feat: LLM-generated fix suggestions for health-check failures

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -115,16 +115,20 @@ def fetch_file_content(
     token: str,
     repo_full_name: str,
     path: str,
-    ref: str,
+    ref: str | None = None,
 ) -> str | None:
     headers = {
         "Authorization": f"token {token}",
         "Accept": "application/vnd.github+json",
     }
+    # ref=None omits the query param entirely rather than sending a literal
+    # "HEAD" or similar - GitHub's Contents API only accepts a real
+    # branch/tag/commit ref, and resolves to the repo's default branch
+    # automatically when the param is absent.
     response = client.get(
         f"/repos/{repo_full_name}/contents/{path}",
         headers=headers,
-        params={"ref": ref},
+        params={"ref": ref} if ref else {},
     )
     if response.status_code == 404:
         return None

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -72,13 +72,14 @@ from scan_worker.flash_review_cache import (
 )
 from scan_worker.github_api import (
     create_check_run,
+    fetch_file_content,
     fetch_pr_changed_files,
     fetch_pr_diff,
     fetch_recent_commits_for_path,
     upsert_pr_comment,
 )
 from scan_worker.managed_audit import run_managed_audit
-from scan_worker.model_tiers import model_for_plan, writing_adapter_for_plan
+from scan_worker.model_tiers import PRO_FALLBACK_MODEL, model_for_plan, writing_adapter_for_plan
 from scan_worker.packet_cache import lookup_cached_result, store_result
 from scan_worker.postgres_graph_store import PostgresRepoGraphStore
 from scan_worker.slack import (
@@ -830,6 +831,95 @@ def _dependency_context_attachment(evidence: dict | None, source_file: str) -> d
     )
 
 
+FIX_SUGGESTION_SYSTEM_PROMPT = """You are diagnosing why an API endpoint stopped responding. You are given
+the endpoint, its status, the exact file/line/symbol implicated by static analysis, and the surrounding
+source code. Respond with ONLY a concise, specific, actionable fix suggestion (2-3 sentences, plain text, no
+markdown fences) - name the actual likely cause and what to change, never a vague "check your code" answer.
+If you cannot identify a plausible concrete cause from what's given, respond with exactly: unknown."""
+
+
+def _health_fix_suggestion_adapter() -> OpenAICompatibleAdapter:
+    # Always Pro, never tier-routed through model_tiers.writing_adapter_for_plan -
+    # this feature is part of every Pro subscription at one fixed cost, not
+    # something that varies by a tier that no longer exists.
+    return OpenAICompatibleAdapter(
+        name="DeepSeek",
+        base_url="https://api.deepseek.com",
+        api_key_env_var="DEEPSEEK_API_KEY",
+        model=PRO_FALLBACK_MODEL,
+        supports_tool_choice=False,
+    )
+
+
+def _find_enclosing_symbol(evidence: dict | None, source_file: str, source_line: int | None) -> str | None:
+    if not evidence or source_line is None:
+        return None
+    modules = evidence.get("repository", {}).get("modules", [])
+    module = next((m for m in modules if m.get("path") == source_file), None)
+    if module is None:
+        return None
+    symbols = module.get("symbols", {})
+    for group in ("functions", "classes"):
+        for entry in symbols.get(group, []):
+            start, end = entry.get("start_line"), entry.get("end_line")
+            if start is not None and end is not None and start <= source_line <= end:
+                return entry.get("name")
+    return None
+
+
+def _fix_suggestion_attachment(
+    installation_id: int,
+    repo_full_name: str,
+    source_file: str,
+    source_line: int | None,
+    method: str,
+    path: str,
+    status_code: int | None,
+    evidence: dict | None,
+) -> dict | None:
+    # Grounded in the file/line/symbol already pinpointed deterministically
+    # by the owner/dependency attachments - the one LLM call in this whole
+    # correlation chain, and it only ever supplements what's already found.
+    # Same degrade-on-any-failure discipline as every other attachment
+    # here: missing code context, a DeepSeek outage, or a low-confidence
+    # model response just means the alert goes out without a suggestion,
+    # never blocks it.
+    try:
+        settings = get_settings()
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        token = _token_sync(installation_id, app_jwt)
+        with httpx.Client(base_url="https://api.github.com") as client:
+            file_content = fetch_file_content(client, token, repo_full_name, source_file)
+        if not file_content:
+            return None
+
+        lines = file_content.splitlines()
+        anchor = (source_line or 1) - 1
+        snippet = "\n".join(lines[max(0, anchor - 15) : min(len(lines), anchor + 15)])
+        user_prompt = json.dumps(
+            {
+                "endpoint": f"{method} {path}",
+                "status_code": status_code,
+                "file": source_file,
+                "line": source_line,
+                "symbol": _find_enclosing_symbol(evidence, source_file, source_line),
+                "code_context": snippet,
+            }
+        )
+        raw = _health_fix_suggestion_adapter().simple_completion(
+            FIX_SUGGESTION_SYSTEM_PROMPT, user_prompt, cwd="."
+        )
+        suggestion = raw.strip()
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "fix-suggestion generation failed (%s); alerting without it", type(exc).__name__
+        )
+        return None
+    if not suggestion or suggestion.lower() == "unknown":
+        return None
+    return normalize_resolution(kind="suggestion", suggestion=suggestion, confidence="inferred")
+
+
 def _attach_recent_commit_for_failure(
     settings,
     installation_id: int,
@@ -837,6 +927,10 @@ def _attach_recent_commit_for_failure(
     source_file: str,
     evidence_resolution: dict | None,
     evidence: dict | None = None,
+    method: str = "",
+    path: str = "",
+    status_code: int | None = None,
+    source_line: int | None = None,
 ) -> dict | None:
     try:
         app_jwt = generate_app_jwt(
@@ -868,6 +962,18 @@ def _attach_recent_commit_for_failure(
     dependency_attachment = _dependency_context_attachment(evidence, source_file)
     if dependency_attachment is not None:
         attachments.append(dependency_attachment)
+    suggestion_attachment = _fix_suggestion_attachment(
+        installation_id,
+        repo_full_name,
+        source_file,
+        source_line,
+        method,
+        path,
+        status_code,
+        evidence,
+    )
+    if suggestion_attachment is not None:
+        attachments.append(suggestion_attachment)
 
     if not attachments:
         return evidence_resolution
@@ -939,6 +1045,10 @@ def run_health_check_sweep_job() -> None:
                         source_file,
                         evidence_resolution,
                         evidence,
+                        method=method,
+                        path=path,
+                        status_code=status_code,
+                        source_line=source_line,
                     )
                 _send_if_webhook_configured(
                     target,

--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -7,6 +7,8 @@ from scan_worker.jobs import (
     GRAPH_BRANCH,
     _attach_recent_commit_for_failure,
     _dependency_context_attachment,
+    _find_enclosing_symbol,
+    _fix_suggestion_attachment,
     _owner_attachment_from_graph,
 )
 from scan_worker.postgres_graph_store import PostgresRepoGraphStore
@@ -139,6 +141,7 @@ def test_attach_recent_commit_for_failure_combines_commit_owner_and_dependency_a
             "evidence_status": "unavailable",
         },
     )
+    monkeypatch.setattr("scan_worker.jobs._fix_suggestion_attachment", lambda *a, **k: None)
 
     result = _attach_recent_commit_for_failure(
         FakeSettings(),
@@ -164,6 +167,7 @@ def test_attach_recent_commit_for_failure_still_returns_something_when_only_comm
         ],
     )
     monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._fix_suggestion_attachment", lambda *a, **k: None)
 
     class FakeSettings:
         github_app_id = "x"
@@ -182,6 +186,7 @@ def test_attach_recent_commit_for_failure_returns_original_resolution_when_nothi
     monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
     monkeypatch.setattr("scan_worker.jobs.fetch_recent_commits_for_path", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._fix_suggestion_attachment", lambda *a, **k: None)
 
     class FakeSettings:
         github_app_id = "x"
@@ -191,3 +196,131 @@ def test_attach_recent_commit_for_failure_returns_original_resolution_when_nothi
     result = _attach_recent_commit_for_failure(FakeSettings(), 901, "org/repo", "x.py", original, None)
 
     assert result is original
+
+
+def _module_with_symbol(path: str, name: str, start: int, end: int) -> dict:
+    return {
+        "path": path,
+        "imports": [],
+        "imported_by": [],
+        "symbols": {"functions": [{"name": name, "start_line": start, "end_line": end}], "classes": []},
+    }
+
+
+def test_find_enclosing_symbol_finds_containing_function():
+    evidence = {"repository": {"modules": [_module_with_symbol("app/handler.py", "do_login", 10, 25)]}}
+    assert _find_enclosing_symbol(evidence, "app/handler.py", 15) == "do_login"
+
+
+def test_find_enclosing_symbol_returns_none_outside_any_symbol_range():
+    evidence = {"repository": {"modules": [_module_with_symbol("app/handler.py", "do_login", 10, 25)]}}
+    assert _find_enclosing_symbol(evidence, "app/handler.py", 100) is None
+
+
+def test_find_enclosing_symbol_returns_none_without_line_or_evidence():
+    assert _find_enclosing_symbol(None, "app/handler.py", 15) is None
+    evidence = {"repository": {"modules": [_module_with_symbol("app/handler.py", "do_login", 10, 25)]}}
+    assert _find_enclosing_symbol(evidence, "app/handler.py", None) is None
+
+
+class FakeHealthSettings:
+    github_app_id = "x"
+    github_app_private_key = "y"
+
+
+def test_fix_suggestion_attachment_returns_none_when_file_content_unavailable(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.get_settings", lambda: FakeHealthSettings())
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: None)
+
+    result = _fix_suggestion_attachment(901, "org/repo", "app/handler.py", 15, "GET", "/v1/users", 500, None)
+
+    assert result is None
+
+
+def test_fix_suggestion_attachment_returns_none_when_model_says_unknown(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.get_settings", lambda: FakeHealthSettings())
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: "def do_login():\n    pass\n")
+
+    class FakeAdapter:
+        def simple_completion(self, system_prompt, user_prompt, cwd):
+            return "unknown"
+
+    monkeypatch.setattr("scan_worker.jobs._health_fix_suggestion_adapter", lambda: FakeAdapter())
+
+    result = _fix_suggestion_attachment(901, "org/repo", "app/handler.py", 15, "GET", "/v1/users", 500, None)
+
+    assert result is None
+
+
+def test_fix_suggestion_attachment_returns_suggestion_when_model_succeeds(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.get_settings", lambda: FakeHealthSettings())
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: "def do_login():\n    pass\n")
+
+    class FakeAdapter:
+        def simple_completion(self, system_prompt, user_prompt, cwd):
+            return "  The DB connection pool is exhausted; increase max_connections.  "
+
+    monkeypatch.setattr("scan_worker.jobs._health_fix_suggestion_adapter", lambda: FakeAdapter())
+
+    result = _fix_suggestion_attachment(901, "org/repo", "app/handler.py", 15, "GET", "/v1/users", 500, None)
+
+    assert result is not None
+    assert result["kind"] == "suggestion"
+    assert result["suggestion"] == "The DB connection pool is exhausted; increase max_connections."
+    assert result["suggestion_status"] == "available"
+
+
+def test_fix_suggestion_attachment_degrades_gracefully_on_any_failure(monkeypatch):
+    def _raise(*a, **k):
+        raise RuntimeError("github app auth broken")
+
+    monkeypatch.setattr("scan_worker.jobs.get_settings", lambda: FakeHealthSettings())
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", _raise)
+
+    result = _fix_suggestion_attachment(901, "org/repo", "app/handler.py", 15, "GET", "/v1/users", 500, None)
+
+    assert result is None
+
+
+def test_attach_recent_commit_for_failure_includes_suggestion_when_available(monkeypatch):
+    class FakeSettings:
+        github_app_id = "x"
+        github_app_private_key = "y"
+
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    monkeypatch.setattr("scan_worker.jobs.fetch_recent_commits_for_path", lambda *a, **k: [])
+    monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs._fix_suggestion_attachment",
+        lambda *a, **k: {
+            "kind": "suggestion",
+            "file": None,
+            "line": None,
+            "end_line": None,
+            "symbol": None,
+            "owner": None,
+            "owner_status": "unavailable",
+            "commit": None,
+            "commit_status": "unavailable",
+            "dependency": None,
+            "dependency_status": "unavailable",
+            "risk": [],
+            "risk_status": "unavailable",
+            "suggestion": "increase the connection pool size",
+            "suggestion_status": "available",
+            "confidence": "inferred",
+            "evidence_path": None,
+            "evidence_status": "unavailable",
+        },
+    )
+
+    result = _attach_recent_commit_for_failure(FakeSettings(), 901, "org/repo", "app/handler.py", None, None)
+
+    assert result["suggestion"] == "increase the connection pool size"

--- a/src/aletheore/evidence_resolution.py
+++ b/src/aletheore/evidence_resolution.py
@@ -14,6 +14,7 @@ CANONICAL_FIELDS = (
     "commit",
     "dependency",
     "risk",
+    "suggestion",
     "confidence",
     "evidence_path",
 )
@@ -34,6 +35,8 @@ def empty_resolution(kind: str = "unknown") -> dict:
         "dependency_status": "unavailable",
         "risk": [],
         "risk_status": "unavailable",
+        "suggestion": None,
+        "suggestion_status": "unavailable",
         "confidence": "unavailable",
         "evidence_path": None,
         "evidence_status": "unavailable",
@@ -51,6 +54,7 @@ def normalize_resolution(
     commit: dict | None = None,
     dependency: str | list[str] | None = None,
     risk: list[dict] | None = None,
+    suggestion: str | None = None,
     confidence: str = "unavailable",
     evidence_path: str | None = None,
 ) -> dict:
@@ -69,6 +73,8 @@ def normalize_resolution(
             "dependency_status": "available" if dependency else "unavailable",
             "risk": risk or [],
             "risk_status": "available" if risk else "unavailable",
+            "suggestion": suggestion,
+            "suggestion_status": "available" if suggestion else "unavailable",
             "confidence": confidence if confidence in CONFIDENCE_ORDER else "unavailable",
             "evidence_path": evidence_path,
             "evidence_status": "available" if evidence_path else "unavailable",

--- a/src/tests/test_evidence_resolution.py
+++ b/src/tests/test_evidence_resolution.py
@@ -220,6 +220,24 @@ def test_attach_risk_evidence_attaches_matching_findings():
     assert result["risk_status"] == "available"
 
 
+def test_normalize_resolution_sets_suggestion_and_status():
+    result = normalize_resolution(kind="owner", suggestion="add a null check here", confidence="inferred")
+    assert result["suggestion"] == "add a null check here"
+    assert result["suggestion_status"] == "available"
+
+    empty = empty_resolution("owner")
+    assert empty["suggestion"] is None
+    assert empty["suggestion_status"] == "unavailable"
+
+
+def test_merge_resolution_carries_suggestion_from_attachment():
+    base = empty_resolution("endpoint")
+    attachment = normalize_resolution(kind="suggestion", suggestion="fix by X", confidence="inferred")
+    merged = merge_resolution(base, attachment)
+    assert merged["suggestion"] == "fix by X"
+    assert merged["suggestion_status"] == "available"
+
+
 def test_resolution_is_json_serializable():
     result = attach_risk_evidence(
         make_evidence(),


### PR DESCRIPTION
## Summary
Extends the existing health-check correlation chain (owner attachment, dependency context from earlier this session) with a real fix suggestion: DeepSeek Pro, grounded in the already-pinpointed file/line/symbol evidence plus the actual surrounding source code, writes a concrete suggested cause and fix. Always Pro, not tier-routed - a fixed part of every Pro subscription.

- New `suggestion`/`suggestion_status` field pair in the shared `evidence_resolution.py` schema.
- `fetch_file_content`'s `ref` parameter is now optional (health-check correlation has no PR head_sha; omitting it resolves the repo's default branch).
- Same graceful-degradation discipline as the rest of this chain: any failure just means no suggestion, never blocks the alert.

## Test plan
- [x] New tests: symbol-at-line lookup, file-content-unavailable, model-says-unknown, successful suggestion, degrades on any exception, end-to-end wiring into the merged resolution
- [x] Existing correlation tests updated to mock the new attachment (previously would've made a real, unmocked network call)
- [x] Full `github-app` suite: 570 passed, 7 skipped
- [x] Full `src` suite: 1447 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)