### PR TITLE
Critical billing/reliability fixes + Aletheore AIR single-tier launch

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -279,8 +279,8 @@ async def get_extra_seats(pool: asyncpg.Pool, installation_id: int) -> int:
     return row["extra_seats"] if row else 0
 
 
-INCLUDED_SEATS = {"indie": 3, "team": 10, "enterprise": 25}
-DEFAULT_SEAT_LIMIT = 3
+INCLUDED_SEATS = {"air": 5}
+DEFAULT_SEAT_LIMIT = 5
 
 
 async def add_installation_member(
@@ -338,9 +338,8 @@ async def is_installation_member(pool: asyncpg.Pool, installation_id: int, githu
 
 # Health check targets live behind the same paid-plan gate as the rest of
 # Settings (_require_admin_installation rejects free plans before any of
-# this is ever reached), so there is no meaningful "free" entry here - this
-# only needs to distinguish among the plans that actually get this far.
-INCLUDED_HEALTH_CHECK_TARGETS = {"indie": 5, "team": 5, "enterprise": 5}
+# this is ever reached), so there is no meaningful "free" entry here.
+INCLUDED_HEALTH_CHECK_TARGETS = {"air": 5}
 DEFAULT_HEALTH_CHECK_TARGET_LIMIT = 5
 
 

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -17,11 +17,10 @@ competing for space with five other sections.
 from html import escape
 from urllib.parse import quote
 
-import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from app_server.admin import _administered_installation_ids
+from app_server.admin import _administered_installation_ids_for_session_or_401
 from app_server.auth import SESSION_COOKIE_NAME, get_current_session
 from app_server.config import get_settings
 from app_server.db import list_installations_for_ids
@@ -313,6 +312,9 @@ function escapeHtml(s) {
     return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
   });
 }
+function planDisplayName(plan) {
+  return plan === 'free' ? 'Aletheore Community' : 'Aletheore AIR';
+}
 """
 
 SIGNIN_HTML = f"""<!DOCTYPE html>
@@ -366,7 +368,7 @@ PICKER_HTML = f"""<!DOCTYPE html>
     const group = document.createElement('div');
     group.className = 'picker-org-group';
     const grid = byOrg[org].map(function (r) {{
-      const planBadge = '<span class="picker-plan' + (r.plan !== 'free' ? ' paid' : '') + '">' + escapeHtml(r.plan) + ' plan</span>';
+      const planBadge = '<span class="picker-plan' + (r.plan !== 'free' ? ' paid' : '') + '">' + escapeHtml(planDisplayName(r.plan)) + '</span>';
       if (r.initialized === false) {{
         const note = r.scan_limit_reached
           ? '10 repos per month limit reached &mdash; please wait for next month'
@@ -472,13 +474,13 @@ async function loadPlanBadge() {
   const subEl = document.getElementById('plan-sub');
   if (!res) return null;
   if (res.status === 402) {
-    nameEl.textContent = 'free';
+    nameEl.textContent = planDisplayName('free');
     subEl.textContent = 'Upgrade for AIRview and settings.';
     return 'free';
   }
   if (!res.ok) { nameEl.textContent = ''; subEl.textContent = ''; return null; }
   const data = await res.json();
-  nameEl.textContent = data.installation.plan + ' plan';
+  nameEl.textContent = planDisplayName(data.installation.plan);
   subEl.textContent = data.installation.plan === 'free' ? 'Upgrade for AIRview and settings.' : 'AIRview and priority scans included.';
   return data;
 }
@@ -1307,8 +1309,12 @@ def _no_store_html(content: str) -> HTMLResponse:
     return HTMLResponse(content, headers={"Cache-Control": "no-store"})
 
 
-_VALID_PLANS = ("indie", "team", "enterprise")
+_VALID_PLANS = ("air",)
 _VALID_INTERVALS = ("month", "year")
+
+
+def _plan_display_name(plan: str) -> str:
+    return "Aletheore Community" if plan == "free" else "Aletheore AIR"
 
 
 def _subscribe_page(title: str, body: str) -> str:
@@ -1327,7 +1333,7 @@ def _subscribe_install_prompt_page(plan: str, next_path: str) -> str:
         "Install the GitHub App",
         f"""
         <h1>Install the Aletheore GitHub App</h1>
-        <p>Install the app on a GitHub organization to activate your {escape(plan.title())} plan.</p>
+        <p>Install the app on a GitHub organization to activate your {escape(_plan_display_name(plan))} plan.</p>
         <a class="btn btn-accent" href="{escape(install_url)}">Install the Aletheore GitHub App</a>
         <p><a href="/dashboard">Cancel</a></p>
         """,
@@ -1339,8 +1345,8 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
         installation = installations[0]
         continue_attrs = f'data-installation-id="{installation["installation_id"]}"'
         body = f"""
-        <h1>Subscribe to {escape(plan.title())}</h1>
-        <p>{escape(installation["account_login"])} is currently on {escape(installation["plan"].title())}.</p>
+        <h1>Subscribe to {escape(_plan_display_name(plan))}</h1>
+        <p>{escape(installation["account_login"])} is currently on {escape(_plan_display_name(installation["plan"]))}.</p>
         <button class="btn btn-accent" id="continue-checkout" {continue_attrs}>Continue to checkout</button>
         <p><a href="/dashboard">Cancel</a></p>
         """
@@ -1351,13 +1357,13 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
                 f'<input type="radio" name="installation_id" value="{installation["installation_id"]}"'
                 f'{" checked" if index == 0 else ""}> '
                 f'{escape(installation["account_login"])} '
-                f'(currently {escape(installation["plan"].title())})'
+                f'(currently {escape(_plan_display_name(installation["plan"]))})'
                 "</label>"
             )
             for index, installation in enumerate(installations)
         )
         body = f"""
-        <h1>Subscribe to {escape(plan.title())}</h1>
+        <h1>Subscribe to {escape(_plan_display_name(plan))}</h1>
         <p>Choose which installation this subscription applies to.</p>
         <div class="claim-options">{options}</div>
         <button class="btn btn-accent" id="continue-checkout">Continue to checkout</button>
@@ -1400,14 +1406,16 @@ async def subscribe_page(request: Request, plan: str = "", interval: str = ""):
     if session is None:
         return RedirectResponse(url=f"/auth/login?next={encoded_next}", status_code=307)
 
+    pool = request.app.state.db_pool
     try:
-        administered_ids = await _administered_installation_ids(session["github_access_token"])
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 401:
-            # The stored GitHub token is dead (revoked, expired) - the signed
-            # session cookie itself is still valid, but GitHub no longer honors
-            # the access token inside it. Clear it and send them through a
-            # fresh sign-in rather than a raw 500.
+        administered_ids = await _administered_installation_ids_for_session_or_401(pool, session)
+    except HTTPException as exc:
+        if exc.status_code == 401:
+            # The stored GitHub token is dead - _administered_installation_ids_for_session_or_401
+            # already tried a transparent refresh-and-retry and, having no
+            # refresh_token or failing anyway, deleted the session server-side.
+            # Clear the now-stale cookie too and send them through a fresh
+            # sign-in rather than a raw 401.
             response = RedirectResponse(url=f"/auth/login?next={encoded_next}", status_code=307)
             response.delete_cookie(SESSION_COOKIE_NAME)
             return response
