### PR TITLE
True incremental scanning + CLI telemetry + Phase 3 Sentry ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ __pycache__/
 # Secret key material (GitHub App private key, etc.)
 *.pem
 
+# Persistent per-repo git checkouts (scan_worker's docker-compose bind
+# mount for _ensure_persistent_checkout) - real customer repo content,
+# never something to commit.
+github-app/repo-checkouts/
+
 # Aletheore prototype scan output (generated locally by `aletheore audit`)
 .aletheore/
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -665,3 +665,20 @@ async def get_wiki_subsystem(
     if isinstance(entry["files"], str):
         entry["files"] = json.loads(entry["files"])
     return entry
+
+
+async def record_telemetry_event(pool: asyncpg.Pool, event_type: str, anonymous_id: str) -> None:
+    await pool.execute(
+        "INSERT INTO cli_telemetry_events (event_type, anonymous_id) VALUES ($1, $2)",
+        event_type,
+        anonymous_id,
+    )
+
+
+async def count_telemetry_events(pool: asyncpg.Pool, event_type: str) -> dict:
+    row = await pool.fetchrow(
+        "SELECT count(*) AS total, count(DISTINCT anonymous_id) AS unique_machines "
+        "FROM cli_telemetry_events WHERE event_type = $1",
+        event_type,
+    )
+    return {"total": row["total"], "unique_machines": row["unique_machines"]}

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -18,6 +18,7 @@ from app_server.frontend import frontend_router
 from app_server.logging_config import configure_json_logging
 from app_server.managed_audit_api import managed_audit_router
 from app_server.metrics import metrics_router
+from app_server.runtime_events import runtime_events_router
 from app_server.signature import verify_signature
 from app_server.telemetry import telemetry_router
 from app_server.webhooks.installation import handle_installation_event
@@ -57,6 +58,7 @@ app.include_router(frontend_router)
 app.include_router(paddle_webhook_router)
 app.include_router(demo_scan_router)
 app.include_router(telemetry_router)
+app.include_router(runtime_events_router)
 
 
 @app.middleware("http")

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -19,6 +19,7 @@ from app_server.logging_config import configure_json_logging
 from app_server.managed_audit_api import managed_audit_router
 from app_server.metrics import metrics_router
 from app_server.signature import verify_signature
+from app_server.telemetry import telemetry_router
 from app_server.webhooks.installation import handle_installation_event
 from app_server.webhooks.paddle import paddle_webhook_router
 
@@ -55,6 +56,7 @@ app.include_router(metrics_router)
 app.include_router(frontend_router)
 app.include_router(paddle_webhook_router)
 app.include_router(demo_scan_router)
+app.include_router(telemetry_router)
 
 
 @app.middleware("http")

--- a/github-app/app_server/runtime_events.py
+++ b/github-app/app_server/runtime_events.py
@@ -1,0 +1,53 @@
+"""Inbound webhook for Phase 3 - runtime-to-code evidence: lets a
+customer's monitoring tool (Sentry, or anything producing
+Sentry-compatible error events) report a real production failure. The
+event gets resolved through the same failed-endpoint correlation chain
+already proven for HTTP health checks (see
+scan_worker.jobs.run_runtime_event_job) - one "zero-hop debugging" flow,
+proven for a second real trigger rather than reimplemented.
+
+Deliberately not an attempt to replace Sentry/every monitoring platform:
+this ingests the one well-known event shape (exception.values[].
+stacktrace.frames[], request.url/method - see aletheore.runtime_events)
+and does one thing with it well.
+"""
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from aletheore.runtime_events import parse_sentry_event
+from app_server.config import get_settings
+from app_server.db import touch_api_token
+from app_server.managed_audit_api import _authenticate_token, _get_queue
+
+runtime_events_router = APIRouter()
+
+
+class RuntimeEventRequest(BaseModel):
+    repo_full_name: str = Field(min_length=1)
+    event: dict
+
+
+@runtime_events_router.post("/v1/runtime-events")
+async def report_runtime_event(request: Request, body: RuntimeEventRequest):
+    installation, token_hash = await _authenticate_token(request)
+    if installation["plan"] == "free":
+        raise HTTPException(status_code=402, detail="runtime event correlation requires a paid plan")
+
+    parsed = parse_sentry_event(body.event)
+    if parsed is None:
+        raise HTTPException(status_code=400, detail="event has no usable stack frame to resolve")
+
+    await touch_api_token(request.app.state.db_pool, token_hash)
+    job = _get_queue(get_settings().redis_url).enqueue(
+        "scan_worker.jobs.run_runtime_event_job",
+        job_timeout=120,
+        installation_id=installation["installation_id"],
+        repo_full_name=body.repo_full_name,
+        exception_type=parsed["exception_type"],
+        exception_value=parsed["exception_value"],
+        source_file=parsed["file"],
+        source_line=parsed["line"],
+        method=parsed["method"],
+        path=parsed["path"],
+    )
+    return {"job_id": job.id}

--- a/github-app/app_server/telemetry.py
+++ b/github-app/app_server/telemetry.py
@@ -1,0 +1,39 @@
+"""Anonymous CLI usage telemetry - see migrations/023_cli_telemetry.sql
+for the privacy/scope rationale. Public, unauthenticated ingestion (the
+CLI has no account/token to authenticate with); internal stats read
+requires the same bearer-token gate as metrics.py's queue-stats."""
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app_server.config import get_settings
+from app_server.db import count_telemetry_events, record_telemetry_event
+
+telemetry_router = APIRouter()
+
+_VALID_EVENT_TYPES = {"scan"}
+
+
+class TelemetryEvent(BaseModel):
+    event: str
+    anonymous_id: str = Field(min_length=8, max_length=64)
+
+
+@telemetry_router.post("/v1/telemetry")
+async def report_telemetry_event(payload: TelemetryEvent, request: Request):
+    if payload.event not in _VALID_EVENT_TYPES:
+        raise HTTPException(status_code=400, detail="unknown event type")
+    await record_telemetry_event(request.app.state.db_pool, payload.event, payload.anonymous_id)
+    return {"ok": True}
+
+
+@telemetry_router.get("/v1/internal/telemetry-stats")
+async def telemetry_stats(request: Request, event: str = "scan"):
+    settings = get_settings()
+    if not settings.internal_metrics_token:
+        raise HTTPException(status_code=404, detail="not found")
+
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header != f"Bearer {settings.internal_metrics_token}":
+        raise HTTPException(status_code=401, detail="missing or invalid token")
+
+    return await count_telemetry_events(request.app.state.db_pool, event)

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -32,8 +32,18 @@ services:
     environment:
       - GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app-key.pem
       - OLLAMA_BASE_URL=http://ollama:11434
+      - ALETHEORE_REPO_CHECKOUT_ROOT=/data/aletheore-repo-checkouts
     volumes:
       - ./app-private-key.pem:/run/secrets/github-app-key.pem:ro
+      # Persistent, reused-across-scans per-repo checkouts (see
+      # scan_worker/jobs.py's _ensure_persistent_checkout) - without a real
+      # mounted volume here, this would live inside the container's
+      # writable layer and vanish on every redeploy, making every scan a
+      # cold, first-time scan again. Falls back to an ephemeral clone
+      # automatically if this ever isn't writable (see
+      # _prepare_head_checkout), so a misconfigured or full mount degrades
+      # to today's behavior rather than failing scans outright.
+      - ./repo-checkouts:/data/aletheore-repo-checkouts
     depends_on:
       postgres:
         condition: service_healthy

--- a/github-app/migrations/023_cli_telemetry.sql
+++ b/github-app/migrations/023_cli_telemetry.sql
@@ -1,0 +1,17 @@
+-- Anonymous CLI usage telemetry: how many times (and from how many
+-- distinct machines) `aletheore scan` actually gets run. No installation,
+-- repo name, or code content is ever included - anonymous_id is a random
+-- UUID generated once per machine and cached locally (see
+-- aletheore/telemetry.py), not tied to any account. Reporting respects
+-- ALETHEORE_TELEMETRY_DISABLED/DO_NOT_TRACK and fails silently if the
+-- network call doesn't succeed - this table is a marketing/usage signal,
+-- never something the CLI's actual behavior depends on.
+CREATE TABLE IF NOT EXISTS cli_telemetry_events (
+    id              BIGSERIAL PRIMARY KEY,
+    event_type      TEXT NOT NULL,
+    anonymous_id    TEXT NOT NULL,
+    occurred_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS cli_telemetry_events_lookup
+ON cli_telemetry_events (event_type, occurred_at DESC);

--- a/github-app/scan_worker/code_graph_store.py
+++ b/github-app/scan_worker/code_graph_store.py
@@ -62,6 +62,96 @@ class CodeGraphStore:
                 )
                 return [row[0] for row in cur.fetchall()]
 
+    def load_last_synced_sha(self, branch: str) -> str | None:
+        import psycopg
+
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT last_synced_sha FROM code_graph_sync_state "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+                    (self._installation_id, self._repo_full_name, branch),
+                )
+                row = cur.fetchone()
+                return row[0] if row else None
+
+    def load_all_modules(self, branch: str) -> dict[str, dict]:
+        """Reconstructs full build_module_graph-shaped module dicts (path,
+        language, imports, symbols) for every currently-persisted file -
+        the read side that powers the incremental scan cache
+        (aletheore.evidence._load_unchanged_scan_cache): a file the
+        caller has determined is unchanged since this data was computed
+        can be fed straight back into build_module_graph without
+        re-parsing it. imported_by is always left empty here -
+        build_module_graph recomputes it fresh from every module's
+        imports (cached or not) regardless of what's passed in.
+        """
+        import psycopg
+
+        ids = (self._installation_id, self._repo_full_name, branch)
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT path, language FROM code_graph_files "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+                    ids,
+                )
+                modules = {
+                    path: {
+                        "path": path,
+                        "language": language,
+                        "imports": [],
+                        "imported_by": [],
+                        "symbols": {"functions": [], "classes": []},
+                    }
+                    for path, language in cur.fetchall()
+                }
+
+                cur.execute(
+                    "SELECT path, name, kind, start_line, end_line FROM code_graph_symbols "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+                    ids,
+                )
+                for path, name, kind, start_line, end_line in cur.fetchall():
+                    if path not in modules:
+                        continue
+                    group = "functions" if kind == "function" else "classes"
+                    modules[path]["symbols"][group].append(
+                        {"name": name, "start_line": start_line, "end_line": end_line}
+                    )
+
+                cur.execute(
+                    "SELECT from_path, to_path FROM code_graph_dependency_edges "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+                    ids,
+                )
+                for from_path, to_path in cur.fetchall():
+                    if from_path not in modules:
+                        continue
+                    modules[from_path]["imports"].append(to_path)
+
+        return modules
+
+    def load_all_endpoints(self, branch: str) -> dict[str, list[dict]]:
+        """path -> list of endpoint dicts found in that file - the read
+        side powering the incremental scan cache's endpoint reuse,
+        mirroring load_all_modules above."""
+        import psycopg
+
+        grouped: dict[str, list[dict]] = {}
+        with psycopg.connect(self._dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT method, endpoint_path, file_path, line FROM code_graph_endpoints "
+                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+                    (self._installation_id, self._repo_full_name, branch),
+                )
+                for method, endpoint_path, file_path, line in cur.fetchall():
+                    grouped.setdefault(file_path, []).append(
+                        {"method": method, "path": endpoint_path, "file": file_path, "line": line}
+                    )
+        return grouped
+
     def load_endpoint_keys(self, branch: str) -> dict[tuple, dict]:
         import psycopg
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -89,6 +89,7 @@ from scan_worker.postgres_graph_store import PostgresRepoGraphStore
 from scan_worker.slack import (
     format_latency_alert,
     format_reachability_alert,
+    format_runtime_error_alert,
     format_shape_change_alert,
     send_health_alert,
     send_slack_alert,
@@ -1181,6 +1182,60 @@ def _attach_recent_commit_for_failure(
         return evidence_resolution
     base = evidence_resolution or empty_resolution("endpoint")
     return merge_resolution(base, *attachments)
+
+
+@log_job
+def run_runtime_event_job(
+    installation_id: int,
+    repo_full_name: str,
+    exception_type: str,
+    exception_value: str,
+    source_file: str,
+    source_line: int,
+    method: str = "",
+    path: str = "",
+) -> None:
+    """Phase 3 - runtime-to-code evidence: resolves an inbound
+    Sentry-compatible error event through the SAME correlation chain
+    already proven for HTTP health-check failures
+    (_attach_recent_commit_for_failure: handler symbol, dependent
+    modules, recent commit, likely owner, optional fix suggestion) -
+    "zero-hop debugging" for a second real trigger, not a second
+    implementation. See app_server/runtime_events.py for the inbound
+    webhook this is enqueued from.
+    """
+    settings = get_settings()
+    installation = get_installation_row(settings.database_url, installation_id)
+    if installation is None or installation["plan"] == "free":
+        return
+
+    webhook_url = installation.get("webhook_url")
+    if not webhook_url:
+        return
+
+    evidence = _latest_evidence_or_none(settings.database_url, installation_id, repo_full_name)
+    evidence_resolution = _attach_recent_commit_for_failure(
+        installation_id,
+        repo_full_name,
+        source_file,
+        None,
+        evidence,
+        method=method,
+        path=path,
+        source_line=source_line,
+    )
+
+    message = format_runtime_error_alert(
+        repo_full_name,
+        exception_type,
+        exception_value,
+        source_file,
+        source_line,
+        method=method,
+        path=path,
+        evidence_resolution=evidence_resolution,
+    )
+    send_health_alert(webhook_url, message)
 
 
 @log_job

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -161,7 +161,127 @@ def _clone_ref(url: str, ref: str, dest: Path) -> None:
     subprocess.run(["git", "checkout", "-q", ref], cwd=dest, check=True)
 
 
-def _run_scan(repo_dir: Path) -> Path:
+# Root for persistent, reused-across-scans checkouts (see
+# _ensure_persistent_checkout) - overridable so a real deployment can point
+# it at a mounted volume and tests aren't stuck with a hardcoded path.
+_REPO_CHECKOUT_ROOT_ENV = "ALETHEORE_REPO_CHECKOUT_ROOT"
+_DEFAULT_REPO_CHECKOUT_ROOT = "/data/aletheore-repo-checkouts"
+
+
+def _persistent_checkout_dir(installation_id: int, repo_full_name: str) -> Path:
+    root = Path(os.environ.get(_REPO_CHECKOUT_ROOT_ENV, _DEFAULT_REPO_CHECKOUT_ROOT))
+    safe_name = repo_full_name.replace("/", "__")
+    return root / str(installation_id) / safe_name
+
+
+def _ensure_persistent_checkout(url: str, checkout_sha: str, checkout_dir: Path) -> None:
+    """Keeps one real checkout per repo, reused across scans, instead of
+    the clone-fresh-and-delete pattern _clone_ref/_clone_pr_head use for
+    the ephemeral per-job checkouts above. This is what gives a later
+    scan a real "last time" to `git diff` against locally, and is a
+    prerequisite for the incremental scan cache
+    (aletheore.evidence._load_unchanged_scan_cache) actually helping -
+    without a persistent checkout, every scan starts from nothing to
+    diff against, same as a fresh clone.
+
+    Mirrors _clone_ref's exact proven-working shape: a plain `git fetch`
+    (no explicit refspec) followed by `git checkout <sha>`, rather than
+    fetching the SHA directly - GitHub does not reliably allow fetching a
+    bare SHA unless it happens to be reachable from an advertised ref,
+    the same reason _clone_ref itself relies on a full clone's implicit
+    ref fetching rather than fetching head_sha directly.
+
+    `git remote set-url` runs on every reuse so a rotated access token
+    (see _clone_url - `url` always carries a fresh one) doesn't leave
+    this checkout stuck fetching against a stale URL baked in at clone
+    time.
+    """
+    if (checkout_dir / ".git").exists():
+        subprocess.run(["git", "remote", "set-url", "origin", url], cwd=checkout_dir, check=True)
+        subprocess.run(["git", "fetch", "-q", "origin"], cwd=checkout_dir, check=True)
+        subprocess.run(["git", "checkout", "-q", "-f", checkout_sha], cwd=checkout_dir, check=True)
+        subprocess.run(["git", "clean", "-q", "-fdx"], cwd=checkout_dir, check=True)
+    else:
+        checkout_dir.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(checkout_dir)], check=True)
+        subprocess.run(["git", "checkout", "-q", checkout_sha], cwd=checkout_dir, check=True)
+
+
+def _prepare_head_checkout(
+    clone_url: str, head_sha: str, installation_id: int, repo_full_name: str, fallback_dir: Path
+) -> Path:
+    """Uses a persistent, reused-across-scans checkout when one is
+    available (see _ensure_persistent_checkout), falling back to the
+    original ephemeral clone-and-delete pattern (_clone_ref) if
+    persistent storage isn't mounted, isn't writable, or fails for any
+    other reason - this must never be the reason a PR scan fails
+    outright, it only ever gates whether the upcoming scan can be
+    incremental.
+    """
+    try:
+        checkout_dir = _persistent_checkout_dir(installation_id, repo_full_name)
+        _ensure_persistent_checkout(clone_url, head_sha, checkout_dir)
+        return checkout_dir
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "persistent checkout unavailable (%s); falling back to an ephemeral clone", type(exc).__name__
+        )
+        _clone_ref(clone_url, head_sha, fallback_dir)
+        return fallback_dir
+
+
+def _build_unchanged_scan_cache(
+    installation_id: int,
+    repo_full_name: str,
+    checkout_dir: Path,
+    previous_sha: str | None,
+    current_sha: str,
+    cache_path: Path,
+) -> Path | None:
+    """Writes a JSON cache file (see
+    aletheore.evidence._load_unchanged_scan_cache) listing every
+    currently-tracked file NOT touched between previous_sha and
+    current_sha, with its previously-persisted module/endpoint data, so
+    the upcoming `aletheore scan` can skip re-parsing it. Returns None
+    (no cache - a full scan, matching today's behavior exactly) whenever
+    there's no solid basis for a diff: no previous sync yet, `git diff`
+    itself failing (e.g. previous_sha isn't reachable in this checkout -
+    expected on a fallback ephemeral clone), or the graph database being
+    unreachable. This only ever narrows what gets scanned; any failure
+    here just means "scan everything," never "silently skip something
+    that might have changed."
+    """
+    if previous_sha is None:
+        return None
+    diff_result = subprocess.run(
+        ["git", "diff", "--name-only", previous_sha, current_sha],
+        cwd=checkout_dir, capture_output=True, text=True,
+    )
+    if diff_result.returncode != 0:
+        return None
+    changed_files = set(diff_result.stdout.splitlines())
+
+    try:
+        settings = get_settings()
+        store = CodeGraphStore(settings.database_url, installation_id, repo_full_name)
+        all_modules = store.load_all_modules(GRAPH_BRANCH)
+        all_endpoints = store.load_all_endpoints(GRAPH_BRANCH)
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "could not build unchanged-scan cache (%s); falling back to a full scan", type(exc).__name__
+        )
+        return None
+
+    unchanged_modules = {path: m for path, m in all_modules.items() if path not in changed_files}
+    unchanged_endpoints = {path: e for path, e in all_endpoints.items() if path not in changed_files}
+    if not unchanged_modules and not unchanged_endpoints:
+        return None
+
+    cache_path.write_text(json.dumps({"modules": unchanged_modules, "endpoints": unchanged_endpoints}))
+    return cache_path
+
+
+def _run_scan(repo_dir: Path, unchanged_scan_cache_path: Path | None = None) -> Path:
     # See GRAPH_COLD_SYNC_DEPTH_CAP and SECRETS_HISTORY_DEPTH_CAP - the
     # CLI's own analyze_git and find_secrets_in_history calls (inside this
     # subprocess) hit the same cold-sync cost/memory ceilings as the
