### PR TITLE
Fix marketing site for AIR launch, correct payment processor name

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -11,12 +11,12 @@
   <meta property="og:site_name" content="Aletheore">
   <meta property="og:url" content="https://www.aletheore.com/">
   <meta property="og:title" content="Aletheore — Evidence-Grounded Code Audits &amp; GitHub Automation">
-  <meta property="og:description" content="Aletheore is more than a scanner. Free deterministic CLI audits (secrets, vulnerabilities, licenses, dead code, git hotspots) plus a hosted GitHub App: automated PR reviews, live endpoint health monitoring, AIRview (an AI-generated, always-current map of your repo's architecture), Slack/Teams alerts, and team seat management.">
+  <meta property="og:description" content="Aletheore is more than a scanner. Free deterministic CLI audits (secrets, vulnerabilities, licenses, dead code, git hotspots) plus a hosted GitHub App: automated PR reviews, live endpoint health monitoring, AIRview (an AI-generated, always-current map of your repo's architecture), Slack/Teams alerts, and team seat management on Aletheore AIR.">
   <meta property="og:image" content="https://www.aletheore.com/assets/logo-mark.png">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Aletheore — Evidence-Grounded Code Audits &amp; GitHub Automation">
-  <meta name="twitter:description" content="Free deterministic CLI scanning plus a hosted GitHub App: dead code detection, live endpoint monitoring, AIRview architecture maps, automated PR reviews, and Slack/Teams alerts.">
+  <meta name="twitter:description" content="Free deterministic CLI scanning (Aletheore Community) plus a hosted GitHub App on Aletheore AIR: dead code detection, live endpoint monitoring, AIRview architecture maps, automated PR reviews, and Slack/Teams alerts.">
   <meta name="twitter:image" content="https://www.aletheore.com/assets/logo-mark.png">
 
   <link rel="icon" type="image/png" href="assets/logo-mark.png">
@@ -33,30 +33,16 @@
     "offers": [
       {
         "@type": "Offer",
-        "name": "Free",
+        "name": "Aletheore Community",
         "price": "0",
         "priceCurrency": "USD"
       },
       {
         "@type": "Offer",
-        "name": "Indie",
-        "price": "29",
+        "name": "Aletheore AIR",
+        "price": "29.99",
         "priceCurrency": "USD",
-        "description": "Up to 3 team members. Managed audits and AIRview builds run on DeepSeek."
-      },
-      {
-        "@type": "Offer",
-        "name": "Team",
-        "price": "79",
-        "priceCurrency": "USD",
-        "description": "Up to 10 team members. Managed audits and AIRview builds run on GPT-4o."
-      },
-      {
-        "@type": "Offer",
-        "name": "Enterprise",
-        "price": "199",
-        "priceCurrency": "USD",
-        "description": "Up to 25 team members. Managed audits and AIRview builds run on Claude Opus."
+        "description": "Up to 5 team members. Managed audits and AIRview builds run on DeepSeek Pro."
       }
     ],
     "featureList": [
@@ -68,12 +54,12 @@
       "MCP server for coding agents",
       "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, Ollama)",
       "GitHub App: automatic PR comments and branch-protection check runs",
-      "AI-powered managed audit reports on pull requests, model quality scaling with plan tier",
+      "AI-powered managed audit reports on pull requests, written by DeepSeek Pro",
       "Automatic Flash reviews on every pull request push",
       "Slack/Teams alerts on new findings",
       "Live API endpoint health monitoring across multiple targets, with a public status API",
       "AIRview: an AI-generated, always-current map of your repo's architecture with dependency diagrams",
-      "Team seat management, seat capacity increasing with plan tier"
+      "Team seat management, up to 5 seats included on Aletheore AIR"
     ]
   }
   </script>

--- a/website/paddle-checkout.js
+++ b/website/paddle-checkout.js
@@ -1,19 +1,11 @@
 // Paddle checkout wiring for the pricing page.