@@ -1416,7 +1424,6 @@ async def subscribe_page(request: Request, plan: str = "", interval: str = ""):
     if not administered_ids:
         return _no_store_html(_subscribe_install_prompt_page(plan, next_path))
 
-    pool = request.app.state.db_pool
     installations = await list_installations_for_ids(pool, list(administered_ids))
     price_id = resolve_price_id_for_plan(plan, interval)
     return _no_store_html(_subscribe_checkout_page(plan, price_id, installations))

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -18,16 +18,16 @@ MODEL_RATES_PER_MILLION_USD = {
 
 STALE_PRICE_MAX_AGE_DAYS = 90
 
-EXTRA_SEAT_MONTHLY_COST_USD = 2.00
+EXTRA_SEAT_MONTHLY_COST_USD = 3.99
 
 # Base monthly price per plan (github-app/../website/pricing.html) - the hard
 # LLM spend cap is set as a fraction of this, not a flat dollar figure, so it
-# scales with what each tier actually pays rather than penalizing cheaper
-# tiers or under-capping expensive ones.
+# scales with what the tier actually pays rather than under- or over-capping
+# it. Single paid tier (Aletheore AIR) - priced monthly regardless of
+# whether a given customer actually pays monthly or annually, since the
+# spend cap is a monthly rolling figure either way.
 PLAN_MONTHLY_PRICE_USD = {
-    "indie": 29.00,
-    "team": 79.00,
-    "enterprise": 199.00,
+    "air": 29.99,
 }
 
 # Deliberately generous: this is a worst-case abuse/runaway-cost ceiling, not

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -1,12 +1,8 @@
 """Paddle price ID to Aletheore plan mapping."""
 
 PADDLE_PRICE_TO_PLAN: dict[str, str] = {
-    "pri_01ky9jwz35hvj5xs6f8xqw6htt": "indie",
-    "pri_01ky9jwzd6k9rhmnj8b4drbygg": "indie",
-    "pri_01ky9jx0gbx02mnn4d166yp3vc": "team",
-    "pri_01ky9jx0rkkkz75atfb29me9mn": "team",
-    "pri_01ky9jx1bkbbkfd9zspcgzd7p8": "enterprise",
-    "pri_01ky9jx1pbbpsexbmtbk1wfej1": "enterprise",
+    "pri_01kyhevc8bkcghfpwjymz16y2h": "air",
+    "pri_01kyhevc9xn6z2nghmy8057jvp": "air",
 }
 
 
@@ -15,12 +11,8 @@ def resolve_plan_for_price_id(price_id: str) -> str | None:
 
 
 PLAN_INTERVAL_TO_PRICE_ID: dict[tuple[str, str], str] = {
-    ("indie", "month"): "pri_01ky9jwz35hvj5xs6f8xqw6htt",
-    ("indie", "year"): "pri_01ky9jwzd6k9rhmnj8b4drbygg",
-    ("team", "month"): "pri_01ky9jx0gbx02mnn4d166yp3vc",
-    ("team", "year"): "pri_01ky9jx0rkkkz75atfb29me9mn",
-    ("enterprise", "month"): "pri_01ky9jx1bkbbkfd9zspcgzd7p8",
-    ("enterprise", "year"): "pri_01ky9jx1pbbpsexbmtbk1wfej1",
+    ("air", "month"): "pri_01kyhevc8bkcghfpwjymz16y2h",
+    ("air", "year"): "pri_01kyhevc9xn6z2nghmy8057jvp",
 }
 
 

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -10,35 +10,63 @@ from app_server.paddle_webhook_verify import verify_paddle_signature
 paddle_webhook_router = APIRouter()
 logger = logging.getLogger(__name__)
 
+# Every subscription lifecycle event that can change what plan an
+# installation should be on. Previously only subscription.created was
+# handled - a cancellation, a card declining until the subscription lapsed,
+# or a tier change via Paddle's own customer portal all landed as one of
+# these other event types and were silently dropped, leaving
+# installations.plan stuck at whatever it was last set to indefinitely.
+_SUBSCRIPTION_EVENT_TYPES = {
+    "subscription.created",
+    "subscription.updated",
+    "subscription.canceled",
+    "subscription.paused",
+    "subscription.resumed",
+}
+
+# Paddle subscription statuses that keep (or restore) paid access. Anything
+# else - canceled, paused, past_due, or any future status - revokes to
+# free immediately. There's no dunning-aware "past due but still allowed"
+# grace tier in this product; erring toward cutting access rather than
+# silently extending it is the safer default for a paid feature.
+_ACTIVE_SUBSCRIPTION_STATUSES = {"active", "trialing"}
+
 
 async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue=None) -> None:
-    if payload.get("event_type") != "subscription.created":
+    event_type = payload.get("event_type")
+    if event_type not in _SUBSCRIPTION_EVENT_TYPES:
         return
 
     data = payload.get("data") or {}
     installation_id_raw = (data.get("custom_data") or {}).get("installation_id")
-    items = data.get("items") or []
-    price_id = items[0].get("price", {}).get("id") if items else None
-    plan = resolve_plan_for_price_id(price_id) if price_id else None
-
     installation_id = None
     if installation_id_raw is not None:
         try:
             installation_id = int(installation_id_raw)
         except (TypeError, ValueError):
             installation_id = None
-
-    if installation_id is None or not plan:
-        logger.warning(
-            "subscription.created missing installation_id or known price id: price_id=%s", price_id
-        )
+    if installation_id is None:
+        logger.warning("%s missing installation_id in custom_data", event_type)
         return
+
+    if data.get("status") in _ACTIVE_SUBSCRIPTION_STATUSES:
+        items = data.get("items") or []
+        price_id = items[0].get("price", {}).get("id") if items else None
+        plan = resolve_plan_for_price_id(price_id) if price_id else None
+        if not plan:
+            logger.warning(
+                "%s has an active status but no resolvable price id: price_id=%s", event_type, price_id
+            )
+            return
+    else:
+        plan = "free"
 
     previous = await get_installation(pool, installation_id)
     previous_plan = previous["plan"] if previous is not None else "free"
 
     await set_installation_plan(pool, installation_id, plan)
-    await add_paddle_ids_to_installation(pool, installation_id, data["id"], data["customer_id"])
+    if "id" in data and "customer_id" in data:
+        await add_paddle_ids_to_installation(pool, installation_id, data["id"], data["customer_id"])
 
     # One-time Live Wiki build, mirroring the GitHub Marketplace path in
     # webhooks/marketplace.py - fires exactly once, on the free -> paid