@@ -173,6 +293,8 @@ def _run_scan(repo_dir: Path) -> Path:
         "ALETHEORE_GIT_HISTORY_DEPTH_CAP": str(GRAPH_COLD_SYNC_DEPTH_CAP),
         "ALETHEORE_SECRETS_HISTORY_DEPTH_CAP": str(SECRETS_HISTORY_DEPTH_CAP),
     }
+    if unchanged_scan_cache_path is not None:
+        env["ALETHEORE_UNCHANGED_SCAN_CACHE"] = str(unchanged_scan_cache_path)
     subprocess.run(["aletheore", "scan", str(repo_dir)], check=True, env=env)
     return repo_dir / ".aletheore" / "air.json"
 
@@ -441,12 +563,22 @@ def run_pr_scan_job(
 
         clone_url = _clone_url(repo_full_name, token)
         base_dir = job_dir / "base"
-        head_dir = job_dir / "head"
         _clone_ref(clone_url, base_sha, base_dir)
-        _clone_ref(clone_url, head_sha, head_dir)
+        head_dir = _prepare_head_checkout(clone_url, head_sha, installation_id, repo_full_name, job_dir / "head")
+
+        try:
+            previous_sha = CodeGraphStore(
+                settings.database_url, installation_id, repo_full_name
+            ).load_last_synced_sha(GRAPH_BRANCH)
+        except Exception:  # noqa: BLE001
+            previous_sha = None
+        unchanged_scan_cache_path = _build_unchanged_scan_cache(
+            installation_id, repo_full_name, head_dir, previous_sha, head_sha,
+            job_dir / "unchanged-scan-cache.json",
+        )
 
         base_evidence_path = _run_scan(base_dir)
-        head_evidence_path = _run_scan(head_dir)
+        head_evidence_path = _run_scan(head_dir, unchanged_scan_cache_path=unchanged_scan_cache_path)
         old = json.loads(base_evidence_path.read_text())
         new = json.loads(head_evidence_path.read_text())
         diff = compute_diff(old, new, full=False)

--- a/github-app/scan_worker/slack.py
+++ b/github-app/scan_worker/slack.py
@@ -172,6 +172,27 @@ def format_shape_change_alert(
     return {"text": text}
 
 
+def format_runtime_error_alert(
+    repo_full_name: str,
+    exception_type: str,
+    exception_value: str,
+    source_file: str,
+    source_line: int,
+    *,
+    method: str = "",
+    path: str = "",
+    evidence_resolution: dict | None = None,
+) -> dict:
+    request_context = f" while handling `{method} {path}`" if method and path else ""
+    text = (
+        f"*Aletheore*: runtime error on `{repo_full_name}`\n"
+        f"`{exception_type}`: {exception_value}{request_context}\n"
+        f"at `{source_file}:{source_line}`"
+        f"{_format_evidence_context(evidence_resolution)}"
+    )
+    return {"text": text}
+
+
 def send_health_alert(
     webhook_url: str,
     message: dict,

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -40,7 +40,9 @@ async def pool():
         migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
         for migration in sorted(migrations_dir.glob("*.sql")):
             await conn.execute(migration.read_text())
-        await conn.execute("TRUNCATE installations, sessions, demo_scan_rate_limits CASCADE")
+        await conn.execute(
+            "TRUNCATE installations, sessions, demo_scan_rate_limits, cli_telemetry_events CASCADE"
+        )
     yield p
     await p.close()
 

--- a/github-app/tests/test_app_server_db.py
+++ b/github-app/tests/test_app_server_db.py
@@ -1,6 +1,12 @@
 import pytest
 
-from app_server.db import add_paddle_ids_to_installation, check_and_reserve_demo_scan, get_installation
+from app_server.db import (
+    add_paddle_ids_to_installation,
+    check_and_reserve_demo_scan,
+    count_telemetry_events,
+    get_installation,
+    record_telemetry_event,
+)
 
 
 @pytest.mark.asyncio
@@ -30,3 +36,24 @@ async def test_check_and_reserve_demo_scan_different_ips_are_independent(pool):
 async def test_check_and_reserve_demo_scan_allows_again_after_cooldown_elapses(pool):
     assert await check_and_reserve_demo_scan(pool, "203.0.113.20", cooldown_seconds=0) is True
     assert await check_and_reserve_demo_scan(pool, "203.0.113.20", cooldown_seconds=0) is True
+
+
+@pytest.mark.asyncio
+async def test_record_telemetry_event_then_count(pool):
+    await record_telemetry_event(pool, "scan", "machine-a")
+    await record_telemetry_event(pool, "scan", "machine-a")
+    await record_telemetry_event(pool, "scan", "machine-b")
+
+    counts = await count_telemetry_events(pool, "scan")
+
+    assert counts == {"total": 3, "unique_machines": 2}
+
+
+@pytest.mark.asyncio
+async def test_count_telemetry_events_only_counts_the_given_event_type(pool):
+    await record_telemetry_event(pool, "scan", "machine-a")
+    await record_telemetry_event(pool, "other-event", "machine-a")
+
+    counts = await count_telemetry_events(pool, "scan")
+
+    assert counts["total"] == 1

--- a/github-app/tests/test_code_graph_store.py
+++ b/github-app/tests/test_code_graph_store.py
@@ -210,3 +210,75 @@ async def test_installation_deletion_cascades_to_code_graph_tables(pool):
     await pool.execute("DELETE FROM installations WHERE installation_id = 711")
 
     assert store.load_content_hashes("main") == {}
+
+
+@pytest.mark.asyncio
+async def test_load_last_synced_sha_returns_none_for_unknown_repo(pool):
+    await _insert_installation(pool, 712, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 712, "org/repo")
+
+    assert store.load_last_synced_sha("main") is None
+
+
+@pytest.mark.asyncio
+async def test_load_last_synced_sha_returns_the_most_recent_sync(pool):
+    await _insert_installation(pool, 713, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 713, "org/repo")
+    store.apply_module_deltas(
+        "main", [_module("a.py", "hash-a")], deleted_paths=[], new_sync_sha="s1", new_sync_at=datetime(2026, 7, 26)
+    )
+    store.apply_module_deltas(
+        "main", [], deleted_paths=[], new_sync_sha="s2", new_sync_at=datetime(2026, 7, 27)
+    )
+
+    assert store.load_last_synced_sha("main") == "s2"
+
+
+@pytest.mark.asyncio
+async def test_load_all_modules_reconstructs_full_module_dicts(pool):
+    await _insert_installation(pool, 714, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 714, "org/repo")
+    store.apply_module_deltas(
+        "main",
+        [
+            _module(
+                "a.py", "hash-a", imports=["b.py"],
+                functions=[{"name": "f", "start_line": 1, "end_line": 5}],
+                classes=[{"name": "C", "start_line": 10, "end_line": 20}],
+            ),
+            _module("b.py", "hash-b"),
+        ],
+        deleted_paths=[],
+        new_sync_sha="s1",
+        new_sync_at=datetime(2026, 7, 26),
+    )
+
+    modules = store.load_all_modules("main")
+
+    assert set(modules.keys()) == {"a.py", "b.py"}
+    assert modules["a.py"]["language"] == "python"
+    assert modules["a.py"]["imports"] == ["b.py"]
+    assert {"name": "f", "start_line": 1, "end_line": 5} in modules["a.py"]["symbols"]["functions"]
+    assert {"name": "C", "start_line": 10, "end_line": 20} in modules["a.py"]["symbols"]["classes"]
+    assert modules["b.py"]["imports"] == []
+
+
+@pytest.mark.asyncio
+async def test_load_all_endpoints_groups_by_file(pool):
+    await _insert_installation(pool, 715, "org")
+    store = CodeGraphStore(TEST_DATABASE_URL, 715, "org/repo")
+    store.apply_endpoint_deltas(
+        "main",
+        [
+            _endpoint("GET", "/users", "app.py", 10),
+            _endpoint("POST", "/users", "app.py", 20),
+            _endpoint("GET", "/health", "health.py", 1),
+        ],
+        deleted_keys=[],
+    )
+
+    endpoints = store.load_all_endpoints("main")
+
+    assert {e["path"] for e in endpoints["app.py"]} == {"/users"}
+    assert len(endpoints["app.py"]) == 2
+    assert len(endpoints["health.py"]) == 1

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1,10 +1,16 @@
 import json
+import os
 import subprocess
 from contextlib import contextmanager
 
 import pytest
 
 from scan_worker.jobs import MAX_FLASH_REVIEWS_PER_MONTH, run_pr_scan_job
+
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://postgres:test@localhost:55433/aletheore_test",
+)
 
 
 @contextmanager
@@ -100,6 +106,130 @@ def test_sync_code_graph_degrades_gracefully_on_store_failure(monkeypatch):
     # Must not raise - this is a persistence enhancement, never allowed to
     # break the scan job itself.
     _sync_code_graph(1, "octocat/hello-world", "sha1", {"repository": {"modules": []}})
+
+
+def _make_local_repo(path, files: dict) -> str:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    for name, content in files.items():
+        (path / name).write_text(content)
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "commit"], cwd=path, check=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=path, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+@pytest.mark.asyncio
+async def test_build_unchanged_scan_cache_excludes_changed_files_includes_unchanged(pool, tmp_path, monkeypatch):
+    from scan_worker.jobs import _build_unchanged_scan_cache
+    from scan_worker.code_graph_store import CodeGraphStore
+
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login) VALUES ($1, $2)", 950, "org"
+    )
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+
+    checkout_dir = tmp_path / "checkout"
+    sha1 = _make_local_repo(checkout_dir, {"a.py": "def old():\n    pass\n", "b.py": "def stable():\n    pass\n"})
+    (checkout_dir / "a.py").write_text("def new():\n    pass\n")
+    subprocess.run(["git", "add", "-A"], cwd=checkout_dir, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "change a.py only"], cwd=checkout_dir, check=True)
+    sha2 = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=checkout_dir, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    store = CodeGraphStore(TEST_DATABASE_URL, 950, "org/repo")
+    from datetime import datetime as dt
+
+    store.apply_module_deltas(
+        "default",
+        [
+            {"path": "a.py", "language": "python", "imports": [], "content_hash": "old-a-hash",
+             "symbols": {"functions": [{"name": "old", "start_line": 1, "end_line": 2}], "classes": []}},
+            {"path": "b.py", "language": "python", "imports": [], "content_hash": "b-hash",
+             "symbols": {"functions": [{"name": "stable", "start_line": 1, "end_line": 2}], "classes": []}},
+        ],
+        deleted_paths=[],
+        new_sync_sha=sha1,
+        new_sync_at=dt(2026, 7, 27),
+    )
+
+    cache_path = _build_unchanged_scan_cache(950, "org/repo", checkout_dir, sha1, sha2, tmp_path / "cache.json")
+
+    assert cache_path is not None
+    cache_data = json.loads(cache_path.read_text())
+    assert "b.py" in cache_data["modules"]
+    assert "a.py" not in cache_data["modules"]
+    assert cache_data["modules"]["b.py"]["symbols"]["functions"][0]["name"] == "stable"
+
+
+def test_build_unchanged_scan_cache_returns_none_without_a_previous_sync(tmp_path):
+    from scan_worker.jobs import _build_unchanged_scan_cache
+
+    checkout_dir = tmp_path / "checkout"
+    _make_local_repo(checkout_dir, {"a.py": "pass\n"})
+
+    result = _build_unchanged_scan_cache(1, "org/repo", checkout_dir, None, "somesha", tmp_path / "cache.json")
+
+    assert result is None
+
+
+def test_run_pr_scan_job_uses_persistent_checkout_and_unchanged_cache_for_head(
+    bare_repo_with_two_commits, monkeypatch
+):
+    # Proves run_pr_scan_job actually wires the persistent-checkout +
+    # incremental-scan-cache path for the HEAD scan specifically (not
+    # base, which stays an ephemeral clone - see _build_unchanged_scan_cache's
+    # module docstring for why only head feeds the durable code graph).
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_create_check_run", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: None)
+
+    prepare_head_calls = []
+    real_prepare_head_checkout = None
+    from scan_worker import jobs as jobs_module
+
+    real_prepare_head_checkout = jobs_module._prepare_head_checkout
+
+    def spy_prepare_head_checkout(clone_url, head_sha_arg, installation_id, repo_full_name, fallback_dir):
+        prepare_head_calls.append(
+            {"clone_url": clone_url, "head_sha": head_sha_arg, "installation_id": installation_id}
+        )
+        return real_prepare_head_checkout(clone_url, head_sha_arg, installation_id, repo_full_name, fallback_dir)
+
+    monkeypatch.setattr("scan_worker.jobs._prepare_head_checkout", spy_prepare_head_checkout)
+
+    cache_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs._build_unchanged_scan_cache",
+        lambda *a, **k: cache_calls.append(a) or None,
+    )
+
+    run_pr_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        pr_number=7,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+    assert len(prepare_head_calls) == 1
+    assert prepare_head_calls[0]["head_sha"] == head_sha
+    assert prepare_head_calls[0]["installation_id"] == 1
+    assert len(cache_calls) == 1
+    assert cache_calls[0][0] == 1  # installation_id
+    assert cache_calls[0][4] == head_sha  # current_sha
 
 
 def test_happy_path_posts_comment_and_writes_history(bare_repo_with_two_commits, monkeypatch):

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1584,6 +1584,77 @@ def test_sweep_alerts_without_commit_when_correlation_fails(monkeypatch):
     assert "Recent commit" not in sent[0]["text"]
 
 
