### PR TITLE
fix: dashboard pending repos, parallel license checks, deepseek adapter, scanner worktree exclusion

### DIFF
--- a/docs/superpowers/plans/2026-07-26-aletheore-pr-review-benchmark-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-26-aletheore-pr-review-benchmark-implementation-plan.md
@@ -1,0 +1,1600 @@
+# Aletheore PR-Review Benchmark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the scripts and case corpus for the public PR-review benchmark defined in `docs/superpowers/specs/2026-07-26-aletheore-pr-review-benchmark-design.md`, comparing Aletheore against Qodo/PR-Agent and DeepSource (named) and CodeRabbit (anonymized).
+
+**Architecture:** A new `benchmarks/pr-review-benchmark/` directory, separate from the shipped `aletheore` package. Small, single-purpose Python modules under `scripts/` (case loading, checkout preparation, per-tool normalization, automated citation/grounding checks, blind anonymization, LLM judging, aggregation) — each a plain function over dicts, matching `src/aletheore/citation_verifier.py`'s existing style, each with its own pytest file. `run_case.py` wires these together per case; live invocation of each external tool (creating throwaway GitHub PRs, installing CodeRabbit's app, calling PR-Agent/DeepSource/an LLM judge) is manual/integration work documented in a README runbook, not unit-tested — everything upstream of that boundary (checkout construction, normalization, grounding checks, anonymization, aggregation) is pure and fully covered by tests.
+
+**Tech Stack:** Python 3.11+, pytest, PyYAML, the already-installed `aletheore` package (editable install from `src/`), `openai` client for the LLM judge (a different model provider than whichever powers the tools under test, per the spec's independence requirement).
+
+## Global Constraints
+
+- Python 3.11+ (matches `src/pyproject.toml:9`'s `requires-python`).
+- Tests use plain `assert` + pytest, no `pytest-randomly` reordering (`src/pyproject.toml:70`: `addopts = ["-p", "no:randomly"]`) — mirror that in this directory's test runs too.
+- Reuse `aletheore.citation_verifier.extract_citations` (`src/aletheore/citation_verifier.py:17`) rather than re-implementing citation parsing.
+- Structured data (ground truth, scoring sheets, sealed mappings) is YAML or JSON, never free-text parsing of prose — `pyyaml` is already a dependency (`src/pyproject.toml:42`).
+- CodeRabbit's raw output is never committed to the repo in any form — only its anonymized, scored summary. Enforced by directory convention (`results/raw/` excluded from git for the CodeRabbit entry specifically — see Task 9).
+- The sealed tool↔label mapping for a case is never opened until that case's manual and LLM scoring are both recorded.
+- The LLM judge model must be a different provider/family than whichever model powers the tools under test in a given run (recorded in `METHODOLOGY.md`).
+- Every module in `scripts/` is a plain function over dicts/paths — no new classes, dataclasses, or frameworks introduced where a function suffices, matching `citation_verifier.py`'s existing shape.
+
+---
+
+## File Structure
+
+```
+benchmarks/pr-review-benchmark/
+  README.md                  # runbook: how to author a case, run the live tools, score, aggregate
+  scripts/
+    cases.py                 # load/validate a case directory
+    build_case_repo.py       # clone + checkout + apply pr.diff -> local checkout
+    adapters.py               # real per-tool invocation (subprocess/API), injectable for tests
+    normalize.py              # per-tool raw output -> common finding schema
+    check_citations.py        # automated grounding check against the real checkout
+    anonymize.py               # blind relabeling + sealed mapping + reveal
+    scoring_template.py        # blank manual/LLM scoring sheet generator
+    llm_judge.py                # independent LLM scoring pass
+    aggregate.py                 # cross-case scorecard + human/LLM agreement rate
+    run_case.py                   # orchestrates one case end-to-end
+  tests/
+    test_cases.py
+    test_build_case_repo.py
+    test_adapters.py
+    test_normalize.py
+    test_check_citations.py
+    test_anonymize.py
+    test_scoring_template.py
+    test_llm_judge.py
+    test_aggregate.py
+    test_run_case.py
+  cases/
+    <case-id>/
+      repo.txt                # repo_url=..., base_commit=..., optional pr_url=...
+      pr.diff
+      ground_truth.yaml        # structured, machine-readable ground truth
+      ground_truth.md           # prose version for the published report
+  results/                       # gitignored except the final anonymized/aggregated artifacts
+    raw/<case-id>/<tool>.json      # CodeRabbit's excluded from git, see Task 9
+    grounding/<case-id>/<tool>.json
+    anon/<case-id>/<label>.json
+    sealed/<case-id>.json
+    scored/<case-id>.yaml
+    llm_judged/<case-id>.json
+  REPORT.md
+  METHODOLOGY.md
+```
+
+---
+
+### Task 1: Case schema — load and validate a test case directory
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/cases.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_cases.py`
+
+**Interfaces:**
+- Produces: `load_repo_pointer(case_dir: Path) -> dict` (keys: `repo_url`, `base_commit`, optionally `pr_url`, `deepsource_run_id`); `load_ground_truth(case_dir: Path) -> dict` (keys: `case_id`, `language`, `category` one of `real_bug_fix`/`injected_bug`/`clean`, `bug_type`, `expected_file`, `expected_line`, `fix_reference`, `description`); `load_case(case_dir: Path) -> dict` (keys: `case_id`, `repo`, `diff_path`, `ground_truth`) — later tasks (`build_case_repo.py`, `run_case.py`) consume exactly this shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_cases.py
+import pytest
+from scripts.cases import load_case, load_repo_pointer, load_ground_truth
+
+
+def make_case(tmp_path, category="injected_bug"):
+    case_dir = tmp_path / "001-example"
+    case_dir.mkdir()
+    (case_dir / "repo.txt").write_text(
+        "repo_url=https://example.com/repo.git\nbase_commit=abc123\n"
+    )
+    (case_dir / "pr.diff").write_text("diff --git a/x.py b/x.py\n")
+    (case_dir / "ground_truth.yaml").write_text(
+        "case_id: 001-example\n"
+        "language: python\n"
+        f"category: {category}\n"
+        "bug_type: sql-injection\n"
+        "expected_file: x.py\n"
+        "expected_line: 10\n"
+        "fix_reference: null\n"
+        "description: test case\n"
+    )
+    return case_dir
+
+
+def test_load_repo_pointer_parses_key_value_pairs(tmp_path):
+    case_dir = make_case(tmp_path)
+    pointer = load_repo_pointer(case_dir)
+    assert pointer == {"repo_url": "https://example.com/repo.git", "base_commit": "abc123"}
+
+
+def test_load_repo_pointer_requires_repo_url_and_base_commit(tmp_path):
+    case_dir = tmp_path / "002-bad"
+    case_dir.mkdir()
+    (case_dir / "repo.txt").write_text("repo_url=https://example.com/repo.git\n")
+    with pytest.raises(ValueError, match="repo_url and base_commit"):
+        load_repo_pointer(case_dir)
+
+
+def test_load_ground_truth_rejects_unknown_category(tmp_path):
+    case_dir = make_case(tmp_path, category="not_a_real_category")
+    with pytest.raises(ValueError, match="category must be one of"):
+        load_ground_truth(case_dir)
+
+
+def test_load_case_returns_combined_case_dict(tmp_path):
+    case_dir = make_case(tmp_path)
+    case = load_case(case_dir)
+    assert case["case_id"] == "001-example"
+    assert case["repo"]["base_commit"] == "abc123"
+    assert case["ground_truth"]["category"] == "injected_bug"
+    assert case["diff_path"] == case_dir / "pr.diff"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_cases.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'scripts.cases'` (or `scripts`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/cases.py
+"""Loads and validates a benchmark test case directory."""
+from pathlib import Path
+import yaml
+
+VALID_CATEGORIES = {"real_bug_fix", "injected_bug", "clean"}
+
+
+def load_repo_pointer(case_dir: Path) -> dict:
+    text = (Path(case_dir) / "repo.txt").read_text()
+    pointer = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        pointer[key.strip()] = value.strip()
+    if "repo_url" not in pointer or "base_commit" not in pointer:
+        raise ValueError(f"{case_dir}/repo.txt must define repo_url and base_commit")
+    return pointer
+
+
+def load_ground_truth(case_dir: Path) -> dict:
+    data = yaml.safe_load((Path(case_dir) / "ground_truth.yaml").read_text())
+    if data.get("category") not in VALID_CATEGORIES:
+        raise ValueError(
+            f"{case_dir}/ground_truth.yaml: category must be one of {VALID_CATEGORIES}"
+        )
+    return data
+
+
+def load_case(case_dir: Path) -> dict:
+    case_dir = Path(case_dir)
+    return {
+        "case_id": case_dir.name,
+        "repo": load_repo_pointer(case_dir),
+        "diff_path": case_dir / "pr.diff",
+        "ground_truth": load_ground_truth(case_dir),
+    }
+```
+
+Also create an empty `benchmarks/pr-review-benchmark/scripts/__init__.py` and `benchmarks/pr-review-benchmark/tests/__init__.py`, and a `benchmarks/pr-review-benchmark/pytest.ini`:
+
+```ini
+[pytest]
+addopts = -p no:randomly
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_cases.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/cases.py \
+        benchmarks/pr-review-benchmark/scripts/__init__.py \
+        benchmarks/pr-review-benchmark/tests/test_cases.py \
+        benchmarks/pr-review-benchmark/tests/__init__.py \
+        benchmarks/pr-review-benchmark/pytest.ini
+git commit -m "feat(benchmark): add case schema loader"
+```
+
+---
+
+### Task 2: Case checkout builder
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/build_case_repo.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_build_case_repo.py`
+
+**Interfaces:**
+- Consumes: `repo_pointer` dict shape from Task 1 (`repo_url`, `base_commit`).
+- Produces: `prepare_case_checkout(repo_pointer: dict, diff_path: Path, workdir: Path) -> Path` — returns the checkout directory with `pr.diff` already applied on top of `base_commit`. Consumed by `run_case.py` (Task 9) and `check_citations.py`'s callers.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_build_case_repo.py
+import subprocess
+from scripts.build_case_repo import prepare_case_checkout
+
+
+def _run(*args, cwd=None):
+    subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+
+
+def make_fixture_repo(tmp_path):
+    remote = tmp_path / "remote.git"
+    work = tmp_path / "seed"
+    work.mkdir()
+    _run("git", "init", cwd=work)
+    _run("git", "config", "user.email", "test@example.com", cwd=work)
+    _run("git", "config", "user.name", "Test", cwd=work)
+    (work / "x.py").write_text("value = 1\n")
+    _run("git", "add", "x.py", cwd=work)
+    _run("git", "commit", "-m", "base", cwd=work)
+    base_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=work, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    (work / "x.py").write_text("value = 2\n")
+    _run("git", "add", "x.py", cwd=work)
+    _run("git", "commit", "-m", "change value", cwd=work)
+
+    diff_path = tmp_path / "pr.diff"
+    diff = subprocess.run(
+        ["git", "diff", base_commit, "HEAD"], cwd=work, check=True, capture_output=True, text=True
+    ).stdout
+    diff_path.write_text(diff)
+
+    _run("git", "clone", "--bare", str(work), str(remote))
+    return remote, base_commit, diff_path
+
+
+def test_prepare_case_checkout_applies_pr_diff_on_base_commit(tmp_path):
+    remote, base_commit, diff_path = make_fixture_repo(tmp_path)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    checkout_dir = prepare_case_checkout(
+        {"repo_url": str(remote), "base_commit": base_commit}, diff_path, workdir
+    )
+
+    assert (checkout_dir / "x.py").read_text() == "value = 2\n"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_build_case_repo.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/build_case_repo.py
+"""Prepares a local checkout of a test case's PR-under-test: clone the
+repo, check out base_commit, and apply pr.diff on top."""
+import subprocess
+from pathlib import Path
+
+
+def prepare_case_checkout(repo_pointer: dict, diff_path: Path, workdir: Path) -> Path:
+    checkout_dir = Path(workdir) / "checkout"
+    subprocess.run(
+        ["git", "clone", repo_pointer["repo_url"], str(checkout_dir)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "checkout", repo_pointer["base_commit"]],
+        cwd=checkout_dir, check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "apply", str(diff_path)],
+        cwd=checkout_dir, check=True, capture_output=True,
+    )
+    return checkout_dir
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_build_case_repo.py -v`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/build_case_repo.py \
+        benchmarks/pr-review-benchmark/tests/test_build_case_repo.py
+git commit -m "feat(benchmark): add case checkout builder"
+```
+
+---
+
+### Task 3: Per-tool output normalizers
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/normalize.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_normalize.py`
+
+**Interfaces:**
+- Consumes: `aletheore.citation_verifier.extract_citations` (existing, `src/aletheore/citation_verifier.py:17`).
+- Produces: `normalize_aletheore(report_text: str) -> list[dict]`, `normalize_pr_agent(raw: dict) -> list[dict]`, `normalize_deepsource(raw: dict) -> list[dict]`, `normalize_coderabbit(raw_comments: list[dict]) -> list[dict]` — each returns the common finding schema `{"file": str|None, "line": int|None, "message": str, "severity": str|None}`, consumed by `check_citations.py` (Task 4) and `run_case.py` (Task 9).
+
+**Note on assumed schemas:** `normalize_pr_agent` assumes PR-Agent's `--pr_url ... review` JSON output has a top-level `code_suggestions` list with `relevant_file`/`relevant_line`/`suggestion_content`/`label` keys, and `normalize_deepsource` assumes an `issues` list with `location.path`/`location.position.begin.line`/`title`/`severity`. These are documented assumptions based on each tool's public docs, not verified against a live run yet — **Task 9's live data-collection step must confirm the actual shape and adjust these two functions (and their tests) if the real output differs.** `normalize_coderabbit` is lower-risk: it consumes the GitHub REST API's PR review-comment shape (`path`, `line`/`original_line`, `body`), which is stable regardless of which bot posted the comment.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_normalize.py
+from scripts.normalize import (
+    normalize_aletheore,
+    normalize_pr_agent,
+    normalize_deepsource,
+    normalize_coderabbit,
+)
+
+
+def test_normalize_aletheore_extracts_citation_and_paragraph_as_message():
+    report = (
+        "This endpoint has no auth check at `app/routes.py:42`, which allows "
+        "unauthenticated access.\n\n"
+        "Unrelated paragraph with no citation."
+    )
+    findings = normalize_aletheore(report)
+    assert findings == [{
+        "file": "app/routes.py",
+        "line": 42,
+        "message": (
+            "This endpoint has no auth check at `app/routes.py:42`, which allows "
+            "unauthenticated access."
+        ),
+        "severity": None,
+    }]
+
+
+def test_normalize_pr_agent_reads_code_suggestions():
+    raw = {
+        "code_suggestions": [
+            {
+                "relevant_file": "app.py",
+                "relevant_line": 10,
+                "suggestion_content": "Use a parameterized query here.",
+                "label": "possible bug",
+            }
+        ]
+    }
+    findings = normalize_pr_agent(raw)
+    assert findings == [{
+        "file": "app.py",
+        "line": 10,
+        "message": "Use a parameterized query here.",
+        "severity": "possible bug",
+    }]
+
+
+def test_normalize_deepsource_reads_issues():
+    raw = {
+        "issues": [
+            {
+                "title": "Unused import",
+                "severity": "minor",
+                "location": {"path": "app.py", "position": {"begin": {"line": 3}}},
+            }
+        ]
+    }
+    findings = normalize_deepsource(raw)
+    assert findings == [{
+        "file": "app.py",
+        "line": 3,
+        "message": "Unused import",
+        "severity": "minor",
+    }]
+
+
+def test_normalize_coderabbit_reads_github_review_comments():
+    raw_comments = [{"path": "app.py", "line": 5, "body": "Missing null check."}]
+    findings = normalize_coderabbit(raw_comments)
+    assert findings == [{
+        "file": "app.py",
+        "line": 5,
+        "message": "Missing null check.",
+        "severity": None,
+    }]
+
+
+def test_normalize_coderabbit_falls_back_to_original_line():
+    raw_comments = [{"path": "app.py", "original_line": 9, "body": "Stale comment."}]
+    findings = normalize_coderabbit(raw_comments)
+    assert findings[0]["line"] == 9
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_normalize.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/normalize.py
+"""Normalizes each tool's raw output into a common finding schema:
+{"file": str|None, "line": int|None, "message": str, "severity": str|None}."""
+from aletheore.citation_verifier import extract_citations
+
+
+def normalize_aletheore(report_text: str) -> list[dict]:
+    findings = []
+    for paragraph in report_text.split("\n\n"):
+        for citation in extract_citations(paragraph):
+            findings.append({
+                "file": citation["file"],
+                "line": citation["line"],
+                "message": paragraph.strip(),
+                "severity": None,
+            })
+    return findings
+
+
+def normalize_pr_agent(raw: dict) -> list[dict]:
+    return [
+        {
+            "file": suggestion.get("relevant_file"),
+            "line": suggestion.get("relevant_line"),
+            "message": suggestion.get("suggestion_content", ""),
+            "severity": suggestion.get("label"),
+        }
+        for suggestion in raw.get("code_suggestions", [])
+    ]
+
+
+def normalize_deepsource(raw: dict) -> list[dict]:
+    findings = []
+    for issue in raw.get("issues", []):
+        location = issue.get("location", {})
+        findings.append({
+            "file": location.get("path"),
+            "line": location.get("position", {}).get("begin", {}).get("line"),
+            "message": issue.get("title", ""),
+            "severity": issue.get("severity"),
+        })
+    return findings
+
+
+def normalize_coderabbit(raw_comments: list[dict]) -> list[dict]:
+    return [
+        {
+            "file": comment.get("path"),
+            "line": comment.get("line") or comment.get("original_line"),
+            "message": comment.get("body", ""),
+            "severity": None,
+        }
+        for comment in raw_comments
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_normalize.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/normalize.py \
+        benchmarks/pr-review-benchmark/tests/test_normalize.py
+git commit -m "feat(benchmark): add per-tool output normalizers"
+```
+
+---
+
+### Task 4: Automated grounding/citation check against the real checkout
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/check_citations.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_check_citations.py`
+
+**Interfaces:**
+- Consumes: common finding schema from Task 3.
+- Produces: `verify_findings_against_checkout(findings: list[dict], checkout_dir: Path) -> dict` (keys: `total_findings`, `verified`, `unverified`, `grounding_rate`) — consumed by `run_case.py` (Task 9) and the report-building step (Task 11).
+
+This is deliberately **not** blinded — it's a fully automated, deterministic check with no human judgment involved, so there's no bias it needs protecting against (unlike Task 6/7's manual and LLM scoring, which score subjective recall/actionability and must stay blind). It runs on real tool names directly.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_check_citations.py
+from scripts.check_citations import verify_findings_against_checkout
+
+
+def make_checkout(tmp_path):
+    (tmp_path / "app.py").write_text("line1\nline2\nline3\n")
+    return tmp_path
+
+
+def test_verify_findings_marks_valid_file_and_line_as_verified(tmp_path):
+    checkout = make_checkout(tmp_path)
+    findings = [{"file": "app.py", "line": 2, "message": "ok", "severity": None}]
+    result = verify_findings_against_checkout(findings, checkout)
+    assert result == {
+        "total_findings": 1,
+        "verified": findings,
+        "unverified": [],
+        "grounding_rate": 1.0,
+    }
+
+
+def test_verify_findings_marks_missing_file_as_unverified(tmp_path):
+    checkout = make_checkout(tmp_path)
+    findings = [{"file": "ghost.py", "line": 1, "message": "hallucinated", "severity": None}]
+    result = verify_findings_against_checkout(findings, checkout)
+    assert result["verified"] == []
+    assert result["unverified"] == findings
+    assert result["grounding_rate"] == 0.0
+
+
+def test_verify_findings_marks_out_of_bounds_line_as_unverified(tmp_path):
+    checkout = make_checkout(tmp_path)
+    findings = [{"file": "app.py", "line": 99, "message": "bad line", "severity": None}]
+    result = verify_findings_against_checkout(findings, checkout)
+    assert result["unverified"] == findings
+
+
+def test_verify_findings_treats_missing_file_key_as_unverified(tmp_path):
+    checkout = make_checkout(tmp_path)
+    findings = [{"file": None, "line": None, "message": "vague comment", "severity": None}]
+    result = verify_findings_against_checkout(findings, checkout)
+    assert result["unverified"] == findings
+
+
+def test_verify_findings_handles_empty_findings_list(tmp_path):
+    checkout = make_checkout(tmp_path)
+    result = verify_findings_against_checkout([], checkout)
+    assert result == {
+        "total_findings": 0,
+        "verified": [],
+        "unverified": [],
+        "grounding_rate": None,
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_check_citations.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/check_citations.py
+"""Extends citation_verifier.py's file-existence check with a real
+line-bounds check against an actual local checkout (not AIR evidence
+— the benchmark harness has direct filesystem access, unlike the
+shipped product's evidence schema)."""
+from pathlib import Path
+
+
+def verify_findings_against_checkout(findings: list[dict], checkout_dir: Path) -> dict:
+    verified = []
+    unverified = []
+    for finding in findings:
+        file_path = finding.get("file")
+        line = finding.get("line")
+        if not file_path:
+            unverified.append(finding)
+            continue
+        full_path = Path(checkout_dir) / file_path
+        if not full_path.is_file():
+            unverified.append(finding)
+            continue
+        if line is not None:
+            line_count = sum(1 for _ in full_path.open())
+            if line < 1 or line > line_count:
+                unverified.append(finding)
+                continue
+        verified.append(finding)
+
+    return {
+        "total_findings": len(findings),
+        "verified": verified,
+        "unverified": unverified,
+        "grounding_rate": (len(verified) / len(findings)) if findings else None,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_check_citations.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/check_citations.py \
+        benchmarks/pr-review-benchmark/tests/test_check_citations.py
+git commit -m "feat(benchmark): add automated grounding check against real checkout"
+```
+
+---
+
+### Task 5: Blind anonymization + sealed mapping
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/anonymize.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_anonymize.py`
+
+**Interfaces:**
+- Produces: `assign_labels(tool_names: list[str], rng: random.Random) -> dict[str, str]` (label → real tool name), `write_anonymized_case(case_id: str, findings_by_tool: dict, results_dir: Path, rng: random.Random) -> dict` (writes `results/anon/<case_id>/<label>.json` and `results/sealed/<case_id>.json`), `reveal_mapping(case_id: str, results_dir: Path) -> dict` — consumed by `run_case.py` (Task 9), the manual scoring workflow (README), and the final report-building step (Task 11).
+
+**Important:** the label↔tool mapping is re-randomized **independently per case** (a fresh `random.Random` seed per case at call time in real runs — tests inject a fixed seed for determinism). If the same tool always mapped to the same label across all ~25 cases, a scorer would learn the pattern within a handful of cases and the blinding would be defeated well before the corpus is finished.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_anonymize.py
+import json
+import random
+from scripts.anonymize import assign_labels, write_anonymized_case, reveal_mapping
+
+
+def test_assign_labels_maps_each_tool_to_a_distinct_label():
+    rng = random.Random(42)
+    mapping = assign_labels(["aletheore", "pr_agent", "deepsource", "coderabbit"], rng)
+    assert set(mapping.keys()) == {"Tool A", "Tool B", "Tool C", "Tool D"}
+    assert set(mapping.values()) == {"aletheore", "pr_agent", "deepsource", "coderabbit"}
+
+
+def test_assign_labels_rejects_more_tools_than_labels():
+    rng = random.Random(1)
+    try:
+        assign_labels(["a", "b", "c", "d", "e"], rng)
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_write_anonymized_case_and_reveal_mapping_round_trip(tmp_path):
+    rng = random.Random(7)
+    findings_by_tool = {
+        "aletheore": [{"file": "x.py", "line": 1, "message": "m", "severity": None}],
+        "pr_agent": [{"file": "y.py", "line": 2, "message": "n", "severity": None}],
+    }
+    result = write_anonymized_case("001-example", findings_by_tool, tmp_path, rng)
+
+    anon_files = sorted(p.name for p in result["anon_dir"].iterdir())
+    assert len(anon_files) == 2
+
+    revealed = reveal_mapping("001-example", tmp_path)
+    assert set(revealed.values()) == {"aletheore", "pr_agent"}
+
+    for label, tool in revealed.items():
+        anon_path = result["anon_dir"] / f"{label.replace(' ', '_').lower()}.json"
+        assert json.loads(anon_path.read_text()) == findings_by_tool[tool]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_anonymize.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/anonymize.py
+"""Blind relabeling of tool outputs per case, so manual and LLM
+scoring never see which tool produced which output. Re-randomized
+independently per case so a scorer can't learn "label X is always
+tool Y" across the corpus."""
+import json
+import random
+from pathlib import Path
+
+LABELS = ["Tool A", "Tool B", "Tool C", "Tool D"]
+
+
+def assign_labels(tool_names: list[str], rng: random.Random) -> dict:
+    if len(tool_names) > len(LABELS):
+        raise ValueError("more tools than available labels")
+    shuffled = list(tool_names)
+    rng.shuffle(shuffled)
+    return dict(zip(LABELS, shuffled))
+
+
+def write_anonymized_case(
+    case_id: str, findings_by_tool: dict, results_dir: Path, rng: random.Random
+) -> dict:
+    label_to_tool = assign_labels(list(findings_by_tool.keys()), rng)
+    tool_to_label = {tool: label for label, tool in label_to_tool.items()}
+
+    anon_dir = Path(results_dir) / "anon" / case_id
+    anon_dir.mkdir(parents=True, exist_ok=True)
+    for tool, findings in findings_by_tool.items():
+        label = tool_to_label[tool]
+        out_path = anon_dir / f"{label.replace(' ', '_').lower()}.json"
+        out_path.write_text(json.dumps(findings, indent=2))
+
+    sealed_dir = Path(results_dir) / "sealed"
+    sealed_dir.mkdir(parents=True, exist_ok=True)
+    sealed_path = sealed_dir / f"{case_id}.json"
+    sealed_path.write_text(json.dumps(label_to_tool, indent=2))
+
+    return {"anon_dir": anon_dir, "sealed_path": sealed_path}
+
+
+def reveal_mapping(case_id: str, results_dir: Path) -> dict:
+    sealed_path = Path(results_dir) / "sealed" / f"{case_id}.json"
+    return json.loads(sealed_path.read_text())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_anonymize.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/anonymize.py \
+        benchmarks/pr-review-benchmark/tests/test_anonymize.py
+git commit -m "feat(benchmark): add blind anonymization with sealed mapping"
+```
+
+---
+
+### Task 6: Blank scoring template generator
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/scoring_template.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_scoring_template.py`
+
+**Interfaces:**
+- Produces: `build_blank_scorecard(case_id: str, labels: list[str]) -> dict`, `write_blank_scorecard(case_id: str, labels: list[str], out_path: Path) -> None` — the YAML shape (`{"case_id": ..., "scores": {label: {"recall": None, "false_positives": [], "actionability": None}}}`) is the exact shape `aggregate.py` (Task 8) reads back from `results/scored/<case_id>.yaml` once filled in by hand.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_scoring_template.py
+import yaml
+from scripts.scoring_template import build_blank_scorecard, write_blank_scorecard
+
+
+def test_build_blank_scorecard_has_one_entry_per_label():
+    card = build_blank_scorecard("001-example", ["Tool A", "Tool B"])
+    assert card == {
+        "case_id": "001-example",
+        "scores": {
+            "Tool A": {"recall": None, "false_positives": [], "actionability": None},
+            "Tool B": {"recall": None, "false_positives": [], "actionability": None},
+        },
+    }
+
+
+def test_write_blank_scorecard_writes_valid_yaml(tmp_path):
+    out_path = tmp_path / "001-example.yaml"
+    write_blank_scorecard("001-example", ["Tool A"], out_path)
+    loaded = yaml.safe_load(out_path.read_text())
+    assert loaded["case_id"] == "001-example"
+    assert loaded["scores"]["Tool A"]["recall"] is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_scoring_template.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/scoring_template.py
+"""Generates a blank manual/LLM scoring template for a case, keyed
+only by anonymized label -- never by real tool name."""
+from pathlib import Path
+import yaml
+
+
+def build_blank_scorecard(case_id: str, labels: list[str]) -> dict:
+    return {
+        "case_id": case_id,
+        "scores": {
+            label: {"recall": None, "false_positives": [], "actionability": None}
+            for label in labels
+        },
+    }
+
+
+def write_blank_scorecard(case_id: str, labels: list[str], out_path: Path) -> None:
+    Path(out_path).write_text(
+        yaml.safe_dump(build_blank_scorecard(case_id, labels), sort_keys=False)
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_scoring_template.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/scoring_template.py \
+        benchmarks/pr-review-benchmark/tests/test_scoring_template.py
+git commit -m "feat(benchmark): add blank scoring template generator"
+```
+
+---
+
+### Task 7: Independent LLM judge
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/llm_judge.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_llm_judge.py`
+
+**Interfaces:**
+- Consumes: ground truth dict (Task 1 shape), anonymized findings dict (`{label: list[finding]}` from Task 5's `anon_dir` contents).
+- Produces: `build_judge_prompt(ground_truth: dict, anonymized_findings: dict) -> str`, `parse_judge_response(response_text: str) -> dict` (shape matches Task 6's per-label score dict, minus `false_positives` defaulting to `[]` only if present), `call_judge_model(client, prompt: str, model: str) -> str` — consumed by `run_case.py`'s live-judging step (documented in README, not itself unit-tested beyond argument-passing since it's a real API call).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_llm_judge.py
+import json
+import pytest
+from scripts.llm_judge import build_judge_prompt, parse_judge_response, call_judge_model
+
+
+def test_build_judge_prompt_includes_ground_truth_and_findings():
+    ground_truth = {"category": "injected_bug", "expected_file": "x.py", "expected_line": 5}
+    anonymized_findings = {"Tool A": [{"file": "x.py", "line": 5, "message": "bug here"}]}
+    prompt = build_judge_prompt(ground_truth, anonymized_findings)
+    assert "injected_bug" in prompt
+    assert "Tool A" in prompt
+    assert "bug here" in prompt
+    assert "recall" in prompt
+
+
+def test_parse_judge_response_extracts_json_object():
+    response_text = (
+        "Here is my scoring:\n"
+        '{"Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}}'
+    )
+    result = parse_judge_response(response_text)
+    assert result == {"Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}}
+
+
+def test_parse_judge_response_rejects_invalid_recall_value():
+    response_text = '{"Tool A": {"recall": "maybe", "false_positives": [], "actionability": 3}}'
+    with pytest.raises(ValueError, match="recall must be hit/partial/miss"):
+        parse_judge_response(response_text)
+
+
+def test_parse_judge_response_raises_when_no_json_present():
+    with pytest.raises(ValueError, match="did not contain a JSON object"):
+        parse_judge_response("I refuse to answer in JSON.")
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    def __init__(self, text):
+        self._text = text
+        self.last_call = None
+
+    def create(self, **kwargs):
+        self.last_call = kwargs
+        return _FakeResponse(self._text)
+
+
+class _FakeChat:
+    def __init__(self, text):
+        self.completions = _FakeCompletions(text)
+
+
+class _FakeClient:
+    def __init__(self, text):
+        self.chat = _FakeChat(text)
+
+
+def test_call_judge_model_passes_prompt_and_model_and_returns_text():
+    client = _FakeClient("mocked response text")
+    result = call_judge_model(client, "the prompt", model="gpt-judge-1")
+    assert result == "mocked response text"
+    assert client.chat.completions.last_call["model"] == "gpt-judge-1"
+    assert client.chat.completions.last_call["messages"] == [
+        {"role": "user", "content": "the prompt"}
+    ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_llm_judge.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/llm_judge.py
+"""Independent LLM scoring pass: builds a rubric prompt from
+anonymized findings and ground truth, and parses the model's
+structured response into scoring_template.py's score shape. The
+judge model must be a different provider/family than whichever
+model powers the tools under test in a given run (see
+METHODOLOGY.md)."""
+import json
+
+
+def build_judge_prompt(ground_truth: dict, anonymized_findings: dict) -> str:
+    return (
+        "You are scoring anonymized code-review tool outputs against a known "
+        "ground truth. Tools are labeled Tool A/B/C/D; you do not know their real "
+        "identities.\n\n"
+        f"Ground truth:\n{json.dumps(ground_truth, indent=2)}\n\n"
+        f"Anonymized findings:\n{json.dumps(anonymized_findings, indent=2)}\n\n"
+        "For each tool label, score:\n"
+        '- recall: "hit", "partial", or "miss" against the ground truth issue\n'
+        "- false_positives: list of findings that are not the ground truth issue and "
+        "are not legitimate secondary issues\n"
+        "- actionability: 1-5, is the finding specific enough to act on\n\n"
+        "Respond with ONLY a JSON object: "
+        '{"Tool A": {"recall": ..., "false_positives": [...], "actionability": ...}, ...}'
+    )
+
+
+def parse_judge_response(response_text: str) -> dict:
+    start = response_text.find("{")
+    end = response_text.rfind("}")
+    if start == -1 or end == -1:
+        raise ValueError("judge response did not contain a JSON object")
+    parsed = json.loads(response_text[start:end + 1])
+    for label, score in parsed.items():
+        if score.get("recall") not in {"hit", "partial", "miss"}:
+            raise ValueError(
+                f"{label}: recall must be hit/partial/miss, got {score.get('recall')!r}"
+            )
+    return parsed
+
+
+def call_judge_model(client, prompt: str, model: str) -> str:
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_llm_judge.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/llm_judge.py \
+        benchmarks/pr-review-benchmark/tests/test_llm_judge.py
+git commit -m "feat(benchmark): add independent LLM judge"
+```
+
+---
+
+### Task 8: Cross-case aggregation and human/LLM agreement rate
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/aggregate.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_aggregate.py`
+
+**Interfaces:**
+- Consumes: `results/scored/<case_id>.yaml` (Task 6 shape, filled in by hand) and `results/llm_judged/<case_id>.json` (Task 7's `parse_judge_response` shape).
+- Produces: `load_manual_scores(results_dir: Path) -> dict`, `load_llm_scores(results_dir: Path) -> dict`, `build_scorecard(manual_scores: dict, llm_scores: dict) -> dict` (keys: `per_tool` keyed by label, `human_llm_agreement` keyed by dimension) — consumed by the report-building step (Task 11).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_aggregate.py
+import json
+import yaml
+from scripts.aggregate import load_manual_scores, load_llm_scores, build_scorecard
+
+
+def test_load_manual_scores_reads_all_scored_yaml_files(tmp_path):
+    scored_dir = tmp_path / "scored"
+    scored_dir.mkdir()
+    (scored_dir / "001.yaml").write_text(yaml.safe_dump({
+        "case_id": "001",
+        "scores": {"Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}},
+    }))
+    scores = load_manual_scores(tmp_path)
+    assert scores == {"001": {"Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}}}
+
+
+def test_load_llm_scores_reads_all_llm_judged_json_files(tmp_path):
+    llm_dir = tmp_path / "llm_judged"
+    llm_dir.mkdir()
+    (llm_dir / "001.json").write_text(json.dumps({
+        "Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}
+    }))
+    scores = load_llm_scores(tmp_path)
+    assert scores == {"001": {"Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}}}
+
+
+def test_build_scorecard_counts_recall_buckets_and_false_positives():
+    manual_scores = {
+        "001": {"Tool A": {"recall": "hit", "false_positives": [], "actionability": 5}},
+        "002": {"Tool A": {"recall": "miss", "false_positives": ["noise"], "actionability": 2}},
+    }
+    scorecard = build_scorecard(manual_scores, llm_scores={})
+    assert scorecard["per_tool"]["Tool A"]["hit"] == 1
+    assert scorecard["per_tool"]["Tool A"]["miss"] == 1
+    assert scorecard["per_tool"]["Tool A"]["false_positive_count"] == 1
+    assert scorecard["per_tool"]["Tool A"]["actionability_total"] == 7
+    assert scorecard["per_tool"]["Tool A"]["actionability_count"] == 2
+
+
+def test_build_scorecard_computes_human_llm_agreement_rate():
+    manual_scores = {
+        "001": {"Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}},
+        "002": {"Tool A": {"recall": "miss", "false_positives": [], "actionability": 2}},
+    }
+    llm_scores = {
+        "001": {"Tool A": {"recall": "hit", "actionability": 4}},
+        "002": {"Tool A": {"recall": "hit", "actionability": 2}},
+    }
+    scorecard = build_scorecard(manual_scores, llm_scores)
+    assert scorecard["human_llm_agreement"]["recall"] == 0.5
+    assert scorecard["human_llm_agreement"]["actionability"] == 1.0
+
+
+def test_build_scorecard_handles_no_llm_scores_at_all():
+    manual_scores = {"001": {"Tool A": {"recall": "hit", "false_positives": [], "actionability": 4}}}
+    scorecard = build_scorecard(manual_scores, llm_scores={})
+    assert scorecard["human_llm_agreement"]["recall"] is None
+    assert scorecard["human_llm_agreement"]["actionability"] is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_aggregate.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/aggregate.py
+"""Builds the final cross-case scorecard from manual and LLM-judge
+scoring records. Runs after both scoring passes are complete for
+every case; grounding_rate (Task 4's automated, non-blind check) is
+merged in separately at report-build time, keyed by real tool name
+since it needs no blinding."""
+import json
+from pathlib import Path
+import yaml
+
+
+def load_manual_scores(results_dir: Path) -> dict:
+    scores = {}
+    for path in sorted((Path(results_dir) / "scored").glob("*.yaml")):
+        data = yaml.safe_load(path.read_text())
+        scores[data["case_id"]] = data["scores"]
+    return scores
+
+
+def load_llm_scores(results_dir: Path) -> dict:
+    scores = {}
+    for path in sorted((Path(results_dir) / "llm_judged").glob("*.json")):
+        scores[path.stem] = json.loads(path.read_text())
+    return scores
+
+
+def build_scorecard(manual_scores: dict, llm_scores: dict) -> dict:
+    per_tool = {}
+    agreement_counts = {"recall": 0, "actionability": 0}
+    compared_counts = {"recall": 0, "actionability": 0}
+
+    for case_id, case_scores in manual_scores.items():
+        llm_case_scores = llm_scores.get(case_id, {})
+        for label, manual in case_scores.items():
+            bucket = per_tool.setdefault(label, {
+                "hit": 0, "partial": 0, "miss": 0,
+                "false_positive_count": 0,
+                "actionability_total": 0, "actionability_count": 0,
+            })
+            recall = manual.get("recall")
+            if recall in ("hit", "partial", "miss"):
+                bucket[recall] += 1
+            bucket["false_positive_count"] += len(manual.get("false_positives") or [])
+            if manual.get("actionability") is not None:
+                bucket["actionability_total"] += manual["actionability"]
+                bucket["actionability_count"] += 1
+
+            llm = llm_case_scores.get(label)
+            if llm is not None:
+                if "recall" in llm:
+                    compared_counts["recall"] += 1
+                    if llm["recall"] == recall:
+                        agreement_counts["recall"] += 1
+                if "actionability" in llm:
+                    compared_counts["actionability"] += 1
+                    if llm["actionability"] == manual.get("actionability"):
+                        agreement_counts["actionability"] += 1
+
+    human_llm_agreement = {}
+    for dimension, compared in compared_counts.items():
+        human_llm_agreement[dimension] = (
+            agreement_counts[dimension] / compared if compared else None
+        )
+
+    return {"per_tool": per_tool, "human_llm_agreement": human_llm_agreement}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_aggregate.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/aggregate.py \
+        benchmarks/pr-review-benchmark/tests/test_aggregate.py
+git commit -m "feat(benchmark): add cross-case scorecard aggregation"
+```
+
+---
+
+### Task 9: Real tool adapters + case orchestrator
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/adapters.py`
+- Create: `benchmarks/pr-review-benchmark/scripts/run_case.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_adapters.py`
+- Test: `benchmarks/pr-review-benchmark/tests/test_run_case.py`
+- Modify: `.gitignore` (repo root) — add the CodeRabbit-specific raw-output exclusion.
+
+**Interfaces:**
+- Consumes: `load_case` (Task 1), `prepare_case_checkout` (Task 2), normalizer functions (Task 3), `verify_findings_against_checkout` (Task 4).
+- Produces: `aletheore_adapter`, `pr_agent_adapter`, `deepsource_adapter`, `coderabbit_adapter` (each `(checkout_dir, case, ...) -> raw output`, real invocation, injectable for tests); `run_case(case_dir: Path, workdir: Path, results_dir: Path, adapters: dict, normalizers: dict) -> dict` — consumed by the live per-case run documented in `README.md`.
+
+**Note on live invocation:** `adapters.py`'s functions genuinely shell out to `aletheore audit`, invoke PR-Agent's CLI against a real `pr_url`, and (for DeepSource/CodeRabbit) call injected fetch functions that hit real APIs — actually running these against live GitHub PRs is integration work done by hand per the README runbook (Task 9 only builds and unit-tests the *wiring*, with fakes standing in for the real subprocess/API calls).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_adapters.py
+from scripts.adapters import (
+    aletheore_adapter,
+    pr_agent_adapter,
+    deepsource_adapter,
+    coderabbit_adapter,
+)
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def test_aletheore_adapter_invokes_audit_against_checkout_dir(tmp_path):
+    calls = []
+
+    def fake_runner(args, **kwargs):
+        calls.append(args)
+        return _FakeCompletedProcess("report text")
+
+    result = aletheore_adapter(tmp_path, case={}, runner=fake_runner)
+    assert calls == [["aletheore", "audit", str(tmp_path)]]
+    assert result == "report text"
+
+
+def test_pr_agent_adapter_invokes_cli_with_pr_url(tmp_path):
+    calls = []
+
+    def fake_runner(args, **kwargs):
+        calls.append(args)
+        return _FakeCompletedProcess('{"code_suggestions": []}')
+
+    case = {"repo": {"pr_url": "https://github.com/example/repo/pull/1"}}
+    result = pr_agent_adapter(tmp_path, case, runner=fake_runner)
+    assert calls == [[
+        "python", "-m", "pr_agent.cli",
+        "--pr_url", "https://github.com/example/repo/pull/1", "review",
+    ]]
+    assert result == {"code_suggestions": []}
+
+
+def test_deepsource_adapter_calls_fetch_issues_with_run_id(tmp_path):
+    case = {"repo": {"deepsource_run_id": "run-42"}}
+    captured = {}
+
+    def fake_fetch(run_id):
+        captured["run_id"] = run_id
+        return {"issues": []}
+
+    result = deepsource_adapter(tmp_path, case, fetch_issues=fake_fetch)
+    assert captured["run_id"] == "run-42"
+    assert result == {"issues": []}
+
+
+def test_coderabbit_adapter_calls_fetch_pr_comments_with_pr_url(tmp_path):
+    case = {"repo": {"pr_url": "https://github.com/example/repo/pull/1"}}
+    captured = {}
+
+    def fake_fetch(pr_url):
+        captured["pr_url"] = pr_url
+        return [{"path": "x.py", "line": 1, "body": "comment"}]
+
+    result = coderabbit_adapter(tmp_path, case, fetch_pr_comments=fake_fetch)
+    assert captured["pr_url"] == "https://github.com/example/repo/pull/1"
+    assert result == [{"path": "x.py", "line": 1, "body": "comment"}]
+```
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_run_case.py
+import json
+from scripts.run_case import run_case
+from tests.test_build_case_repo import make_fixture_repo
+
+
+def test_run_case_writes_raw_and_grounding_output_for_each_tool(tmp_path):
+    remote, base_commit, diff_path = make_fixture_repo(tmp_path)
+
+    case_dir = tmp_path / "cases" / "001-example"
+    case_dir.mkdir(parents=True)
+    (case_dir / "repo.txt").write_text(f"repo_url={remote}\nbase_commit={base_commit}\n")
+    diff_path.rename(case_dir / "pr.diff")
+    (case_dir / "ground_truth.yaml").write_text(
+        "case_id: 001-example\nlanguage: python\ncategory: injected_bug\n"
+        "bug_type: test\nexpected_file: x.py\nexpected_line: 1\n"
+        "fix_reference: null\ndescription: test\n"
+    )
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    results_dir = tmp_path / "results"
+
+    adapters = {"fake_tool": lambda checkout_dir, case: "finding at `x.py:1`."}
+    normalizers = {
+        "fake_tool": lambda raw: [{"file": "x.py", "line": 1, "message": raw, "severity": None}]
+    }
+
+    result = run_case(case_dir, workdir, results_dir, adapters, normalizers)
+
+    assert result["case_id"] == "001-example"
+    raw_path = results_dir / "raw" / "001-example" / "fake_tool.json"
+    assert json.loads(raw_path.read_text()) == "finding at `x.py:1`."
+
+    grounding_path = results_dir / "grounding" / "001-example" / "fake_tool.json"
+    grounding = json.loads(grounding_path.read_text())
+    assert grounding["grounding_rate"] == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_adapters.py tests/test_run_case.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/adapters.py
+"""Real per-tool invocation. Each adapter takes (checkout_dir, case,
+...) and returns raw output ready for scripts/normalize.py. Adapters
+that shell out or call an API accept an injectable runner/fetcher so
+command construction is unit-testable without actually invoking
+external tools or the network."""
+import json
+import subprocess
+
+
+def aletheore_adapter(checkout_dir, case, runner=subprocess.run):
+    result = runner(
+        ["aletheore", "audit", str(checkout_dir)],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def pr_agent_adapter(checkout_dir, case, runner=subprocess.run):
+    result = runner(
+        ["python", "-m", "pr_agent.cli", "--pr_url", case["repo"]["pr_url"], "review"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def deepsource_adapter(checkout_dir, case, fetch_issues):
+    return fetch_issues(case["repo"]["deepsource_run_id"])
+
+
+def coderabbit_adapter(checkout_dir, case, fetch_pr_comments):
+    return fetch_pr_comments(case["repo"]["pr_url"])
+```
+
+```python
+# benchmarks/pr-review-benchmark/scripts/run_case.py
+"""Orchestrates one full case run: prepare checkout, invoke each tool
+adapter, normalize output, run the automated grounding check, and
+store raw + grounding results."""
+import json
+from pathlib import Path
+
+from scripts.cases import load_case
+from scripts.build_case_repo import prepare_case_checkout
+from scripts.check_citations import verify_findings_against_checkout
+
+
+def run_case(case_dir: Path, workdir: Path, results_dir: Path, adapters: dict, normalizers: dict) -> dict:
+    case = load_case(case_dir)
+    checkout_dir = prepare_case_checkout(case["repo"], case["diff_path"], workdir)
+
+    raw_dir = Path(results_dir) / "raw" / case["case_id"]
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    grounding_dir = Path(results_dir) / "grounding" / case["case_id"]
+    grounding_dir.mkdir(parents=True, exist_ok=True)
+
+    findings_by_tool = {}
+    for tool_name, adapter in adapters.items():
+        raw_output = adapter(checkout_dir, case)
+        (raw_dir / f"{tool_name}.json").write_text(json.dumps(raw_output, indent=2))
+
+        findings = normalizers[tool_name](raw_output)
+        grounding = verify_findings_against_checkout(findings, checkout_dir)
+        (grounding_dir / f"{tool_name}.json").write_text(json.dumps(grounding, indent=2))
+
+        findings_by_tool[tool_name] = findings
+
+    return {"case_id": case["case_id"], "checkout_dir": checkout_dir, "findings_by_tool": findings_by_tool}
+```
+
+Add to the repo root `.gitignore`:
+
+```
+# PR-review benchmark: CodeRabbit's raw transcript is never committed (ToS §4.2 — see
+# docs/superpowers/specs/2026-07-26-aletheore-pr-review-benchmark-design.md); only its
+# anonymized scored summary is published.
+benchmarks/pr-review-benchmark/results/raw/*/coderabbit.json
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_adapters.py tests/test_run_case.py -v`
+Expected: 4 passed (adapters) + 1 passed (run_case).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/adapters.py \
+        benchmarks/pr-review-benchmark/scripts/run_case.py \
+        benchmarks/pr-review-benchmark/tests/test_adapters.py \
+        benchmarks/pr-review-benchmark/tests/test_run_case.py \
+        .gitignore
+git commit -m "feat(benchmark): add real tool adapters and case orchestrator"
+```
+
+---
+
+### Task 10: Author the 25-case corpus
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/cases/<case-id>/repo.txt`, `pr.diff`, `ground_truth.yaml`, `ground_truth.md` — one set per case, ~25 total.
+
+This is data curation, not code — no tests apply. Follow this exact repeatable procedure per case type. **Never assert a commit hash or PR URL you have not personally verified with `git log` / `gh api` against the real repo** — an unverified citation in the benchmark's own ground truth would undercut the entire premise.
+
+**Real bug-fix reconstructions (~15, aim for ~4 Python, ~4 TypeScript/JS, ~4 Go, ~3 Java):**
+1. Pick a popular OSS repo in the target language.
+2. Search its history for a clear bug-fix commit: `git log --oneline --grep='fix' <repo>` (or GitHub's search UI for `is:pr is:merged fix` filtered to that repo), then read the actual commit diff and message to confirm it's a real, single-purpose bug fix (not a refactor mislabeled "fix") and ideally references an issue number.
+3. Record the fix commit's hash. Verify its parent commit is a clean checkout point: `git show <fix_commit>^:<file>` for each changed file.
+4. Generate the case's `pr.diff` as the **inverse** of the fix (this reintroduces the bug as the "proposed change" under test): `git diff <fix_commit> <fix_commit>^ -- <changed files> > pr.diff`.
+5. Set `repo.txt`'s `base_commit` to `<fix_commit>` (the post-fix state — applying the inverse diff on top reproduces the pre-fix buggy state).
+6. Write `ground_truth.yaml` with `category: real_bug_fix`, `fix_reference` set to the fix commit's full URL, `expected_file`/`expected_line` pointing at the actual buggy line the fix changed, and a one-paragraph `description`.
+7. Write `ground_truth.md`: 2-4 sentences in prose, for the published report, describing what the bug was and why it mattered — written for a reader who isn't going to open the diff.
+
+**Injected bugs (~6, targeting categories underrepresented in the real set — likely candidates: SQL injection via string concatenation, off-by-one loop bound, missing null/None check, race condition via non-atomic read-modify-write, hardcoded secret, swallowed exception):**
+1. Pick a small, clean PR (or a clean file state) from any of the corpus repos or a new one.
+2. Hand-author a diff that introduces exactly one of the bug patterns above — keep the change small and the bug unambiguous (this is ground truth; it must not be debatable whether it's really a bug).
+3. Write `ground_truth.yaml` with `category: injected_bug`, `fix_reference: null`, and precise `expected_file`/`expected_line`/`bug_type`/`description` — written and committed **before** any tool is run against this case (pre-registration; do not adjust ground truth after seeing what a tool flagged).
+4. Write `ground_truth.md` in the same prose style as the real cases.
+
+**Clean PRs (~4, no real bug):**
+1. Pick a genuinely clean, small, real merged PR (a docs fix, a rename, a trivial refactor) with no defects.
+2. `ground_truth.yaml`: `category: clean`, `bug_type: null`, `expected_file: null`, `expected_line: null`, `description` explains why this PR is clean and what a false positive here would look like.
+3. `ground_truth.md`: short note that this is a deliberately clean control case.
+
+- [ ] **Step 1: Author all ~25 `cases/<case-id>/` directories per the procedure above.**
+- [ ] **Step 2: Run `pytest tests/test_cases.py` plus a manual spot-check** — `python -c "from scripts.cases import load_case; load_case('cases/<case-id>')"` for every case directory — to confirm every case parses without raising.
+- [ ] **Step 3: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/cases/
+git commit -m "data(benchmark): author 25-case test corpus (real, injected, clean)"
+```
+
+---
+
+### Task 11: Report and methodology generation
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/scripts/build_report.py`
+- Create: `benchmarks/pr-review-benchmark/METHODOLOGY.md` (template, filled in at run time)
+- Test: `benchmarks/pr-review-benchmark/tests/test_build_report.py`
+
+**Interfaces:**
+- Consumes: `build_scorecard` output (Task 8), `reveal_mapping` (Task 5), grounding results (Task 4, loaded per real tool name from `results/grounding/`).
+- Produces: `merge_grounding_into_scorecard(scorecard: dict, grounding_by_case_and_tool: dict, case_label_maps: dict) -> dict` (attaches `grounding_rate` onto each tool's real name after reveal), `render_report_markdown(scorecard: dict) -> str` — writes the final `REPORT.md`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# benchmarks/pr-review-benchmark/tests/test_build_report.py
+from scripts.build_report import merge_grounding_into_scorecard, render_report_markdown
+
+
+def test_merge_grounding_into_scorecard_attaches_rate_by_real_tool_name():
+    scorecard = {"per_tool": {"Tool A": {"hit": 1, "miss": 0}}, "human_llm_agreement": {}}
+    grounding_by_case_and_tool = {"001": {"aletheore": {"grounding_rate": 1.0}}}
+    case_label_maps = {"001": {"Tool A": "aletheore"}}
+
+    merged = merge_grounding_into_scorecard(scorecard, grounding_by_case_and_tool, case_label_maps)
+    assert merged["per_tool"]["aletheore"]["grounding_rate"] == 1.0
+
+
+def test_render_report_markdown_includes_per_tool_table():
+    scorecard = {
+        "per_tool": {
+            "aletheore": {
+                "hit": 10, "partial": 2, "miss": 3,
+                "false_positive_count": 1,
+                "actionability_total": 45, "actionability_count": 15,
+                "grounding_rate": 0.97,
+            }
+        },
+        "human_llm_agreement": {"recall": 0.9, "actionability": 0.8},
+    }
+    markdown = render_report_markdown(scorecard)
+    assert "aletheore" in markdown
+    assert "0.97" in markdown
+    assert "0.9" in markdown
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_build_report.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# benchmarks/pr-review-benchmark/scripts/build_report.py
+"""Merges the automated grounding check (Task 4, real tool names, no
+blinding needed) into the blind-scored scorecard (Task 8, label-keyed)
+after each case's mapping has been revealed, and renders the final
+report table."""
+
+
+def merge_grounding_into_scorecard(scorecard: dict, grounding_by_case_and_tool: dict, case_label_maps: dict) -> dict:
+    real_name_by_label = {}
+    for case_id, label_to_tool in case_label_maps.items():
+        for label, tool in label_to_tool.items():
+            real_name_by_label[label] = tool
+
+    grounding_rates_by_tool = {}
+    for case_id, grounding_by_tool in grounding_by_case_and_tool.items():
+        for tool, grounding in grounding_by_tool.items():
+            grounding_rates_by_tool.setdefault(tool, []).append(grounding["grounding_rate"])
+
+    per_tool = {}
+    for label, stats in scorecard["per_tool"].items():
+        real_name = real_name_by_label.get(label, label)
+        merged_stats = dict(stats)
+        rates = grounding_rates_by_tool.get(real_name)
+        if rates:
+            merged_stats["grounding_rate"] = sum(rates) / len(rates)
+        per_tool[real_name] = merged_stats
+
+    return {"per_tool": per_tool, "human_llm_agreement": scorecard["human_llm_agreement"]}
+
+
+def render_report_markdown(scorecard: dict) -> str:
+    lines = [
+        "# Aletheore PR-Review Benchmark — Results",
+        "",
+        "| Tool | Hit | Partial | Miss | False Positives | Avg Actionability | Grounding Rate |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for tool, stats in scorecard["per_tool"].items():
+        avg_actionability = (
+            stats["actionability_total"] / stats["actionability_count"]
+            if stats.get("actionability_count") else "n/a"
+        )
+        grounding_rate = stats.get("grounding_rate", "n/a")
+        lines.append(
+            f"| {tool} | {stats.get('hit', 0)} | {stats.get('partial', 0)} | "
+            f"{stats.get('miss', 0)} | {stats.get('false_positive_count', 0)} | "
+            f"{avg_actionability} | {grounding_rate} |"
+        )
+
+    lines += [
+        "",
+        "## Human/LLM judge agreement",
+        "",
+        f"- Recall agreement: {scorecard['human_llm_agreement'].get('recall', 'n/a')}",
+        f"- Actionability agreement: {scorecard['human_llm_agreement'].get('actionability', 'n/a')}",
+    ]
+    return "\n".join(lines)
+```
+
+Create `benchmarks/pr-review-benchmark/METHODOLOGY.md` with this starting template (fields filled in when the live run happens):
+
+```markdown
+# Methodology
+
+- **Run date:** TBD at execution time
+- **Aletheore version/model:** TBD
+- **Qodo/PR-Agent version/model:** TBD (pinned to the same model as Aletheore where possible)
+- **DeepSource plan/version:** TBD
+- **CodeRabbit plan/version (anonymized as "Tool D" or similar in the report):** TBD
+- **LLM judge model:** TBD (must be a different provider/family than the models above)
+- **Corpus:** 25 cases — 15 real bug-fix reconstructions, 6 injected bugs, 4 clean PRs, across Python/TypeScript/Go/Java
+- **Known limitations:** see `docs/superpowers/specs/2026-07-26-aletheore-pr-review-benchmark-design.md`'s
+  "Known Limitations" section — reproduced in full in the published report, not just linked.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd benchmarks/pr-review-benchmark && pytest tests/test_build_report.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/scripts/build_report.py \
+        benchmarks/pr-review-benchmark/tests/test_build_report.py \
+        benchmarks/pr-review-benchmark/METHODOLOGY.md
+git commit -m "feat(benchmark): add grounding merge and report rendering"
+```
+
+---
+
+### Task 12: README runbook + end-to-end dry run on 2 cases
+
+**Files:**
+- Create: `benchmarks/pr-review-benchmark/README.md`
+
+**Interfaces:** none new — this task wires Tasks 1-11 together as documented, manual steps and validates the pipeline actually works end-to-end before running the full 25-case corpus.
+
+- [ ] **Step 1: Write `README.md`** covering: how to author a case (link to Task 10's procedure), how to open a real throwaway PR per case on a scratch repo/fork, how to install CodeRabbit's GitHub App on that scratch repo, how to run PR-Agent against it (`python -m pr_agent.cli --pr_url ... review`), how to fetch DeepSource's issue list and CodeRabbit's PR review comments via their respective APIs to feed into `adapters.py`'s injected `fetch_issues`/`fetch_pr_comments` callables, how to run `scripts/run_case.py` per case, how to fill in `results/scored/<case_id>.yaml` by hand from the anonymized `results/anon/<case_id>/` files, how to run the LLM judge, and how to run `scripts/build_report.py`'s functions to produce the final `REPORT.md`.
+
+- [ ] **Step 2: Pick 2 already-authored cases (one real, one injected) and run the full pipeline live**: prepare checkout, run all four real adapters, normalize, check citations, anonymize, fill in the manual scoring YAML blind, run the LLM judge, reveal, merge, render. Confirm every step in the README actually works as written against real tools — fix any place `normalize_pr_agent`/`normalize_deepsource`'s assumed schema (flagged in Task 3) doesn't match the real output, updating both the normalizer and its test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add benchmarks/pr-review-benchmark/README.md
+git commit -m "docs(benchmark): add runbook, validated against a 2-case dry run"
+```
+
+If Step 2 required normalizer fixes, commit those separately first with their own updated tests, referencing what the real tool output actually looked like.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every design-spec section maps to a task — corpus/ground truth (Task 10), competitor lineup/legal handling (Task 9's adapters + `.gitignore` exclusion + Task 9's ToS-driven CodeRabbit exclusion from raw commits), execution pipeline (Tasks 1, 2, 9), scoring rubric + blind judging + dual LLM/manual pass (Tasks 5, 6, 7, 8), publication/reproducibility (Task 11), known limitations (reproduced verbatim in `METHODOLOGY.md`, Task 11).
+- **Placeholder scan:** no TBD/TODO in code; `METHODOLOGY.md`'s template TBDs are explicitly a fill-in-at-runtime template, not an unfinished task.
+- **Type consistency:** the finding schema (`file`/`line`/`message`/`severity`) is identical across Tasks 3, 4, 9; the score schema (`recall`/`false_positives`/`actionability`) is identical across Tasks 6, 7, 8; `case_id`/`repo`/`diff_path`/`ground_truth` from Task 1 is consumed unchanged by Tasks 2 and 9.

--- a/docs/superpowers/specs/2026-07-26-aletheore-pr-review-benchmark-design.md
+++ b/docs/superpowers/specs/2026-07-26-aletheore-pr-review-benchmark-design.md
@@ -106,10 +106,13 @@ benchmarks/pr-review-benchmark/
     check_citations.py      # extends citation_verifier.py's file-existence check with a
                              # real line-bounds check against the actual checkout
     anonymize.py            # relabels tool identities -> Tool A/B/C/D, writes a sealed mapping
+    llm_judge.py            # independent LLM scoring pass over the same anonymized outputs
   results/
     raw/<case-id>/<tool>.json          # CodeRabbit's raw output excluded from public commit
-    scored/<case-id>.md                # blind scoring sheet
-    mapping.sealed.json                 # tool<->label mapping, opened only after scoring locks
+    scored/<case-id>.md                # your blind manual scoring sheet (authoritative)
+    llm_judged/<case-id>.json           # independent LLM judge's blind scoring pass
+    mapping.sealed.json                 # tool<->label mapping, opened only after both scoring
+                                         # passes lock
   REPORT.md
   METHODOLOGY.md
 ```
@@ -138,9 +141,23 @@ Per case, per tool:
   advice that could apply to any codebase.
 
 **Blind process:** `anonymize.py` relabels tool identities to A/B/C/D before any case is
-scored; the sealed mapping for a given case is only reopened after that case's scoring is
-locked, removing the single biggest credibility risk — the benchmark's own author
+scored; the sealed mapping for a given case is only reopened after both scoring passes below
+are locked, removing the single biggest credibility risk — the benchmark's own author
 unconsciously favoring Aletheore's output during judgment calls.
+
+**Dual blind judging.** Every case gets two independent scoring passes against the rubric
+above, both blind to tool identity and blind to each other (the LLM judge never sees your
+scores, and vice versa):
+
+1. **Your manual review** — authoritative for the published headline scorecard.
+2. **An independent LLM judge** (`llm_judge.py`) — a model not itself under test (a different
+   provider/family than whichever model powers Aletheore's audit step and PR-Agent's config in
+   this run, recorded in `METHODOLOGY.md`) scores the same anonymized outputs against the same
+   ground truth and rubric.
+
+The human/LLM agreement rate per rubric dimension is published alongside the headline
+scorecard as an additional credibility signal; a case where the two diverge is called out
+explicitly in the report rather than smoothed over or quietly dropped.
 
 ## Publication & Reproducibility
 
@@ -169,3 +186,8 @@ mixed outcome reads as more credible than a clean sweep.
   Qodo/PR-Agent, or CodeRabbit. It stays in the comparison, but the report calls this out
   explicitly as a caveat on that entry specifically, rather than implying full architectural
   parity across all four.
+- **The LLM judge is a second opinion, not ground truth.** It has its own potential blind
+  spots (e.g., over-weighting confident phrasing) and is not presented as equivalent in
+  authority to the manual review — the human score is what the headline scorecard reports;
+  the LLM judge's role is the published agreement-rate signal and a check against reviewer
+  fatigue, not a replacement for the manual pass.

--- a/docs/superpowers/specs/2026-07-26-aletheore-pr-review-benchmark-design.md
+++ b/docs/superpowers/specs/2026-07-26-aletheore-pr-review-benchmark-design.md
@@ -1,0 +1,171 @@
+# Aletheore PR-Review Benchmark — Design Spec
+
+## Overview
+
+Aletheore's core marketing claim is "evidence-grounded" — every claim a generated report makes
+must trace back to a specific field in the deterministic scan evidence (`air.json`), enforced in
+code today by `src/aletheore/citation_verifier.py`'s file-existence check on `file:line`
+citations, and by the mandatory "what evidence doesn't cover" discipline documented in
+`src/aletheore/manual/part-7-perspectives.md`. That claim is currently an assertion, not a
+demonstrated fact to a prospective buyer. This spec defines a public benchmark that tests it
+directly against real AI PR-review competitors, on real and reconstructed bugs, scored blind.
+
+This is a one-time dated snapshot, not a product feature or an ongoing service — it lives
+alongside the codebase as a benchmark artifact, reusing existing code
+(`citation_verifier.py`'s logic) rather than extending the shipped product.
+
+## Goals
+
+- Produce a reproducible comparison of Aletheore against **Qodo/PR-Agent** and **DeepSource**
+  (named) and **CodeRabbit** (anonymized, for ToS reasons — see Competitor Lineup) across
+  ~25 test cases spanning 4-5 languages.
+- Score every tool on recall, false-positive rate, citation/grounding accuracy, and
+  actionability — not just the headline metric Aletheore is expected to win on.
+- Publish the full methodology, raw outputs (except CodeRabbit's, see below), and scoring
+  sheet alongside the report, so the result is independently checkable rather than taken on
+  faith.
+- Reuse `citation_verifier.py`'s existing file-existence logic as the automated half of the
+  grounding score, extended with a real line-bounds check against the actual checkout (this
+  benchmark has filesystem access competitors' evidence schema doesn't need to support).
+
+## Non-Goals
+
+- **No fully-automated, reusable benchmarking harness** (rejected as "Option B" during design
+  — a YAML-driven orchestrator with a scoring dashboard is a second product-shaped effort;
+  scripts here exist only to remove copy-paste error from a semi-automated, otherwise manual
+  process).
+- **No Greptile or SonarQube entries.** SonarQube/SonarCloud has an explicit anti-benchmarking
+  clause (AUP §5) identical in effect to CodeRabbit's; Greptile's ToS bars using the platform
+  "to develop or offer a competing product," which is a plausible reading and not worth the
+  risk for a fourth entry when Qodo/DeepSource already anchor the named comparison.
+- **No Graphite entry.** Graphite's AI reviewer (formerly "Diamond," now folded into
+  "Graphite Agent") has no benchmarking restriction found and could be a clean named addition
+  later, but a fifth entry isn't needed to hit this benchmark's goals — deferred, not excluded
+  for cause.
+- **No ongoing tracked leaderboard.** This is a single dated snapshot; periodic re-runs as
+  competitors' products change is a real future idea, explicitly deferred, not committed to
+  here.
+- **No formal speed/cost benchmarking** — qualitative notes only, not a scored dimension.
+- **No second anonymized entry** invented solely to make CodeRabbit's entry less identifiable
+  by elimination. That residual "soft tell" is accepted and disclosed (see Known Limitations)
+  rather than solved by adding an entry the benchmark doesn't otherwise need.
+
+## Competitor Lineup & Legal Handling
+
+ToS research (2026-07-26) found:
+
+| Tool | Benchmarking restriction | Treatment |
+|---|---|---|
+| CodeRabbit | Explicit: bars disclosing benchmark results without written consent (ToS §4.2) | Anonymized as "Tool D" or similar |
+| SonarQube/SonarCloud | Explicit: same effect (Acceptable Use Policy §5) | Excluded entirely |
+| Greptile | No explicit benchmark ban, but bars using the platform "to develop or offer a competing product" | Excluded (gray area, not worth the risk for a 4th entry) |
+| DeepSource | No restriction found | Named directly |
+| Graphite (AI reviewer, "Diamond" deprecated → now "Graphite Agent") | No restriction found | Not included in v1 (see Non-Goals); clean if added later |
+| Qodo/PR-Agent | Apache 2.0 OSS, self-hosted, no account/ToS at all | Named directly |
+
+CodeRabbit handling specifics: install on a test repo to generate real output, capture it
+privately, but publish only the anonymized *scored summary* — never the raw transcript,
+screenshots of its real UI, verbatim branding/footer text, or any other detail (model choice,
+pricing, links) that would identify it. The raw CodeRabbit output is excluded from the public
+commit for this reason (see Publication & Reproducibility).
+
+## Test Corpus & Ground Truth
+
+~25 test cases across Python, TypeScript/JS, Go, and Java (Aletheore's strongest scanner
+languages), split three ways:
+
+1. **~15 real bug-fix reconstructions.** Find a merged bug-fix commit in a popular OSS repo
+   (clear `fix:`/"Fixes #N" message, ideally a linked issue), check out the state immediately
+   before that fix, and submit that state as the "PR under test." The actual fix commit is the
+   ground truth. This mirrors the methodology Greptile's own published benchmark used (50
+   PRs/5 repos, bugs reconstructed from real bug-fix commits) — a known, citable precedent,
+   not a method invented for this exercise.
+2. **~6 injected bugs.** Deliberately introduce a known bug pattern (SQL injection via string
+   concatenation, off-by-one, missing null/None check, race condition, hardcoded secret) into
+   an otherwise-clean PR, targeting categories underrepresented in the real set. Ground truth
+   (file, line, category, expected finding) is written down *before* any tool runs against the
+   case — pre-registered, not scored after the fact from whatever a tool happened to flag.
+3. **~4 clean PRs with no real bug**, added during design beyond what was originally scoped,
+   because this is the direct test of false-positive/hallucination behavior on code with
+   nothing wrong with it — central to the grounding claim this benchmark exists to test.
+
+Each case directory records: which repo/commit, the PR diff, and the ground-truth document.
+
+## Architecture (Execution Pipeline)
+
+New top-level directory `benchmarks/pr-review-benchmark/`:
+
+```
+benchmarks/pr-review-benchmark/
+  cases/<case-id>/
+    repo.txt              # repo + base commit / PR-under-test pointer
+    pr.diff
+    ground_truth.md        # pre-registered: file, line, category, expected finding
+  scripts/
+    run_case.py            # clones repo, applies PR, invokes each tool, dumps raw JSON output
+    check_citations.py      # extends citation_verifier.py's file-existence check with a
+                             # real line-bounds check against the actual checkout
+    anonymize.py            # relabels tool identities -> Tool A/B/C/D, writes a sealed mapping
+  results/
+    raw/<case-id>/<tool>.json          # CodeRabbit's raw output excluded from public commit
+    scored/<case-id>.md                # blind scoring sheet
+    mapping.sealed.json                 # tool<->label mapping, opened only after scoring locks
+  REPORT.md
+  METHODOLOGY.md
+```
+
+**Model parity.** Where the model is under our control (Aletheore's audit step, PR-Agent's
+bring-your-own-key config), both are pinned to the same underlying model, so the comparison
+isolates grounding architecture rather than which LLM is smarter. DeepSource's and
+CodeRabbit's models are opaque and not controllable — disclosed explicitly as "this measures
+the product as a real user gets it," not an apples-to-apples model comparison.
+
+**Nondeterminism.** Single run per case for cost/time reasons, except a ~5-case spot-check
+subset run 3× to report a variance sanity-check rather than presenting single noisy LLM runs
+as if they were stable.
+
+## Scoring Rubric & Blind Judging
+
+Per case, per tool:
+
+- **Recall** — hit / partial / miss on the real or injected bug.
+- **False positives** — count and list of non-issues raised, with particular weight on the 4
+  clean-PR cases where any finding at all is a false positive by construction.
+- **Citation/grounding accuracy** — automated via `check_citations.py`: does each cited
+  file:line actually exist and fall within the real file's line count in the checkout used for
+  that case.
+- **Actionability** — manual, 1-5 scale: is the finding specific enough to act on, or generic
+  advice that could apply to any codebase.
+
+**Blind process:** `anonymize.py` relabels tool identities to A/B/C/D before any case is
+scored; the sealed mapping for a given case is only reopened after that case's scoring is
+locked, removing the single biggest credibility risk — the benchmark's own author
+unconsciously favoring Aletheore's output during judgment calls.
+
+## Publication & Reproducibility
+
+`REPORT.md` (adaptable into a `website/` page later) plus the full
+`benchmarks/pr-review-benchmark/` directory committed to this repo: cases, ground truth, raw
+outputs (CodeRabbit's excluded per the legal handling above — only its anonymized scored
+summary is published), scoring sheets, and `METHODOLOGY.md` recording exact run dates, model
+versions, and the specific product versions/plans of DeepSource, CodeRabbit, and Qodo/PR-Agent
+used, since all three will keep changing after this snapshot is taken.
+
+Framing: report all four scoring dimensions honestly for every tool, including where a
+competitor wins one. Headline framing emphasizes grounding/citation accuracy as Aletheore's
+differentiator, but the scorecard itself is never edited to hide an unfavorable result — a
+mixed outcome reads as more credible than a clean sweep.
+
+## Known Limitations (stated in the report up front, not discovered later)
+
+- **CodeRabbit's anonymized entry is a soft tell.** A single unnamed "Tool D" next to three
+  named tools is guessable by elimination. Accepted rather than solved by adding an
+  unnecessary second anonymized entry.
+- **Single-run scoring on ~20 of 25 cases** — LLM nondeterminism means an individual case
+  result is noisier than the spot-checked subset; the report states this plainly rather than
+  presenting all cases as equally stable.
+- **DeepSource is architecturally different from the other three.** It's closer to static
+  analysis plus AI-assisted autofix than a pure LLM PR-reviewer in the same shape as Aletheore,
+  Qodo/PR-Agent, or CodeRabbit. It stays in the comparison, but the report calls this out
+  explicitly as a caveat on that entry specifically, rather than implying full architectural
+  parity across all four.

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -5,11 +5,13 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from aletheore.evidence_resolution import resolve_code_evidence
 from app_server.admin import (
     _administered_installation_ids_or_401,
+    _github_http_client,
     _repo_installation_id,
     _require_admin_installation,
     _require_seat_if_paid,
 )
 from app_server.auth import get_current_session
+from app_server.config import get_settings
 from app_server.db import (
     get_installation,
     get_endpoint_health_summary_since,
@@ -21,6 +23,7 @@ from app_server.db import (
     list_repos_for_installations,
     list_wiki_subsystems,
 )
+from app_server.github_auth import generate_app_jwt, get_installation_token
 
 dashboard_router = APIRouter()
 MIN_CHECKS_FOR_STALE_CONFIDENCE = 5
@@ -50,6 +53,59 @@ def find_stale_endpoints(
     return stale
 
 
+async def _uninitialized_repos_for_installation(
+    installation_id: int, plan: str, already_known: set[str]
+) -> list[dict]:
+    """Repos a GitHub App installation covers that have never completed a
+    scan yet. Installing (or paying for) an installation creates no
+    per-repo record by itself - webhooks/installation.py's
+    handle_installation_event only upserts the installations table, and a
+    repo only gets a repo_history row once its first scan actually
+    completes. Without this, a freshly installed or freshly upgraded
+    installation shows nothing at all in "Your repositories" until that
+    first scan finishes (which can take minutes), with no feedback in the
+    meantime - confirmed as a real gap dogfooding this against a live
+    installation.
+
+    Best-effort: this is a page enrichment, not the primary data - ANY
+    failure (a bad/missing app key, a revoked installation, a rate limit, a
+    GitHub outage, a network error) returns an empty list rather than
+    failing the whole page. A user's already-scanned repos must still load
+    even if this best-effort lookup can't run at all.
+    """
+    try:
+        settings = get_settings()
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        token = await get_installation_token(installation_id, app_jwt)
+        response = _github_http_client().get(
+            "/installation/repositories",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        response.raise_for_status()
+    except Exception:
+        return []
+
+    result = []
+    for repo in response.json().get("repositories", []):
+        full_name = repo["full_name"]
+        if full_name in already_known:
+            continue
+        org, _, repo_name = full_name.partition("/")
+        result.append(
+            {
+                "org": org,
+                "repo": repo_name,
+                "repo_full_name": full_name,
+                "plan": plan,
+                "initialized": False,
+            }
+        )
+    return result
+
+
 @dashboard_router.get("/app/repos")
 async def list_my_repos(request: Request):
     session = await get_current_session(request)
@@ -60,6 +116,7 @@ async def list_my_repos(request: Request):
     pool = request.app.state.db_pool
     repos = await list_repos_for_installations(pool, list(administered_ids))
     result = []
+    known_by_installation: dict[int, set[str]] = {}
     for row in repos:
         # repo_full_name is the source of truth for the org/repo split used
         # in every /app/{org}/{repo} route - account_login is a display
@@ -71,8 +128,20 @@ async def list_my_repos(request: Request):
                 "repo": repo,
                 "repo_full_name": row["repo_full_name"],
                 "plan": row["plan"],
+                "initialized": True,
             }
         )
+        known_by_installation.setdefault(row["installation_id"], set()).add(row["repo_full_name"])
+
+    for installation_id in administered_ids:
+        installation = await get_installation(pool, installation_id)
+        if installation is None:
+            continue
+        known = known_by_installation.get(installation_id, set())
+        result.extend(
+            await _uninitialized_repos_for_installation(installation_id, installation["plan"], known)
+        )
+
     return {"repos": result}
 
 

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -114,6 +114,9 @@ a { color: var(--accent); }
 .picker-plan { display: inline-block; margin-top: 7px; font-size: 11px; font-weight: 500; padding: 2px 9px; border-radius: 99px; background: var(--slate-100); color: var(--slate-600); }
 .picker-plan.paid { background: var(--accent-soft); color: var(--accent-strong); }
 .picker-card-arrow { color: var(--slate-400); font-size: 16px; flex-shrink: 0; }
+.picker-card-pending { cursor: default; }
+.picker-card-pending:hover { border-color: var(--border); box-shadow: var(--shadow-card); transform: none; }
+.picker-pending-note { margin-top: 4px; font-size: 11.5px; color: var(--slate-500); }
 
 /* ---- Shared UI atoms ---- */
 .btn { font-family: var(--font-sans); font-size: 12.5px; font-weight: 500; border-radius: 7px; padding: 7px 12px;
@@ -353,10 +356,19 @@ PICKER_HTML = f"""<!DOCTYPE html>
     const group = document.createElement('div');
     group.className = 'picker-org-group';
     const grid = byOrg[org].map(function (r) {{
+      const planBadge = '<span class="picker-plan' + (r.plan !== 'free' ? ' paid' : '') + '">' + escapeHtml(r.plan) + ' plan</span>';
+      if (r.initialized === false) {{
+        return '<div class="picker-card picker-card-pending">' +
+          '<div class="picker-card-icon"><i class="ti ti-git-branch" aria-hidden="true"></i></div>' +
+          '<div class="picker-card-body"><div class="picker-repo">' + escapeHtml(r.repo) + '</div>' +
+          planBadge +
+          '<div class="picker-pending-note">Initialization required &mdash; waiting for the first scan to complete</div></div>' +
+          '</div>';
+      }}
       return '<a class="picker-card" href="/dashboard/' + encodeURIComponent(r.org) + '/' + encodeURIComponent(r.repo) + '">' +
         '<div class="picker-card-icon"><i class="ti ti-git-branch" aria-hidden="true"></i></div>' +
         '<div class="picker-card-body"><div class="picker-repo">' + escapeHtml(r.repo) + '</div>' +
-        '<span class="picker-plan' + (r.plan !== 'free' ? ' paid' : '') + '">' + escapeHtml(r.plan) + ' plan</span></div>' +
+        planBadge + '</div>' +
         '<i class="ti ti-chevron-right picker-card-arrow" aria-hidden="true"></i></a>';
     }}).join('');
     group.innerHTML = '<div class="picker-org-label">' + escapeHtml(org) + '</div><div class="picker-grid">' + grid + '</div>';

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -113,6 +113,149 @@ async def test_list_my_repos_returns_repos_across_administered_installations(poo
 
 
 @pytest.mark.asyncio
+async def test_list_my_repos_includes_uninitialized_repos_with_no_scan_yet(pool, monkeypatch):
+    # A freshly installed (or freshly paid) installation has no repo_history
+    # rows at all until its first scan completes - it must still show up,
+    # not vanish entirely, per the real gap found dogfooding this: a user
+    # paid for their personal-account installation and the dashboard kept
+    # showing nothing for it.
+    await upsert_installation(pool, 801, "some-user")
+    await set_installation_plan(pool, 801, "team")
+
+    monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
+
+    async def fake_get_installation_token(installation_id, app_jwt, http_client=None):
+        return "fake-installation-token"
+
+    monkeypatch.setattr("app_server.dashboard.get_installation_token", fake_get_installation_token)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/user/installations":
+            return httpx.Response(200, json={"total_count": 1, "installations": [{"id": 801}]})
+        if request.url.path == "/installation/repositories":
+            return httpx.Response(200, json={
+                "repositories": [{"full_name": "some-user/proctor-browser"}],
+            })
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    await create_session(
+        pool, "sess-1", 42, "octocat",
+        encrypt_access_token("gho_faketoken", "test-session-secret"),
+        datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    monkeypatch.setattr(
+        "app_server.admin._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    monkeypatch.setattr(
+        "app_server.dashboard._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+
+    app.state.db_pool = pool
+    signed = sign_session_id("sess-1", "test-session-secret")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"session": signed}) as client:
+        response = await client.get("/app/repos")
+
+    assert response.status_code == 200
+    repos = response.json()["repos"]
+    assert repos == [{
+        "org": "some-user",
+        "repo": "proctor-browser",
+        "repo_full_name": "some-user/proctor-browser",
+        "plan": "team",
+        "initialized": False,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_list_my_repos_does_not_duplicate_already_scanned_repos(pool, monkeypatch):
+    # A repo that already has a completed scan must not ALSO show up as an
+    # "uninitialized" duplicate just because it's still covered by the
+    # installation's real GitHub repo list.
+    await upsert_installation(pool, 802, "some-user")
+    await insert_repo_history(
+        pool, 802, "some-user/already-scanned", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+
+    monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
+
+    async def fake_get_installation_token(installation_id, app_jwt, http_client=None):
+        return "fake-installation-token"
+
+    monkeypatch.setattr("app_server.dashboard.get_installation_token", fake_get_installation_token)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/user/installations":
+            return httpx.Response(200, json={"total_count": 1, "installations": [{"id": 802}]})
+        if request.url.path == "/installation/repositories":
+            return httpx.Response(200, json={
+                "repositories": [{"full_name": "some-user/already-scanned"}],
+            })
+        raise AssertionError(f"unexpected request: {request.url.path}")
+
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    await create_session(
+        pool, "sess-1", 42, "octocat",
+        encrypt_access_token("gho_faketoken", "test-session-secret"),
+        datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    monkeypatch.setattr(
+        "app_server.admin._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    monkeypatch.setattr(
+        "app_server.dashboard._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+
+    app.state.db_pool = pool
+    signed = sign_session_id("sess-1", "test-session-secret")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"session": signed}) as client:
+        response = await client.get("/app/repos")
+
+    assert response.status_code == 200
+    repos = response.json()["repos"]
+    assert repos == [{
+        "org": "some-user",
+        "repo": "already-scanned",
+        "repo_full_name": "some-user/already-scanned",
+        "plan": "free",
+        "initialized": True,
+    }]
+
+
+@pytest.mark.asyncio
+async def test_list_my_repos_ignores_github_failure_when_fetching_uninitialized_repos(pool, monkeypatch):
+    # If the installation-token exchange or repo listing call fails (rate
+    # limit, revoked installation, transient GitHub outage), a user must
+    # still see their already-scanned repos rather than getting a 502 for
+    # the whole page over a "nice to have" enrichment.
+    await upsert_installation(pool, 803, "some-user")
+
+    monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
+
+    async def fake_get_installation_token(installation_id, app_jwt, http_client=None):
+        raise httpx.HTTPStatusError(
+            "boom",
+            request=httpx.Request("POST", "https://api.github.com/x"),
+            response=httpx.Response(403),
+        )
+
+    monkeypatch.setattr("app_server.dashboard.get_installation_token", fake_get_installation_token)
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[803])
+    async with client:
+        response = await client.get("/app/repos")
+
+    assert response.status_code == 200
+    assert response.json()["repos"] == []
+
+
+@pytest.mark.asyncio
 async def test_app_repos_response_is_not_cacheable(pool, monkeypatch):
     # /app/... carries per-installation data (which repos someone
     # administers, at minimum) - a cached copy must never be replayable

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -88,6 +88,12 @@ KNOWN_ADAPTERS = [
         api_key_env_var="GEMINI_API_KEY",
         model="gemini-3.5-flash",
     ),
+    OpenAICompatibleAdapter(
+        name="deepseek",
+        base_url="https://api.deepseek.com",
+        api_key_env_var="DEEPSEEK_API_KEY",
+        model="deepseek-v4-pro",
+    ),
 ]
 
 MANUAL_DIR = str(Path(__file__).resolve().parent / "manual")

--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -5,6 +5,7 @@ import tomllib
 import urllib.error
 import urllib.request
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from xml.etree import ElementTree
 
@@ -24,6 +25,11 @@ from aletheore.vulnerabilities import (
 PYPI_URL_TEMPLATE = "https://pypi.org/pypi/{name}/{version}/json"
 NPM_URL_TEMPLATE = "https://registry.npmjs.org/{name}/{version}"
 DEFAULT_TIMEOUT_SECONDS = 10
+# Each check is one blocking registry HTTP call; a repo with hundreds of
+# pinned dependencies (real case: 441) took 3+ minutes fully serial, enough
+# to blow the hosted worker's per-job timeout on its own. Bounded, not
+# unbounded, so this stays polite to registries under a large repo.
+LICENSE_CHECK_CONCURRENCY = 20
 
 # Same reasoning as vulnerabilities.py: certifi's CA bundle explicitly, since a
 # python.org macOS install commonly has no default CA bundle configured.
@@ -234,6 +240,24 @@ _LICENSE_FETCHERS = {
 }
 
 
+def _fetch_one_license(pin: tuple[str, str, str], timeout: int) -> str | None:
+    name, version, ecosystem = pin
+    try:
+        return _LICENSE_FETCHERS[ecosystem](name, version, timeout)
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        OSError,
+        json.JSONDecodeError,
+        ElementTree.ParseError,
+    ):
+        # A single package's registry lookup failing (network hiccup, the
+        # package removed, a malformed response) isn't the same as the whole
+        # check being unreachable - it's reported as an "unknown" finding
+        # rather than silently dropped or failing everything else.
+        return None
+
+
 def check_dependency_licenses(
     repo_path: Path,
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
@@ -254,34 +278,29 @@ def check_dependency_licenses(
         return {"checked": True, "reason": None, "repo_license": repo_license, "findings": []}
 
     findings = []
-    for index, (name, version, ecosystem) in enumerate(pins, start=1):
-        if on_progress is not None:
-            on_progress(index, len(pins), name)
-        try:
-            license_text = _LICENSE_FETCHERS[ecosystem](name, version, timeout)
-        except (
-            urllib.error.URLError,
-            TimeoutError,
-            OSError,
-            json.JSONDecodeError,
-            ElementTree.ParseError,
+    # Each registry lookup is an independent blocking HTTP call - a thread
+    # pool overlaps their network wait time instead of paying it serially.
+    # executor.map (not as_completed) preserves pins' original order in the
+    # results regardless of which thread finishes first, so progress
+    # reporting and finding order both stay deterministic.
+    with ThreadPoolExecutor(max_workers=LICENSE_CHECK_CONCURRENCY) as executor:
+        license_texts = executor.map(lambda pin: _fetch_one_license(pin, timeout), pins)
+        for index, ((name, version, ecosystem), license_text) in enumerate(
+            zip(pins, license_texts), start=1
         ):
-            # A single package's registry lookup failing (network hiccup, the
-            # package removed, a malformed response) isn't the same as the whole
-            # check being unreachable - it's reported as an "unknown" finding
-            # rather than silently dropped or failing everything else.
-            license_text = None
+            if on_progress is not None:
+                on_progress(index, len(pins), name)
 
-        category = categorize_license(license_text)
-        if category != "permissive":
-            findings.append(
-                {
-                    "ecosystem": ecosystem,
-                    "package": name,
-                    "installed_version": version,
-                    "license": license_text,
-                    "category": category,
-                }
-            )
+            category = categorize_license(license_text)
+            if category != "permissive":
+                findings.append(
+                    {
+                        "ecosystem": ecosystem,
+                        "package": name,
+                        "installed_version": version,
+                        "license": license_text,
+                        "category": category,
+                    }
+                )
 
     return {"checked": True, "reason": None, "repo_license": repo_license, "findings": findings}

--- a/src/aletheore/scanner/detect.py
+++ b/src/aletheore/scanner/detect.py
@@ -203,11 +203,28 @@ def _npm_dependencies(repo_path: Path) -> dict[str, str]:
     return {**data.get("dependencies", {}), **data.get("devDependencies", {})}
 
 
+def _nested_git_roots(repo_path: Path) -> set[Path]:
+    """Directories other than repo_path itself that contain their own `.git`
+    entry (file or directory) - a linked worktree (`git worktree add`) or a
+    submodule checked out the classic way, and therefore a separate git
+    working tree, not this repo's own source. Unlike cache/build dirs, these
+    have no fixed name to add to IGNORED_DIRS - a real scan found one at
+    `.claude/worktrees/<name>/`, doubling every file inside it."""
+    return {
+        git_entry.parent
+        for git_entry in repo_path.rglob(".git")
+        if git_entry.parent != repo_path
+    }
+
+
 def _iter_source_files(repo_path: Path):
+    nested_git_roots = _nested_git_roots(repo_path)
     for path in repo_path.rglob("*"):
         if not path.is_file():
             continue
         if any(part in IGNORED_DIRS for part in path.parts):
+            continue
+        if any(root in path.parents for root in nested_git_roots):
             continue
         yield path
 

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -14,7 +14,7 @@ import tree_sitter_rust as tsrust
 import tree_sitter_typescript as tstypescript
 from tree_sitter import Language, Node, Parser
 
-from aletheore.scanner.detect import IGNORED_DIRS
+from aletheore.scanner.detect import IGNORED_DIRS, _nested_git_roots
 
 PY_LANGUAGE = Language(tspython.language())
 JS_LANGUAGE = Language(tsjavascript.language())
@@ -64,10 +64,13 @@ KNOWN_SOURCE_EXTENSIONS_WITHOUT_GRAMMAR = {
 
 
 def _iter_source_files(repo_path: Path):
+    nested_git_roots = _nested_git_roots(repo_path)
     for path in sorted(repo_path.rglob("*")):
         if not path.is_file():
             continue
         if any(part in IGNORED_DIRS for part in path.parts):
+            continue
+        if any(root in path.parents for root in nested_git_roots):
             continue
         yield path
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -521,6 +521,7 @@ def test_known_adapters_includes_every_provider():
         "grok-build",
         "grok",
         "ollama",
+        "deepseek",
     }
 
 

--- a/src/tests/test_detect.py
+++ b/src/tests/test_detect.py
@@ -134,6 +134,28 @@ def test_detect_languages_ignores_cache_dirs(tmp_path):
     assert by_name["python"]["file_count"] == 1
 
 
+def test_detect_languages_ignores_nested_git_worktree(tmp_path):
+    # A linked git worktree (`git worktree add`) is a directory containing its own
+    # `.git` file (not a directory - that's what distinguishes it from a submodule
+    # checked out the classic way, but both are "a separate git working tree" for
+    # this purpose) pointing back at the main repo's `.git/worktrees/<name>`. It can
+    # be named anything - unlike cache dirs, there's no fixed name to add to
+    # IGNORED_DIRS. Found on a real scan: a repo with a worktree at
+    # `.claude/worktrees/<name>/` double-counted every file in it.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("x = 1\n")
+
+    worktree = repo / "some-custom-worktree-name"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: /elsewhere/.git/worktrees/some-custom-worktree-name\n")
+    (worktree / "main.py").write_text("x = 1\ny = 2\n")
+
+    languages = detect_languages(repo)
+    by_name = {entry["name"]: entry for entry in languages}
+    assert by_name["python"]["file_count"] == 1
+
+
 def test_detect_ai_usage_finds_a_provider_in_requirements_txt(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -105,6 +105,25 @@ def test_build_module_graph_ignores_cache_and_build_dirs(tmp_path):
     assert {m["path"] for m in modules} == {"main.py"}
 
 
+def test_build_module_graph_ignores_nested_git_worktree(tmp_path):
+    # Same real-world bug as test_detect.py's version of this test: a linked git
+    # worktree is a directory (any name) containing its own `.git` file, and its
+    # contents duplicated every real module in a live scan (confirmed: 203 of 492
+    # modules were `.claude/worktrees/<name>/`-prefixed duplicates of real files).
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("x = 1\n")
+
+    worktree = repo / "some-custom-worktree-name"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: /elsewhere/.git/worktrees/some-custom-worktree-name\n")
+    (worktree / "main.py").write_text("x = 1\ny = 2\n")
+
+    modules, _, unparseable = build_module_graph(repo)
+    assert unparseable == []
+    assert {m["path"] for m in modules} == {"main.py"}
+
+
 def test_build_module_graph_extracts_typescript_imports(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -274,6 +274,33 @@ def test_check_dependency_licenses_reports_progress_per_dependency(tmp_path):
     assert calls == [(1, 2, "flask"), (2, 2, "requests")]
 
 
+def test_check_dependency_licenses_checks_dependencies_concurrently_not_serially(tmp_path):
+    # Real-world finding: a hosted PR scan against a repo with 441 pinned
+    # dependencies took ~3+ minutes on this step alone (one blocking HTTP
+    # call per dependency, fully serial), blowing the hosted worker's
+    # internal timeout budget. 30 dependencies here, each with a simulated
+    # 0.1s network round-trip: serial would take >= 3.0s; with real
+    # concurrency this must complete in a small fraction of that.
+    import time
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    requirements = "\n".join(f"pkg{i}==1.0.{i}" for i in range(30))
+    (repo / "requirements.txt").write_text(requirements + "\n")
+
+    def slow_urlopen(request, timeout=None, context=None):
+        time.sleep(0.1)
+        return _mock_response({"info": {"license": "MIT", "classifiers": []}})
+
+    with patch("aletheore.licenses.urllib.request.urlopen", side_effect=slow_urlopen):
+        start = time.monotonic()
+        result = check_dependency_licenses(repo)
+        elapsed = time.monotonic() - start
+
+    assert result["checked"] is True
+    assert elapsed < 1.0, f"took {elapsed:.2f}s - lookups are not running concurrently"
+
+
 def test_check_dependency_licenses_on_progress_not_called_with_no_pins(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
Four independent, isolated fixes found and built while dogfooding the product against a real installation:

- **fix(benchmark): exclude nested git worktree/submodule contents from repo scans** — the scanner's IGNORED_DIRS is a fixed name list with no concept of "this is a separate git working tree"; a linked worktree under any directory name got scanned as if it were part of the parent repo. Verified: module count on the real repo dropped from 492 to 289 (exactly the 203 duplicates) after the fix.
- **feat: add deepseek adapter to KNOWN_ADAPTERS** — registers DeepSeek as a generic OpenAI-compatible provider (`deepseek-v4-pro`, matching the model already used in `model_tiers.py`) so `aletheore audit --agent deepseek` works.
- **fix: show uninitialized repos in "Your repositories" instead of nothing** — a freshly installed or freshly upgraded GitHub App installation showed nothing at all in the dashboard until its first scan completed (which can take minutes or time out). Now fetches the installation's real repo list from GitHub for any installation with no scanned repos yet, and shows it as a non-clickable "Initialization required" card instead of silently omitting it.
- **fix: check dependency licenses concurrently instead of serially** — `check_dependency_licenses` issued one blocking HTTP call per pinned dependency, fully serial. Confirmed against a real hosted PR scan on a 441-dependency repo: this step alone took 3+ minutes cold, enough on its own to blow the hosted worker's per-job timeout. Now runs through a bounded `ThreadPoolExecutor` (20 workers) via `executor.map`, which preserves result order exactly as before.

## Test plan
- [x] `src/` full suite: 730 passed (excluding known pre-existing untracked duplicate files)
- [x] `github-app/` full suite: 543 passed, 7 skipped
- [x] Scanner fix verified against a real scan (module count 492→289)
- [x] License-check fix verified with a new concurrency regression test (30 simulated 0.1s lookups complete in <1s vs 3s+ serial)
- [x] Dashboard fix has 3 new tests covering: uninitialized repos surfaced, no duplication of already-scanned repos, graceful degradation on GitHub API failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)