--- a/github-app/migrations/026_air_single_paid_tier.sql
+++ b/github-app/migrations/026_air_single_paid_tier.sql
@@ -1,0 +1,8 @@
+-- Aletheore now has a single paid tier (Aletheore AIR, internal plan
+-- string "air") instead of indie/team/enterprise - any installation
+-- still on one of those old plan strings would otherwise silently lose
+-- its seat/health-target limits and spend cap (INCLUDED_SEATS,
+-- INCLUDED_HEALTH_CHECK_TARGETS, and PLAN_MONTHLY_PRICE_USD no longer
+-- have entries for them) the moment this migration's application code
+-- deploys.
+UPDATE installations SET plan = 'air' WHERE plan IN ('indie', 'team', 'enterprise');

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1274,127 +1274,157 @@ def run_health_check_sweep_job() -> None:
         base_url = target["base_url"]
         threshold_ms = target["latency_threshold_ms"]
 
-        evidence = get_latest_evidence(dsn, installation_id, repo_full_name)
-        if evidence is None:
-            continue
-
-        for entry in _endpoint_results(evidence, base_url):
-            if entry.get("skipped"):
-                continue
-            method = entry["method"]
-            path = entry["path"]
-            source_file = entry.get("file")
-            source_line = entry.get("line")
-            evidence_resolution = entry.get("evidence_resolution")
-            reachable = entry["reachable"]
-            status_code = entry.get("status_code")
-            latency_ms = entry.get("latency_ms")
-            response_shape = entry.get("response_shape")
-            prior = get_last_endpoint_health(
-                dsn,
+        try:
+            _run_health_check_sweep_for_target(
+                dsn, target, installation_id, repo_full_name, target_id, base_url, threshold_ms
+            )
+        except Exception as exc:  # noqa: BLE001
+            # One customer's dead webhook URL, an unreachable target, or any
+            # other failure here must not take down the sweep for every
+            # other installation - this loop runs every
+            # HEALTH_SWEEP_INTERVAL_SECONDS for the whole paying customer
+            # base, so one bad target skipping its own cycle is far
+            # preferable to all of them silently going stale.
+            logging.getLogger("scan_worker.jobs").warning(
+                "health check sweep failed for installation=%s repo=%s target=%s (%s)",
                 installation_id,
                 repo_full_name,
-                method,
-                path,
-                target_id=target_id,
+                target_id,
+                type(exc).__name__,
+                exc_info=True,
             )
 
+
+def _run_health_check_sweep_for_target(
+    dsn: str,
+    target: dict,
+    installation_id: int,
+    repo_full_name: str,
+    target_id: int,
+    base_url: str,
+    threshold_ms: int | None,
+) -> None:
+    evidence = get_latest_evidence(dsn, installation_id, repo_full_name)
+    if evidence is None:
+        return
+
+    for entry in _endpoint_results(evidence, base_url):
+        if entry.get("skipped"):
+            continue
+        method = entry["method"]
+        path = entry["path"]
+        source_file = entry.get("file")
+        source_line = entry.get("line")
+        evidence_resolution = entry.get("evidence_resolution")
+        reachable = entry["reachable"]
+        status_code = entry.get("status_code")
+        latency_ms = entry.get("latency_ms")
+        response_shape = entry.get("response_shape")
+        prior = get_last_endpoint_health(
+            dsn,
+            installation_id,
+            repo_full_name,
+            method,
+            path,
+            target_id=target_id,
+        )
+
+        reachability_flipped = (prior is None and not reachable) or (
+            prior is not None and prior.get("reachable") != reachable
+        )
+
+        if reachability_flipped and not reachable:
+            for _ in range(HEALTH_CHECK_DOWN_RETRY_ATTEMPTS):
+                time.sleep(HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS)
+                retry_result = _recheck_single_endpoint(entry, base_url)
+                if retry_result.get("reachable"):
+                    reachable = True
+                    status_code = retry_result.get("status_code")
+                    latency_ms = retry_result.get("latency_ms")
+                    response_shape = retry_result.get("response_shape")
+                    break
             reachability_flipped = (prior is None and not reachable) or (
                 prior is not None and prior.get("reachable") != reachable
             )
 
-            if reachability_flipped and not reachable:
-                for _ in range(HEALTH_CHECK_DOWN_RETRY_ATTEMPTS):
-                    time.sleep(HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS)
-                    retry_result = _recheck_single_endpoint(entry, base_url)
-                    if retry_result.get("reachable"):
-                        reachable = True
-                        status_code = retry_result.get("status_code")
-                        latency_ms = retry_result.get("latency_ms")
-                        response_shape = retry_result.get("response_shape")
-                        break
-                reachability_flipped = (prior is None and not reachable) or (
-                    prior is not None and prior.get("reachable") != reachable
+        if reachability_flipped:
+            if not reachable and source_file:
+                evidence_resolution = _attach_recent_commit_for_failure(
+                    installation_id,
+                    repo_full_name,
+                    source_file,
+                    evidence_resolution,
+                    evidence,
+                    method=method,
+                    path=path,
+                    status_code=status_code,
+                    source_line=source_line,
                 )
-
-            if reachability_flipped:
-                if not reachable and source_file:
-                    evidence_resolution = _attach_recent_commit_for_failure(
-                        installation_id,
-                        repo_full_name,
-                        source_file,
-                        evidence_resolution,
-                        evidence,
-                        method=method,
-                        path=path,
-                        status_code=status_code,
-                        source_line=source_line,
-                    )
-                _send_if_webhook_configured(
-                    target,
-                    format_reachability_alert(
-                        repo_full_name,
-                        method,
-                        path,
-                        source_file,
-                        source_line,
-                        reachable,
-                        evidence_resolution=evidence_resolution,
-                    ),
-                )
-
-            if _latency_flipped(prior, reachable, latency_ms, threshold_ms):
-                _send_if_webhook_configured(
-                    target,
-                    format_latency_alert(
-                        repo_full_name,
-                        method,
-                        path,
-                        source_file,
-                        source_line,
-                        latency_ms,
-                        threshold_ms,
-                        latency_ms > threshold_ms,
-                        evidence_resolution=evidence_resolution,
-                    ),
-                )
-
-            shape_changed = (
-                reachable
-                and not reachability_flipped
-                and prior is not None
-                and prior.get("reachable") is True
-                and prior.get("response_shape") is not None
-                and response_shape is not None
-                and prior["response_shape"] != response_shape
+            _send_if_webhook_configured(
+                target,
+                format_reachability_alert(
+                    repo_full_name,
+                    method,
+                    path,
+                    source_file,
+                    source_line,
+                    reachable,
+                    evidence_resolution=evidence_resolution,
+                ),
             )
-            if shape_changed:
-                _send_if_webhook_configured(
-                    target,
-                    format_shape_change_alert(
-                        repo_full_name,
-                        method,
-                        path,
-                        source_file,
-                        source_line,
-                        prior["response_shape"],
-                        response_shape,
-                        evidence_resolution=evidence_resolution,
-                    ),
-                )
 
-            insert_endpoint_health(
-                dsn,
-                installation_id,
-                repo_full_name,
-                method,
-                path,
-                reachable,
-                status_code,
-                latency_ms,
-                response_shape=response_shape,
-                target_id=target_id,
+        if _latency_flipped(prior, reachable, latency_ms, threshold_ms):
+            _send_if_webhook_configured(
+                target,
+                format_latency_alert(
+                    repo_full_name,
+                    method,
+                    path,
+                    source_file,
+                    source_line,
+                    latency_ms,
+                    threshold_ms,
+                    latency_ms > threshold_ms,
+                    evidence_resolution=evidence_resolution,
+                ),
             )
+
+        shape_changed = (
+            reachable
+            and not reachability_flipped
+            and prior is not None
+            and prior.get("reachable") is True
+            and prior.get("response_shape") is not None
+            and response_shape is not None
+            and prior["response_shape"] != response_shape
+        )
+        if shape_changed:
+            _send_if_webhook_configured(
+                target,
+                format_shape_change_alert(
+                    repo_full_name,
+                    method,
+                    path,
+                    source_file,
+                    source_line,
+                    prior["response_shape"],
+                    response_shape,
+                    evidence_resolution=evidence_resolution,
+                ),
+            )
+
+        insert_endpoint_health(
+            dsn,
+            installation_id,
+            repo_full_name,
+            method,
+            path,
+            reachable,
+            status_code,
+            latency_ms,
+            response_shape=response_shape,
+            target_id=target_id,
+        )
 
 
 @log_job

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -687,7 +687,7 @@ def _sign_and_persist_audit_report(
 def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_number: int) -> None:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    plan = installation["plan"] if installation is not None else "indie"
+    plan = installation["plan"] if installation is not None else "air"
 
     if plan != "free" and not check_and_reserve_monthly_repo_scan_slot(
         settings.database_url, installation_id, repo_full_name, MAX_SCANNED_REPOS_PER_MONTH
@@ -775,7 +775,7 @@ def run_managed_audit_api_job(
 ) -> str:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    plan = installation["plan"] if installation is not None else "indie"
+    plan = installation["plan"] if installation is not None else "air"
     with installation_spend_lock(settings.database_url, installation_id):
         extra_seats = get_extra_seats(settings.database_url, installation_id)
         monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
@@ -1550,7 +1550,7 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
         return  # nothing scanned for this repo yet - nothing to build from
 
     installation = get_installation_row(dsn, installation_id)
-    plan = installation["plan"] if installation is not None else "indie"
+    plan = installation["plan"] if installation is not None else "air"
     model_used = model_for_plan(plan)
 
     naming_adapter = _live_wiki_naming_adapter()

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -19,7 +19,7 @@ from app_server.db import (
 from app_server.main import app
 
 
-async def _logged_in_client(pool, monkeypatch, installation_id=100, plan="indie"):
+async def _logged_in_client(pool, monkeypatch, installation_id=100, plan="air"):
     monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
     await upsert_installation(pool, installation_id, "octocat")
     await set_installation_plan(pool, installation_id, plan)
@@ -332,7 +332,7 @@ async def test_add_health_check_target_returns_422_for_non_integer_threshold(poo
 async def test_add_health_check_target_enforces_plan_limit(pool, monkeypatch):
     # Pro's included limit is 5 (INCLUDED_HEALTH_CHECK_TARGETS) - filling
     # it up, then the 6th add should be rejected.
-    client = await _logged_in_client(pool, monkeypatch, installation_id=100, plan="indie")
+    client = await _logged_in_client(pool, monkeypatch, installation_id=100, plan="air")
     async with client:
         for i in range(5):
             response = await client.post(
@@ -601,7 +601,7 @@ async def test_first_admin_to_arrive_is_auto_seated(pool, monkeypatch):
         response = await client.get("/admin/octocat/hello-world")
     assert response.status_code == 200
     assert [m["github_login"] for m in response.json()["members"]] == ["octocat"]
-    assert response.json()["seat_limit"] == 3
+    assert response.json()["seat_limit"] == 5
 
 
 @pytest.mark.asyncio
@@ -649,10 +649,12 @@ async def test_removing_a_member_revokes_access(pool, monkeypatch):
 async def test_add_member_enforces_seat_cap(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
     async with client:
-        await client.get("/admin/octocat/hello-world")  # seats octocat (1 of 3)
-        await client.post("/admin/octocat/hello-world/members", json={"github_login": "alice"})  # 2 of 3
-        await client.post("/admin/octocat/hello-world/members", json={"github_login": "bob"})  # 3 of 3
-        response = await client.post("/admin/octocat/hello-world/members", json={"github_login": "carol"})
+        await client.get("/admin/octocat/hello-world")  # seats octocat (1 of 5)
+        await client.post("/admin/octocat/hello-world/members", json={"github_login": "alice"})  # 2 of 5
+        await client.post("/admin/octocat/hello-world/members", json={"github_login": "bob"})  # 3 of 5
+        await client.post("/admin/octocat/hello-world/members", json={"github_login": "carol"})  # 4 of 5
+        await client.post("/admin/octocat/hello-world/members", json={"github_login": "dave"})  # 5 of 5
+        response = await client.post("/admin/octocat/hello-world/members", json={"github_login": "erin"})
     assert response.status_code == 409
     assert "seat limit reached" in response.json()["detail"]
 

--- a/github-app/tests/test_frontend_subscribe.py
+++ b/github-app/tests/test_frontend_subscribe.py
@@ -75,7 +75,7 @@ async def test_invalid_plan_returns_400(pool):
 async def test_invalid_interval_returns_400(pool):
     app.state.db_pool = pool
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        response = await client.get("/subscribe?plan=indie&interval=daily")
+        response = await client.get("/subscribe?plan=air&interval=daily")
     assert response.status_code == 400
 
 
@@ -83,12 +83,12 @@ async def test_invalid_interval_returns_400(pool):
 async def test_not_signed_in_redirects_to_login_preserving_plan_and_interval(pool):
     app.state.db_pool = pool
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        response = await client.get("/subscribe?plan=team&interval=year", follow_redirects=False)
+        response = await client.get("/subscribe?plan=air&interval=year", follow_redirects=False)
     assert response.status_code == 307
     location = response.headers["location"]
     assert "/auth/login" in location
     assert "next=" in location
-    assert "plan%3Dteam" in location
+    assert "plan%3Dair" in location
     assert "interval%3Dyear" in location
 
 
@@ -96,7 +96,7 @@ async def test_not_signed_in_redirects_to_login_preserving_plan_and_interval(poo
 async def test_dead_github_token_redirects_to_login_and_clears_session(pool, monkeypatch):
     client = await _logged_in_client_with_dead_token(pool, monkeypatch)
     async with client:
-        response = await client.get("/subscribe?plan=indie&interval=month", follow_redirects=False)
+        response = await client.get("/subscribe?plan=air&interval=month", follow_redirects=False)
     assert response.status_code == 307
     assert "/auth/login" in response.headers["location"]
     assert response.cookies.get("session") is None
@@ -106,7 +106,7 @@ async def test_dead_github_token_redirects_to_login_and_clears_session(pool, mon
 async def test_zero_installations_shows_install_prompt(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch, [])
     async with client:
-        response = await client.get("/subscribe?plan=indie&interval=month")
+        response = await client.get("/subscribe?plan=air&interval=month")
     assert response.status_code == 200
     assert "Install the Aletheore GitHub App" in response.text
     assert "github.com/apps/aletheore/installations/new" in response.text
@@ -118,12 +118,12 @@ async def test_one_installation_shows_checkout_with_current_plan(pool, monkeypat
     await upsert_installation(pool, 2001, "acme")
     client = await _logged_in_client(pool, monkeypatch, [2001])
     async with client:
-        response = await client.get("/subscribe?plan=team&interval=month")
+        response = await client.get("/subscribe?plan=air&interval=month")
     assert response.status_code == 200
     assert "acme" in response.text
-    assert "currently on Free" in response.text
+    assert "currently on Aletheore Community" in response.text
     assert 'data-installation-id="2001"' in response.text
-    assert "pri_01ky9jx0gbx02mnn4d166yp3vc" in response.text  # team monthly price id
+    assert "pri_01kyhevc8bkcghfpwjymz16y2h" in response.text  # air monthly price id
     assert "customData" in response.text
     assert "successUrl" in response.text and "dashboard" in response.text
     assert 'href="/dashboard"' in response.text
@@ -135,10 +135,10 @@ async def test_multiple_installations_shows_selection(pool, monkeypatch):
     await upsert_installation(pool, 2003, "beta-corp")
     client = await _logged_in_client(pool, monkeypatch, [2002, 2003])
     async with client:
-        response = await client.get("/subscribe?plan=enterprise&interval=year")
+        response = await client.get("/subscribe?plan=air&interval=year")
     assert response.status_code == 200
     assert 'value="2002"' in response.text
     assert 'value="2003"' in response.text
     assert "acme" in response.text
     assert "beta-corp" in response.text
-    assert "pri_01ky9jx1pbbpsexbmtbk1wfej1" in response.text  # enterprise yearly price id
+    assert "pri_01kyhevc9xn6z2nghmy8057jvp" in response.text  # air yearly price id

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1759,6 +1759,64 @@ def test_sweep_sends_down_alert_on_first_unreachable_check(monkeypatch):
     assert "down" in sent[0]["text"]
 
 
+def test_sweep_isolates_one_targets_failure_from_others(monkeypatch):
+    # One installation's broken webhook URL (or any other failure) must not
+    # take down the sweep for every other installation - this job runs
+    # every HEALTH_SWEEP_INTERVAL_SECONDS for the whole customer base.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_health_check_targets_all",
+        lambda dsn: [
+            {
+                "target_id": 1,
+                "installation_id": 1,
+                "repo_full_name": "acme/broken",
+                "label": "Primary",
+                "base_url": "https://api.example.com",
+                "latency_threshold_ms": None,
+                "webhook_url": "https://hooks.slack.com/broken",
+            },
+            {
+                "target_id": 2,
+                "installation_id": 2,
+                "repo_full_name": "acme/healthy",
+                "label": "Primary",
+                "base_url": "https://api.example.com",
+                "latency_threshold_ms": None,
+                "webhook_url": "https://hooks.slack.com/healthy",
+            },
+        ],
+    )
+
+    def fake_get_latest_evidence(dsn, installation_id, repo_full_name):
+        if installation_id == 1:
+            raise RuntimeError("simulated failure for installation 1")
+        return {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}}
+
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", fake_get_latest_evidence)
+    monkeypatch.setattr(
+        "scan_worker.jobs.run_healthcheck",
+        lambda endpoints, base_url: {
+            "results": [{"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 90.0}]
+        },
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_last_endpoint_health", lambda dsn, iid, repo, method, path, target_id=None: None
+    )
+    inserted = []
+    monkeypatch.setattr("scan_worker.jobs.insert_endpoint_health", lambda *a, **k: inserted.append(a))
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: None)
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    # Installation 2's target was still processed despite installation 1's
+    # get_latest_evidence blowing up first in iteration order.
+    assert len(inserted) == 1
+    assert inserted[0][1] == 2
+
+
 def test_sweep_threads_endpoint_source_location_into_alert(monkeypatch):
     sent = _patch_sweep(
         monkeypatch,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -387,7 +387,7 @@ def test_slack_alert_fires_on_paid_install_with_webhook_url_and_new_secret(
     monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: None)
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row",
-        lambda *a, **k: {"plan": "indie", "webhook_url": "https://hooks.slack.com/x"},
+        lambda *a, **k: {"plan": "air", "webhook_url": "https://hooks.slack.com/x"},
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     sent = {}
@@ -414,7 +414,7 @@ def test_check_run_failure_on_new_secret(bare_repo_with_two_commits, monkeypatch
     monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     created = {}
     monkeypatch.setattr(
@@ -432,7 +432,7 @@ def test_check_run_failure_on_new_secret(bare_repo_with_two_commits, monkeypatch
 
 def test_maybe_create_regression_risk_check_run_creates_neutral_check_run(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr(
         "scan_worker.jobs.list_recent_endpoint_incidents",
         lambda *a, **k: [
@@ -479,7 +479,7 @@ def test_maybe_create_regression_risk_check_run_creates_neutral_check_run(monkey
 
 def test_maybe_create_regression_risk_check_run_skips_when_no_incidents(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.list_recent_endpoint_incidents", lambda *a, **k: [])
     created = []
     monkeypatch.setattr("scan_worker.jobs.create_check_run", lambda *a, **k: created.append(True))
@@ -525,7 +525,7 @@ def test_maybe_create_regression_risk_check_run_skips_free_plan(monkeypatch):
 
 def test_managed_audit_api_job_returns_report_text(monkeypatch):
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -546,7 +546,7 @@ def test_managed_audit_api_job_returns_report_text(monkeypatch):
 
 def test_managed_audit_api_job_signs_and_persists_the_report(monkeypatch):
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -582,7 +582,7 @@ def test_managed_audit_api_job_signs_and_persists_the_report(monkeypatch):
 
 def test_managed_audit_api_job_still_returns_report_when_signing_fails(monkeypatch):
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -609,7 +609,7 @@ def test_managed_audit_api_job_still_returns_report_when_signing_fails(monkeypat
 
 def test_managed_audit_api_job_raises_when_spend_cap_reached(monkeypatch):
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 999.0)
@@ -655,7 +655,7 @@ def test_managed_audit_pr_job_clones_pr_head_runs_audit_and_replies(monkeypatch,
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
@@ -712,7 +712,7 @@ def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_pat
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
@@ -777,7 +777,7 @@ def test_managed_audit_pr_job_still_posts_report_when_signing_fails(monkeypatch,
     )
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
@@ -836,7 +836,7 @@ def test_managed_audit_pr_job_skips_llm_call_when_spend_cap_reached(monkeypatch,
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
@@ -892,7 +892,7 @@ def test_managed_audit_pr_job_skips_llm_call_when_rate_limited(monkeypatch, tmp_
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
@@ -939,7 +939,7 @@ def test_flash_review_job_skips_free_tier(monkeypatch):
 def test_flash_review_job_skips_when_debounced(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: False
@@ -957,7 +957,7 @@ def test_flash_review_job_skips_when_debounced(monkeypatch):
 def test_flash_review_job_skips_when_spend_cap_reached(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
@@ -978,7 +978,7 @@ def test_flash_review_job_skips_when_spend_cap_reached(monkeypatch):
 def test_flash_review_job_skips_when_monthly_review_count_reached(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
@@ -1003,7 +1003,7 @@ def test_flash_review_job_skips_when_monthly_review_count_reached(monkeypatch):
 def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
@@ -1041,7 +1041,7 @@ def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
 def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
@@ -1100,7 +1100,7 @@ def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkey
     # symbol's real source into review_diff, not just that the pure
     # function (already covered in test_flash_review.py) works in isolation.
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -1169,7 +1169,7 @@ def test_flash_review_job_passes_changed_file_contents_to_review_diff(monkeypatc
     # flash_review.py). review_diff can only catch that if it's actually
     # given the changed files' real content to check citations against.
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -1209,7 +1209,7 @@ def test_flash_review_job_passes_changed_file_contents_to_review_diff(monkeypatc
 def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestion_syntax(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
@@ -1251,7 +1251,7 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
 def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
@@ -1309,7 +1309,7 @@ def test_run_live_wiki_full_build_job_skips_model_call_on_cache_hit(monkeypatch)
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr(
         "scan_worker.jobs.lookup_cached_result",
         lambda *a, **k: ({"description": "Cached, verified description.", "files": []}, "deepseek-v4-pro"),
@@ -1530,7 +1530,7 @@ def test_sweep_attaches_recent_commit_on_confirmed_down(monkeypatch):
             "response_shape": None,
         },
     )
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr(
         "scan_worker.jobs._commit_attachment_from_graph",
         lambda installation_id, repo_full_name, source_file: {
@@ -1589,7 +1589,7 @@ def test_sweep_alerts_without_commit_when_correlation_fails(monkeypatch):
             "response_shape": None,
         },
     )
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
 
     def _raise(*a, **k):
         raise RuntimeError("github api unavailable")
@@ -1609,7 +1609,7 @@ def test_run_runtime_event_job_sends_alert_with_resolved_chain(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row",
-        lambda *a, **k: {"plan": "indie", "webhook_url": "https://hooks.slack.com/runtime"},
+        lambda *a, **k: {"plan": "air", "webhook_url": "https://hooks.slack.com/runtime"},
     )
     monkeypatch.setattr(
         "scan_worker.jobs._latest_evidence_or_none",
@@ -1663,7 +1663,7 @@ def test_run_runtime_event_job_skips_free_plan(monkeypatch):
 
 def test_run_runtime_event_job_skips_when_no_webhook_configured(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._attach_recent_commit_for_failure", lambda *a, **k: None)
     called = []
@@ -1992,7 +1992,7 @@ def test_maybe_update_live_wiki_skips_when_no_clusters_affected(monkeypatch):
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     called = []
     monkeypatch.setattr(
         "scan_worker.live_wiki.generate_subsystems", lambda *a, **k: called.append(1)
@@ -2007,7 +2007,7 @@ def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monke
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
 
     fake_record = {
         "subsystem_id": "0",
@@ -2076,7 +2076,7 @@ def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_wit
 def test_run_pr_scan_job_skips_paid_repo_past_monthly_scan_cap(bare_repo_with_two_commits, monkeypatch):
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: False)
     cloned = []
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: cloned.append(True))
@@ -2132,7 +2132,7 @@ def test_run_pr_scan_job_free_plan_is_not_subject_to_monthly_scan_cap(bare_repo_
 
 def test_flash_review_job_skips_paid_repo_past_monthly_scan_cap(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: False)
     attempted = []
     monkeypatch.setattr(
@@ -2150,7 +2150,7 @@ def test_flash_review_job_skips_paid_repo_past_monthly_scan_cap(monkeypatch):
 
 def test_managed_audit_pr_job_skips_paid_repo_past_monthly_scan_cap(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: False)
     cloned = []
     monkeypatch.setattr("scan_worker.jobs._clone_pr_head", lambda *a, **k: cloned.append(True))
@@ -2187,7 +2187,7 @@ def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"}
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
 
     fake_record = {
@@ -2248,7 +2248,7 @@ def test_run_live_wiki_full_build_job_passes_fetch_line_count_through(monkeypatc
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     sentinel = lambda path: 42  # noqa: E731
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
 
@@ -2273,7 +2273,7 @@ def test_maybe_update_live_wiki_passes_fetch_line_count_through(monkeypatch):
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "indie"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     sentinel = lambda path: 42  # noqa: E731
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
 

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -24,9 +24,7 @@ def test_cost_for_usage_small_real_call():
 
 
 def test_base_cap_for_plan_is_half_of_tier_price():
-    assert base_cap_for_plan("indie") == pytest.approx(14.50)
-    assert base_cap_for_plan("team") == pytest.approx(39.50)
-    assert base_cap_for_plan("enterprise") == pytest.approx(99.50)
+    assert base_cap_for_plan("air") == pytest.approx(14.995)
 
 
 def test_base_cap_for_plan_free_or_unknown_plan_has_no_budget():
@@ -39,7 +37,7 @@ def test_monthly_cap_for_installation_base_only():
 
 
 def test_monthly_cap_for_installation_with_extra_seats():
-    assert monthly_cap_for_installation(7.00, 3) == pytest.approx(13.00)
+    assert monthly_cap_for_installation(7.00, 3) == pytest.approx(18.97)
 
 
 def test_stale_models_returns_empty_when_all_recently_verified():

--- a/github-app/tests/test_paddle_pricing.py
+++ b/github-app/tests/test_paddle_pricing.py
@@ -1,14 +1,23 @@
-from app_server.paddle_pricing import resolve_plan_for_price_id
+from app_server.paddle_pricing import resolve_plan_for_price_id, resolve_price_id_for_plan
 
 
-def test_resolves_all_six_real_price_ids():
-    assert resolve_plan_for_price_id("pri_01ky9jwz35hvj5xs6f8xqw6htt") == "indie"
-    assert resolve_plan_for_price_id("pri_01ky9jwzd6k9rhmnj8b4drbygg") == "indie"
-    assert resolve_plan_for_price_id("pri_01ky9jx0gbx02mnn4d166yp3vc") == "team"
-    assert resolve_plan_for_price_id("pri_01ky9jx0rkkkz75atfb29me9mn") == "team"
-    assert resolve_plan_for_price_id("pri_01ky9jx1bkbbkfd9zspcgzd7p8") == "enterprise"
-    assert resolve_plan_for_price_id("pri_01ky9jx1pbbpsexbmtbk1wfej1") == "enterprise"
+def test_resolves_both_real_air_price_ids():
+    assert resolve_plan_for_price_id("pri_01kyhevc8bkcghfpwjymz16y2h") == "air"
+    assert resolve_plan_for_price_id("pri_01kyhevc9xn6z2nghmy8057jvp") == "air"
 
 
 def test_unknown_price_id_returns_none():
     assert resolve_plan_for_price_id("pri_totally_unknown") is None
+
+
+def test_resolve_price_id_for_plan_round_trips_both_intervals():
+    monthly = resolve_price_id_for_plan("air", "month")
+    annual = resolve_price_id_for_plan("air", "year")
+    assert resolve_plan_for_price_id(monthly) == "air"
+    assert resolve_plan_for_price_id(annual) == "air"
+    assert monthly != annual
+
+
+def test_resolve_price_id_for_plan_returns_none_for_unknown_plan_or_interval():
+    assert resolve_price_id_for_plan("free", "month") is None
+    assert resolve_price_id_for_plan("air", "week") is None

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -27,8 +27,22 @@ def _subscription_created_payload(price_id: str, installation_id: int) -> dict:
         "data": {
             "id": "sub_test_123",
             "customer_id": "ctm_test_456",
+            "status": "active",
             "custom_data": {"installation_id": str(installation_id)},
             "items": [{"price": {"id": price_id}}],
+        },
+    }
+
+
+def _subscription_event_payload(event_type: str, status: str, installation_id: int, price_id: str | None = None) -> dict:
+    return {
+        "event_type": event_type,
+        "data": {
+            "id": "sub_test_123",
+            "customer_id": "ctm_test_456",
+            "status": status,
+            "custom_data": {"installation_id": str(installation_id)},
+            "items": [{"price": {"id": price_id}}] if price_id else [],
         },
     }
 
@@ -162,3 +176,98 @@ async def test_replaying_subscription_created_only_triggers_wiki_build_once(pool
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
 
     fake_queue.enqueue.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_subscription_canceled_revokes_to_free(pool):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (300, 'acme', 'indie')"
+    )
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 300)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 300)
+    assert installation["plan"] == "free"
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscription_paused_revokes_to_free(pool):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (301, 'acme', 'team')"
+    )
+    payload = _subscription_event_payload("subscription.paused", "paused", 301)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 301)
+    assert installation["plan"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_subscription_past_due_revokes_to_free(pool):
+    # No dunning-aware grace tier yet - a lapsed payment cuts access
+    # immediately rather than silently continuing to grant it.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (302, 'acme', 'indie')"
+    )
+    payload = _subscription_event_payload("subscription.updated", "past_due", 302)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 302)
+    assert installation["plan"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_downgrades_between_paid_tiers(pool):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (303, 'acme', 'team')"
+    )
+    payload = _subscription_event_payload(
+        "subscription.updated", "active", 303, price_id="pri_01ky9jwz35hvj5xs6f8xqw6htt"
+    )
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 303)
+    assert installation["plan"] == "indie"
+    # Paid-to-paid change must not re-trigger the one-time wiki build.
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscription_resumed_restores_paid_access(pool):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (304, 'acme', 'free')"
+    )
+    payload = _subscription_event_payload(
+        "subscription.resumed", "active", 304, price_id="pri_01ky9jwz35hvj5xs6f8xqw6htt"
+    )
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 304)
+    assert installation["plan"] == "indie"
+    # Resuming after a cancellation is a free -> paid transition again,
+    # so the one-time wiki build fires once more.
+    fake_queue.enqueue.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unhandled_event_type_is_ignored(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (305, 'acme', 'indie')"
+    )
+    payload = _subscription_event_payload("transaction.completed", "completed", 305)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    installation = await get_installation(pool, 305)
+    assert installation["plan"] == "indie"

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -54,12 +54,12 @@ async def test_valid_subscription_created_updates_installation_plan(pool, monkey
     await pool.execute(
         "INSERT INTO installations (installation_id, account_login, plan) VALUES (100, 'acme', 'free')"
     )
-    body = json.dumps(_subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", 100)).encode()
+    body = json.dumps(_subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 100)).encode()
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
     assert response.status_code == 200
     installation = await get_installation(pool, 100)
-    assert installation["plan"] == "indie"
+    assert installation["plan"] == "air"
     assert installation["paddle_subscription_id"] == "sub_test_123"
     assert installation["paddle_customer_id"] == "ctm_test_456"
 
@@ -71,7 +71,7 @@ async def test_invalid_signature_rejected_with_no_write(pool, monkeypatch):
     await pool.execute(
         "INSERT INTO installations (installation_id, account_login, plan) VALUES (101, 'acme', 'free')"
     )
-    body = json.dumps(_subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", 101)).encode()
+    body = json.dumps(_subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 101)).encode()
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post(
             "/webhooks/paddle", content=body, headers={"paddle-signature": "ts=1;h1=deadbeef"}
@@ -84,7 +84,7 @@ async def test_invalid_signature_rejected_with_no_write(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_missing_signature_header_rejected(pool):
     app.state.db_pool = pool
-    body = json.dumps(_subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", 102)).encode()
+    body = json.dumps(_subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 102)).encode()
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/webhooks/paddle", content=body)
     assert response.status_code == 401
@@ -109,7 +109,7 @@ async def test_unknown_price_id_returns_200_but_writes_nothing(pool, monkeypatch
 async def test_missing_installation_id_returns_200_but_writes_nothing(pool, monkeypatch):
     monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
     app.state.db_pool = pool
-    payload = _subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", 104)
+    payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 104)
     del payload["data"]["custom_data"]["installation_id"]
     body = json.dumps(payload).encode()
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -124,7 +124,7 @@ async def test_duplicate_delivery_is_idempotent(pool, monkeypatch):
     await pool.execute(
         "INSERT INTO installations (installation_id, account_login, plan) VALUES (105, 'acme', 'free')"
     )
-    body = json.dumps(_subscription_created_payload("pri_01ky9jx0gbx02mnn4d166yp3vc", 105)).encode()
+    body = json.dumps(_subscription_created_payload("pri_01kyhevc9xn6z2nghmy8057jvp", 105)).encode()
     headers = {"paddle-signature": _sign(body)}
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         r1 = await client.post("/webhooks/paddle", content=body, headers=headers)
@@ -132,7 +132,7 @@ async def test_duplicate_delivery_is_idempotent(pool, monkeypatch):
     assert r1.status_code == 200
     assert r2.status_code == 200
     installation = await get_installation(pool, 105)
-    assert installation["plan"] == "team"
+    assert installation["plan"] == "air"
 
 
 @pytest.mark.asyncio
@@ -140,11 +140,11 @@ async def test_free_to_paid_transition_triggers_live_wiki_full_build(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 200, "acme")  # defaults to plan='free'
 
-    payload = _subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", 200)
+    payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 200)
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
 
     installation = await get_installation(pool, 200)
-    assert installation["plan"] == "indie"
+    assert installation["plan"] == "air"
     fake_queue.enqueue.assert_called_once()
     args, kwargs = fake_queue.enqueue.call_args
     assert args[0] == "scan_worker.jobs.run_live_wiki_full_build_for_installation_job"
@@ -155,14 +155,14 @@ async def test_free_to_paid_transition_triggers_live_wiki_full_build(pool):
 async def test_paid_to_paid_change_does_not_retrigger_live_wiki_full_build(pool):
     fake_queue = MagicMock()
     await pool.execute(
-        "INSERT INTO installations (installation_id, account_login, plan) VALUES (201, 'acme', 'indie')"
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (201, 'acme', 'air')"
     )
 
-    payload = _subscription_created_payload("pri_01ky9jx0gbx02mnn4d166yp3vc", 201)
+    payload = _subscription_created_payload("pri_01kyhevc9xn6z2nghmy8057jvp", 201)
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
 
     installation = await get_installation(pool, 201)
-    assert installation["plan"] == "team"
+    assert installation["plan"] == "air"
     fake_queue.enqueue.assert_not_called()
 
 
@@ -170,7 +170,7 @@ async def test_paid_to_paid_change_does_not_retrigger_live_wiki_full_build(pool)
 async def test_replaying_subscription_created_only_triggers_wiki_build_once(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 202, "acme")  # defaults to plan='free'
-    payload = _subscription_created_payload("pri_01ky9jwz35hvj5xs6f8xqw6htt", 202)
+    payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 202)
 
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
@@ -182,7 +182,7 @@ async def test_replaying_subscription_created_only_triggers_wiki_build_once(pool
 async def test_subscription_canceled_revokes_to_free(pool):
     fake_queue = MagicMock()
     await pool.execute(
-        "INSERT INTO installations (installation_id, account_login, plan) VALUES (300, 'acme', 'indie')"
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (300, 'acme', 'air')"
     )
     payload = _subscription_event_payload("subscription.canceled", "canceled", 300)
 
@@ -197,7 +197,7 @@ async def test_subscription_canceled_revokes_to_free(pool):
 async def test_subscription_paused_revokes_to_free(pool):
     fake_queue = MagicMock()
     await pool.execute(
-        "INSERT INTO installations (installation_id, account_login, plan) VALUES (301, 'acme', 'team')"
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (301, 'acme', 'air')"
     )
     payload = _subscription_event_payload("subscription.paused", "paused", 301)
 
@@ -213,7 +213,7 @@ async def test_subscription_past_due_revokes_to_free(pool):
     # immediately rather than silently continuing to grant it.
     fake_queue = MagicMock()
     await pool.execute(
-        "INSERT INTO installations (installation_id, account_login, plan) VALUES (302, 'acme', 'indie')"
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (302, 'acme', 'air')"
     )
     payload = _subscription_event_payload("subscription.updated", "past_due", 302)
 
@@ -224,20 +224,21 @@ async def test_subscription_past_due_revokes_to_free(pool):
 
 
 @pytest.mark.asyncio
-async def test_subscription_updated_downgrades_between_paid_tiers(pool):
+async def test_subscription_updated_refreshes_plan_without_retriggering_wiki_build(pool):
     fake_queue = MagicMock()
     await pool.execute(
-        "INSERT INTO installations (installation_id, account_login, plan) VALUES (303, 'acme', 'team')"
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (303, 'acme', 'air')"
     )
     payload = _subscription_event_payload(
-        "subscription.updated", "active", 303, price_id="pri_01ky9jwz35hvj5xs6f8xqw6htt"
+        "subscription.updated", "active", 303, price_id="pri_01kyhevc9xn6z2nghmy8057jvp"
     )
 
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
 
     installation = await get_installation(pool, 303)
-    assert installation["plan"] == "indie"
-    # Paid-to-paid change must not re-trigger the one-time wiki build.
+    assert installation["plan"] == "air"
+    # Paid-to-paid change (e.g. switching monthly <-> annual) must not
+    # re-trigger the one-time wiki build.
     fake_queue.enqueue.assert_not_called()
 
 
@@ -248,13 +249,13 @@ async def test_subscription_resumed_restores_paid_access(pool):
         "INSERT INTO installations (installation_id, account_login, plan) VALUES (304, 'acme', 'free')"
     )
     payload = _subscription_event_payload(
-        "subscription.resumed", "active", 304, price_id="pri_01ky9jwz35hvj5xs6f8xqw6htt"
+        "subscription.resumed", "active", 304, price_id="pri_01kyhevc8bkcghfpwjymz16y2h"
     )
 
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
 
     installation = await get_installation(pool, 304)
-    assert installation["plan"] == "indie"
+    assert installation["plan"] == "air"
     # Resuming after a cancellation is a free -> paid transition again,
     # so the one-time wiki build fires once more.
     fake_queue.enqueue.assert_called_once()
@@ -263,11 +264,11 @@ async def test_subscription_resumed_restores_paid_access(pool):
 @pytest.mark.asyncio
 async def test_unhandled_event_type_is_ignored(pool):
     await pool.execute(
-        "INSERT INTO installations (installation_id, account_login, plan) VALUES (305, 'acme', 'indie')"
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (305, 'acme', 'air')"
     )
     payload = _subscription_event_payload("transaction.completed", "completed", 305)
 
     await handle_paddle_webhook_event(payload, pool, "redis://unused")
 
     installation = await get_installation(pool, 305)
-    assert installation["plan"] == "indie"
+    assert installation["plan"] == "air"


### PR DESCRIPTION
## Summary
- Paddle webhooks now handle the full subscription lifecycle (created/updated/canceled/paused/resumed), not just created - a cancellation or lapsed payment previously left an installation with paid access forever.
- `run_health_check_sweep_job` no longer lets one installation's failure (e.g. a dead webhook URL) skip every other installation's health checks for that sweep cycle.
- Collapsed indie/team/enterprise into a single paid tier: **Aletheore AIR** ($29.99/mo or $299.90/yr, live Paddle price ids created this session), with the free tier now branded **Aletheore Community**. Updated paddle_pricing.py, llm_cost.py, db.py's seat/health-target limits, and frontend.py's plan display text accordingly. New migration converts any installation still on an old plan string to `air`.
- Fixed `/subscribe` (the page most tied to revenue) still using the pre-refresh bare token check instead of the session-refresh-aware helper built earlier this session - a customer with a refreshable-but-expired token was getting logged out mid-checkout instead of transparently refreshed.

## Test plan
- [x] Full github-app test suite passes (653 passed, 7 skipped)