### PR TITLE
feat: durable, incrementally-updated code graph (Phase 2 data model)

### DIFF
--- a/github-app/migrations/022_incremental_code_graph.sql
+++ b/github-app/migrations/022_incremental_code_graph.sql
@@ -1,0 +1,83 @@
+-- Durable, incrementally-updated code graph: the persistent counterpart to
+-- repo_history's evidence JSONB blob. repo_history stores one full,
+-- whole-repo snapshot per scan - useful as a point-in-time record, but it
+-- gives no way to update only what a push actually changed, and no way to
+-- query a single file/symbol/dependency edge/endpoint without pulling and
+-- re-parsing the entire latest blob. These tables let a push update only
+-- the rows for files that actually changed, matching the same
+-- (installation_id, repo_full_name, branch) keying convention already
+-- established by evidence_git_* (see 020_evidence_git_graph.sql) for the
+-- git-history/ownership graph.
+--
+-- Scope note: this models file/symbol/dependency-edge/endpoint state only.
+-- Ownership is already covered by evidence_git_ownership; findings
+-- (secrets/audit/Flash Review results, with an open/resolved lifecycle)
+-- are deliberately out of scope here and left for a follow-up once this
+-- graph foundation is proven in production.
+
+CREATE TABLE IF NOT EXISTS code_graph_sync_state (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    branch           TEXT NOT NULL,
+    last_synced_sha  TEXT NOT NULL,
+    last_synced_at   TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (installation_id, repo_full_name, branch)
+);
+
+CREATE TABLE IF NOT EXISTS code_graph_files (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    branch           TEXT NOT NULL,
+    path             TEXT NOT NULL,
+    language         TEXT,
+    content_hash     TEXT NOT NULL,
+    updated_at       TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (installation_id, repo_full_name, branch, path)
+);
+
+CREATE TABLE IF NOT EXISTS code_graph_symbols (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    branch           TEXT NOT NULL,
+    path             TEXT NOT NULL,
+    name             TEXT NOT NULL,
+    kind             TEXT NOT NULL,
+    start_line       INT NOT NULL,
+    end_line         INT NOT NULL,
+    PRIMARY KEY (installation_id, repo_full_name, branch, path, name, start_line)
+);
+
+-- Every incremental update replaces "all symbols for this file" as a unit
+-- (see code_graph_store.py's apply_file_deltas) - this is the lookup this
+-- pattern needs, separate from the primary key above.
+CREATE INDEX IF NOT EXISTS code_graph_symbols_by_path
+ON code_graph_symbols (installation_id, repo_full_name, branch, path);
+
+CREATE TABLE IF NOT EXISTS code_graph_dependency_edges (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    branch           TEXT NOT NULL,
+    from_path        TEXT NOT NULL,
+    to_path          TEXT NOT NULL,
+    PRIMARY KEY (installation_id, repo_full_name, branch, from_path, to_path)
+);
+
+-- "What depends on this file" (used to find affected dependent graph
+-- regions when a file changes) queries by to_path - the primary key above
+-- is ordered by from_path first, so this needs its own index.
+CREATE INDEX IF NOT EXISTS code_graph_edges_by_to_path
+ON code_graph_dependency_edges (installation_id, repo_full_name, branch, to_path);
+
+CREATE TABLE IF NOT EXISTS code_graph_endpoints (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    branch           TEXT NOT NULL,
+    method           TEXT NOT NULL,
+    endpoint_path    TEXT NOT NULL,
+    file_path        TEXT NOT NULL,
+    line             INT,
+    PRIMARY KEY (installation_id, repo_full_name, branch, method, endpoint_path)
+);
+
+CREATE INDEX IF NOT EXISTS code_graph_endpoints_by_file
+ON code_graph_endpoints (installation_id, repo_full_name, branch, file_path);

--- a/github-app/scan_worker/code_graph_store.py
+++ b/github-app/scan_worker/code_graph_store.py
@@ -1,0 +1,193 @@
+"""Hosted persistence for the durable, incrementally-updated code graph:
+files -> symbols -> dependency edges -> endpoints, keyed by
+installation_id/repo_full_name/branch (same convention as
+postgres_graph_store.py's git-history graph). The counterpart to
+repo_history's evidence JSONB blob snapshot, but addressable at
+file/symbol/edge/endpoint granularity and updated incrementally - only
+the rows for files that actually changed (see aletheore.code_graph_diff)
+are touched on each apply, instead of repo_history's whole-blob rewrite
+on every single scan.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+
+class CodeGraphStore:
+    def __init__(self, dsn: str, installation_id: int, repo_full_name: str):
+        self._dsn = dsn
+        self._installation_id = installation_id
+        self._repo_full_name = repo_full_name
+
+    def load_content_hashes(self, branch: str) -> dict[str, str]:
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT path, content_hash FROM code_graph_files "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+                    (self._installation_id, self._repo_full_name, branch),
+                )
+                return dict(cur.fetchall())
+
+    def load_symbols_for_path(self, branch: str, path: str) -> list[dict]:
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT name, kind, start_line, end_line FROM code_graph_symbols "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s AND path = %s",
+                    (self._installation_id, self._repo_full_name, branch, path),
+                )
+                return [
+                    {"name": name, "kind": kind, "start_line": start_line, "end_line": end_line}
+                    for name, kind, start_line, end_line in cur.fetchall()
+                ]
+
+    def load_dependents(self, branch: str, path: str) -> list[str]:
+        """Files that import `path` - the 'dependent graph regions' for a
+        change to this file."""
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT from_path FROM code_graph_dependency_edges "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s AND to_path = %s "
+                    "ORDER BY from_path",
+                    (self._installation_id, self._repo_full_name, branch, path),
+                )
+                return [row[0] for row in cur.fetchall()]
+
+    def load_endpoint_keys(self, branch: str) -> dict[tuple, dict]:
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT method, endpoint_path, file_path, line FROM code_graph_endpoints "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+                    (self._installation_id, self._repo_full_name, branch),
+                )
+                return {
+                    (method, endpoint_path): {"file": file_path, "line": line}
+                    for method, endpoint_path, file_path, line in cur.fetchall()
+                }
+
+    def apply_module_deltas(
+        self,
+        branch: str,
+        changed_modules: list[dict],
+        deleted_paths: list[str],
+        new_sync_sha: str,
+        new_sync_at: datetime,
+    ) -> None:
+        import psycopg
+
+        ids = (self._installation_id, self._repo_full_name, branch)
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO code_graph_sync_state "
+                    "(installation_id, repo_full_name, branch, last_synced_sha, last_synced_at) "
+                    "VALUES (%s, %s, %s, %s, %s) "
+                    "ON CONFLICT (installation_id, repo_full_name, branch) "
+                    "DO UPDATE SET last_synced_sha = EXCLUDED.last_synced_sha, "
+                    "last_synced_at = EXCLUDED.last_synced_at",
+                    (*ids, new_sync_sha, new_sync_at),
+                )
+
+                # A deleted file's own rows go, and so does anything that
+                # was pointing AT it - an edge from an unchanged file to a
+                # now-deleted one is stale, not something to leave behind
+                # for the next apply to clean up.
+                for path in deleted_paths:
+                    cur.execute(
+                        "DELETE FROM code_graph_files WHERE installation_id = %s AND repo_full_name = %s "
+                        "AND branch = %s AND path = %s",
+                        (*ids, path),
+                    )
+                    cur.execute(
+                        "DELETE FROM code_graph_symbols WHERE installation_id = %s AND repo_full_name = %s "
+                        "AND branch = %s AND path = %s",
+                        (*ids, path),
+                    )
+                    cur.execute(
+                        "DELETE FROM code_graph_dependency_edges WHERE installation_id = %s "
+                        "AND repo_full_name = %s AND branch = %s AND (from_path = %s OR to_path = %s)",
+                        (*ids, path, path),
+                    )
+
+                for module in changed_modules:
+                    path = module["path"]
+                    cur.execute(
+                        "INSERT INTO code_graph_files "
+                        "(installation_id, repo_full_name, branch, path, language, content_hash, updated_at) "
+                        "VALUES (%s, %s, %s, %s, %s, %s, %s) "
+                        "ON CONFLICT (installation_id, repo_full_name, branch, path) "
+                        "DO UPDATE SET language = EXCLUDED.language, content_hash = EXCLUDED.content_hash, "
+                        "updated_at = EXCLUDED.updated_at",
+                        (*ids, path, module.get("language"), module["content_hash"], new_sync_at),
+                    )
+
+                    # Symbols and this file's own outgoing edges are always
+                    # a full replace for the file, not a row-by-row upsert -
+                    # a changed file's old symbols/imports may no longer
+                    # exist at all, so there's no stable per-symbol key to
+                    # upsert against.
+                    cur.execute(
+                        "DELETE FROM code_graph_symbols WHERE installation_id = %s AND repo_full_name = %s "
+                        "AND branch = %s AND path = %s",
+                        (*ids, path),
+                    )
+                    symbols = module.get("symbols", {})
+                    for kind, entries in (("function", symbols.get("functions", [])), ("class", symbols.get("classes", []))):
+                        for entry in entries:
+                            cur.execute(
+                                "INSERT INTO code_graph_symbols "
+                                "(installation_id, repo_full_name, branch, path, name, kind, start_line, end_line) "
+                                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+                                (*ids, path, entry["name"], kind, entry["start_line"], entry["end_line"]),
+                            )
+
+                    cur.execute(
+                        "DELETE FROM code_graph_dependency_edges WHERE installation_id = %s "
+                        "AND repo_full_name = %s AND branch = %s AND from_path = %s",
+                        (*ids, path),
+                    )
+                    for target in module.get("imports", []):
+                        cur.execute(
+                            "INSERT INTO code_graph_dependency_edges "
+                            "(installation_id, repo_full_name, branch, from_path, to_path) "
+                            "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING",
+                            (*ids, path, target),
+                        )
+            conn.commit()
+
+    def apply_endpoint_deltas(
+        self, branch: str, changed_endpoints: list[dict], deleted_keys: list[tuple]
+    ) -> None:
+        import psycopg
+
+        ids = (self._installation_id, self._repo_full_name, branch)
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                for method, endpoint_path in deleted_keys:
+                    cur.execute(
+                        "DELETE FROM code_graph_endpoints WHERE installation_id = %s AND repo_full_name = %s "
+                        "AND branch = %s AND method = %s AND endpoint_path = %s",
+                        (*ids, method, endpoint_path),
+                    )
+                for endpoint in changed_endpoints:
+                    cur.execute(
+                        "INSERT INTO code_graph_endpoints "
+                        "(installation_id, repo_full_name, branch, method, endpoint_path, file_path, line) "
+                        "VALUES (%s, %s, %s, %s, %s, %s, %s) "
+                        "ON CONFLICT (installation_id, repo_full_name, branch, method, endpoint_path) "
+                        "DO UPDATE SET file_path = EXCLUDED.file_path, line = EXCLUDED.line",
+                        (*ids, endpoint["method"], endpoint["path"], endpoint.get("file"), endpoint.get("line")),
+                    )
+            conn.commit()

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -18,6 +18,7 @@ from rq import get_current_job
 from app_server.audit_signing import content_hash, sign_report
 from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
+from aletheore.code_graph_diff import diff_endpoints, diff_modules
 from aletheore.evidence import write_evidence
 from aletheore.git_intel.analyzer import analyze_git, compute_hotspots
 from aletheore.evidence_resolution import (
@@ -78,12 +79,12 @@ from scan_worker.github_api import (
     fetch_file_content,
     fetch_pr_changed_files,
     fetch_pr_diff,
-    fetch_recent_commits_for_path,
     upsert_pr_comment,
 )
 from scan_worker.managed_audit import run_managed_audit
 from scan_worker.model_tiers import PRO_FALLBACK_MODEL, model_for_plan, writing_adapter_for_plan
 from scan_worker.packet_cache import lookup_cached_result, store_result
+from scan_worker.code_graph_store import CodeGraphStore
 from scan_worker.postgres_graph_store import PostgresRepoGraphStore
 from scan_worker.slack import (
     format_latency_alert,
@@ -211,6 +212,46 @@ def _sync_persistent_git_graph(installation_id: int, repo_full_name: str, repo_d
             "persistent git graph sync failed (%s); keeping this scan's own git data", type(exc).__name__
         )
     return evidence
+
+
+def _sync_code_graph(installation_id: int, repo_full_name: str, head_sha: str, evidence: dict) -> None:
+    """Updates the durable, incrementally-queryable code graph
+    (code_graph_files/symbols/dependency_edges/endpoints) from this
+    scan's fresh evidence - the counterpart to _sync_persistent_git_graph
+    above, for the code model rather than git history. repo_history's
+    evidence JSONB blob is a whole-repo snapshot rewritten on every single
+    scan; this only touches the rows for files whose extracted content
+    actually changed (see aletheore.code_graph_diff), so the durable
+    graph is addressable and queryable at file/symbol/edge/endpoint
+    granularity instead of "re-parse the latest blob every time you need
+    one fact from it." Never allowed to fail the scan itself: any error
+    here just leaves the durable graph stale until the next successful
+    scan, same discipline as the git graph sync above.
+    """
+    try:
+        settings = get_settings()
+        store = CodeGraphStore(settings.database_url, installation_id, repo_full_name)
+
+        modules = evidence.get("repository", {}).get("modules", [])
+        previous_hashes = store.load_content_hashes(GRAPH_BRANCH)
+        changed_modules, deleted_paths = diff_modules(previous_hashes, modules)
+        store.apply_module_deltas(
+            GRAPH_BRANCH,
+            changed_modules,
+            deleted_paths,
+            new_sync_sha=head_sha,
+            new_sync_at=datetime.now(timezone.utc),
+        )
+
+        endpoints = evidence.get("repository", {}).get("api_endpoints", {}).get("endpoints", [])
+        previous_endpoints = store.load_endpoint_keys(GRAPH_BRANCH)
+        changed_endpoints, deleted_keys = diff_endpoints(previous_endpoints, endpoints)
+        store.apply_endpoint_deltas(GRAPH_BRANCH, changed_endpoints, deleted_keys)
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "code graph sync failed (%s); durable graph left stale until next successful scan",
+            type(exc).__name__,
+        )
 
 
 def _insert_history(installation_id: int, repo_full_name: str, evidence: dict) -> None:
@@ -413,6 +454,7 @@ def run_pr_scan_job(
         client = httpx.Client(base_url="https://api.github.com")
         upsert_pr_comment(client, token, repo_full_name, pr_number, format_diff_comment(diff))
         new = _sync_persistent_git_graph(installation_id, repo_full_name, head_dir, new)
+        _sync_code_graph(installation_id, repo_full_name, head_sha, new)
         _insert_history(installation_id, repo_full_name, new)
 
         # These are side effects, not the primary deliverable above - a failure in
@@ -803,13 +845,45 @@ def _recheck_single_endpoint(entry: dict, base_url: str) -> dict:
     return results[0]
 
 
+def _commit_attachment_from_graph(installation_id: int, repo_full_name: str, source_file: str) -> dict | None:
+    # Reads the same persisted, incrementally-synced graph
+    # _owner_attachment_from_graph (below) already uses, instead of a live
+    # GitHub API call (fetch_recent_commits_for_path) - evidence_git_file_churn
+    # already has this exact data cached from the last scan. Degrades to
+    # None (no commit attachment, not a broken alert) if this repo has no
+    # graph data yet or the database is unreachable - same discipline as
+    # every other attachment in this correlation chain.
+    #
+    # Known, deliberate trade-off: RecentCommit (git_intel/graph_store.py)
+    # captures sha/author/committed_at but never a commit message - the
+    # live API path this replaces did show one ("Recent commit: `abc123`
+    # - fixed the bug"). Slack rendering (slack.py) already treats it as
+    # optional, so this only means a slightly less detailed alert line,
+    # not a broken one. Capturing commit subjects in the persisted graph
+    # is a real, separate follow-up if that detail turns out to matter.
+    try:
+        settings = get_settings()
+        store = PostgresRepoGraphStore(settings.database_url, installation_id, repo_full_name)
+        snapshot = store.load("unused", GRAPH_BRANCH)
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "commit correlation from graph failed (%s); alerting without it", type(exc).__name__
+        )
+        return None
+    churn = snapshot.file_churn.get(source_file)
+    if churn is None or not churn.recent_commits:
+        return None
+    latest = churn.recent_commits[0]
+    return normalize_resolution(
+        kind="commit",
+        commit={"sha": latest.sha, "author_name": latest.author_name, "author_email": latest.author_email},
+        confidence="weak",
+    )
+
+
 def _owner_attachment_from_graph(installation_id: int, repo_full_name: str, source_file: str) -> dict | None:
     # Prefers the persisted graph over a live API call: no extra GitHub
-    # round-trip, and it still answers if GitHub itself is degraded. Only
-    # ever supplements the commit attachment below (which stays the
-    # existing, already-proven live lookup) - never the sole source, since
-    # a repo with no PR-triggered scan since this shipped has no graph data
-    # yet and this simply finds nothing to attach.
+    # round-trip, and it still answers if GitHub itself is degraded.
     try:
         settings = get_settings()
         store = PostgresRepoGraphStore(settings.database_url, installation_id, repo_full_name)
@@ -939,7 +1013,6 @@ def _fix_suggestion_attachment(
 
 
 def _attach_recent_commit_for_failure(
-    settings,
     installation_id: int,
     repo_full_name: str,
     source_file: str,
@@ -950,30 +1023,10 @@ def _attach_recent_commit_for_failure(
     status_code: int | None = None,
     source_line: int | None = None,
 ) -> dict | None:
-    try:
-        app_jwt = generate_app_jwt(
-            settings.github_app_id,
-            settings.github_app_private_key,
-        )
-        token = _token_sync(installation_id, app_jwt)
-        with httpx.Client(base_url="https://api.github.com") as client:
-            commits = fetch_recent_commits_for_path(
-                client,
-                token,
-                repo_full_name,
-                source_file,
-                limit=1,
-            )
-    except Exception as exc:  # noqa: BLE001
-        logging.getLogger("scan_worker.jobs").warning(
-            "commit correlation failed (%s); alerting without it",
-            type(exc).__name__,
-        )
-        commits = []
-
     attachments = []
-    if commits:
-        attachments.append(normalize_resolution(kind="commit", commit=commits[0], confidence="weak"))
+    commit_attachment = _commit_attachment_from_graph(installation_id, repo_full_name, source_file)
+    if commit_attachment is not None:
+        attachments.append(commit_attachment)
     owner_attachment = _owner_attachment_from_graph(installation_id, repo_full_name, source_file)
     if owner_attachment is not None:
         attachments.append(owner_attachment)
@@ -1057,7 +1110,6 @@ def run_health_check_sweep_job() -> None:
             if reachability_flipped:
                 if not reachable and source_file:
                     evidence_resolution = _attach_recent_commit_for_failure(
-                        settings,
                         installation_id,
                         repo_full_name,
                         source_file,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -849,18 +849,12 @@ def _commit_attachment_from_graph(installation_id: int, repo_full_name: str, sou
     # Reads the same persisted, incrementally-synced graph
     # _owner_attachment_from_graph (below) already uses, instead of a live
     # GitHub API call (fetch_recent_commits_for_path) - evidence_git_file_churn
-    # already has this exact data cached from the last scan. Degrades to
-    # None (no commit attachment, not a broken alert) if this repo has no
-    # graph data yet or the database is unreachable - same discipline as
-    # every other attachment in this correlation chain.
-    #
-    # Known, deliberate trade-off: RecentCommit (git_intel/graph_store.py)
-    # captures sha/author/committed_at but never a commit message - the
-    # live API path this replaces did show one ("Recent commit: `abc123`
-    # - fixed the bug"). Slack rendering (slack.py) already treats it as
-    # optional, so this only means a slightly less detailed alert line,
-    # not a broken one. Capturing commit subjects in the persisted graph
-    # is a real, separate follow-up if that detail turns out to matter.
+    # already has this exact data cached from the last scan, including the
+    # commit subject (git_intel/incremental.py's stream_commit_touches
+    # captures %s alongside sha/author/date). Degrades to None (no commit
+    # attachment, not a broken alert) if this repo has no graph data yet
+    # or the database is unreachable - same discipline as every other
+    # attachment in this correlation chain.
     try:
         settings = get_settings()
         store = PostgresRepoGraphStore(settings.database_url, installation_id, repo_full_name)
@@ -876,7 +870,12 @@ def _commit_attachment_from_graph(installation_id: int, repo_full_name: str, sou
     latest = churn.recent_commits[0]
     return normalize_resolution(
         kind="commit",
-        commit={"sha": latest.sha, "author_name": latest.author_name, "author_email": latest.author_email},
+        commit={
+            "sha": latest.sha,
+            "author_name": latest.author_name,
+            "author_email": latest.author_email,
+            "subject": latest.subject,
+        },
         confidence="weak",
     )
 

--- a/github-app/scan_worker/postgres_graph_store.py
+++ b/github-app/scan_worker/postgres_graph_store.py
@@ -83,6 +83,10 @@ class PostgresRepoGraphStore:
                                 author_name=r["author_name"],
                                 author_email=r["author_email"],
                                 committed_at=datetime.fromisoformat(r["committed_at"]),
+                                # .get(): rows written before subject-capture
+                                # was added have no such key - default ""
+                                # rather than KeyError.
+                                subject=r.get("subject", ""),
                             )
                             for r in recent_commits
                         ],
@@ -190,6 +194,7 @@ class PostgresRepoGraphStore:
                                             "author_name": r.author_name,
                                             "author_email": r.author_email,
                                             "committed_at": r.committed_at.isoformat(),
+                                            "subject": r.subject,
                                         }
                                         for r in churn.recent_commits
                                     ]

--- a/github-app/tests/test_code_graph_store.py
+++ b/github-app/tests/test_code_graph_store.py
@@ -1,0 +1,212 @@
+import os
+from datetime import datetime
+
+import pytest
+
+from scan_worker.code_graph_store import CodeGraphStore
+
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://postgres:test@localhost:55433/aletheore_test",
+)
+
+
+async def _insert_installation(pool, installation_id: int, account_login: str) -> None:
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login) VALUES ($1, $2)",
+        installation_id,
+        account_login,
+    )
+
+
+def _module(path, content_hash, language="python", imports=None, functions=None, classes=None):
+    return {
+        "path": path,
+        "language": language,
+        "imports": imports or [],
+        "symbols": {"functions": functions or [], "classes": classes or []},
+        "content_hash": content_hash,
+    }
+
+
+def _endpoint(method, path, file, line):
+    return {"method": method, "path": path, "file": file, "line": line}
+
+
+@pytest.mark.asyncio
+async def test_load_content_hashes_returns_empty_for_unknown_repo(pool):
+    await _insert_installation(pool, 701, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 701, "org/repo")
+
+    assert store.load_content_hashes("main") == {}
+
+
+@pytest.mark.asyncio
+async def test_apply_module_deltas_then_load_round_trips_content_hashes(pool):
+    await _insert_installation(pool, 702, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 702, "org/repo")
+    modules = [
+        _module("a.py", "hash-a", imports=["b.py"], functions=[{"name": "f", "start_line": 1, "end_line": 2}]),
+        _module("b.py", "hash-b"),
+    ]
+
+    store.apply_module_deltas(
+        "main", modules, deleted_paths=[], new_sync_sha="s1", new_sync_at=datetime(2026, 7, 26)
+    )
+
+    assert store.load_content_hashes("main") == {"a.py": "hash-a", "b.py": "hash-b"}
+
+
+@pytest.mark.asyncio
+async def test_apply_module_deltas_persists_symbols_and_edges(pool):
+    await _insert_installation(pool, 703, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 703, "org/repo")
+    modules = [
+        _module(
+            "a.py", "hash-a", imports=["b.py"],
+            functions=[{"name": "f", "start_line": 1, "end_line": 5}],
+            classes=[{"name": "C", "start_line": 10, "end_line": 20}],
+        ),
+        _module("b.py", "hash-b"),
+    ]
+
+    store.apply_module_deltas(
+        "main", modules, deleted_paths=[], new_sync_sha="s1", new_sync_at=datetime(2026, 7, 26)
+    )
+
+    symbols = store.load_symbols_for_path("main", "a.py")
+    assert {"name": "f", "kind": "function", "start_line": 1, "end_line": 5} in symbols
+    assert {"name": "C", "kind": "class", "start_line": 10, "end_line": 20} in symbols
+
+    assert store.load_dependents("main", "b.py") == ["a.py"]
+
+
+@pytest.mark.asyncio
+async def test_apply_module_deltas_only_touches_changed_files(pool):
+    # Core incrementality guarantee: re-applying with an unrelated new file
+    # must not disturb an already-persisted, unchanged file's rows.
+    await _insert_installation(pool, 704, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 704, "org/repo")
+    store.apply_module_deltas(
+        "main",
+        [_module("a.py", "hash-a", functions=[{"name": "f", "start_line": 1, "end_line": 2}])],
+        deleted_paths=[],
+        new_sync_sha="s1",
+        new_sync_at=datetime(2026, 7, 26),
+    )
+
+    store.apply_module_deltas(
+        "main",
+        [_module("c.py", "hash-c")],
+        deleted_paths=[],
+        new_sync_sha="s2",
+        new_sync_at=datetime(2026, 7, 27),
+    )
+
+    assert store.load_content_hashes("main") == {"a.py": "hash-a", "c.py": "hash-c"}
+    assert store.load_symbols_for_path("main", "a.py") == [
+        {"name": "f", "kind": "function", "start_line": 1, "end_line": 2}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_module_deltas_replaces_symbols_for_a_changed_file(pool):
+    await _insert_installation(pool, 705, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 705, "org/repo")
+    store.apply_module_deltas(
+        "main",
+        [_module("a.py", "hash-a", functions=[{"name": "old_fn", "start_line": 1, "end_line": 2}])],
+        deleted_paths=[],
+        new_sync_sha="s1",
+        new_sync_at=datetime(2026, 7, 26),
+    )
+
+    store.apply_module_deltas(
+        "main",
+        [_module("a.py", "hash-a2", functions=[{"name": "new_fn", "start_line": 5, "end_line": 6}])],
+        deleted_paths=[],
+        new_sync_sha="s2",
+        new_sync_at=datetime(2026, 7, 27),
+    )
+
+    symbols = store.load_symbols_for_path("main", "a.py")
+    assert symbols == [{"name": "new_fn", "kind": "function", "start_line": 5, "end_line": 6}]
+
+
+@pytest.mark.asyncio
+async def test_apply_module_deltas_removes_deleted_file_and_its_edges(pool):
+    await _insert_installation(pool, 706, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 706, "org/repo")
+    store.apply_module_deltas(
+        "main",
+        [_module("a.py", "hash-a", imports=["b.py"]), _module("b.py", "hash-b")],
+        deleted_paths=[],
+        new_sync_sha="s1",
+        new_sync_at=datetime(2026, 7, 26),
+    )
+
+    store.apply_module_deltas(
+        "main", [], deleted_paths=["a.py"], new_sync_sha="s2", new_sync_at=datetime(2026, 7, 27)
+    )
+
+    assert "a.py" not in store.load_content_hashes("main")
+    assert store.load_dependents("main", "b.py") == []
+
+
+@pytest.mark.asyncio
+async def test_load_endpoint_keys_returns_empty_for_unknown_repo(pool):
+    await _insert_installation(pool, 707, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 707, "org/repo")
+
+    assert store.load_endpoint_keys("main") == {}
+
+
+@pytest.mark.asyncio
+async def test_apply_endpoint_deltas_then_load_round_trips(pool):
+    await _insert_installation(pool, 708, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 708, "org/repo")
+    endpoints = [_endpoint("GET", "/users", "app.py", 10)]
+
+    store.apply_endpoint_deltas("main", endpoints, deleted_keys=[])
+
+    assert store.load_endpoint_keys("main") == {("GET", "/users"): {"file": "app.py", "line": 10}}
+
+
+@pytest.mark.asyncio
+async def test_apply_endpoint_deltas_removes_deleted_keys(pool):
+    await _insert_installation(pool, 709, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 709, "org/repo")
+    store.apply_endpoint_deltas("main", [_endpoint("GET", "/users", "app.py", 10)], deleted_keys=[])
+
+    store.apply_endpoint_deltas("main", [], deleted_keys=[("GET", "/users")])
+
+    assert store.load_endpoint_keys("main") == {}
+
+
+@pytest.mark.asyncio
+async def test_different_branches_are_isolated(pool):
+    await _insert_installation(pool, 710, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 710, "org/repo")
+
+    store.apply_module_deltas(
+        "main", [_module("a.py", "hash-a")], deleted_paths=[], new_sync_sha="s1", new_sync_at=datetime(2026, 7, 26)
+    )
+    store.apply_module_deltas(
+        "feature", [_module("b.py", "hash-b")], deleted_paths=[], new_sync_sha="s2", new_sync_at=datetime(2026, 7, 27)
+    )
+
+    assert store.load_content_hashes("main") == {"a.py": "hash-a"}
+    assert store.load_content_hashes("feature") == {"b.py": "hash-b"}
+
+
+@pytest.mark.asyncio
+async def test_installation_deletion_cascades_to_code_graph_tables(pool):
+    await _insert_installation(pool, 711, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 711, "org/repo")
+    store.apply_module_deltas(
+        "main", [_module("a.py", "hash-a")], deleted_paths=[], new_sync_sha="s1", new_sync_at=datetime(2026, 7, 26)
+    )
+
+    await pool.execute("DELETE FROM installations WHERE installation_id = 711")
+
+    assert store.load_content_hashes("main") == {}

--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -122,8 +122,8 @@ async def test_commit_attachment_from_graph_uses_most_recent_commit(pool, monkey
         "unused",
         GRAPH_BRANCH,
         [
-            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",)),
-            CommitTouch("s2", "Bob", "b@example.com", datetime(2026, 6, 8), ("app/handler.py",)),
+            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",), "initial handler"),
+            CommitTouch("s2", "Bob", "b@example.com", datetime(2026, 6, 8), ("app/handler.py",), "fix null check"),
         ],
         new_sync_sha="s2",
         new_sync_at=datetime(2026, 6, 8),
@@ -136,6 +136,7 @@ async def test_commit_attachment_from_graph_uses_most_recent_commit(pool, monkey
     assert attachment["kind"] == "commit"
     assert attachment["commit"]["sha"] == "s2"
     assert attachment["commit"]["author_name"] == "Bob"
+    assert attachment["commit"]["subject"] == "fix null check"
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -3,9 +3,11 @@ from datetime import datetime
 
 import pytest
 
+from aletheore.evidence_resolution import normalize_resolution
 from scan_worker.jobs import (
     GRAPH_BRANCH,
     _attach_recent_commit_for_failure,
+    _commit_attachment_from_graph,
     _dependency_context_attachment,
     _find_enclosing_symbol,
     _fix_suggestion_attachment,
@@ -103,22 +105,66 @@ def test_owner_attachment_from_graph_degrades_gracefully_on_db_failure(monkeypat
     assert _owner_attachment_from_graph(803, "org/repo", "app/handler.py") is None
 
 
+@pytest.mark.asyncio
+async def test_commit_attachment_from_graph_uses_most_recent_commit(pool, monkeypatch):
+    # Replaces a live GitHub API round-trip (fetch_recent_commits_for_path)
+    # with a read from the same persisted, incrementally-synced graph
+    # _owner_attachment_from_graph already uses - evidence_git_file_churn
+    # already has this exact data cached from the last scan; there's no
+    # reason a failing-endpoint alert should hit the live API for it.
+    await _insert_installation(pool, 804, "org")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    store = PostgresRepoGraphStore(TEST_DATABASE_URL, 804, "org/repo")
+
+    from aletheore.git_intel.graph_store import CommitTouch
+
+    store.apply_commits(
+        "unused",
+        GRAPH_BRANCH,
+        [
+            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",)),
+            CommitTouch("s2", "Bob", "b@example.com", datetime(2026, 6, 8), ("app/handler.py",)),
+        ],
+        new_sync_sha="s2",
+        new_sync_at=datetime(2026, 6, 8),
+        reset=True,
+    )
+
+    attachment = _commit_attachment_from_graph(804, "org/repo", "app/handler.py")
+
+    assert attachment is not None
+    assert attachment["kind"] == "commit"
+    assert attachment["commit"]["sha"] == "s2"
+    assert attachment["commit"]["author_name"] == "Bob"
+
+
+@pytest.mark.asyncio
+async def test_commit_attachment_from_graph_returns_none_when_no_data(pool, monkeypatch):
+    await _insert_installation(pool, 805, "org")
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+
+    assert _commit_attachment_from_graph(805, "org/repo", "never/scanned.py") is None
+
+
+def test_commit_attachment_from_graph_degrades_gracefully_on_db_failure(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://nonexistent-host-for-this-test/db")
+
+    assert _commit_attachment_from_graph(806, "org/repo", "app/handler.py") is None
+
+
 def test_attach_recent_commit_for_failure_combines_commit_owner_and_dependency_attachments(monkeypatch):
     # Proves all three sources merge into one resolution without any of
-    # them depending on the others being present - the live commit lookup
-    # keeps working exactly as before, and the two new attachments are
-    # purely additive.
-    class FakeSettings:
-        github_app_id = "x"
-        github_app_private_key = "y"
-
-    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
-    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
+    # them depending on the others being present. The commit lookup now
+    # reads the persisted graph (_commit_attachment_from_graph) instead of
+    # a live API call - see test_commit_attachment_from_graph_* above for
+    # that function's own coverage against a real database.
     monkeypatch.setattr(
-        "scan_worker.jobs.fetch_recent_commits_for_path",
-        lambda client, token, repo, path, limit=1: [
-            {"sha": "abc123", "author": "Carol", "date": "2026-07-20T00:00:00Z", "subject": "fix"}
-        ],
+        "scan_worker.jobs._commit_attachment_from_graph",
+        lambda installation_id, repo_full_name, source_file: normalize_resolution(
+            kind="commit",
+            commit={"sha": "abc123", "author_name": "Carol", "author_email": "carol@example.com"},
+            confidence="weak",
+        ),
     )
     monkeypatch.setattr(
         "scan_worker.jobs._owner_attachment_from_graph",
@@ -144,7 +190,6 @@ def test_attach_recent_commit_for_failure_combines_commit_owner_and_dependency_a
     monkeypatch.setattr("scan_worker.jobs._fix_suggestion_attachment", lambda *a, **k: None)
 
     result = _attach_recent_commit_for_failure(
-        FakeSettings(),
         901,
         "org/repo",
         "app/handler.py",
@@ -158,42 +203,28 @@ def test_attach_recent_commit_for_failure_combines_commit_owner_and_dependency_a
 
 
 def test_attach_recent_commit_for_failure_still_returns_something_when_only_commit_available(monkeypatch):
-    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
-    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
     monkeypatch.setattr(
-        "scan_worker.jobs.fetch_recent_commits_for_path",
-        lambda client, token, repo, path, limit=1: [
-            {"sha": "abc123", "author": "Carol", "date": "2026-07-20T00:00:00Z", "subject": "fix"}
-        ],
+        "scan_worker.jobs._commit_attachment_from_graph",
+        lambda installation_id, repo_full_name, source_file: normalize_resolution(
+            kind="commit", commit={"sha": "abc123", "author_name": "Carol"}, confidence="weak"
+        ),
     )
     monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._fix_suggestion_attachment", lambda *a, **k: None)
 
-    class FakeSettings:
-        github_app_id = "x"
-        github_app_private_key = "y"
-
-    result = _attach_recent_commit_for_failure(
-        FakeSettings(), 901, "org/repo", "unknown-file.py", None, None
-    )
+    result = _attach_recent_commit_for_failure(901, "org/repo", "unknown-file.py", None, None)
 
     assert result["commit"]["sha"] == "abc123"
     assert result["owner"] is None
 
 
 def test_attach_recent_commit_for_failure_returns_original_resolution_when_nothing_found(monkeypatch):
-    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
-    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
-    monkeypatch.setattr("scan_worker.jobs.fetch_recent_commits_for_path", lambda *a, **k: [])
+    monkeypatch.setattr("scan_worker.jobs._commit_attachment_from_graph", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._fix_suggestion_attachment", lambda *a, **k: None)
 
-    class FakeSettings:
-        github_app_id = "x"
-        github_app_private_key = "y"
-
     original = {"kind": "endpoint"}
-    result = _attach_recent_commit_for_failure(FakeSettings(), 901, "org/repo", "x.py", original, None)
+    result = _attach_recent_commit_for_failure(901, "org/repo", "x.py", original, None)
 
     assert result is original
 
@@ -289,13 +320,7 @@ def test_fix_suggestion_attachment_degrades_gracefully_on_any_failure(monkeypatc
 
 
 def test_attach_recent_commit_for_failure_includes_suggestion_when_available(monkeypatch):
-    class FakeSettings:
-        github_app_id = "x"
-        github_app_private_key = "y"
-
-    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
-    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
-    monkeypatch.setattr("scan_worker.jobs.fetch_recent_commits_for_path", lambda *a, **k: [])
+    monkeypatch.setattr("scan_worker.jobs._commit_attachment_from_graph", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
     monkeypatch.setattr(
         "scan_worker.jobs._fix_suggestion_attachment",
@@ -321,6 +346,6 @@ def test_attach_recent_commit_for_failure_includes_suggestion_when_available(mon
         },
     )
 
-    result = _attach_recent_commit_for_failure(FakeSettings(), 901, "org/repo", "app/handler.py", None, None)
+    result = _attach_recent_commit_for_failure(901, "org/repo", "app/handler.py", None, None)
 
     assert result["suggestion"] == "increase the connection pool size"

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1390,7 +1390,7 @@ def test_sweep_attaches_recent_commit_on_confirmed_down(monkeypatch):
             "symbol": None,
             "owner": None,
             "owner_status": "unavailable",
-            "commit": {"sha": "abc123def456", "author_name": "Ada"},
+            "commit": {"sha": "abc123def456", "author_name": "Ada", "subject": "touched the handler"},
             "commit_status": "available",
             "dependency": None,
             "dependency_status": "unavailable",
@@ -1407,11 +1407,8 @@ def test_sweep_attaches_recent_commit_on_confirmed_down(monkeypatch):
     run_health_check_sweep_job()
 
     assert len(sent) == 1
-    # No commit subject: the persisted graph (RecentCommit) captures
-    # sha/author/date but never a commit message - see the module-level
-    # note on _commit_attachment_from_graph for why this is a deliberate,
-    # disclosed trade-off, not a bug.
     assert "Recent commit: `abc123de`" in sent[0]["text"]
+    assert "touched the handler" in sent[0]["text"]
 
 
 def test_sweep_alerts_without_commit_when_correlation_fails(monkeypatch):

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -12,6 +12,96 @@ def _noop_spend_lock(*args, **kwargs):
     yield
 
 
+class _FakeCodeGraphStore:
+    """Stands in for scan_worker.code_graph_store.CodeGraphStore so
+    _sync_code_graph's wiring can be tested without a real database - the
+    store's own persistence is already covered directly, against a real
+    Postgres instance, in test_code_graph_store.py."""
+
+    def __init__(self, dsn, installation_id, repo_full_name):
+        self.installation_id = installation_id
+        self.repo_full_name = repo_full_name
+        self.content_hashes = {}
+        self.endpoint_keys = {}
+        self.applied_module_deltas = None
+        self.applied_endpoint_deltas = None
+
+    def load_content_hashes(self, branch):
+        return self.content_hashes
+
+    def load_endpoint_keys(self, branch):
+        return self.endpoint_keys
+
+    def apply_module_deltas(self, branch, changed_modules, deleted_paths, new_sync_sha, new_sync_at):
+        self.applied_module_deltas = {
+            "branch": branch, "changed_modules": changed_modules,
+            "deleted_paths": deleted_paths, "new_sync_sha": new_sync_sha,
+        }
+
+    def apply_endpoint_deltas(self, branch, changed_endpoints, deleted_keys):
+        self.applied_endpoint_deltas = {
+            "branch": branch, "changed_endpoints": changed_endpoints, "deleted_keys": deleted_keys,
+        }
+
+
+def test_sync_code_graph_applies_module_and_endpoint_deltas(monkeypatch):
+    from scan_worker.jobs import _sync_code_graph
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    fake_store = _FakeCodeGraphStore("dsn", 1, "octocat/hello-world")
+    monkeypatch.setattr("scan_worker.jobs.CodeGraphStore", lambda *a, **k: fake_store)
+
+    evidence = {
+        "repository": {
+            "modules": [
+                {"path": "a.py", "language": "python", "imports": [], "symbols": {"functions": [], "classes": []}}
+            ],
+            "api_endpoints": {"endpoints": [{"method": "GET", "path": "/x", "file": "a.py", "line": 1}]},
+        }
+    }
+
+    _sync_code_graph(1, "octocat/hello-world", "sha1", evidence)
+
+    assert fake_store.applied_module_deltas["changed_modules"][0]["path"] == "a.py"
+    assert fake_store.applied_module_deltas["new_sync_sha"] == "sha1"
+    assert fake_store.applied_endpoint_deltas["changed_endpoints"] == [
+        {"method": "GET", "path": "/x", "file": "a.py", "line": 1}
+    ]
+
+
+def test_sync_code_graph_skips_unchanged_modules(monkeypatch):
+    from scan_worker.jobs import _sync_code_graph
+    from aletheore.code_graph_diff import module_content_hash
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    module = {"path": "a.py", "language": "python", "imports": [], "symbols": {"functions": [], "classes": []}}
+    fake_store = _FakeCodeGraphStore("dsn", 1, "octocat/hello-world")
+    fake_store.content_hashes = {"a.py": module_content_hash(module)}
+    monkeypatch.setattr("scan_worker.jobs.CodeGraphStore", lambda *a, **k: fake_store)
+
+    evidence = {"repository": {"modules": [module]}}
+
+    _sync_code_graph(1, "octocat/hello-world", "sha1", evidence)
+
+    assert fake_store.applied_module_deltas["changed_modules"] == []
+    assert fake_store.applied_module_deltas["deleted_paths"] == []
+
+
+def test_sync_code_graph_degrades_gracefully_on_store_failure(monkeypatch):
+    from scan_worker.jobs import _sync_code_graph
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+
+    def _broken_store(*a, **k):
+        raise RuntimeError("no database")
+
+    monkeypatch.setattr("scan_worker.jobs.CodeGraphStore", _broken_store)
+
+    # Must not raise - this is a persistence enhancement, never allowed to
+    # break the scan job itself.
+    _sync_code_graph(1, "octocat/hello-world", "sha1", {"repository": {"modules": []}})
+
+
 def test_happy_path_posts_comment_and_writes_history(bare_repo_with_two_commits, monkeypatch):
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     posted = {}
@@ -1290,18 +1380,26 @@ def test_sweep_attaches_recent_commit_on_confirmed_down(monkeypatch):
         },
     )
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
-    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr(
-        "scan_worker.jobs.fetch_recent_commits_for_path",
-        lambda client, token, repo, path, limit=1: [
-            {
-                "sha": "abc123def456",
-                "author": "Ada",
-                "date": "2026-07-23T10:00:00Z",
-                "subject": "touched the handler",
-            }
-        ],
+        "scan_worker.jobs._commit_attachment_from_graph",
+        lambda installation_id, repo_full_name, source_file: {
+            "kind": "commit",
+            "file": None,
+            "line": None,
+            "end_line": None,
+            "symbol": None,
+            "owner": None,
+            "owner_status": "unavailable",
+            "commit": {"sha": "abc123def456", "author_name": "Ada"},
+            "commit_status": "available",
+            "dependency": None,
+            "dependency_status": "unavailable",
+            "risk": [],
+            "risk_status": "unavailable",
+            "confidence": "weak",
+            "evidence_path": None,
+            "evidence_status": "unavailable",
+        },
     )
 
     from scan_worker.jobs import run_health_check_sweep_job
@@ -1309,8 +1407,11 @@ def test_sweep_attaches_recent_commit_on_confirmed_down(monkeypatch):
     run_health_check_sweep_job()
 
     assert len(sent) == 1
+    # No commit subject: the persisted graph (RecentCommit) captures
+    # sha/author/date but never a commit message - see the module-level
+    # note on _commit_attachment_from_graph for why this is a deliberate,
+    # disclosed trade-off, not a bug.
     assert "Recent commit: `abc123de`" in sent[0]["text"]
-    assert "touched the handler" in sent[0]["text"]
 
 
 def test_sweep_alerts_without_commit_when_correlation_fails(monkeypatch):

--- a/github-app/tests/test_migrate.py
+++ b/github-app/tests/test_migrate.py
@@ -62,6 +62,11 @@ def test_run_migrations_applies_all_files_to_a_fresh_database(fresh_database):
         "llm_spend",
         "flash_review_state",
         "schema_migrations",
+        "code_graph_sync_state",
+        "code_graph_files",
+        "code_graph_symbols",
+        "code_graph_dependency_edges",
+        "code_graph_endpoints",
     ):
         assert expected in tables
 

--- a/src/aletheore/code_graph_diff.py
+++ b/src/aletheore/code_graph_diff.py
@@ -1,0 +1,81 @@
+"""Diffs a fresh full-repo scan result (build_module_graph's modules,
+map_api_endpoints's endpoints) against the previously persisted code
+graph state, to compute the incremental delta a push should write.
+
+Reuses build_module_graph/map_api_endpoints as-is - the scan itself
+still walks and re-parses the whole repo every time (see
+scan_worker/code_graph_store.py's module docstring for why true
+parse-level incrementality - skipping unchanged files' AST parsing
+entirely - is a separate, larger piece of work requiring a persistent
+per-repo checkout the hosted service doesn't keep today; every hosted
+scan clones fresh and deletes the clone afterward). What's incremental
+here is the WRITE: only files/edges/endpoints that actually changed get
+upserted, and rows for anything no longer present get deleted, instead
+of "wipe and reinsert everything" (repo_history's whole-blob snapshot
+approach).
+"""
+import hashlib
+import json
+
+
+def module_content_hash(module: dict) -> str:
+    """A stable fingerprint of everything about a module that this graph
+    tracks (language, resolved imports, symbols) - deliberately NOT the
+    module's path or imported_by (both are either identity, not content,
+    or derived from OTHER files' imports - a change there doesn't mean
+    THIS file changed) and NOT raw file bytes, so a comment-only or
+    whitespace-only edit (no symbol/import change) correctly produces no
+    delta."""
+    stable = json.dumps(
+        {
+            "language": module.get("language"),
+            "imports": sorted(module.get("imports", [])),
+            "symbols": module.get("symbols", {}),
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(stable.encode("utf-8")).hexdigest()
+
+
+def diff_modules(previous_hashes: dict[str, str], modules: list[dict]) -> tuple[list[dict], list[str]]:
+    """previous_hashes: path -> content_hash already persisted.
+
+    Returns (changed_modules, deleted_paths). changed_modules is the
+    subset of `modules` (each with an added "content_hash" key) that's
+    new or whose content_hash differs from what's already persisted.
+    """
+    changed = []
+    current_paths = set()
+    for module in modules:
+        path = module["path"]
+        current_paths.add(path)
+        content_hash = module_content_hash(module)
+        if previous_hashes.get(path) != content_hash:
+            changed.append({**module, "content_hash": content_hash})
+    deleted_paths = [path for path in previous_hashes if path not in current_paths]
+    return changed, deleted_paths
+
+
+def _endpoint_key(endpoint: dict) -> tuple:
+    return (endpoint.get("method"), endpoint.get("path"))
+
+
+def diff_endpoints(
+    previous: dict[tuple, dict], endpoints: list[dict]
+) -> tuple[list[dict], list[tuple]]:
+    """previous: (method, path) -> {"file": ..., "line": ...} already
+    persisted. Returns (changed_endpoints, deleted_keys)."""
+    changed = []
+    current_keys = set()
+    for endpoint in endpoints:
+        key = _endpoint_key(endpoint)
+        current_keys.add(key)
+        prior = previous.get(key)
+        if (
+            prior is None
+            or prior.get("file") != endpoint.get("file")
+            or prior.get("line") != endpoint.get("line")
+        ):
+            changed.append(endpoint)
+    deleted_keys = [key for key in previous if key not in current_keys]
+    return changed, deleted_keys

--- a/src/aletheore/git_intel/graph_store.py
+++ b/src/aletheore/git_intel/graph_store.py
@@ -33,6 +33,7 @@ class RecentCommit:
     author_name: str
     author_email: str
     committed_at: datetime
+    subject: str = ""
 
 
 @dataclass
@@ -69,6 +70,7 @@ class CommitTouch:
     author_email: str
     committed_at: datetime
     files: tuple[str, ...]
+    subject: str = ""
 
 
 @dataclass

--- a/src/aletheore/git_intel/incremental.py
+++ b/src/aletheore/git_intel/incremental.py
@@ -86,7 +86,7 @@ def stream_commit_touches(
     prefix = _scan_root_prefix(repo_path)
     args = [
         "log",
-        f"--format={_RECORD_SEP_FORMAT}%H{_FIELD_SEP}%an{_FIELD_SEP}%ae{_FIELD_SEP}%ad",
+        f"--format={_RECORD_SEP_FORMAT}%H{_FIELD_SEP}%an{_FIELD_SEP}%ae{_FIELD_SEP}%ad{_FIELD_SEP}%s",
         "--date=iso-strict",
         "--name-only",
     ]
@@ -105,14 +105,19 @@ def stream_commit_touches(
     assert proc.stdout is not None
 
     pending_header: tuple[str, str, str, datetime] | None = None
+    pending_subject: str = ""
     pending_files: list[str] = []
     try:
         for raw_line in proc.stdout:
             line = raw_line.rstrip("\n")
             if line.startswith(_RECORD_SEP):
                 if pending_header is not None:
-                    yield CommitTouch(*pending_header, files=tuple(pending_files))
-                sha, name, email, date_str = line[1:].split(_FIELD_SEP)
+                    yield CommitTouch(*pending_header, files=tuple(pending_files), subject=pending_subject)
+                # maxsplit=4: a subject line containing a literal field-sep
+                # byte (vanishingly unlikely - it's a control character, not
+                # something a real commit message would contain) lands
+                # whole in the subject rather than breaking the unpack.
+                sha, name, email, date_str, pending_subject = line[1:].split(_FIELD_SEP, 4)
                 pending_header = (sha, name, email, datetime.fromisoformat(date_str))
                 pending_files = []
             elif line.strip():
@@ -124,7 +129,7 @@ def stream_commit_touches(
                 if path:
                     pending_files.append(path)
         if pending_header is not None:
-            yield CommitTouch(*pending_header, files=tuple(pending_files))
+            yield CommitTouch(*pending_header, files=tuple(pending_files), subject=pending_subject)
     finally:
         proc.stdout.close()
         returncode = proc.wait()
@@ -221,7 +226,9 @@ def fold(snapshot: GraphSnapshot, commits: list[CommitTouch]) -> GraphSnapshot:
         cadence[week] = cadence.get(week, 0) + 1
 
         unique_files = sorted(set(commit.files))
-        recent = RecentCommit(commit.sha, commit.author_name, commit.author_email, commit.committed_at)
+        recent = RecentCommit(
+            commit.sha, commit.author_name, commit.author_email, commit.committed_at, commit.subject
+        )
         for path in unique_files:
             churn = file_churn.get(path)
             if churn is None:

--- a/src/aletheore/git_intel/sqlite_store.py
+++ b/src/aletheore/git_intel/sqlite_store.py
@@ -112,6 +112,9 @@ class SQLiteRepoGraphStore:
                     author_name=r["author_name"],
                     author_email=r["author_email"],
                     committed_at=datetime.fromisoformat(r["committed_at"]),
+                    # .get(): rows written before subject-capture was added
+                    # have no such key - default "" rather than KeyError.
+                    subject=r.get("subject", ""),
                 )
                 for r in json.loads(recent_json)
             ]
@@ -183,6 +186,7 @@ class SQLiteRepoGraphStore:
                                     "author_name": r.author_name,
                                     "author_email": r.author_email,
                                     "committed_at": r.committed_at.isoformat(),
+                                    "subject": r.subject,
                                 }
                                 for r in churn.recent_commits
                             ]

--- a/src/tests/test_code_graph_diff.py
+++ b/src/tests/test_code_graph_diff.py
@@ -1,0 +1,127 @@
+from aletheore.code_graph_diff import diff_endpoints, diff_modules, module_content_hash
+
+
+def _module(path, **overrides):
+    base = {
+        "path": path,
+        "language": "python",
+        "imports": [],
+        "imported_by": [],
+        "symbols": {"functions": [], "classes": []},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_module_content_hash_ignores_path_and_imported_by():
+    # imported_by is derived from OTHER files' imports, not this module's
+    # own content - two modules with identical language/imports/symbols
+    # but different imported_by must hash the same, since a change in
+    # some other file's imports shouldn't mark THIS file as changed.
+    a = _module("a.py", imported_by=["x.py"])
+    b = _module("a.py", imported_by=["y.py", "z.py"])
+    assert module_content_hash(a) == module_content_hash(b)
+
+
+def test_module_content_hash_changes_when_symbols_change():
+    a = _module("a.py", symbols={"functions": [], "classes": []})
+    b = _module("a.py", symbols={"functions": [{"name": "f", "start_line": 1, "end_line": 2}], "classes": []})
+    assert module_content_hash(a) != module_content_hash(b)
+
+
+def test_module_content_hash_changes_when_imports_change():
+    a = _module("a.py", imports=["b.py"])
+    b = _module("a.py", imports=["c.py"])
+    assert module_content_hash(a) != module_content_hash(b)
+
+
+def test_module_content_hash_is_stable_regardless_of_import_order():
+    a = _module("a.py", imports=["b.py", "c.py"])
+    b = _module("a.py", imports=["c.py", "b.py"])
+    assert module_content_hash(a) == module_content_hash(b)
+
+
+def test_diff_modules_returns_new_file_as_changed():
+    modules = [_module("a.py")]
+    changed, deleted = diff_modules({}, modules)
+
+    assert len(changed) == 1
+    assert changed[0]["path"] == "a.py"
+    assert changed[0]["content_hash"] == module_content_hash(modules[0])
+    assert deleted == []
+
+
+def test_diff_modules_skips_unchanged_file():
+    module = _module("a.py")
+    previous_hashes = {"a.py": module_content_hash(module)}
+
+    changed, deleted = diff_modules(previous_hashes, [module])
+
+    assert changed == []
+    assert deleted == []
+
+
+def test_diff_modules_detects_changed_file():
+    old_module = _module("a.py", imports=["b.py"])
+    new_module = _module("a.py", imports=["c.py"])
+    previous_hashes = {"a.py": module_content_hash(old_module)}
+
+    changed, deleted = diff_modules(previous_hashes, [new_module])
+
+    assert len(changed) == 1
+    assert changed[0]["path"] == "a.py"
+
+
+def test_diff_modules_detects_deleted_file():
+    previous_hashes = {"a.py": "some-hash", "b.py": "other-hash"}
+
+    changed, deleted = diff_modules(previous_hashes, [_module("b.py")])
+
+    assert deleted == ["a.py"]
+
+
+def test_diff_modules_handles_empty_previous_and_current():
+    changed, deleted = diff_modules({}, [])
+    assert changed == []
+    assert deleted == []
+
+
+def _endpoint(method, path, file, line):
+    return {"method": method, "path": path, "file": file, "line": line, "handler": "h"}
+
+
+def test_diff_endpoints_returns_new_endpoint_as_changed():
+    endpoints = [_endpoint("GET", "/users", "app.py", 10)]
+
+    changed, deleted = diff_endpoints({}, endpoints)
+
+    assert changed == endpoints
+    assert deleted == []
+
+
+def test_diff_endpoints_skips_unchanged_endpoint():
+    endpoint = _endpoint("GET", "/users", "app.py", 10)
+    previous = {("GET", "/users"): {"file": "app.py", "line": 10}}
+
+    changed, deleted = diff_endpoints(previous, [endpoint])
+
+    assert changed == []
+    assert deleted == []
+
+
+def test_diff_endpoints_detects_moved_endpoint():
+    endpoint = _endpoint("GET", "/users", "app.py", 25)
+    previous = {("GET", "/users"): {"file": "app.py", "line": 10}}
+
+    changed, deleted = diff_endpoints(previous, [endpoint])
+
+    assert changed == [endpoint]
+    assert deleted == []
+
+
+def test_diff_endpoints_detects_removed_endpoint():
+    previous = {("GET", "/users"): {"file": "app.py", "line": 10}}
+
+    changed, deleted = diff_endpoints(previous, [])
+
+    assert deleted == [("GET", "/users")]


### PR DESCRIPTION
## Summary
- New persistent, queryable code graph: `code_graph_files/symbols/dependency_edges/endpoints`, keyed by (installation_id, repo_full_name, branch) matching the existing `evidence_git_*` convention. The counterpart to `repo_history`'s opaque per-scan JSONB blob - addressable at file/symbol/edge/endpoint granularity, and only the rows for files whose actual content (symbols/imports) changed get written on each scan.
- `aletheore/code_graph_diff.py`: diffs a fresh scan's modules/endpoints against previously persisted content hashes.
- `scan_worker/code_graph_store.py`: Postgres persistence, mirroring `postgres_graph_store.py`'s pattern.
- `scan_worker/jobs.py`: `_sync_code_graph` wires this into `run_pr_scan_job` alongside the existing git-graph sync.
- Closed a real inconsistency found while auditing the health-check failure correlation chain: `_attach_recent_commit_for_failure`'s "recent commit" step now reads the same persisted graph the adjacent owner lookup already used, instead of an extra live GitHub API call.
- Restored commit-subject capture in the incremental git graph (`git_intel/incremental.py` now streams `%s` alongside sha/author/date) so that correlation alerts keep their full detail (`"Recent commit: \`abc123\` - fixed the bug"`), fully backward compatible via a defaulted field.

## Scope note
The scan/parse step itself still re-parses the whole repo every time (fresh clone, full `aletheore scan`) - what's incremental here is the *write*. True parse-level incrementality (skip re-parsing unchanged files) needs a persistent per-repo checkout between scans, which the hosted service doesn't keep today. That's a distinct, larger follow-up, not attempted in this PR.

## Test plan
- [x] `github-app/tests/` - 592 passed, 7 skipped
- [x] `src/tests/` - 747 passed
- [x] New tests for `code_graph_diff.py`, `code_graph_store.py` (against a real Postgres instance), the `_sync_code_graph`/`_commit_attachment_from_graph` wiring, and commit-subject capture