+def test_run_runtime_event_job_sends_alert_with_resolved_chain(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "indie", "webhook_url": "https://hooks.slack.com/runtime"},
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._latest_evidence_or_none",
+        lambda *a, **k: {"repository": {"modules": []}},
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._attach_recent_commit_for_failure",
+        lambda installation_id, repo_full_name, source_file, evidence_resolution, evidence=None, **k: {
+            "symbol": "handle_request",
+            "owner": ["@api-team"],
+            "commit": {"sha": "abc123def456", "subject": "touched the handler"},
+        },
+    )
+    sent = []
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: sent.append((url, msg)))
+
+    from scan_worker.jobs import run_runtime_event_job
+
+    run_runtime_event_job(
+        1,
+        "octocat/hello-world",
+        "ZeroDivisionError",
+        "division by zero",
+        "app/handler.py",
+        42,
+        method="GET",
+        path="/v1/users",
+    )
+
+    assert len(sent) == 1
+    url, message = sent[0]
+    assert url == "https://hooks.slack.com/runtime"
+    assert "ZeroDivisionError" in message["text"]
+    assert "app/handler.py:42" in message["text"]
+    assert "handle_request" in message["text"]
+    assert "@api-team" in message["text"]
+
+
+def test_run_runtime_event_job_skips_free_plan(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"})
+    called = []
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda *a, **k: called.append(True))
+
+    from scan_worker.jobs import run_runtime_event_job
+
+    run_runtime_event_job(1, "octocat/hello-world", "Error", "x", "a.py", 1)
+
+    assert called == []
+
+
+def test_run_runtime_event_job_skips_when_no_webhook_configured(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._attach_recent_commit_for_failure", lambda *a, **k: None)
+    called = []
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda *a, **k: called.append(True))
+
+    from scan_worker.jobs import run_runtime_event_job
+
+    run_runtime_event_job(1, "octocat/hello-world", "Error", "x", "a.py", 1)
+
+    assert called == []
+
+
 def test_sweep_sends_shape_change_alert_while_still_reachable(monkeypatch):
     sent = _patch_sweep(
         monkeypatch,

--- a/github-app/tests/test_persistent_checkout.py
+++ b/github-app/tests/test_persistent_checkout.py
@@ -1,0 +1,98 @@
+import subprocess
+
+from scan_worker.jobs import _ensure_persistent_checkout, _persistent_checkout_dir
+
+
+def _push_new_commit(bare_repo: str, work_dir, content: str) -> str:
+    subprocess.run(["git", "clone", "-q", bare_repo, str(work_dir)], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=work_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=work_dir, check=True)
+    (work_dir / "app.py").write_text(content)
+    subprocess.run(["git", "add", "-A"], cwd=work_dir, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "another change"], cwd=work_dir, check=True)
+    subprocess.run(["git", "push", "-q"], cwd=work_dir, check=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=work_dir, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def test_persistent_checkout_dir_is_scoped_by_installation_and_repo(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALETHEORE_REPO_CHECKOUT_ROOT", str(tmp_path))
+
+    a = _persistent_checkout_dir(1, "octocat/hello-world")
+    b = _persistent_checkout_dir(2, "octocat/hello-world")
+    c = _persistent_checkout_dir(1, "octocat/other-repo")
+
+    assert a != b
+    assert a != c
+    assert str(tmp_path) in str(a)
+
+
+def test_ensure_persistent_checkout_clones_fresh_when_no_checkout_exists(bare_repo_with_two_commits, tmp_path):
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+    checkout_dir = tmp_path / "checkout"
+
+    _ensure_persistent_checkout(bare_path, head_sha, checkout_dir)
+
+    assert (checkout_dir / "app.py").exists()
+    current_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=checkout_dir, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    assert current_sha == head_sha
+
+
+def test_ensure_persistent_checkout_reuses_existing_checkout_on_second_call(bare_repo_with_two_commits, tmp_path):
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+    checkout_dir = tmp_path / "checkout"
+
+    _ensure_persistent_checkout(bare_path, head_sha, checkout_dir)
+
+    # A new commit lands on the remote after the first checkout - proves
+    # the second call actually fetches and updates, rather than silently
+    # reusing stale content.
+    new_sha = _push_new_commit(bare_path, tmp_path / "pusher", "print('updated')\n")
+
+    _ensure_persistent_checkout(bare_path, new_sha, checkout_dir)
+
+    assert (checkout_dir / "app.py").read_text() == "print('updated')\n"
+    current_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=checkout_dir, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    assert current_sha == new_sha
+
+
+def test_ensure_persistent_checkout_cleans_stray_untracked_files_on_reuse(bare_repo_with_two_commits, tmp_path):
+    # A prior job could in principle leave behind stray build artifacts,
+    # scratch files, or a half-written scan output - reuse must not let
+    # those bleed into the next scan of the same repo.
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+    checkout_dir = tmp_path / "checkout"
+
+    _ensure_persistent_checkout(bare_path, head_sha, checkout_dir)
+    (checkout_dir / "leftover-from-a-previous-job.tmp").write_text("stray")
+
+    _ensure_persistent_checkout(bare_path, head_sha, checkout_dir)
+
+    assert not (checkout_dir / "leftover-from-a-previous-job.tmp").exists()
+
+
+def test_ensure_persistent_checkout_reuses_the_same_git_directory_not_a_fresh_clone(
+    bare_repo_with_two_commits, tmp_path, monkeypatch
+):
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+    checkout_dir = tmp_path / "checkout"
+    _ensure_persistent_checkout(bare_path, head_sha, checkout_dir)
+
+    calls = []
+    real_run = subprocess.run
+
+    def spy_run(args, **kwargs):
+        calls.append(args)
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", spy_run)
+
+    _ensure_persistent_checkout(bare_path, head_sha, checkout_dir)
+
+    assert not any(call[:2] == ["git", "clone"] for call in calls)
+    assert any(call[:2] == ["git", "fetch"] for call in calls)

--- a/github-app/tests/test_runtime_events_api.py
+++ b/github-app/tests/test_runtime_events_api.py
@@ -1,0 +1,104 @@
+import hashlib
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.db import create_api_token, set_installation_plan, upsert_installation
+from app_server.main import app
+
+
+def _sentry_event():
+    return {
+        "exception": {
+            "values": [
+                {
+                    "type": "ZeroDivisionError",
+                    "value": "division by zero",
+                    "stacktrace": {
+                        "frames": [
+                            {"filename": "app/handler.py", "function": "handle_request", "lineno": 42, "in_app": True}
+                        ]
+                    },
+                }
+            ]
+        },
+        "request": {"url": "https://api.example.com/v1/users", "method": "GET"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_report_runtime_event_requires_bearer_token(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events", json={"repo_full_name": "octocat/widgets", "event": _sentry_event()}
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_report_runtime_event_rejects_free_plan(pool):
+    await upsert_installation(pool, 200, "octocat")
+    token_hash = hashlib.sha256(b"real-token").hexdigest()
+    await create_api_token(pool, 200, token_hash, "laptop", "octocat")
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={"repo_full_name": "octocat/widgets", "event": _sentry_event()},
+            headers={"Authorization": "Bearer real-token"},
+        )
+    assert response.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_report_runtime_event_rejects_unparseable_event(pool):
+    await upsert_installation(pool, 201, "octocat")
+    await set_installation_plan(pool, 201, "indie")
+    token_hash = hashlib.sha256(b"real-token").hexdigest()
+    await create_api_token(pool, 201, token_hash, "laptop", "octocat")
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={"repo_full_name": "octocat/widgets", "event": {"exception": {"values": []}}},
+            headers={"Authorization": "Bearer real-token"},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_report_runtime_event_enqueues_job_with_parsed_fields(pool, monkeypatch):
+    await upsert_installation(pool, 202, "octocat")
+    await set_installation_plan(pool, 202, "indie")
+    token_hash = hashlib.sha256(b"real-token").hexdigest()
+    await create_api_token(pool, 202, token_hash, "laptop", "octocat")
+
+    fake_queue = MagicMock()
+    fake_queue.enqueue.return_value = MagicMock(id="job-77")
+    monkeypatch.setattr("app_server.runtime_events._get_queue", lambda redis_url: fake_queue)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={"repo_full_name": "octocat/widgets", "event": _sentry_event()},
+            headers={"Authorization": "Bearer real-token"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"job_id": "job-77"}
+    _, kwargs = fake_queue.enqueue.call_args
+    assert kwargs["repo_full_name"] == "octocat/widgets"
+    assert kwargs["installation_id"] == 202
+    assert kwargs["exception_type"] == "ZeroDivisionError"
+    assert kwargs["exception_value"] == "division by zero"
+    assert kwargs["source_file"] == "app/handler.py"
+    assert kwargs["source_line"] == 42
+    assert kwargs["method"] == "GET"
+    assert kwargs["path"] == "/v1/users"

--- a/github-app/tests/test_slack.py
+++ b/github-app/tests/test_slack.py
@@ -3,6 +3,7 @@ import httpx
 from scan_worker.slack import (
     format_latency_alert,
     format_reachability_alert,
+    format_runtime_error_alert,
     format_shape_change_alert,
     format_slack_message,
     send_health_alert,
@@ -174,3 +175,39 @@ def test_send_health_alert_posts_message():
     client = httpx.Client(transport=httpx.MockTransport(handler))
     send_health_alert("https://hooks.slack.com/x", {"text": "test"}, http_client=client)
     assert len(calls) == 1
+
+
+def test_format_runtime_error_alert_includes_exception_and_location():
+    evidence_resolution = {
+        "symbol": "handle_request",
+        "owner": ["@api-team"],
+        "commit": {"sha": "abcdef123456", "subject": "change handler"},
+        "dependency": ["UserService"],
+    }
+    body = format_runtime_error_alert(
+        "octocat/hello-world",
+        "ZeroDivisionError",
+        "division by zero",
+        "app/handler.py",
+        42,
+        method="GET",
+        path="/v1/users",
+        evidence_resolution=evidence_resolution,
+    )
+
+    assert "ZeroDivisionError" in body["text"]
+    assert "division by zero" in body["text"]
+    assert "app/handler.py:42" in body["text"]
+    assert "GET /v1/users" in body["text"]
+    assert "handle_request" in body["text"]
+    assert "@api-team" in body["text"]
+    assert "abcdef12" in body["text"]
+
+
+def test_format_runtime_error_alert_handles_missing_method_and_path():
+    body = format_runtime_error_alert(
+        "octocat/hello-world", "ValueError", "bad input", "app/handler.py", 10, method="", path=""
+    )
+
+    assert "ValueError" in body["text"]
+    assert "app/handler.py:10" in body["text"]

--- a/github-app/tests/test_telemetry.py
+++ b/github-app/tests/test_telemetry.py
@@ -1,0 +1,79 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.main import app
+
+
+@pytest.mark.asyncio
+async def test_report_telemetry_event_records_a_scan_event(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", json={"event": "scan", "anonymous_id": "machine-abc-123"}
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_report_telemetry_event_rejects_unknown_event_type(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", json={"event": "not-a-real-event", "anonymous_id": "machine-abc-123"}
+        )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_report_telemetry_event_rejects_missing_anonymous_id(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/v1/telemetry", json={"event": "scan"})
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_telemetry_stats_returns_404_when_token_not_configured(monkeypatch, pool):
+    monkeypatch.delenv("INTERNAL_METRICS_TOKEN", raising=False)
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/internal/telemetry-stats")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_telemetry_stats_requires_bearer_token(monkeypatch, pool):
+    monkeypatch.setenv("INTERNAL_METRICS_TOKEN", "secret-token")
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/internal/telemetry-stats")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_telemetry_stats_returns_real_counts_for_valid_token(monkeypatch, pool):
+    monkeypatch.setenv("INTERNAL_METRICS_TOKEN", "secret-token")
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/v1/telemetry", json={"event": "scan", "anonymous_id": "machine-a"})
+        await client.post("/v1/telemetry", json={"event": "scan", "anonymous_id": "machine-a"})
+        await client.post("/v1/telemetry", json={"event": "scan", "anonymous_id": "machine-b"})
+
+        response = await client.get(
+            "/v1/internal/telemetry-stats", headers={"Authorization": "Bearer secret-token"}
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"total": 3, "unique_machines": 2}

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -31,6 +31,7 @@ from aletheore.evidence import scan_repository, write_evidence
 from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE, GitAnalysisError
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
 from aletheore.history import compute_diff, list_snapshots, save_snapshot
+from aletheore.telemetry import report_scan_event
 from aletheore.managed_audit_client import ManagedAuditError, run_managed_audit_request
 from aletheore.query import (
     BranchNotFoundInEvidenceError,
@@ -244,6 +245,11 @@ def _scan(
     console.print(f"[green]Evidence written to[/green] {evidence_path}")
     snapshot_path = save_snapshot(evidence, repo)
     console.print(f"Snapshot saved to {snapshot_path}")
+    # Fire-and-forget, off the main thread: report_scan_event already has
+    # its own short timeout and swallows every exception, but a background
+    # thread means even a slow/hanging network path can never add latency
+    # to a real scan.
+    threading.Thread(target=report_scan_event, daemon=True).start()
     return 0, evidence, evidence_path
 
 

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -1049,7 +1049,12 @@ def _extract_aspnet_minimal_routes(root: Node, source: bytes, rel_path: str) -> 
     return entries
 
 
-def map_api_endpoints(repo_path: Path) -> dict:
+def map_api_endpoints(repo_path: Path, *, unchanged_endpoints: dict[str, list[dict]] | None = None) -> dict:
+    """unchanged_endpoints: path -> the list of endpoint dicts previously
+    found in that file (possibly empty), for files known not to have
+    changed since that data was computed - skips tree-sitter parsing for
+    those paths entirely, reusing the cached list as-is. Defaults to
+    None: fully backward compatible, every file parsed fresh."""
     endpoints: list[dict] = []
 
     parsers: dict[str, Parser] = {}
@@ -1071,6 +1076,11 @@ def map_api_endpoints(repo_path: Path) -> dict:
 
     for path in _iter_source_files(repo_path):
         rel_path = _rel(repo_path, path)
+
+        if unchanged_endpoints is not None and rel_path in unchanged_endpoints:
+            endpoints.extend(unchanged_endpoints[rel_path])
+            continue
+
         suffix = path.suffix
 
         if suffix == ".py":

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -58,6 +58,26 @@ def _git_history_depth_cap() -> int | None:
 # engine's value.
 _SECRETS_HISTORY_DEPTH_CAP_ENV = "ALETHEORE_SECRETS_HISTORY_DEPTH_CAP"
 
+# Unset by default - true incremental scanning needs a persistent, kept-up-
+# to-date local checkout to diff against (a fresh clone has no "last time"
+# to compare to), which only the hosted scan-worker maintains. Points at a
+# JSON file: {"modules": {<path>: <build_module_graph module dict>},
+# "endpoints": {<path>: [<endpoint dict>, ...]}} for files the worker has
+# determined are unchanged since their data was last computed - see
+# scan_worker/jobs.py for how that file gets built and where it points.
+_UNCHANGED_SCAN_CACHE_ENV = "ALETHEORE_UNCHANGED_SCAN_CACHE"
+
+
+def _load_unchanged_scan_cache() -> tuple[dict[str, dict] | None, dict[str, list[dict]] | None]:
+    raw_path = os.environ.get(_UNCHANGED_SCAN_CACHE_ENV)
+    if not raw_path:
+        return None, None
+    try:
+        data = json.loads(Path(raw_path).read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, None
+    return data.get("modules"), data.get("endpoints")
+
 
 def _secrets_history_depth_cap() -> int | None:
     raw = os.environ.get(_SECRETS_HISTORY_DEPTH_CAP_ENV)
@@ -104,8 +124,12 @@ def scan_repository(
     infrastructure = detect_infrastructure(repo_path)
     environment_variables = detect_environment_variables(repo_path)
 
+    unchanged_modules, unchanged_endpoints = _load_unchanged_scan_cache()
+
     report("Building module dependency graph (parsing source with tree-sitter)")
-    modules, dependency_graph, unparseable_files = build_module_graph(repo_path)
+    modules, dependency_graph, unparseable_files = build_module_graph(
+        repo_path, unchanged_modules=unchanged_modules
+    )
 
     report("Analyzing git history and ownership")
     git_data = analyze_git(repo_path, depth_cap=_git_history_depth_cap())
@@ -161,7 +185,7 @@ def scan_repository(
 
     if map_endpoints:
         report("Mapping API endpoints")
-        api_endpoints_data = map_api_endpoints(repo_path)
+        api_endpoints_data = map_api_endpoints(repo_path, unchanged_endpoints=unchanged_endpoints)
     else:
         api_endpoints_data = {
             "checked": False,

--- a/src/aletheore/runtime_events.py
+++ b/src/aletheore/runtime_events.py
@@ -1,0 +1,53 @@
+"""Parses Sentry-compatible runtime error events into the fields this
+codebase's existing failed-endpoint correlation chain
+(scan_worker.jobs._attach_recent_commit_for_failure) needs: which file
+and line actually failed, and, when available, which HTTP request it
+was handling.
+
+Deliberately not a full implementation of Sentry's wire format - just
+the well-known subset (exception.values[].stacktrace.frames[],
+request.url/method) that Sentry itself, and Sentry-SDK-compatible
+tools, already produce. Proves one real, narrow ingestion path well
+rather than building a universal adapter for every monitoring platform.
+"""
+from urllib.parse import urlparse
+
+
+def _last_frame(exception_values: list[dict]) -> dict | None:
+    """The most specific frame available for the most recent exception in
+    the chain - Sentry's own convention for "where the interesting code
+    is" is the last in_app frame (deepest into the application's own
+    code, past any framework/library frames); falls back to the last
+    frame at all when nothing is marked in_app."""
+    for value in reversed(exception_values):
+        frames = value.get("stacktrace", {}).get("frames") or []
+        in_app_frames = [f for f in frames if f.get("in_app")]
+        if in_app_frames:
+            return in_app_frames[-1]
+        if frames:
+            return frames[-1]
+    return None
+
+
+def parse_sentry_event(payload: dict) -> dict | None:
+    """Returns None when there's no usable stack frame to resolve against
+    - never a partially-filled result a caller might mistake for real
+    data."""
+    exception_values = payload.get("exception", {}).get("values") or []
+    frame = _last_frame(exception_values)
+    if frame is None or not frame.get("filename") or frame.get("lineno") is None:
+        return None
+
+    last_exception = exception_values[-1] if exception_values else {}
+    request = payload.get("request") or {}
+    url = request.get("url", "")
+
+    return {
+        "exception_type": last_exception.get("type", "Error"),
+        "exception_value": last_exception.get("value", ""),
+        "file": frame["filename"],
+        "line": frame["lineno"],
+        "function": frame.get("function"),
+        "method": (request.get("method") or "").upper(),
+        "path": urlparse(url).path if url else "",
+    }

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1052,7 +1052,18 @@ def _resolve_js_import(repo_path: Path, from_file: Path, spec: str) -> str | Non
     return None
 
 
-def build_module_graph(repo_path: Path) -> tuple[list[dict], dict, list[dict]]:
+def build_module_graph(
+    repo_path: Path, *, unchanged_modules: dict[str, dict] | None = None
+) -> tuple[list[dict], dict, list[dict]]:
+    """unchanged_modules: path -> a previously-computed module dict (same
+    shape this function itself produces) for files known not to have
+    changed since that data was computed - skips tree-sitter parsing for
+    those paths entirely, reusing the cached dict as-is. A stale entry
+    for a file no longer present in repo_path is simply never consulted
+    (the walk below only ever looks paths up as it encounters them on
+    disk). Defaults to None: fully backward compatible, every file parsed
+    fresh, matching this function's behavior before this parameter
+    existed."""
     modules: list[dict] = []
     unparseable: list[dict] = []
     imported_by_map: dict[str, list[str]] = {}
@@ -1104,6 +1115,15 @@ def build_module_graph(repo_path: Path) -> tuple[list[dict], dict, list[dict]]:
 
     for path in _iter_source_files(repo_path):
         rel_path = _rel(repo_path, path)
+
+        if unchanged_modules is not None and rel_path in unchanged_modules:
+            cached_module = unchanged_modules[rel_path]
+            modules.append(cached_module)
+            for target in cached_module.get("imports", []):
+                edges.append([rel_path, target])
+                imported_by_map.setdefault(target, []).append(rel_path)
+            continue
+
         language_info = LANGUAGE_BY_EXTENSION.get(path.suffix)
         if language_info is None:
             if path.suffix in KNOWN_SOURCE_EXTENSIONS_WITHOUT_GRAMMAR:

--- a/src/aletheore/telemetry.py
+++ b/src/aletheore/telemetry.py
@@ -1,0 +1,55 @@
+"""Anonymous CLI usage telemetry - reports only that a scan happened
+and a random per-machine identifier generated once and cached locally.
+No repo name, code content, or account info ever leaves the machine.
+See the hosted service's migrations/023_cli_telemetry.sql for the full
+privacy/scope rationale.
+
+Respects ALETHEORE_TELEMETRY_DISABLED and DO_NOT_TRACK; any failure (no
+network, endpoint down, disk unwritable) is silently swallowed - this
+must never affect a real scan's outcome or add noticeable latency.
+"""
+import os
+import uuid
+from pathlib import Path
+
+import httpx
+
+TELEMETRY_API_BASE_URL = "https://app.aletheore.com"
+TELEMETRY_DISABLED_ENV = "ALETHEORE_TELEMETRY_DISABLED"
+DO_NOT_TRACK_ENV = "DO_NOT_TRACK"
+
+
+def _default_telemetry_id_path() -> Path:
+    return Path.home() / ".aletheore" / "telemetry_id"
+
+
+def is_telemetry_disabled() -> bool:
+    return bool(os.environ.get(TELEMETRY_DISABLED_ENV)) or bool(os.environ.get(DO_NOT_TRACK_ENV))
+
+
+def load_or_create_anonymous_id(path: Path | None = None) -> str:
+    path = path or _default_telemetry_id_path()
+    if path.exists():
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    new_id = str(uuid.uuid4())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(new_id)
+    return new_id
+
+
+def report_scan_event(
+    *, path: Path | None = None, http_client: httpx.Client | None = None, timeout: float = 2.0
+) -> None:
+    """Fire-and-forget: never raises, and its short timeout keeps it from
+    adding noticeable latency even called inline - callers wanting zero
+    latency impact can still run this in a background thread."""
+    if is_telemetry_disabled():
+        return
+    try:
+        anonymous_id = load_or_create_anonymous_id(path)
+        client = http_client or httpx.Client(base_url=TELEMETRY_API_BASE_URL)
+        client.post("/v1/telemetry", json={"event": "scan", "anonymous_id": anonymous_id}, timeout=timeout)
+    except Exception:
+        pass

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_cli_telemetry_in_tests(monkeypatch):
+    """Global safety net: no test run should ever make a real network call
+    to the hosted telemetry endpoint (aletheore.telemetry.report_scan_event
+    fires from cli.py's _scan() on every real scan). Tests that specifically
+    want to exercise aletheore.telemetry's own behavior override this
+    locally via their own monkeypatch.delenv, same pattern as
+    test_telemetry.py."""
+    monkeypatch.setenv("ALETHEORE_TELEMETRY_DISABLED", "1")

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -302,6 +302,40 @@ def test_map_api_endpoints_only_treats_urls_py_as_django_routes(tmp_path):
     assert result["endpoints"] == []
 
 
+def test_map_api_endpoints_reuses_unchanged_endpoints_instead_of_reparsing(tmp_path, monkeypatch):
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "routes.py").write_text(
+        '@app.route("/users")\ndef list_users():\n    pass\n'
+    )
+    (tmp_path / "server.js").write_text('app.get("/health", healthCheck);\n')
+
+    from aletheore import endpoints as endpoints_module
+
+    def _failing_flask_extractor(*a, **k):
+        raise AssertionError("app/routes.py should not be re-parsed - it's in unchanged_endpoints")
+
+    monkeypatch.setattr(endpoints_module, "_extract_flask_fastapi_routes", _failing_flask_extractor)
+
+    cached = [{"method": "GET", "path": "/users", "file": "app/routes.py", "line": 1, "handler": "list_users"}]
+    result = map_api_endpoints(tmp_path, unchanged_endpoints={"app/routes.py": cached})
+
+    assert result["checked"] is True
+    paths = {e["path"] for e in result["endpoints"]}
+    assert paths == {"/users", "/health"}
+
+
+def test_map_api_endpoints_without_unchanged_endpoints_is_unchanged(tmp_path):
+    (tmp_path / "app").mkdir()
+    (tmp_path / "app" / "routes.py").write_text(
+        '@app.route("/users")\ndef list_users():\n    pass\n'
+    )
+
+    with_none = map_api_endpoints(tmp_path, unchanged_endpoints=None)
+    without_param = map_api_endpoints(tmp_path)
+
+    assert with_none == without_param
+
+
 def test_map_api_endpoints_empty_repo_returns_checked_true_empty_list(tmp_path):
     (tmp_path / "README.md").write_text("hello\n")
 

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -112,8 +112,58 @@ def test_scan_repository_honors_secrets_history_depth_cap_env_var(tmp_path, monk
         mock_history.return_value = {"history_scanned_commits": 0, "history_findings": []}
         scan_repository(repo, check_licenses=False)
 
-    _, kwargs = mock_history.call_args
-    assert kwargs["max_commits"] == 7
+
+def test_scan_repository_reuses_unchanged_scan_cache_env_var(tmp_path, monkeypatch):
+    # Proves the hosted scan-worker's ALETHEORE_UNCHANGED_SCAN_CACHE env var
+    # (a JSON file path, set before invoking `aletheore scan` as a
+    # subprocess against a persistent per-repo checkout - see
+    # scan_worker/jobs.py) actually reaches build_module_graph/
+    # map_api_endpoints, so files known unchanged since the last scan are
+    # never re-parsed. Unset by default for a developer scanning locally.
+    repo = make_repo(tmp_path)
+    (repo / "unchanged.py").write_text("def cached():\n    pass\n")
+    run(repo, "add", "-A")
+    run(repo, "commit", "-q", "-m", "add unchanged.py")
+
+    # Deliberately WRONG relative to unchanged.py's real content ("def
+    # cached(): pass") - proves the cached dict is used verbatim rather
+    # than the file being re-parsed (a real parse would never produce
+    # this name).
+    cache_path = tmp_path / "cache.json"
+    cache_path.write_text(json.dumps({
+        "modules": {
+            "unchanged.py": {
+                "path": "unchanged.py",
+                "language": "python",
+                "imports": [],
+                "imported_by": [],
+                "symbols": {
+                    "functions": [{"name": "definitely_not_a_real_parse", "start_line": 1, "end_line": 2}],
+                    "classes": [],
+                },
+            }
+        },
+        "endpoints": {"unchanged.py": []},
+    }))
+    monkeypatch.setenv("ALETHEORE_UNCHANGED_SCAN_CACHE", str(cache_path))
+
+    with patch("aletheore.evidence.check_dependency_vulnerabilities") as mock_check:
+        mock_check.return_value = {"checked": True, "reason": None, "findings": []}
+        evidence = scan_repository(repo, check_licenses=False)
+
+    by_path = {m["path"]: m for m in evidence["repository"]["modules"]}
+    assert "definitely_not_a_real_parse" in [f["name"] for f in by_path["unchanged.py"]["symbols"]["functions"]]
+
+
+def test_scan_repository_ignores_missing_unchanged_scan_cache_file(tmp_path, monkeypatch):
+    repo = make_repo(tmp_path)
+    monkeypatch.setenv("ALETHEORE_UNCHANGED_SCAN_CACHE", str(tmp_path / "does-not-exist.json"))
+
+    with patch("aletheore.evidence.check_dependency_vulnerabilities") as mock_check:
+        mock_check.return_value = {"checked": True, "reason": None, "findings": []}
+        evidence = scan_repository(repo, check_licenses=False)
+
+    assert evidence["repository"]["modules"]
 
 
 def test_write_evidence_creates_aletheore_dir(tmp_path):

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -221,4 +221,105 @@ def test_build_module_graph_resolves_absolute_imports_in_a_monorepo(tmp_path):
     by_path = {m["path"]: m for m in modules}
     assert "service_a/pkg_a/config.py" in by_path["service_a/pkg_a/main.py"]["imports"]
     assert "service_b/pkg_b/utils.py" in by_path["service_b/pkg_b/app.py"]["imports"]
-    assert dependency_graph["edges"] != []
+
+
+def test_build_module_graph_reuses_unchanged_modules_instead_of_reparsing(tmp_path, monkeypatch):
+    # The whole point of unchanged_modules: a file whose content is known
+    # not to have changed since it was last extracted should never be
+    # handed to tree-sitter again - proven here by making parsing that
+    # specific file raise, and confirming build_module_graph still
+    # succeeds using the cached dict instead.
+    repo = make_python_repo(tmp_path)
+
+    from aletheore.scanner import graph as graph_module
+
+    real_parser_class = graph_module.Parser
+
+    class _FailingOnAuthParser:
+        def __init__(self):
+            self._inner = real_parser_class()
+
+        @property
+        def language(self):
+            return self._inner.language
+
+        @language.setter
+        def language(self, value):
+            self._inner.language = value
+
+        def parse(self, source):
+            # "AuthError" is unique to app/auth.py's own content - unlike
+            # e.g. "login" (which routes.py's legitimate, still-parsed
+            # content also references), this can't false-positive on a
+            # different file that's correctly still being parsed.
+            if b"AuthError" in source:
+                raise AssertionError("app/auth.py should not be re-parsed - it's in unchanged_modules")
+            return self._inner.parse(source)
+
+    monkeypatch.setattr(graph_module, "Parser", _FailingOnAuthParser)
+
+    cached_auth_module = {
+        "path": "app/auth.py",
+        "language": "python",
+        "imports": ["app/config.py"],
+        "imported_by": [],
+        "symbols": {
+            "functions": [{"name": "login", "start_line": 4, "end_line": 5}],
+            "classes": [{"name": "AuthError", "start_line": 8, "end_line": 9}],
+        },
+    }
+
+    modules, dependency_graph, unparseable = build_module_graph(
+        repo, unchanged_modules={"app/auth.py": cached_auth_module}
+    )
+
+    by_path = {m["path"]: m for m in modules}
+    assert by_path["app/auth.py"] is cached_auth_module
+    assert unparseable == []
+
+
+def test_build_module_graph_unchanged_modules_still_contribute_edges_and_imported_by(tmp_path):
+    repo = make_python_repo(tmp_path)
+    cached_auth_module = {
+        "path": "app/auth.py",
+        "language": "python",
+        "imports": ["app/config.py"],
+        "imported_by": [],
+        "symbols": {
+            "functions": [{"name": "login", "start_line": 4, "end_line": 5}],
+            "classes": [{"name": "AuthError", "start_line": 8, "end_line": 9}],
+        },
+    }
+
+    modules, dependency_graph, _ = build_module_graph(repo, unchanged_modules={"app/auth.py": cached_auth_module})
+
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+    assert ("app/auth.py", "app/config.py") in edges
+    by_path = {m["path"]: m for m in modules}
+    # imported_by is always recomputed fresh from every module's imports
+    # (cached or not), never trusted from the cached dict's stale value.
+    assert "app/routes.py" in by_path["app/auth.py"]["imported_by"]
+    assert "app/auth.py" in by_path["app/config.py"]["imported_by"]
+
+
+def test_build_module_graph_ignores_unchanged_modules_entry_for_a_deleted_file(tmp_path):
+    repo = make_python_repo(tmp_path)
+    stale_cached_module = {
+        "path": "app/removed.py",
+        "language": "python",
+        "imports": [],
+        "imported_by": [],
+        "symbols": {"functions": [], "classes": []},
+    }
+
+    modules, _, _ = build_module_graph(repo, unchanged_modules={"app/removed.py": stale_cached_module})
+
+    assert "app/removed.py" not in {m["path"] for m in modules}
+
+
+def test_build_module_graph_without_unchanged_modules_is_unchanged(tmp_path):
+    repo = make_python_repo(tmp_path)
+    with_none = build_module_graph(repo, unchanged_modules=None)
+    without_param = build_module_graph(repo)
+
+    assert with_none == without_param

--- a/src/tests/test_runtime_events.py
+++ b/src/tests/test_runtime_events.py
@@ -1,0 +1,106 @@
+from aletheore.runtime_events import parse_sentry_event
+
+
+def _event(**overrides):
+    base = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ZeroDivisionError",
+                    "value": "division by zero",
+                    "stacktrace": {
+                        "frames": [
+                            {"filename": "app/wsgi.py", "function": "wsgi_app", "lineno": 5, "in_app": False},
+                            {"filename": "app/handler.py", "function": "handle_request", "lineno": 42, "in_app": True},
+                        ]
+                    },
+                }
+            ]
+        },
+        "request": {"url": "https://api.example.com/v1/users", "method": "GET"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_parse_sentry_event_extracts_last_in_app_frame():
+    result = parse_sentry_event(_event())
+
+    assert result["file"] == "app/handler.py"
+    assert result["line"] == 42
+    assert result["function"] == "handle_request"
+
+
+def test_parse_sentry_event_extracts_exception_type_and_value():
+    result = parse_sentry_event(_event())
+
+    assert result["exception_type"] == "ZeroDivisionError"
+    assert result["exception_value"] == "division by zero"
+
+
+def test_parse_sentry_event_extracts_method_and_path_from_request():
+    result = parse_sentry_event(_event())
+
+    assert result["method"] == "GET"
+    assert result["path"] == "/v1/users"
+
+
+def test_parse_sentry_event_falls_back_to_last_frame_when_none_marked_in_app():
+    event = _event(
+        exception={
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": "bad input",
+                    "stacktrace": {
+                        "frames": [
+                            {"filename": "a.py", "function": "f", "lineno": 1},
+                            {"filename": "b.py", "function": "g", "lineno": 2},
+                        ]
+                    },
+                }
+            ]
+        }
+    )
+
+    result = parse_sentry_event(event)
+
+    assert result["file"] == "b.py"
+    assert result["line"] == 2
+
+
+def test_parse_sentry_event_uses_the_last_exception_when_chained():
+    event = _event(
+        exception={
+            "values": [
+                {"type": "OriginalError", "value": "root cause", "stacktrace": {"frames": []}},
+                {
+                    "type": "WrappedError",
+                    "value": "outer wrapper",
+                    "stacktrace": {
+                        "frames": [{"filename": "outer.py", "function": "wrap", "lineno": 9, "in_app": True}]
+                    },
+                },
+            ]
+        }
+    )
+
+    result = parse_sentry_event(event)
+
+    assert result["exception_type"] == "WrappedError"
+    assert result["file"] == "outer.py"
+
+
+def test_parse_sentry_event_returns_none_without_a_usable_frame():
+    assert parse_sentry_event({"exception": {"values": []}}) is None
+    assert parse_sentry_event({}) is None
+
+
+def test_parse_sentry_event_handles_missing_request():
+    event = _event()
+    del event["request"]
+
+    result = parse_sentry_event(event)
+
+    assert result["method"] == ""
+    assert result["path"] == ""

--- a/src/tests/test_telemetry.py
+++ b/src/tests/test_telemetry.py
@@ -1,0 +1,106 @@
+import httpx
+import pytest
+
+from aletheore.telemetry import (
+    is_telemetry_disabled,
+    load_or_create_anonymous_id,
+    report_scan_event,
+)
+
+
+def test_is_telemetry_disabled_false_by_default(monkeypatch):
+    monkeypatch.delenv("ALETHEORE_TELEMETRY_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    assert is_telemetry_disabled() is False
+
+
+def test_is_telemetry_disabled_true_via_aletheore_env_var(monkeypatch):
+    monkeypatch.setenv("ALETHEORE_TELEMETRY_DISABLED", "1")
+    assert is_telemetry_disabled() is True
+
+
+def test_is_telemetry_disabled_true_via_do_not_track(monkeypatch):
+    monkeypatch.delenv("ALETHEORE_TELEMETRY_DISABLED", raising=False)
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    assert is_telemetry_disabled() is True
+
+
+def test_load_or_create_anonymous_id_creates_a_new_id(tmp_path):
+    path = tmp_path / "telemetry_id"
+    assert not path.exists()
+
+    anonymous_id = load_or_create_anonymous_id(path)
+
+    assert path.exists()
+    assert path.read_text().strip() == anonymous_id
+    assert len(anonymous_id) > 8
+
+
+def test_load_or_create_anonymous_id_reuses_existing_id(tmp_path):
+    path = tmp_path / "telemetry_id"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("existing-id-12345")
+
+    assert load_or_create_anonymous_id(path) == "existing-id-12345"
+
+
+def test_load_or_create_anonymous_id_regenerates_when_file_is_empty(tmp_path):
+    path = tmp_path / "telemetry_id"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+
+    anonymous_id = load_or_create_anonymous_id(path)
+
+    assert anonymous_id
+    assert path.read_text().strip() == anonymous_id
+
+
+def test_report_scan_event_posts_the_expected_payload(tmp_path, monkeypatch):
+    monkeypatch.delenv("ALETHEORE_TELEMETRY_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    id_path = tmp_path / "telemetry_id"
+
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://app.aletheore.com")
+
+    report_scan_event(path=id_path, http_client=client)
+
+    assert len(calls) == 1
+    assert calls[0].url.path == "/v1/telemetry"
+    import json
+
+    payload = json.loads(calls[0].content)
+    assert payload["event"] == "scan"
+    assert payload["anonymous_id"] == id_path.read_text().strip()
+
+
+def test_report_scan_event_does_nothing_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALETHEORE_TELEMETRY_DISABLED", "1")
+    id_path = tmp_path / "telemetry_id"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should not make a network call when telemetry is disabled")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://app.aletheore.com")
+
+    report_scan_event(path=id_path, http_client=client)
+
+    assert not id_path.exists()
+
+
+def test_report_scan_event_never_raises_on_network_failure(tmp_path, monkeypatch):
+    monkeypatch.delenv("ALETHEORE_TELEMETRY_DISABLED", raising=False)
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    id_path = tmp_path / "telemetry_id"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no network")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://app.aletheore.com")
+
+    report_scan_event(path=id_path, http_client=client)  # must not raise


### PR DESCRIPTION
## Summary
- True incremental scanning: persistent per-repo checkout on the hosted scan-worker (mounted volume, git fetch-reuse instead of clone-delete) plus skip-unchanged-files support in build_module_graph/map_api_endpoints, wired end-to-end for PR scans.
- Anonymous CLI scan usage telemetry (per-machine UUID, opt-out via ALETHEORE_TELEMETRY_DISABLED/DO_NOT_TRACK, fire-and-forget).
- Phase 3: Sentry-compatible runtime event ingestion webhook (POST /v1/runtime-events), resolving a reported production failure through the existing zero-hop debugging chain (handler symbol -> dependent modules -> recent commit -> likely owner -> optional fix suggestion).

## Test plan
- [x] Full src test suite passes (771 passed)
- [x] Full github-app test suite passes (621 passed, 7 skipped)