### PR TITLE
fix: verify claimed citation lines against real file content

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -69,6 +69,28 @@ def gather_file_context(
     return "\n\n".join(parts)
 
 
+def fetch_changed_file_contents(
+    client,
+    token: str,
+    repo_full_name: str,
+    changed_files: list[str],
+    head_ref: str,
+) -> dict[str, str]:
+    """Structured file->content lookup for _line_citation_content_matches -
+    a parallel fetch to gather_file_context's formatted prompt blob, since
+    that function's return type (one joined string) can't answer "what's
+    the real content of this specific file" for verification."""
+    contents = {}
+    for path in changed_files[:MAX_CONTEXT_FILES]:
+        content = fetch_file_content(client, token, repo_full_name, path, head_ref)
+        if content is None:
+            continue
+        if len(content.encode("utf-8")) > MAX_CONTEXT_FILE_BYTES:
+            continue
+        contents[path] = content
+    return contents
+
+
 def build_code_evidence_context(evidence: dict | None, changed_files: list[str]) -> str:
     if not evidence:
         return ""
@@ -204,6 +226,60 @@ def build_referenced_symbol_context(
     return "\n\n".join(parts)
 
 
+_QUOTED_STRING_RE = re.compile(r"'([^'\n]{8,})'|\"([^\"\n]{8,})\"")
+LINE_CITATION_CONTEXT_WINDOW = 2
+
+
+def _quoted_strings(text: str) -> list[str]:
+    """Literal quoted snippets in a finding's own text - a real anchor to
+    check the finding's claimed line against, when one exists. Short
+    quotes (under 8 chars) are skipped: real code is full of short quoted
+    tokens ('x', "ok") that aren't meaningful evidence of a specific
+    location."""
+    matches = []
+    for match in _QUOTED_STRING_RE.finditer(text):
+        matches.append(match.group(1) if match.group(1) is not None else match.group(2))
+    return matches
+
+
+def _line_citation_content_matches(finding: dict, file_contents: dict[str, str]) -> bool:
+    """Verifies a finding's claimed line against the real file content
+    already fetched for this diff, when there's something concrete to
+    check it against.
+
+    Confirmed as a real production gap: on a real PR (case
+    001-flask-cli-key-quote, pr-review-benchmark corpus, PR #213), Flash
+    Review correctly quoted the exact buggy string verbatim but cited it
+    at line 561 in a ~1000-line file, when that string only actually
+    appears at line 798. `_diff_valid_lines`'s coarse diff-range check
+    couldn't catch this: the whole file counted as "in the diff" (each of
+    this benchmark's cases is opened as a brand-new file in its scratch
+    repo, so GitHub reports the entire file as added), so any line number
+    the model invented passed that check. This proves the claimed
+    content is actually near the claimed line, independent of diff shape.
+
+    Returns True (pass) when there's nothing to check: no real content
+    was fetched for this file (e.g. it was skipped for size, or the fetch
+    failed - this check only ever adds scrutiny, never rejects for a
+    reason unrelated to the citation itself), or the finding names no
+    literal quoted string to verify against.
+    """
+    content = file_contents.get(finding["file"])
+    if content is None:
+        return True
+    lines = content.splitlines()
+    line = finding["line"]
+    if line < 1 or line > len(lines):
+        return False
+    quoted = _quoted_strings(finding.get("issue") or "") + _quoted_strings(finding.get("suggestion") or "")
+    if not quoted:
+        return True
+    window_start = max(0, line - 1 - LINE_CITATION_CONTEXT_WINDOW)
+    window_end = min(len(lines), line + LINE_CITATION_CONTEXT_WINDOW)
+    window_text = "\n".join(lines[window_start:window_end])
+    return any(q in window_text for q in quoted)
+
+
 _FILE_MARKER_RE = re.compile(r"^--- (.+) ---$")
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
@@ -235,9 +311,14 @@ def _diff_valid_lines(diff_text: str) -> dict[str, set[int]]:
     return valid_lines
 
 
-def _validate_findings(findings: list[dict], diff_text: str) -> list[dict]:
+def _validate_findings(
+    findings: list[dict], diff_text: str, file_contents: dict[str, str] | None = None
+) -> list[dict]:
     valid_lines = _diff_valid_lines(diff_text)
-    return [f for f in findings if f["line"] in valid_lines.get(f["file"], set())]
+    in_diff = [f for f in findings if f["line"] in valid_lines.get(f["file"], set())]
+    if not file_contents:
+        return in_diff
+    return [f for f in in_diff if _line_citation_content_matches(f, file_contents)]
 
 
 _NON_SUBSTANTIVE_FILENAMES = {
@@ -280,6 +361,7 @@ def review_diff(
     cache_lookup: Callable[[str], list[dict] | None] | None = None,
     cache_write: Callable[[str, list[dict], str], None] | None = None,
     model_used: str = "deepseek-v4-flash",
+    file_contents: dict[str, str] | None = None,
 ) -> list[dict]:
     if not diff_text.strip():
         return []
@@ -291,7 +373,7 @@ def review_diff(
             logger.warning("flash review cache lookup failed (%s); treating as miss", type(exc).__name__)
             cached = None
         if cached is not None:
-            return _validate_findings(cached, diff_text)
+            return _validate_findings(cached, diff_text, file_contents)
 
     adapter = OpenAICompatibleAdapter(
         name="DeepSeek",
@@ -348,4 +430,4 @@ def review_diff(
         except Exception as exc:
             logger.warning("flash review cache write failed (%s); continuing without cache", type(exc).__name__)
 
-    return _validate_findings(valid, diff_text)
+    return _validate_findings(valid, diff_text, file_contents)

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import time
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -63,6 +64,7 @@ from scan_worker.db import (
 from scan_worker.flash_review import (
     build_code_evidence_context,
     build_referenced_symbol_context,
+    fetch_changed_file_contents,
     gather_file_context,
     is_non_substantive_diff,
     review_diff,
@@ -666,6 +668,7 @@ def run_flash_review_job(
             findings: list[dict] = []
         else:
             file_context = gather_file_context(client, token, repo_full_name, changed_files, head_sha)
+            file_contents = fetch_changed_file_contents(client, token, repo_full_name, changed_files, head_sha)
             evidence = _latest_evidence_or_none(settings.database_url, installation_id, repo_full_name)
             code_evidence_context = build_code_evidence_context(evidence, changed_files)
 
@@ -701,6 +704,7 @@ def run_flash_review_job(
                     cache_lookup=_cache_lookup,
                     cache_write=_cache_write,
                     model_used="deepseek-v4-flash",
+                    file_contents=file_contents,
                 )
             else:
                 findings = review_diff(
@@ -711,6 +715,7 @@ def run_flash_review_job(
                     cache_lookup=_cache_lookup,
                     cache_write=_cache_write,
                     model_used="deepseek-v4-flash",
+                    file_contents=file_contents,
                 )
         record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
         increment_flash_review_count(settings.database_url, installation_id)
@@ -1167,6 +1172,42 @@ def _live_wiki_update_writing_adapter() -> OpenAICompatibleAdapter:
     )
 
 
+def _real_line_count_fetcher(
+    installation_id: int, repo_full_name: str, ref: str | None
+) -> Callable[[str], int | None] | None:
+    """Backs generate_subsystems/generate_overview's fetch_line_count
+    param with a real GitHub Contents API lookup, closing the same
+    documented citation-verification gap fixed in flash_review.py and
+    citation_verifier.py: without this, a citation naming a real file but
+    a fabricated line number is reported as verified. Degrades to None
+    (falls back to file-existence-only verification) on any setup
+    failure - this is a verification enhancement, never allowed to break
+    wiki generation itself.
+    """
+    try:
+        settings = get_settings()
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        token = _token_sync(installation_id, app_jwt)
+        client = httpx.Client(base_url="https://api.github.com")
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "could not set up line-count fetcher (%s); citations checked for file existence only",
+            type(exc).__name__,
+        )
+        return None
+
+    def _fetch_line_count(path: str) -> int | None:
+        try:
+            content = fetch_file_content(client, token, repo_full_name, path, ref)
+        except Exception:  # noqa: BLE001
+            return None
+        if content is None:
+            return None
+        return len(content.splitlines())
+
+    return _fetch_line_count
+
+
 def _store_wiki_generation(
     dsn: str,
     installation_id: int,
@@ -1175,6 +1216,7 @@ def _store_wiki_generation(
     fresh_records: list[dict],
     writing_adapter,
     source_commit: str | None,
+    fetch_line_count: Callable[[str], int | None] | None = None,
 ) -> None:
     """Upserts freshly-generated subsystem records, prunes any subsystem
     whose cluster no longer exists in the current evidence at all, then
@@ -1204,7 +1246,9 @@ def _store_wiki_generation(
     if not all_records:
         return
 
-    overview = live_wiki.generate_overview(evidence, list(all_records.values()), writing_adapter)
+    overview = live_wiki.generate_overview(
+        evidence, list(all_records.values()), writing_adapter, fetch_line_count=fetch_line_count
+    )
     upsert_wiki_overview(
         dsn, installation_id, repo_full_name, overview["description"], overview["diagram_mermaid"], source_commit
     )
@@ -1223,6 +1267,7 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
 
     naming_adapter = _live_wiki_naming_adapter()
     writing_adapter = _live_wiki_full_build_writing_adapter(plan)
+    fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
     records = live_wiki.generate_subsystems(
         evidence,
         naming_adapter,
@@ -1232,8 +1277,12 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
             dsn, installation_id, repo_full_name, packet, output, used
         ),
         model_used=model_used,
+        fetch_line_count=fetch_line_count,
     )
-    _store_wiki_generation(dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None)
+    _store_wiki_generation(
+        dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
+        fetch_line_count=fetch_line_count,
+    )
 
 
 @log_job
@@ -1275,6 +1324,7 @@ def _maybe_update_live_wiki(
     dsn = settings.database_url
     naming_adapter = _live_wiki_naming_adapter()
     writing_adapter = _live_wiki_update_writing_adapter()
+    fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
     records = live_wiki.generate_subsystems(
         evidence,
         naming_adapter,
@@ -1285,7 +1335,9 @@ def _maybe_update_live_wiki(
             dsn, installation_id, repo_full_name, packet, output, used
         ),
         model_used=live_wiki.UPDATE_MODEL,
+        fetch_line_count=fetch_line_count,
     )
     _store_wiki_generation(
-        settings.database_url, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha
+        settings.database_url, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
+        fetch_line_count=fetch_line_count,
     )

--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -109,12 +109,16 @@ def _sanitize_written_files(written_files, brief_files: list[dict]) -> list[dict
     return sanitized
 
 
-def _validate_written_output(parsed: dict | None, evidence: dict) -> tuple[dict, str] | None:
+def _validate_written_output(
+    parsed: dict | None,
+    evidence: dict,
+    fetch_line_count: Callable[[str], int | None] | None = None,
+) -> tuple[dict, str] | None:
     if parsed is None or not isinstance(parsed.get("description"), str) or not parsed["description"].strip():
         return None
 
     description = parsed["description"].strip()
-    if not verify_citations(description, evidence)["all_verified"]:
+    if not verify_citations(description, evidence, fetch_line_count=fetch_line_count)["all_verified"]:
         return None
     return parsed, description
 
@@ -129,6 +133,7 @@ def build_subsystem_record(
     cache_lookup: Callable[[dict], tuple[dict, str] | None] | None = None,
     cache_write: Callable[[dict, dict, str], None] | None = None,
     model_used: str = "",
+    fetch_line_count: Callable[[str], int | None] | None = None,
 ) -> dict | None:
     packet = build_evidence_packet(
         evidence, cluster, brief, model_used, cache_eligible=cache_lookup is not None
@@ -144,7 +149,7 @@ def build_subsystem_record(
             cached = None
         if cached is not None:
             cached_output, _cached_model_used = cached
-            candidate = _validate_written_output(cached_output, evidence)
+            candidate = _validate_written_output(cached_output, evidence, fetch_line_count)
             if candidate is not None:
                 parsed, description = candidate
 
@@ -152,7 +157,7 @@ def build_subsystem_record(
         user_prompt = json.dumps({"name": name, "brief": brief})
         raw = writing_adapter.simple_completion(SUBSYSTEM_WRITING_SYSTEM_PROMPT, user_prompt, cwd=".")
         raw_parsed = _parse_json_object(raw)
-        candidate = _validate_written_output(raw_parsed, evidence)
+        candidate = _validate_written_output(raw_parsed, evidence, fetch_line_count)
         if candidate is None:
             return None
         parsed, description = candidate
@@ -192,6 +197,7 @@ def generate_subsystems(
     cache_lookup: Callable[[dict], tuple[dict, str] | None] | None = None,
     cache_write: Callable[[dict, dict, str], None] | None = None,
     model_used: str = "",
+    fetch_line_count: Callable[[str], int | None] | None = None,
 ) -> list[dict]:
     """Generates subsystem records. If cluster_ids is given, only those
     clusters are processed (incremental update); otherwise every cluster
@@ -221,13 +227,20 @@ def generate_subsystems(
             cache_lookup=cache_lookup,
             cache_write=cache_write,
             model_used=model_used,
+            fetch_line_count=fetch_line_count,
         )
         if record is not None:
             records.append(record)
     return records
 
 
-def generate_overview(evidence: dict, all_subsystem_records: list[dict], writing_adapter) -> dict:
+def generate_overview(
+    evidence: dict,
+    all_subsystem_records: list[dict],
+    writing_adapter,
+    *,
+    fetch_line_count: Callable[[str], int | None] | None = None,
+) -> dict:
     """all_subsystem_records must be the full current set (freshly
     generated ones merged with unchanged ones already in storage) - the
     overview narrates how every subsystem relates, not just the ones that
@@ -242,7 +255,7 @@ def generate_overview(evidence: dict, all_subsystem_records: list[dict], writing
     description = parsed.get("description") if parsed else None
     if not isinstance(description, str) or not description.strip():
         description = "Overview description unavailable."
-    elif not verify_citations(description, evidence)["all_verified"]:
+    elif not verify_citations(description, evidence, fetch_line_count=fetch_line_count)["all_verified"]:
         description = "Overview description unavailable."
 
     return {"description": description, "diagram_mermaid": diagram}

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock, patch
 from scan_worker.flash_review import (
     FLASH_REVIEW_SYSTEM_PROMPT,
     _diff_valid_lines,
+    _line_citation_content_matches,
     _names_referenced_in_diff,
+    _quoted_strings,
     _validate_findings,
     build_code_evidence_context,
     build_referenced_symbol_context,
@@ -50,6 +52,86 @@ def test_validate_findings_drops_finding_outside_diff_hunks():
     ]
 
     assert _validate_findings(findings, diff_text) == [{"file": "a.py", "line": 1, "issue": "valid"}]
+
+
+def test_quoted_strings_extracts_single_and_double_quoted_literals():
+    text = 'Missing quote: \'When "--cert" is set, "--key is not used.\''
+    assert _quoted_strings(text) == ['When "--cert" is set, "--key is not used.']
+
+
+def test_quoted_strings_ignores_short_quotes():
+    # Real code has lots of short quoted tokens ('x', "ok") that aren't
+    # meaningful anchors - only longer literal snippets are worth checking.
+    assert _quoted_strings("set x = 'ok'") == []
+
+
+def test_quoted_strings_returns_empty_for_no_quotes():
+    assert _quoted_strings("this issue names no literal string") == []
+
+
+def test_line_citation_content_matches_true_when_quoted_string_is_at_claimed_line():
+    finding = {"file": "a.py", "line": 3, "issue": 'missing quote: \'a specific buggy string here\''}
+    file_contents = {"a.py": "one\ntwo\na specific buggy string here\nfour"}
+
+    assert _line_citation_content_matches(finding, file_contents) is True
+
+
+def test_line_citation_content_matches_false_when_quoted_string_is_elsewhere():
+    # Reproduces the real production case: Flash Review quoted the exact
+    # buggy string verbatim but cited line 561 in a ~1000 line file when
+    # the string only actually appears at line 798 - the coarse diff-range
+    # check alone can't catch this because 561 is still "in the diff"
+    # (see PR #213, case 001-flask-cli-key-quote in the pr-review-benchmark
+    # corpus). This proves the claimed line's real content backs the claim.
+    lines = ["filler"] * 20
+    lines[1] = "a specific buggy string here"  # real location: line 2
+    finding = {"file": "a.py", "line": 15, "issue": "missing quote: 'a specific buggy string here'"}
+    file_contents = {"a.py": "\n".join(lines)}
+
+    assert _line_citation_content_matches(finding, file_contents) is False
+
+
+def test_line_citation_content_matches_tolerates_a_small_context_window():
+    finding = {"file": "a.py", "line": 2, "issue": 'missing quote: \'a specific buggy string here\''}
+    file_contents = {"a.py": "one\ntwo\na specific buggy string here\nfour"}
+
+    assert _line_citation_content_matches(finding, file_contents) is True
+
+
+def test_line_citation_content_matches_true_when_no_quoted_string_to_check():
+    finding = {"file": "a.py", "line": 1, "issue": "a vague issue with no literal quote"}
+    file_contents = {"a.py": "one\ntwo"}
+
+    assert _line_citation_content_matches(finding, file_contents) is True
+
+
+def test_line_citation_content_matches_true_when_file_content_unavailable():
+    finding = {"file": "missing.py", "line": 1, "issue": "'some specific quoted text'"}
+
+    assert _line_citation_content_matches(finding, {}) is True
+
+
+def test_line_citation_content_matches_false_when_line_out_of_bounds():
+    finding = {"file": "a.py", "line": 99, "issue": "anything"}
+    file_contents = {"a.py": "one\ntwo"}
+
+    assert _line_citation_content_matches(finding, file_contents) is False
+
+
+def test_validate_findings_drops_finding_whose_quoted_content_is_at_the_wrong_line():
+    diff_lines = "\n".join(f" line{i}" for i in range(1, 21))
+    diff_text = f"--- a.py ---\n@@ -1,20 +1,20 @@\n{diff_lines}"
+    findings = [
+        {"file": "a.py", "line": 15, "issue": "wrong line: 'a specific buggy string here'"},
+        {"file": "a.py", "line": 2, "issue": "right line: 'a specific buggy string here'"},
+    ]
+    file_lines = ["filler"] * 20
+    file_lines[1] = "a specific buggy string here"  # real location: line 2
+    file_contents = {"a.py": "\n".join(file_lines)}
+
+    assert _validate_findings(findings, diff_text, file_contents=file_contents) == [
+        {"file": "a.py", "line": 2, "issue": "right line: 'a specific buggy string here'"}
+    ]
 
 
 def test_is_non_substantive_diff_true_for_lockfile_only():
@@ -553,3 +635,61 @@ def test_gather_file_context_stops_at_total_byte_budget(monkeypatch):
     result = flash_review.gather_file_context(None, "tok", "o/r", ["a.py", "b.py", "c.py"], "sha")
 
     assert result.count("0123456789") == 1
+
+
+def test_fetch_changed_file_contents_returns_path_to_content_mapping(monkeypatch):
+    from scan_worker import flash_review
+
+    def fake_fetch(client, token, repo, path, ref):
+        return f"content of {path}"
+
+    monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
+
+    result = flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py", "b.py"], "sha")
+
+    assert result == {"a.py": "content of a.py", "b.py": "content of b.py"}
+
+
+def test_fetch_changed_file_contents_skips_files_where_fetch_returns_none(monkeypatch):
+    from scan_worker import flash_review
+
+    def fake_fetch(client, token, repo, path, ref):
+        return None if path == "missing.py" else "real content"
+
+    monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
+
+    result = flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py", "missing.py"], "sha")
+
+    assert result == {"a.py": "real content"}
+
+
+def test_fetch_changed_file_contents_skips_oversized_files(monkeypatch):
+    from scan_worker import flash_review
+
+    monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILE_BYTES", 5)
+
+    def fake_fetch(client, token, repo, path, ref):
+        return "way too long for the cap"
+
+    monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
+
+    result = flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py"], "sha")
+
+    assert result == {}
+
+
+def test_fetch_changed_file_contents_stops_at_max_files(monkeypatch):
+    from scan_worker import flash_review
+
+    monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILES", 2)
+    fetched = []
+
+    def fake_fetch(client, token, repo, path, ref):
+        fetched.append(path)
+        return "x" * 10
+
+    monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
+
+    flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py", "b.py", "c.py", "d.py"], "sha")
+
+    assert fetched == ["a.py", "b.py"]

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -820,6 +820,7 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
+    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
         lambda diff_text, file_context="", **kwargs: [
@@ -877,6 +878,7 @@ def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkey
     )
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["dashboard.py"])
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
+    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
     monkeypatch.setattr(
         "scan_worker.jobs._latest_evidence_or_none",
         lambda *a, **k: {
@@ -922,6 +924,49 @@ def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkey
     assert "def _github_http_client() -> httpx.Client" in captured["referenced_symbol_context"]
 
 
+def test_flash_review_job_passes_changed_file_contents_to_review_diff(monkeypatch):
+    # Real production gap this closes: Flash Review can correctly quote a
+    # buggy string verbatim while citing the wrong line for it (confirmed
+    # on a real PR - see _line_citation_content_matches's docstring in
+    # flash_review.py). review_diff can only catch that if it's actually
+    # given the changed files' real content to check citations against.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_pr_diff",
+        lambda *a, **k: "--- app.py ---\n@@ -1,1 +1,1 @@\n+broken",
+    )
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_changed_file_contents",
+        lambda *a, **k: {"app.py": "real content of app.py"},
+    )
+    captured = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.review_diff",
+        lambda diff_text, file_context="", **kwargs: captured.update(kwargs) or [],
+    )
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert captured["file_contents"] == {"app.py": "real content of app.py"}
+
+
 def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestion_syntax(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
@@ -940,6 +985,7 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
+    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
         lambda diff_text, file_context="", **kwargs: [
@@ -980,6 +1026,7 @@ def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+fine")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
     monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
+    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", **kwargs: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
@@ -1598,7 +1645,7 @@ def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monke
     stored = {}
     monkeypatch.setattr(
         "scan_worker.jobs._store_wiki_generation",
-        lambda dsn, iid, repo, evidence, records, adapter, commit: stored.update(
+        lambda dsn, iid, repo, evidence, records, adapter, commit, **k: stored.update(
             records=records, commit=commit
         ),
     )
@@ -1685,7 +1732,7 @@ def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
     stored = {}
     monkeypatch.setattr(
         "scan_worker.jobs._store_wiki_generation",
-        lambda dsn, iid, repo, evidence, records, adapter, commit: stored.update(
+        lambda dsn, iid, repo, evidence, records, adapter, commit, **k: stored.update(
             records=records, commit=commit
         ),
     )
@@ -1694,6 +1741,85 @@ def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
 
     assert stored["records"] == [fake_record]
     assert stored["commit"] is None
+
+
+def test_real_line_count_fetcher_returns_none_when_token_setup_fails(monkeypatch):
+    from scan_worker.jobs import _real_line_count_fetcher
+
+    monkeypatch.setattr(
+        "scan_worker.jobs.generate_app_jwt",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no key configured")),
+    )
+
+    assert _real_line_count_fetcher(1, "octocat/hello-world", None) is None
+
+
+def test_real_line_count_fetcher_returns_real_line_count(monkeypatch):
+    from scan_worker.jobs import _real_line_count_fetcher
+
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_file_content",
+        lambda client, token, repo, path, ref: "one\ntwo\nthree" if path == "app.py" else None,
+    )
+
+    fetch_line_count = _real_line_count_fetcher(1, "octocat/hello-world", "sha1")
+
+    assert fetch_line_count is not None
+    assert fetch_line_count("app.py") == 3
+    assert fetch_line_count("missing.py") is None
+
+
+def test_run_live_wiki_full_build_job_passes_fetch_line_count_through(monkeypatch):
+    from scan_worker.jobs import run_live_wiki_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    sentinel = lambda path: 42  # noqa: E731
+    monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
+
+    captured_subsystems = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.generate_subsystems",
+        lambda *a, **k: captured_subsystems.update(k) or [],
+    )
+    captured_store = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs._store_wiki_generation",
+        lambda *a, **k: captured_store.update(k),
+    )
+
+    run_live_wiki_full_build_job(1, "octocat/hello-world")
+
+    assert captured_subsystems["fetch_line_count"] is sentinel
+    assert captured_store["fetch_line_count"] is sentinel
+
+
+def test_maybe_update_live_wiki_passes_fetch_line_count_through(monkeypatch):
+    from scan_worker.jobs import _maybe_update_live_wiki
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    sentinel = lambda path: 42  # noqa: E731
+    monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
+
+    captured_subsystems = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.generate_subsystems",
+        lambda *a, **k: captured_subsystems.update(k) or [],
+    )
+    captured_store = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs._store_wiki_generation",
+        lambda *a, **k: captured_store.update(k),
+    )
+
+    _maybe_update_live_wiki(1, "octocat/hello-world", _wiki_evidence(), ["auth/login.py"], "sha1")
+
+    assert captured_subsystems["fetch_line_count"] is sentinel
+    assert captured_store["fetch_line_count"] is sentinel
 
 
 def test_run_live_wiki_full_build_for_installation_job_enqueues_per_repo(monkeypatch):

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -191,6 +191,41 @@ def test_build_subsystem_record_rejects_description_with_hallucinated_citation()
     assert build_subsystem_record(evidence, cluster, brief, "Authentication", adapter) is None
 
 
+def test_build_subsystem_record_rejects_description_citation_beyond_real_line_count():
+    # Closes the same documented gap as citation_verifier.py's
+    # verify_citations: without a real line count, a citation naming a
+    # real file but a fabricated line is reported as verified. When
+    # fetch_line_count is given, a citation beyond the file's real length
+    # is rejected the same way an unknown file already is.
+    evidence = make_evidence()
+    cluster = evidence["architecture"]["clusters"][0]
+    brief = _brief_for(evidence)
+    adapter = _adapter(
+        json.dumps({"description": "See `auth/login.py:99999` for details.", "files": []})
+    )
+
+    record = build_subsystem_record(
+        evidence, cluster, brief, "Authentication", adapter, fetch_line_count=lambda path: 20
+    )
+
+    assert record is None
+
+
+def test_build_subsystem_record_keeps_description_citation_within_real_line_count():
+    evidence = make_evidence()
+    cluster = evidence["architecture"]["clusters"][0]
+    brief = _brief_for(evidence)
+    adapter = _adapter(
+        json.dumps({"description": "See `auth/login.py:10` for details.", "files": []})
+    )
+
+    record = build_subsystem_record(
+        evidence, cluster, brief, "Authentication", adapter, fetch_line_count=lambda path: 20
+    )
+
+    assert record is not None
+
+
 def test_build_subsystem_record_uses_cache_hit_and_skips_model_call():
     evidence = make_evidence()
     cluster = evidence["architecture"]["clusters"][0]
@@ -348,6 +383,26 @@ def test_generate_overview_falls_back_on_hallucinated_citation():
     overview = generate_overview(evidence, subsystem_records, adapter)
 
     assert overview["description"] == "Overview description unavailable."
+
+
+def test_generate_overview_rejects_citation_beyond_real_line_count():
+    evidence = make_evidence()
+    subsystem_records = [{"subsystem_id": "0", "name": "Authentication", "description": "Handles login."}]
+    adapter = _adapter(json.dumps({"description": "See `auth/login.py:99999` for the entry point."}))
+
+    overview = generate_overview(evidence, subsystem_records, adapter, fetch_line_count=lambda path: 20)
+
+    assert overview["description"] == "Overview description unavailable."
+
+
+def test_generate_overview_keeps_citation_within_real_line_count():
+    evidence = make_evidence()
+    subsystem_records = [{"subsystem_id": "0", "name": "Authentication", "description": "Handles login."}]
+    adapter = _adapter(json.dumps({"description": "See `auth/login.py:10` for the entry point."}))
+
+    overview = generate_overview(evidence, subsystem_records, adapter, fetch_line_count=lambda path: 20)
+
+    assert overview["description"] == "See `auth/login.py:10` for the entry point."
 
 
 def test_affected_cluster_ids_maps_changed_files_to_clusters():

--- a/src/aletheore/citation_verifier.py
+++ b/src/aletheore/citation_verifier.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Callable
 
 # Matches file:line citations in report text, e.g. "server/routes/billing.ts:142"
 # or "`app.py:12`". Deliberately narrow (word chars, dots, slashes, hyphens in the
@@ -22,17 +23,31 @@ def extract_citations(report_text: str) -> list[dict]:
     return citations
 
 
-def verify_citations(report_text: str, evidence: dict) -> dict:
+def verify_citations(
+    report_text: str,
+    evidence: dict,
+    *,
+    fetch_line_count: Callable[[str], int | None] | None = None,
+) -> dict:
     """Checks each file:line citation in a generated report against the
     deterministic evidence it was supposedly grounded in.
 
-    This verifies file existence, which AIR data can answer with certainty.
-    It does not verify the cited line is where the claimed issue actually
-    lives - AIR doesn't record per-file line counts, so a citation naming a
-    real file but a fabricated line would still be reported as "verified"
-    here. That is a real limitation, not an oversight: report an explicit
-    unavailable rather than a false confidence, per this codebase's
-    evidence-resolution rule of never inventing certainty it doesn't have.
+    This always verifies file existence, which AIR data can answer with
+    certainty. It does NOT verify the cited line is where the claimed
+    issue actually lives unless `fetch_line_count` is given - AIR itself
+    doesn't record per-file line counts, so without a fetcher, a citation
+    naming a real file but a fabricated line is still reported as
+    "verified" here (a real, documented limitation, not an oversight).
+
+    `fetch_line_count`, when given, closes that gap: it's called with a
+    citation's file path and must return that file's real line count (or
+    None if unavailable, e.g. a fetch failure - which never turns into a
+    false "unverified", it just skips the bounds check for that citation
+    and falls back to file-existence-only). Confirmed as a real,
+    reproducible bug when unguarded: Flash Review once cited a real,
+    correctly-quoted issue at a line 237 lines away from where it actually
+    is (see flash_review.py's _line_citation_content_matches) - a fabricated
+    line is a real failure mode, not a hypothetical one.
     """
     known_paths = _known_file_paths(evidence)
     citations = extract_citations(report_text)
@@ -40,10 +55,15 @@ def verify_citations(report_text: str, evidence: dict) -> dict:
     verified = []
     unverified = []
     for citation in citations:
-        if citation["file"] in known_paths:
-            verified.append(citation)
-        else:
+        if citation["file"] not in known_paths:
             unverified.append(citation)
+            continue
+        if fetch_line_count is not None:
+            line_count = fetch_line_count(citation["file"])
+            if line_count is not None and citation["line"] > line_count:
+                unverified.append(citation)
+                continue
+        verified.append(citation)
 
     return {
         "total_citations": len(citations),

--- a/src/tests/test_citation_verifier.py
+++ b/src/tests/test_citation_verifier.py
@@ -79,3 +79,44 @@ def test_verify_citations_handles_report_with_no_citations():
         "unverified": [],
         "all_verified": True,
     }
+
+
+def test_verify_citations_without_fetch_line_count_ignores_fabricated_lines():
+    # Documents the existing, acknowledged limitation: without a real line
+    # count to check against, a citation naming a real file but a
+    # fabricated line number is still reported as verified.
+    text = "Issue found at `server/routes/billing.ts:99999`."
+    result = verify_citations(text, make_evidence())
+
+    assert result["all_verified"] is True
+
+
+def test_verify_citations_with_fetch_line_count_catches_a_fabricated_line():
+    # Closes the gap above when a real line count is available: this is
+    # the same category of bug confirmed in Flash Review on a real PR (see
+    # flash_review.py's _line_citation_content_matches) - a citation
+    # naming a real file but a line beyond its real length is a fabricated
+    # citation, not a verified one.
+    text = "Issue found at `server/routes/billing.ts:99999`."
+    result = verify_citations(text, make_evidence(), fetch_line_count=lambda path: 200)
+
+    assert result["all_verified"] is False
+    assert result["unverified"] == [{"file": "server/routes/billing.ts", "line": 99999}]
+
+
+def test_verify_citations_with_fetch_line_count_keeps_a_real_line():
+    text = "Issue found at `server/routes/billing.ts:142`."
+    result = verify_citations(text, make_evidence(), fetch_line_count=lambda path: 200)
+
+    assert result["all_verified"] is True
+    assert result["verified"] == [{"file": "server/routes/billing.ts", "line": 142}]
+
+
+def test_verify_citations_with_fetch_line_count_returning_none_skips_bounds_check():
+    # A fetcher that can't determine a file's line count (e.g. a fetch
+    # failure) must not turn into a false "unverified" - the citation
+    # falls back to file-existence-only, same as without a fetcher at all.
+    text = "Issue found at `server/routes/billing.ts:99999`."
+    result = verify_citations(text, make_evidence(), fetch_line_count=lambda path: None)
+
+    assert result["all_verified"] is True


### PR DESCRIPTION
## Summary
- Root-caused via a real live PR (pr-review-benchmark case 001, `ArihantK15/proctor-browser#213`): Flash Review correctly quoted a buggy string verbatim but cited it at line 561 in a ~1000-line file, when the string only actually appears at line 798 — the existing diff-range check couldn't catch this since the whole file counted as "in the diff" (a benchmark scratch-repo artifact).
- `flash_review.py`: new `_line_citation_content_matches` verifies a finding's claimed line against the real file content already fetched for the diff, when the finding quotes a literal string. New `fetch_changed_file_contents` supplies that content; wired through `review_diff`/`_validate_findings` and `jobs.py`'s `run_flash_review_job`.
- `citation_verifier.py`: `verify_citations` gains an optional `fetch_line_count` callable, closing its own documented limitation ("a citation naming a real file but a fabricated line would still be reported as verified").
- `live_wiki.py` + `jobs.py`: threads the same capability through `build_subsystem_record`/`generate_subsystems`/`generate_overview` and both real call sites, backed by a new `_real_line_count_fetcher` that degrades gracefully on any setup failure.
- All changes are additive/backward-compatible (new keyword-only params, default `None` preserves prior behavior exactly).

## Test plan
- [x] `github-app/tests/` — 575 passed, 7 skipped
- [x] `src/tests/` — 734 passed
- [x] New unit tests for `_line_citation_content_matches`, `_quoted_strings`, `fetch_changed_file_contents`, `verify_citations`'s `fetch_line_count`, and wiring tests for both `run_flash_review_job` and both Live Wiki job call sites