### PR TITLE
feat: add LLM-based suggestion section to managed audit reports

### DIFF
--- a/github-app/scan_worker/managed_audit.py
+++ b/github-app/scan_worker/managed_audit.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from pathlib import Path
 from typing import Callable
 
@@ -5,12 +7,56 @@ import aletheore.cli as _aletheore_cli
 from aletheore.report import run_reasoning_phase
 from scan_worker.model_tiers import writing_adapter_for_plan
 
+LLM_SUGGESTION_SYSTEM_PROMPT = """You have just been given a completed, evidence-backed code audit report.
+Based on it, provide your own broader assessment: a single overall quality rating out of 10 with a one-sentence
+justification, followed by 3-5 concrete improvement suggestions a strong engineer might make after reading this
+report - things beyond what the evidence-backed findings already state, or a different way to prioritize them.
+Be specific and actionable, never vague ("consider best practices"). Respond with ONLY this JSON shape:
+{"rating": <int 1-10>, "rating_justification": "<one sentence>", "suggestions": ["<suggestion 1>", ...]}
+No markdown fences, no other text."""
+
+
+def _llm_based_suggestion_section(
+    report_text: str, plan: str, on_usage: Callable[[int, int], None] | None = None
+) -> str | None:
+    # Purely additive, and never allowed to break a real audit: the
+    # evidence-backed report above this section is the product's core
+    # promise ("no claim without evidence"), and this is the one place
+    # that promise is deliberately relaxed - clearly labeled, never mixed
+    # into the findings themselves. Any failure (bad JSON, missing key,
+    # model outage) just means this section doesn't get appended.
+    try:
+        adapter = writing_adapter_for_plan(plan, on_usage=on_usage)
+        raw = adapter.simple_completion(LLM_SUGGESTION_SYSTEM_PROMPT, report_text, cwd=".")
+        parsed = json.loads(raw)
+        rating = parsed.get("rating")
+        justification = parsed.get("rating_justification") or ""
+        suggestions = [s for s in parsed.get("suggestions", []) if isinstance(s, str) and s.strip()]
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.managed_audit").warning(
+            "LLM-based suggestion section failed (%s); shipping the audit without it", type(exc).__name__
+        )
+        return None
+    if not isinstance(rating, int) or not (1 <= rating <= 10) or not suggestions:
+        return None
+
+    lines = [
+        "\n\n---\n\n## LLM Based Suggestion (Not Evidence Backed)\n",
+        "_Everything above is Aletheore's deterministic, evidence-grounded audit. "
+        "The section below is the model's own broader judgment, not tied to a specific "
+        "citation - treat it as a second opinion, not a finding._\n",
+        f"**Overall rating: {rating}/10** — {justification}\n",
+        "**Suggestions:**",
+    ]
+    lines.extend(f"- {suggestion}" for suggestion in suggestions)
+    return "\n".join(lines)
+
 
 def run_managed_audit(
     repo_path: Path,
     manual_dir: str | None = None,
     on_usage: Callable[[int, int], None] | None = None,
-    plan: str = "indie",
+    plan: str = "pro",
 ) -> str:
     adapter = writing_adapter_for_plan(plan, on_usage=on_usage)
     report_path = run_reasoning_phase(
@@ -18,4 +64,9 @@ def run_managed_audit(
         str(repo_path),
         manual_dir or _aletheore_cli.MANUAL_DIR,
     )
-    return Path(report_path).read_text()
+    report_text = Path(report_path).read_text()
+
+    suggestion_section = _llm_based_suggestion_section(report_text, plan, on_usage=on_usage)
+    if suggestion_section:
+        report_text += suggestion_section
+    return report_text

--- a/github-app/tests/test_managed_audit.py
+++ b/github-app/tests/test_managed_audit.py
@@ -1,6 +1,7 @@
+import json
 from pathlib import Path
 
-from scan_worker.managed_audit import run_managed_audit
+from scan_worker.managed_audit import _llm_based_suggestion_section, run_managed_audit
 
 
 def test_run_managed_audit_returns_report_text(tmp_path, monkeypatch):
@@ -50,3 +51,95 @@ def test_run_managed_audit_threads_on_usage_to_the_adapter(tmp_path, monkeypatch
     assert adapter._on_usage is not None
     adapter._on_usage(50, 10)
     assert received == [(50, 10)]
+
+
+class _FakeSuggestionAdapter:
+    def __init__(self, response: str):
+        self._response = response
+
+    def simple_completion(self, system_prompt, user_prompt, cwd):
+        return self._response
+
+
+def test_llm_based_suggestion_section_formats_rating_and_suggestions(monkeypatch):
+    response = json.dumps(
+        {
+            "rating": 7,
+            "rating_justification": "solid tests, thin error handling",
+            "suggestions": ["Add retries around the payment webhook call", "Extract the 300-line handler"],
+        }
+    )
+    monkeypatch.setattr(
+        "scan_worker.managed_audit.writing_adapter_for_plan",
+        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+    )
+
+    section = _llm_based_suggestion_section("# Real Report\n\nfindings", "pro")
+
+    assert section is not None
+    assert "LLM Based Suggestion (Not Evidence Backed)" in section
+    assert "7/10" in section
+    assert "solid tests, thin error handling" in section
+    assert "Add retries around the payment webhook call" in section
+    assert "Extract the 300-line handler" in section
+
+
+def test_llm_based_suggestion_section_returns_none_for_malformed_json(monkeypatch):
+    monkeypatch.setattr(
+        "scan_worker.managed_audit.writing_adapter_for_plan",
+        lambda plan, on_usage=None: _FakeSuggestionAdapter("not json at all"),
+    )
+
+    assert _llm_based_suggestion_section("report", "pro") is None
+
+
+def test_llm_based_suggestion_section_returns_none_for_out_of_range_rating(monkeypatch):
+    response = json.dumps({"rating": 15, "rating_justification": "x", "suggestions": ["do a thing"]})
+    monkeypatch.setattr(
+        "scan_worker.managed_audit.writing_adapter_for_plan",
+        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+    )
+
+    assert _llm_based_suggestion_section("report", "pro") is None
+
+
+def test_llm_based_suggestion_section_returns_none_when_suggestions_empty(monkeypatch):
+    response = json.dumps({"rating": 8, "rating_justification": "x", "suggestions": []})
+    monkeypatch.setattr(
+        "scan_worker.managed_audit.writing_adapter_for_plan",
+        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+    )
+
+    assert _llm_based_suggestion_section("report", "pro") is None
+
+
+def test_llm_based_suggestion_section_degrades_gracefully_on_adapter_failure(monkeypatch):
+    def _raise(plan, on_usage=None):
+        raise RuntimeError("no credentials")
+
+    monkeypatch.setattr("scan_worker.managed_audit.writing_adapter_for_plan", _raise)
+
+    assert _llm_based_suggestion_section("report", "pro") is None
+
+
+def test_run_managed_audit_appends_llm_suggestion_section_when_available(tmp_path, monkeypatch):
+    repo_path = tmp_path / "repo"
+    (repo_path / ".aletheore").mkdir(parents=True)
+
+    def fake_run_reasoning_phase(adapter, repo_path_arg, manual_dir):
+        report_path = Path(repo_path_arg) / ".aletheore" / "audit-report.md"
+        report_path.write_text("# Real Report\n\nfindings here")
+        return str(report_path)
+
+    monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
+    response = json.dumps({"rating": 6, "rating_justification": "ok", "suggestions": ["tighten input validation"]})
+    monkeypatch.setattr(
+        "scan_worker.managed_audit.writing_adapter_for_plan",
+        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+    )
+
+    result = run_managed_audit(repo_path)
+
+    assert "# Real Report" in result
+    assert "LLM Based Suggestion (Not Evidence Backed)" in result
+    assert "tighten input validation" in result


### PR DESCRIPTION
## Summary
- Adds a new "LLM Based Suggestion (Not Evidence Backed)" section appended to managed audit reports: a 1-10 overall rating plus 3-5 concrete improvement suggestions from the model, clearly labeled as separate from the evidence-backed findings.
- Purely additive - a second `simple_completion` call after the existing agentic `run_reasoning_phase` flow; never touches the core evidence-grounded report generation.
- Graceful degradation: malformed JSON, out-of-range rating, empty suggestions, or adapter failure all just skip the section (logged, report ships without it).
- `run_managed_audit`'s default `plan` flips from `"indie"` to `"pro"`, matching the single-Pro-tier restructuring.

## Test plan
- [x] `python3 -m pytest -q tests/test_managed_audit.py -v` - 8/8 passed (2 pre-existing + 6 new)
- [x] Full `github-app` suite: 576 passed, 7 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)