-const PADDLE_ENVIRONMENT = "sandbox";
-const PADDLE_CLIENT_TOKEN = "test_4c86268368fd75d088763f49248";
+const PADDLE_ENVIRONMENT = "production";
+const PADDLE_CLIENT_TOKEN = "live_e7aef6edd9b215cd9059dab0c3d";
 
 const TIERS = {
-  indie: {
-    name: "Indie",
-    priceId: { month: "pri_01ky9jwz35hvj5xs6f8xqw6htt", year: "pri_01ky9jwzd6k9rhmnj8b4drbygg" },
-  },
-  team: {
-    name: "Team",
-    priceId: { month: "pri_01ky9jx0gbx02mnn4d166yp3vc", year: "pri_01ky9jx0rkkkz75atfb29me9mn" },
-  },
-  enterprise: {
-    name: "Enterprise",
-    priceId: { month: "pri_01ky9jx1bkbbkfd9zspcgzd7p8", year: "pri_01ky9jx1pbbpsexbmtbk1wfej1" },
+  air: {
+    name: "Aletheore AIR",
+    priceId: { month: "pri_01kyhevc8bkcghfpwjymz16y2h", year: "pri_01kyhevc9xn6z2nghmy8057jvp" },
   },
 };
 

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pricing — Aletheore</title>
-  <meta name="description" content="Free deterministic CLI scanning forever. Indie, Team, and Enterprise add managed AI audits, AIRview, live endpoint monitoring, and team seats - model quality and seats scale with plan.">
+  <meta name="description" content="Aletheore Community: free deterministic CLI scanning forever. Aletheore AIR ($29.99/mo): managed AI audits, AIRview, live endpoint monitoring, automated PR reviews, and team seats.">
   <link rel="canonical" href="https://www.aletheore.com/pricing">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Aletheore">
   <meta property="og:url" content="https://www.aletheore.com/pricing">
   <meta property="og:title" content="Pricing — Aletheore">
-  <meta property="og:description" content="Free deterministic CLI scanning forever. Indie, Team, and Enterprise add managed AI audits, AIRview, live endpoint monitoring, and team seats - model quality and seats scale with plan.">
+  <meta property="og:description" content="Aletheore Community: free deterministic CLI scanning forever. Aletheore AIR ($29.99/mo): managed AI audits, AIRview, live endpoint monitoring, automated PR reviews, and team seats.">
   <meta property="og:image" content="https://www.aletheore.com/assets/logo-mark.png">
   <link rel="icon" type="image/png" href="assets/logo-mark.png">
   <link rel="stylesheet" href="styles.css">
@@ -35,7 +35,7 @@
 
     <section class="pricing-hero">
       <h1>Simple, honest pricing.</h1>
-      <p class="section-intro">The deterministic scanner is free forever. Indie, Team, and Enterprise add managed AI audits and AIRview - the model writing them, and the seats included, scale with plan.</p>
+      <p class="section-intro">Aletheore Community is the deterministic scanner, free forever. Aletheore AIR adds managed AI audits, AIRview, automated PR reviews, endpoint monitoring, and team seats.</p>
 
       <div class="billing-toggle" role="group" aria-label="Billing interval">
         <button type="button" data-interval="month" class="active">Monthly</button>
@@ -44,7 +44,7 @@
 
       <div class="pricing-grid">
         <article class="price-card">
-          <h3>Free</h3>
+          <h3>Aletheore Community</h3>
           <div class="price-now">$0</div>
           <div class="price-sub">forever</div>
           <ul>
@@ -55,44 +55,20 @@
           </ul>
         </article>
 
-        <article class="price-card" data-tier="indie">
-          <h3>Indie</h3>
-          <div class="price-now">$29</div>
-          <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 3 team members</div>
+        <article class="price-card pro" data-tier="air">
+          <h3>Aletheore AIR</h3>
+          <div class="price-now">$29.99</div>
+          <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 5 team members</div>
           <ul>
-            <li>Everything in Free.</li>
-            <li>Managed audits and AIRview, written by DeepSeek.</li>
+            <li>Everything in Community.</li>
+            <li>Managed audits and AIRview, written by DeepSeek Pro.</li>
             <li>Automatic Flash reviews on every push to an open pull request.</li>
             <li>Slack / Teams alerts on new findings.</li>
             <li>Branch-protection Check Runs for new secrets.</li>
             <li>Endpoint health monitoring across multiple targets, with a public status API.</li>
             <li>+$3.99/mo per additional team member.</li>
           </ul>
-          <button type="button" class="btn btn-primary" data-subscribe="indie">Subscribe</button>
-        </article>
-
-        <article class="price-card pro" data-tier="team">
-          <h3>Team</h3>
-          <div class="price-now">$79</div>
-          <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 10 team members</div>
-          <ul>
-            <li>Everything in Indie.</li>
-            <li>Managed audits and AIRview, written by GPT-4o.</li>
-            <li>+$3.99/mo per additional team member.</li>
-          </ul>
-          <button type="button" class="btn btn-primary" data-subscribe="team">Subscribe</button>
-        </article>
-
-        <article class="price-card" data-tier="enterprise">
-          <h3>Enterprise</h3>
-          <div class="price-now">$199</div>
-          <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 25 team members</div>
-          <ul>
-            <li>Everything in Team.</li>
-            <li>Managed audits and AIRview, written by Claude Opus.</li>
-            <li>+$3.99/mo per additional team member.</li>
-          </ul>
-          <button type="button" class="btn btn-primary" data-subscribe="enterprise">Subscribe</button>
+          <button type="button" class="btn btn-primary" data-subscribe="air">Subscribe</button>
         </article>
       </div>
       <p class="section-intro" style="margin-top: 28px;">

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -30,8 +30,8 @@
       <h2>The free CLI</h2>
       <p>Running <code>aletheore scan</code> locally sends nothing to Aletheore's servers. Evidence is written to your own machine. If you use an AI-assisted audit command, evidence, not source code, is sent to whichever LLM provider you configure, using your own API key.</p>
 
-      <h2>The GitHub App paid tiers</h2>
-      <p>Installing the GitHub App is a different trust boundary. Source code is transiently cloned to run a scan, then immediately discarded. Only derived evidence, such as secrets findings, dependency graphs, and endpoint health rows, is stored. Managed audit and AIRview runs send evidence, not source code, to the LLM provider your plan uses (DeepSeek, OpenAI, or Anthropic, depending on tier - see <a href="pricing.html">Pricing</a>), using our shared key.</p>
+      <h2>The GitHub App (Aletheore AIR)</h2>
+      <p>Installing the GitHub App is a different trust boundary. Source code is transiently cloned to run a scan, then immediately discarded. Only derived evidence, such as secrets findings, dependency graphs, and endpoint health rows, is stored. Managed audit and AIRview runs send evidence, not source code, to our LLM provider (DeepSeek), using our shared key.</p>
 
       <h2>What we store</h2>
       <p>For paid installations: your GitHub account or organization identity, evidence snapshots from scans, and, if configured, a Slack/Teams webhook URL and health-check monitoring settings. We do not sell this data or share it beyond the service providers necessary to run Aletheore, including our LLM provider for managed audits and our payment provider for billing.</p>

--- a/website/refund.html
+++ b/website/refund.html
@@ -34,7 +34,7 @@
       <p>Subscriptions can be cancelled at any time and will remain active until the end of the current billing period. We do not offer prorated refunds for partial months after the initial 14-day window, since the plan gives you continued access through the period you already paid for.</p>
 
       <h2>How to request one</h2>
-      <p>Email <a href="mailto:arihantkaul@outlook.com">arihantkaul@outlook.com</a> with your GitHub organization or account name. Refunds are processed through Lemon Squeezy back to your original payment method.</p>
+      <p>Email <a href="mailto:arihantkaul@outlook.com">arihantkaul@outlook.com</a> with your GitHub organization or account name. Refunds are processed through Paddle back to your original payment method.</p>
     </main>
   </div>
   <script src="vendor/motion.js"></script>

--- a/website/terms.html
+++ b/website/terms.html
@@ -31,7 +31,7 @@
       <p>Aletheore is a repository audit tool: a free, open-source, local-first CLI and a paid GitHub App tier for managed audits, Slack/Teams alerts, branch-protection Check Runs, and endpoint health monitoring. The free tier is available under the terms of its open-source license in the project repository.</p>
 
       <h2>The paid subscription</h2>
-      <p>Paid plans are Indie ($29/month, up to 3 team members), Team ($79/month, up to 10 team members), and Enterprise ($199/month, up to 25 team members), with additional members beyond a plan's included seats billed at $3.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Lemon Squeezy, acting as merchant of record. By subscribing, you agree to Lemon Squeezy's own terms of service in addition to these.</p>
+      <p>The paid plan is Aletheore AIR ($29.99/month or $299.90/year, up to 5 team members), with additional members beyond the plan's included seats billed at $3.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>
 
       <h2>Acceptable use</h2>
       <p>You may not use Aletheore to scan repositories you do not have the right to scan, or to circumvent security measures of systems you do not own or have explicit permission to test.</p>


### PR DESCRIPTION
## Summary
- `website/pricing.html`, `website/index.html` (JSON-LD offers + copy) updated from Indie/Team/Enterprise to the single Aletheore Community (free) / Aletheore AIR ($29.99/mo, $299.90/yr) model.
- `website/paddle-checkout.js` was still hardcoded to Paddle **sandbox** environment/client token and the old 3-tier price ID map - this was actively broken: clicking Subscribe passed an old plan key (`indie`/`team`/`enterprise`) to `app.aletheore.com/subscribe`, which now only accepts `air` and would 400. Fixed to production environment, the real live client token, and the real AIR price ids.
- `website/terms.html` and `website/refund.html` both named "Lemon Squeezy" as the payment processor/merchant of record - corrected to Paddle (the processor actually in use).
- `website/privacy.html` updated the paid-tier LLM-provider description (was "DeepSeek, OpenAI, or Anthropic depending on tier" - now always DeepSeek, matching the single-tier model).

## Test plan
- [x] JS syntax check passes (`node -c paddle-checkout.js`)
- [x] All HTML files have balanced tags and valid JSON-LD
- [x] Grepped the whole website/ directory for any remaining indie/team/enterprise/Lemon Squeezy references - none found