### PR TITLE
Reliability/security hardening: scan-on-connect, silent failures, Paddle 500s, key hygiene

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import logging
 import secrets
 
 import httpx
@@ -36,6 +37,7 @@ from app_server.db import (
 from app_server.url_validation import UnsafeURLError, validate_external_https_url
 
 admin_router = APIRouter()
+logger = logging.getLogger(__name__)
 
 # No control characters (including newlines/tabs) or DEL - a label is a
 # single line of display text stored verbatim and shown back in the admin
@@ -150,6 +152,9 @@ async def _try_refresh_session_token(pool, session: dict) -> str | None:
             settings.github_client_secret,
         )
     except Exception:
+        logger.warning(
+            "GitHub token refresh failed for session %s", session["id"], exc_info=True
+        )
         return None
 
     await update_session_tokens(

--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import hashlib
 import hmac
 import logging
 import secrets
@@ -8,6 +7,8 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from itsdangerous import BadSignature, URLSafeTimedSerializer
@@ -26,8 +27,24 @@ auth_router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+def _derive_key(session_secret: str, purpose: bytes, length: int = 32) -> bytes:
+    """One root SESSION_SECRET, cryptographically independent subkeys per
+    purpose - encrypting stored GitHub tokens and signing session/oauth
+    cookies used to share raw key material, so anything that weakened one
+    (a side channel, a future flaw in either primitive) could compromise
+    the other for no reason beyond convenience.
+    """
+    return HKDF(algorithm=hashes.SHA256(), length=length, salt=None, info=purpose).derive(
+        session_secret.encode()
+    )
+
+
 def _fernet_key(session_secret: str) -> bytes:
-    return base64.urlsafe_b64encode(hashlib.sha256(session_secret.encode()).digest())
+    return base64.urlsafe_b64encode(_derive_key(session_secret, b"aletheore-token-encryption"))
+
+
+def _signing_secret(session_secret: str) -> str:
+    return _derive_key(session_secret, b"aletheore-cookie-signing").hex()
 
 
 def encrypt_access_token(access_token: str, session_secret: str) -> str:
@@ -106,12 +123,12 @@ def _fetch_installation_details(installation_id: int, app_jwt: str) -> dict:
 
 
 def sign_session_id(session_id: str, secret: str) -> str:
-    return URLSafeTimedSerializer(secret).dumps(session_id)
+    return URLSafeTimedSerializer(_signing_secret(secret)).dumps(session_id)
 
 
 def unsign_session_id(signed: str, secret: str) -> str | None:
     try:
-        return URLSafeTimedSerializer(secret).loads(
+        return URLSafeTimedSerializer(_signing_secret(secret)).loads(
             signed,
             max_age=int(SESSION_TTL.total_seconds()),
         )
@@ -120,12 +137,12 @@ def unsign_session_id(signed: str, secret: str) -> str | None:
 
 
 def sign_oauth_state(state: str, secret: str) -> str:
-    return URLSafeTimedSerializer(secret, salt="oauth-state").dumps(state)
+    return URLSafeTimedSerializer(_signing_secret(secret), salt="oauth-state").dumps(state)
 
 
 def unsign_oauth_state(signed: str, secret: str) -> str | None:
     try:
-        return URLSafeTimedSerializer(secret, salt="oauth-state").loads(
+        return URLSafeTimedSerializer(_signing_secret(secret), salt="oauth-state").loads(
             signed,
             max_age=int(OAUTH_STATE_TTL.total_seconds()),
         )

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -20,6 +20,7 @@ from app_server.db import (
     get_latest_evidence,
     get_recent_endpoint_health,
     get_recent_history,
+    get_wiki_build_status,
     get_wiki_overview,
     get_wiki_subsystem,
     list_repos_for_installations,
@@ -247,10 +248,14 @@ async def get_dashboard_wiki(org: str, repo: str, request: Request):
     if overview is not None:
         overview["updated_at"] = overview["updated_at"].isoformat()
 
+    build_status = await get_wiki_build_status(pool, installation_id, repo_full_name)
+
     subsystems = await list_wiki_subsystems(pool, installation_id, repo_full_name)
     return {
         "repo_full_name": repo_full_name,
         "overview": overview,
+        "build_status": build_status["status"] if build_status is not None else None,
+        "build_error": build_status["error_message"] if build_status is not None else None,
         "subsystems": [
             {
                 "subsystem_id": s["subsystem_id"],

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -678,6 +678,19 @@ async def list_repos_for_installations(pool: asyncpg.Pool, installation_ids: lis
     return [dict(row) for row in rows]
 
 
+async def get_wiki_build_status(pool: asyncpg.Pool, installation_id: int, repo_full_name: str) -> dict | None:
+    row = await pool.fetchrow(
+        """
+        SELECT status, error_message, updated_at
+        FROM wiki_build_status
+        WHERE installation_id = $1 AND repo_full_name = $2
+        """,
+        installation_id,
+        repo_full_name,
+    )
+    return dict(row) if row else None
+
+
 async def get_wiki_overview(pool: asyncpg.Pool, installation_id: int, repo_full_name: str) -> dict | None:
     row = await pool.fetchrow(
         """

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1088,7 +1088,13 @@ async function loadWiki() {{
   if (!res.ok) {{ body.innerHTML = '<div class="empty-state">AIRview unavailable.</div>'; return; }}
   const data = await res.json();
   if (!data.overview) {{
-    body.innerHTML = '<div class="empty-state">AIRview hasn\\'t been built yet - it generates automatically shortly after upgrading.</div>';
+    if (data.build_status === 'failed') {{
+      body.innerHTML = '<div class="empty-state">AIRview build failed' +
+        (data.build_error ? ': ' + escapeHtml(data.build_error) : '.') +
+        ' Contact support if this persists.</div>';
+    }} else {{
+      body.innerHTML = '<div class="empty-state">AIRview hasn\\'t been built yet - it generates automatically shortly after upgrading.</div>';
+    }}
     return;
   }}
   let html = '<div class="wiki-banner"><div class="wiki-banner-text"><b>Built once by a frontier model, kept current by a fast one.</b> Every diagram edge below is a real import in this repo, never inferred.</div></div>' +

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -798,6 +798,13 @@ HEALTH_HTML = _page_head("Endpoint health — {repo} — Aletheore") + _shell(
       </div>
       <div class="section-body" id="health-body"><div class="empty-state">Loading&hellip;</div></div>
     </section>
+    <section class="section" id="stale-endpoints-section" style="display:none;">
+      <div class="section-head">
+        <div class="section-title"><i class="ti ti-alert-triangle" aria-hidden="true"></i>Never reachable</div>
+        <span class="section-sub">Found in code, checked repeatedly, never once returned successfully</span>
+      </div>
+      <div class="section-body" id="stale-endpoints-body"></div>
+    </section>
 """
 ) + f"""
 <script>
@@ -915,6 +922,25 @@ async function loadResults() {{
     html += '</div></div>';
   }});
   body.innerHTML = html;
+
+  const staleEndpoints = data.stale_endpoints || [];
+  const staleSection = document.getElementById('stale-endpoints-section');
+  const staleBody = document.getElementById('stale-endpoints-body');
+  if (staleEndpoints.length === 0) {{
+    staleSection.style.display = 'none';
+  }} else {{
+    staleSection.style.display = '';
+    let staleHtml = '<div class="health-grid">';
+    staleEndpoints.forEach(function (e) {{
+      const location = e.file ? escapeHtml(e.file) + (e.line ? ':' + e.line : '') : '';
+      staleHtml += '<div class="health-row"><span class="chip warning">Never reachable</span>' +
+        '<span class="health-endpoint">' + escapeHtml(e.method) + ' ' + escapeHtml(e.path) + '</span>' +
+        (location ? '<span class="health-checked">' + location + '</span>' : '') +
+        '<span class="health-checked">' + e.check_count + ' checks</span></div>';
+    }});
+    staleHtml += '</div>';
+    staleBody.innerHTML = staleHtml;
+  }}
 }}
 
 loadTargets();

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -130,7 +130,7 @@ async def webhook(request: Request):
     pool = request.app.state.db_pool
 
     if event in ("installation", "installation_repositories"):
-        await handle_installation_event(event, payload, pool)
+        await handle_installation_event(event, payload, pool, settings.redis_url)
     elif event == "marketplace_purchase":
         from app_server.webhooks.marketplace import handle_marketplace_event
 

--- a/github-app/app_server/paddle_webhook_verify.py
+++ b/github-app/app_server/paddle_webhook_verify.py
@@ -26,6 +26,9 @@ def verify_paddle_signature(
     if abs(time.time() - ts) > tolerance_seconds:
         return False
 
-    signed_payload = f"{ts}:{raw_body.decode('utf-8')}"
+    try:
+        signed_payload = f"{ts}:{raw_body.decode('utf-8')}"
+    except UnicodeDecodeError:
+        return False
     expected = hmac.new(secret.encode("utf-8"), signed_payload.encode("utf-8"), hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, h1)

--- a/github-app/app_server/webhooks/installation.py
+++ b/github-app/app_server/webhooks/installation.py
@@ -1,7 +1,32 @@
+import logging
+
+import httpx
+
+from app_server.config import get_settings
 from app_server.db import delete_installation, upsert_installation
+from app_server.github_auth import generate_app_jwt, get_installation_token
+
+logger = logging.getLogger(__name__)
 
 
-async def handle_installation_event(event_name: str, payload: dict, pool) -> None:
+async def _fetch_all_installation_repo_full_names(installation_id: int) -> list[str]:
+    settings = get_settings()
+    app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+    token = await get_installation_token(installation_id, app_jwt)
+    response = httpx.Client(base_url="https://api.github.com").get(
+        "/installation/repositories",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response.raise_for_status()
+    return [repo["full_name"] for repo in response.json().get("repositories", [])]
+
+
+async def handle_installation_event(
+    event_name: str, payload: dict, pool, redis_url: str, queue=None
+) -> None:
     action = payload.get("action")
     installation = payload["installation"]
     installation_id = installation["id"]
@@ -12,3 +37,41 @@ async def handle_installation_event(event_name: str, payload: dict, pool) -> Non
         return
 
     await upsert_installation(pool, installation_id, account_login)
+
+    # Without this, a repo with no open pull requests never gets scanned
+    # at all - run_pr_scan_job is the only other thing that writes a
+    # repo_history row, and it only fires on a PR event. A freshly
+    # connected repo would otherwise sit "Initialization required" on
+    # the dashboard forever, with no feedback or path forward.
+    repo_full_names: list[str] = []
+    if event_name == "installation" and action == "created":
+        # The payload's own `repositories` field is only reliable for
+        # repository_selection == "selected" - fetching the live list
+        # covers "all" too, and matches what the "Your repositories" page
+        # already uses as its source of truth.
+        try:
+            repo_full_names = await _fetch_all_installation_repo_full_names(installation_id)
+        except Exception:
+            logger.warning(
+                "failed to enumerate repos for new installation %s", installation_id, exc_info=True
+            )
+    elif event_name == "installation_repositories" and action == "added":
+        repo_full_names = [
+            repo["full_name"] for repo in payload.get("repositories_added", [])
+        ]
+
+    if not repo_full_names:
+        return
+
+    if queue is None:
+        from redis import Redis
+        from rq import Queue
+
+        queue = Queue("scans", connection=Redis.from_url(redis_url))
+    for repo_full_name in repo_full_names:
+        queue.enqueue(
+            "scan_worker.jobs.run_initial_scan_job",
+            job_timeout=300,
+            installation_id=installation_id,
+            repo_full_name=repo_full_name,
+        )

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -96,7 +96,13 @@ async def handle_paddle_webhook(request: Request) -> Response:
     if not signature or not verify_paddle_signature(raw_body, signature, settings.paddle_webhook_secret):
         return Response(status_code=401)
 
-    payload = await request.json()
+    try:
+        payload = await request.json()
+    except ValueError:
+        return Response(status_code=401)
+    if not isinstance(payload, dict):
+        return Response(status_code=401)
+
     await handle_paddle_webhook_event(payload, request.app.state.db_pool, settings.redis_url)
 
     return Response(status_code=200)

--- a/github-app/migrations/027_wiki_build_status.sql
+++ b/github-app/migrations/027_wiki_build_status.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS wiki_build_status (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    error_message    TEXT,
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (installation_id, repo_full_name)
+);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -656,6 +656,32 @@ def delete_wiki_subsystems_not_in(
         conn.commit()
 
 
+def set_wiki_build_status(
+    dsn: str,
+    installation_id: int,
+    repo_full_name: str,
+    status: str,
+    error_message: str | None = None,
+) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO wiki_build_status
+                    (installation_id, repo_full_name, status, error_message, updated_at)
+                VALUES (%s, %s, %s, %s, now())
+                ON CONFLICT (installation_id, repo_full_name) DO UPDATE
+                SET status = EXCLUDED.status,
+                    error_message = EXCLUDED.error_message,
+                    updated_at = now()
+                """,
+                (installation_id, repo_full_name, status, error_message),
+            )
+        conn.commit()
+
+
 def insert_evidence_packet_cache_row(
     dsn: str,
     installation_id: int,

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -110,6 +110,27 @@ def fetch_pr_changed_files(
     return [file["filename"] for file in response.json().get("files", [])]
 
 
+def fetch_default_branch_head_sha(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+) -> str:
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    repo_response = client.get(f"/repos/{repo_full_name}", headers=headers)
+    repo_response.raise_for_status()
+    default_branch = repo_response.json()["default_branch"]
+
+    commit_response = client.get(
+        f"/repos/{repo_full_name}/commits/{default_branch}",
+        headers=headers,
+    )
+    commit_response.raise_for_status()
+    return commit_response.json()["sha"]
+
+
 def fetch_file_content(
     client: httpx.Client,
     token: str,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -79,6 +79,7 @@ from scan_worker.flash_review_cache import (
 )
 from scan_worker.github_api import (
     create_check_run,
+    fetch_default_branch_head_sha,
     fetch_file_content,
     fetch_pr_changed_files,
     fetch_pr_diff,
@@ -642,6 +643,63 @@ def run_pr_scan_job(
             _post_failure_comment(settings, installation_id, repo_full_name, pr_number, exc)
         except Exception:  # noqa: BLE001
             pass
+    finally:
+        shutil.rmtree(job_dir, ignore_errors=True)
+
+
+@log_job
+def run_initial_scan_job(installation_id: int, repo_full_name: str) -> None:
+    """Scans a repo's default branch once, right after it's connected (a
+    brand-new installation, or a repo added to an existing one) - see
+    webhooks/installation.py. Without this, a repo with no open pull
+    requests never gets scanned at all: run_pr_scan_job is the only other
+    thing that ever writes a repo_history row, and it only fires on a PR
+    event. A repo could otherwise sit "Initialization required" on the
+    dashboard forever with no feedback or path forward.
+
+    Best-effort and silent on failure - there's no PR to comment a
+    failure on, and the dashboard's existing "Initialization required"
+    state is already a truthful (if unhelpful) signal rather than one
+    this job needs to actively correct.
+    """
+    settings = get_settings()
+
+    installation = get_installation_row(settings.database_url, installation_id)
+    if installation is not None and installation["plan"] != "free":
+        if not check_and_reserve_monthly_repo_scan_slot(
+            settings.database_url, installation_id, repo_full_name, MAX_SCANNED_REPOS_PER_MONTH
+        ):
+            return
+
+    job_dir = _job_temp_dir()
+    try:
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        token = _token_sync(installation_id, app_jwt)
+        client = httpx.Client(base_url="https://api.github.com")
+
+        head_sha = fetch_default_branch_head_sha(client, token, repo_full_name)
+        clone_url = _clone_url(repo_full_name, token)
+        repo_dir = job_dir / "repo"
+        _clone_ref(clone_url, head_sha, repo_dir)
+
+        evidence_path = _run_scan(repo_dir)
+        evidence = json.loads(evidence_path.read_text())
+        evidence = _sync_persistent_git_graph(installation_id, repo_full_name, repo_dir, evidence)
+        _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
+        _insert_history(installation_id, repo_full_name, evidence)
+
+        # A repo added to an already-paid installation should get its
+        # AIRview build right away too, rather than waiting for enough
+        # incremental pushes to slowly build clusters one at a time - the
+        # same gap the Paddle subscription.created wiki-build trigger
+        # closed for brand-new upgrades.
+        if installation is not None and installation["plan"] != "free":
+            try:
+                run_live_wiki_full_build_job(installation_id, repo_full_name)
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001
+        pass
     finally:
         shutil.rmtree(job_dir, ignore_errors=True)
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -62,6 +62,7 @@ from scan_worker.db import (
     list_wiki_subsystems,
     record_llm_spend,
     set_last_reviewed_sha,
+    set_wiki_build_status,
     upsert_wiki_overview,
     upsert_wiki_subsystem,
 )
@@ -1671,24 +1672,36 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
     plan = installation["plan"] if installation is not None else "air"
     model_used = model_for_plan(plan)
 
-    naming_adapter = _live_wiki_naming_adapter()
-    writing_adapter = _live_wiki_full_build_writing_adapter(plan)
-    fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
-    records = live_wiki.generate_subsystems(
-        evidence,
-        naming_adapter,
-        writing_adapter,
-        cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
-        cache_write=lambda packet, output, used: store_result(
-            dsn, installation_id, repo_full_name, packet, output, used
-        ),
-        model_used=model_used,
-        fetch_line_count=fetch_line_count,
-    )
-    _store_wiki_generation(
-        dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
-        fetch_line_count=fetch_line_count,
-    )
+    try:
+        naming_adapter = _live_wiki_naming_adapter()
+        writing_adapter = _live_wiki_full_build_writing_adapter(plan)
+        fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
+        records = live_wiki.generate_subsystems(
+            evidence,
+            naming_adapter,
+            writing_adapter,
+            cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
+            cache_write=lambda packet, output, used: store_result(
+                dsn, installation_id, repo_full_name, packet, output, used
+            ),
+            model_used=model_used,
+            fetch_line_count=fetch_line_count,
+        )
+        _store_wiki_generation(
+            dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
+            fetch_line_count=fetch_line_count,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Without this, a failed build (LLM error, DB error) just leaves the
+        # AIRview page permanently blank with no way for the customer to
+        # tell "still building" apart from "broke and is never coming back".
+        logging.getLogger("scan_worker.jobs").warning(
+            "live wiki full build failed for installation=%s repo=%s (%s)",
+            installation_id, repo_full_name, exc,
+        )
+        set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+        return
+    set_wiki_build_status(dsn, installation_id, repo_full_name, "ready")
 
 
 @log_job

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -552,6 +552,23 @@ def _post_failure_comment(
     upsert_pr_comment(client, token, repo_full_name, pr_number, _failure_body(error))
 
 
+def _post_flash_review_failure_comment(
+    settings,
+    installation_id: int,
+    repo_full_name: str,
+    pr_number: int,
+    error: Exception,
+) -> None:
+    app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+    token = _token_sync(installation_id, app_jwt)
+    client = httpx.Client(base_url="https://api.github.com")
+    body = (
+        f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n\n"
+        f"Aletheore couldn't complete this flash review: {error}"
+    )
+    upsert_pr_comment(client, token, repo_full_name, pr_number, body, marker=FLASH_REVIEW_MARKER)
+
+
 @log_job
 def run_pr_scan_job(
     installation_id: int,
@@ -909,92 +926,113 @@ def run_flash_review_job(
         if get_flash_review_count_this_month(settings.database_url, installation_id) >= MAX_FLASH_REVIEWS_PER_MONTH:
             return
 
-        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
-        token = _token_sync(installation_id, app_jwt)
-        client = httpx.Client(base_url="https://api.github.com")
-
-        last_reviewed_sha = get_last_reviewed_sha(
-            settings.database_url, installation_id, repo_full_name, pr_number
-        )
-        diff_base = last_reviewed_sha or base_sha
-        diff_text = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha)
-        changed_files = fetch_pr_changed_files(client, token, repo_full_name, diff_base, head_sha)
-
-        spend_accumulator = {"total": 0.0}
-
-        if is_non_substantive_diff(changed_files):
-            findings: list[dict] = []
-        else:
-            file_context = gather_file_context(client, token, repo_full_name, changed_files, head_sha)
-            file_contents = fetch_changed_file_contents(client, token, repo_full_name, changed_files, head_sha)
-            evidence = _latest_evidence_or_none(settings.database_url, installation_id, repo_full_name)
-            code_evidence_context = build_code_evidence_context(evidence, changed_files)
-
-            def _fetch_symbol_source(file_path: str, start_line: int, end_line: int) -> str | None:
-                content = fetch_file_content(client, token, repo_full_name, file_path, head_sha)
-                if content is None:
-                    return None
-                return "\n".join(content.splitlines()[start_line - 1 : end_line])
-
-            referenced_symbol_context = build_referenced_symbol_context(
-                evidence, changed_files, diff_text, _fetch_symbol_source
+        try:
+            _run_flash_review(
+                settings, installation_id, repo_full_name, pr_number, base_sha, head_sha
             )
-            dsn = settings.database_url
-
-            def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-                spend_accumulator["total"] += cost_for_usage(
-                    "deepseek-v4-flash", prompt_tokens, completion_tokens
+        except Exception as exc:  # noqa: BLE001
+            try:
+                _post_flash_review_failure_comment(
+                    settings, installation_id, repo_full_name, pr_number, exc
                 )
+            except Exception:  # noqa: BLE001
+                pass
 
-            def _cache_lookup(diff: str) -> list[dict] | None:
-                return lookup_cached_flash_review_result(dsn, installation_id, repo_full_name, diff)
 
-            def _cache_write(diff: str, found: list[dict], used: str) -> None:
-                store_flash_review_result(dsn, installation_id, repo_full_name, diff, found, used)
+def _run_flash_review(
+    settings,
+    installation_id: int,
+    repo_full_name: str,
+    pr_number: int,
+    base_sha: str,
+    head_sha: str,
+) -> None:
+    app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+    token = _token_sync(installation_id, app_jwt)
+    client = httpx.Client(base_url="https://api.github.com")
 
-            if code_evidence_context:
-                findings = review_diff(
-                    diff_text,
-                    file_context=file_context,
-                    code_evidence_context=code_evidence_context,
-                    on_usage=_on_usage,
-                    referenced_symbol_context=referenced_symbol_context,
-                    cache_lookup=_cache_lookup,
-                    cache_write=_cache_write,
-                    model_used="deepseek-v4-flash",
-                    file_contents=file_contents,
-                )
-            else:
-                findings = review_diff(
-                    diff_text,
-                    file_context=file_context,
-                    on_usage=_on_usage,
-                    referenced_symbol_context=referenced_symbol_context,
-                    cache_lookup=_cache_lookup,
-                    cache_write=_cache_write,
-                    model_used="deepseek-v4-flash",
-                    file_contents=file_contents,
-                )
-        record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
-        increment_flash_review_count(settings.database_url, installation_id)
+    last_reviewed_sha = get_last_reviewed_sha(
+        settings.database_url, installation_id, repo_full_name, pr_number
+    )
+    diff_base = last_reviewed_sha or base_sha
+    diff_text = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha)
+    changed_files = fetch_pr_changed_files(client, token, repo_full_name, diff_base, head_sha)
 
-        if findings:
-            lines = [f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n"]
-            for finding in findings:
-                lines.append(f"- `{finding['file']}:{finding['line']}` — {finding['issue']}")
-                suggestion = finding.get("suggestion")
-                if suggestion:
-                    lines.append(f"  ```\n  {suggestion}\n  ```")
-            body = "\n".join(lines)
-        else:
-            body = (
-                f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n\nNo issues found in this diff."
+    spend_accumulator = {"total": 0.0}
+
+    if is_non_substantive_diff(changed_files):
+        findings: list[dict] = []
+    else:
+        file_context = gather_file_context(client, token, repo_full_name, changed_files, head_sha)
+        file_contents = fetch_changed_file_contents(client, token, repo_full_name, changed_files, head_sha)
+        evidence = _latest_evidence_or_none(settings.database_url, installation_id, repo_full_name)
+        code_evidence_context = build_code_evidence_context(evidence, changed_files)
+
+        def _fetch_symbol_source(file_path: str, start_line: int, end_line: int) -> str | None:
+            content = fetch_file_content(client, token, repo_full_name, file_path, head_sha)
+            if content is None:
+                return None
+            return "\n".join(content.splitlines()[start_line - 1 : end_line])
+
+        referenced_symbol_context = build_referenced_symbol_context(
+            evidence, changed_files, diff_text, _fetch_symbol_source
+        )
+        dsn = settings.database_url
+
+        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+            spend_accumulator["total"] += cost_for_usage(
+                "deepseek-v4-flash", prompt_tokens, completion_tokens
             )
 
-        upsert_pr_comment(client, token, repo_full_name, pr_number, body, marker=FLASH_REVIEW_MARKER)
-        set_last_reviewed_sha(
-            settings.database_url, installation_id, repo_full_name, pr_number, head_sha
+        def _cache_lookup(diff: str) -> list[dict] | None:
+            return lookup_cached_flash_review_result(dsn, installation_id, repo_full_name, diff)
+
+        def _cache_write(diff: str, found: list[dict], used: str) -> None:
+            store_flash_review_result(dsn, installation_id, repo_full_name, diff, found, used)
+
+        if code_evidence_context:
+            findings = review_diff(
+                diff_text,
+                file_context=file_context,
+                code_evidence_context=code_evidence_context,
+                on_usage=_on_usage,
+                referenced_symbol_context=referenced_symbol_context,
+                cache_lookup=_cache_lookup,
+                cache_write=_cache_write,
+                model_used="deepseek-v4-flash",
+                file_contents=file_contents,
+            )
+        else:
+            findings = review_diff(
+                diff_text,
+                file_context=file_context,
+                on_usage=_on_usage,
+                referenced_symbol_context=referenced_symbol_context,
+                cache_lookup=_cache_lookup,
+                cache_write=_cache_write,
+                model_used="deepseek-v4-flash",
+                file_contents=file_contents,
+            )
+    record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
+    increment_flash_review_count(settings.database_url, installation_id)
+
+    if findings:
+        lines = [f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n"]
+        for finding in findings:
+            lines.append(f"- `{finding['file']}:{finding['line']}` — {finding['issue']}")
+            suggestion = finding.get("suggestion")
+            if suggestion:
+                lines.append(f"  ```\n  {suggestion}\n  ```")
+        body = "\n".join(lines)
+    else:
+        body = (
+            f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n\nNo issues found in this diff."
         )
+
+    upsert_pr_comment(client, token, repo_full_name, pr_number, body, marker=FLASH_REVIEW_MARKER)
+    set_last_reviewed_sha(
+        settings.database_url, installation_id, repo_full_name, pr_number, head_sha
+    )
 
 
 def _send_if_webhook_configured(installation: dict, message: dict) -> None:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -36,6 +36,7 @@ from app_server.github_auth import generate_app_jwt, get_installation_token
 from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation
 from app_server.logging_config import log_job
 from app_server.rate_limit import cooldown_seconds_for_loc, total_loc_from_evidence
+from app_server.url_validation import UnsafeURLError, validate_external_https_url
 from scan_worker import live_wiki
 from scan_worker.db import (
     check_and_reserve_flash_review_attempt,
@@ -1304,6 +1305,27 @@ def _run_health_check_sweep_for_target(
     base_url: str,
     threshold_ms: int | None,
 ) -> None:
+    # validate_external_https_url only ever ran once, when the target was
+    # saved (admin.py) - re-checking here, immediately before every fetch,
+    # closes the DNS-rebinding window down to the gap between this call and
+    # the actual request instead of "until someone edits the target again."
+    # A customer could otherwise register a domain that resolves to a public
+    # IP at save time, pass validation, then repoint DNS at an internal
+    # service or cloud metadata endpoint before the next sweep - whose
+    # response would then get echoed back to that customer's own dashboard
+    # via response_shape.
+    try:
+        validate_external_https_url(base_url)
+    except UnsafeURLError as exc:
+        logging.getLogger("scan_worker.jobs").warning(
+            "skipping health check for installation=%s repo=%s target=%s - %s",
+            installation_id,
+            repo_full_name,
+            target_id,
+            exc,
+        )
+        return
+
     evidence = get_latest_evidence(dsn, installation_id, repo_full_name)
     if evidence is None:
         return

--- a/github-app/scan_worker/managed_audit.py
+++ b/github-app/scan_worker/managed_audit.py
@@ -54,9 +54,9 @@ def _llm_based_suggestion_section(
 
 def run_managed_audit(
     repo_path: Path,
+    plan: str,
     manual_dir: str | None = None,
     on_usage: Callable[[int, int], None] | None = None,
-    plan: str = "pro",
 ) -> str:
     adapter = writing_adapter_for_plan(plan, on_usage=on_usage)
     report_path = run_reasoning_phase(

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -198,7 +198,7 @@ async def test_administered_ids_for_session_deletes_session_when_no_refresh_toke
 
 
 @pytest.mark.asyncio
-async def test_administered_ids_for_session_deletes_session_when_refresh_fails(pool, monkeypatch):
+async def test_administered_ids_for_session_deletes_session_when_refresh_fails(pool, monkeypatch, caplog):
     session = await _create_session_with_tokens(
         pool, monkeypatch, "sess-refreshfails", "gho_dead", refresh_token="ghr_alsodead"
     )
@@ -216,10 +216,16 @@ async def test_administered_ids_for_session_deletes_session_when_refresh_fails(p
 
     monkeypatch.setattr("app_server.admin.refresh_github_access_token", fake_refresh)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await _administered_installation_ids_for_session_or_401(pool, session)
+    # Before this fix, a failed refresh attempt (dead refresh_token, GitHub
+    # outage, unexpected response shape) was swallowed with a bare `except
+    # Exception: return None` - nothing distinguished it in logs from the
+    # unremarkable "no refresh_token on file" case.
+    with caplog.at_level("WARNING", logger="app_server.admin"):
+        with pytest.raises(HTTPException) as exc_info:
+            await _administered_installation_ids_for_session_or_401(pool, session)
     assert exc_info.value.status_code == 401
     assert await get_session(pool, "sess-refreshfails") is None
+    assert any("token refresh failed" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -10,7 +10,10 @@ from app_server.auth import (
     refresh_github_access_token,
     sign_session_id,
     unsign_session_id,
+    _derive_key,
+    _fernet_key,
     _is_safe_next_path,
+    _signing_secret,
 )
 from app_server.db import create_session, get_installation, get_session
 from app_server.main import app
@@ -75,6 +78,19 @@ def test_unsign_rejects_tampered_value():
     tampered_first = ("a" if first[0] != "a" else "b") + first[1:]
     tampered = f"{tampered_first}.{rest}"
     assert unsign_session_id(tampered, "test-secret") is None
+
+
+def test_signing_and_encryption_keys_derived_from_same_secret_are_independent():
+    # Before this fix, both the session/oauth-state cookie signature and
+    # the Fernet key encrypting stored GitHub tokens were derived straight
+    # from SESSION_SECRET with no domain separation - reusing one secret
+    # across a signing primitive and an encryption primitive is the kind
+    # of key reuse that can let a weakness in either compromise both.
+    signing_material = _derive_key("test-secret", b"aletheore-cookie-signing")
+    encryption_material = _derive_key("test-secret", b"aletheore-token-encryption")
+    assert signing_material != encryption_material
+    assert _signing_secret("test-secret") != "test-secret"
+    assert _fernet_key("test-secret") != _fernet_key("wrong-secret")
 
 
 def test_safe_relative_next_path_accepted():

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -40,6 +40,21 @@ async def _seed_wiki_subsystem(pool, installation_id, repo_full_name, subsystem_
     )
 
 
+async def _seed_wiki_build_status(pool, installation_id, repo_full_name, status, error_message=None):
+    await pool.execute(
+        """
+        INSERT INTO wiki_build_status (installation_id, repo_full_name, status, error_message)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (installation_id, repo_full_name) DO UPDATE
+        SET status = EXCLUDED.status, error_message = EXCLUDED.error_message
+        """,
+        installation_id,
+        repo_full_name,
+        status,
+        error_message,
+    )
+
+
 async def _logged_in_client(pool, monkeypatch, administered_ids):
     monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
     await create_session(
@@ -782,6 +797,35 @@ async def test_dashboard_wiki_returns_null_overview_when_not_yet_generated(pool,
     body = response.json()
     assert body["overview"] is None
     assert body["subsystems"] == []
+    assert body["build_status"] is None
+    assert body["build_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_dashboard_wiki_surfaces_failed_build_status(pool, monkeypatch):
+    # Before this fix, a failed build left the dashboard indistinguishable
+    # from "hasn't been built yet" - the customer had no way to tell a
+    # transient in-progress state apart from a build that's never coming.
+    await upsert_installation(pool, 605, "octocat")
+    await set_installation_plan(pool, 605, "indie")
+    await insert_repo_history(
+        pool,
+        605,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {"repository": {"modules": []}},
+    )
+    await _seed_wiki_build_status(pool, 605, "octocat/hello-world", "failed", "model provider unavailable")
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[605])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/wiki")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["overview"] is None
+    assert body["build_status"] == "failed"
+    assert body["build_error"] == "model provider unavailable"
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_installation_webhook.py
+++ b/github-app/tests/test_installation_webhook.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from app_server.db import get_installation, upsert_installation
@@ -5,12 +7,19 @@ from app_server.webhooks.installation import handle_installation_event
 
 
 @pytest.mark.asyncio
-async def test_installation_created_upserts_row(pool):
+async def test_installation_created_upserts_row(pool, monkeypatch):
+    async def _fake_fetch(installation_id):
+        return []
+
+    monkeypatch.setattr(
+        "app_server.webhooks.installation._fetch_all_installation_repo_full_names",
+        _fake_fetch,
+    )
     payload = {
         "action": "created",
         "installation": {"id": 555, "account": {"login": "octocat"}},
     }
-    await handle_installation_event("installation", payload, pool)
+    await handle_installation_event("installation", payload, pool, "redis://unused")
     row = await get_installation(pool, 555)
     assert row["account_login"] == "octocat"
 
@@ -22,7 +31,7 @@ async def test_installation_deleted_removes_row(pool):
         "action": "deleted",
         "installation": {"id": 555, "account": {"login": "octocat"}},
     }
-    await handle_installation_event("installation", payload, pool)
+    await handle_installation_event("installation", payload, pool, "redis://unused")
     assert await get_installation(pool, 555) is None
 
 
@@ -31,7 +40,86 @@ async def test_installation_repositories_added_upserts_row(pool):
     payload = {
         "action": "added",
         "installation": {"id": 556, "account": {"login": "someorg"}},
+        "repositories_added": [],
     }
-    await handle_installation_event("installation_repositories", payload, pool)
+    await handle_installation_event("installation_repositories", payload, pool, "redis://unused")
     row = await get_installation(pool, 556)
     assert row["account_login"] == "someorg"
+
+
+@pytest.mark.asyncio
+async def test_installation_created_enqueues_initial_scan_for_every_repo(pool, monkeypatch):
+    async def _fake_fetch(installation_id):
+        return ["octocat/one", "octocat/two"]
+
+    monkeypatch.setattr(
+        "app_server.webhooks.installation._fetch_all_installation_repo_full_names",
+        _fake_fetch,
+    )
+    fake_queue = MagicMock()
+    payload = {
+        "action": "created",
+        "installation": {"id": 557, "account": {"login": "octocat"}},
+    }
+    await handle_installation_event("installation", payload, pool, "redis://unused", queue=fake_queue)
+
+    assert fake_queue.enqueue.call_count == 2
+    enqueued_repos = {call.kwargs["repo_full_name"] for call in fake_queue.enqueue.call_args_list}
+    assert enqueued_repos == {"octocat/one", "octocat/two"}
+    for call in fake_queue.enqueue.call_args_list:
+        assert call.args[0] == "scan_worker.jobs.run_initial_scan_job"
+        assert call.kwargs["installation_id"] == 557
+
+
+@pytest.mark.asyncio
+async def test_installation_created_does_not_crash_when_repo_enumeration_fails(pool, monkeypatch):
+    async def _raise(installation_id):
+        raise RuntimeError("GitHub API unavailable")
+
+    monkeypatch.setattr(
+        "app_server.webhooks.installation._fetch_all_installation_repo_full_names", _raise
+    )
+    fake_queue = MagicMock()
+    payload = {
+        "action": "created",
+        "installation": {"id": 558, "account": {"login": "octocat"}},
+    }
+    await handle_installation_event("installation", payload, pool, "redis://unused", queue=fake_queue)
+
+    row = await get_installation(pool, 558)
+    assert row["account_login"] == "octocat"
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_installation_repositories_added_enqueues_initial_scan_for_new_repos_only(pool, monkeypatch):
+    fake_queue = MagicMock()
+    payload = {
+        "action": "added",
+        "installation": {"id": 559, "account": {"login": "someorg"}},
+        "repositories_added": [{"full_name": "someorg/newly-added"}],
+    }
+    await handle_installation_event(
+        "installation_repositories", payload, pool, "redis://unused", queue=fake_queue
+    )
+
+    fake_queue.enqueue.assert_called_once()
+    args, kwargs = fake_queue.enqueue.call_args
+    assert args[0] == "scan_worker.jobs.run_initial_scan_job"
+    assert kwargs["installation_id"] == 559
+    assert kwargs["repo_full_name"] == "someorg/newly-added"
+
+
+@pytest.mark.asyncio
+async def test_installation_repositories_removed_does_not_enqueue_a_scan(pool, monkeypatch):
+    fake_queue = MagicMock()
+    payload = {
+        "action": "removed",
+        "installation": {"id": 560, "account": {"login": "someorg"}},
+        "repositories_removed": [{"full_name": "someorg/gone"}],
+    }
+    await handle_installation_event(
+        "installation_repositories", payload, pool, "redis://unused", queue=fake_queue
+    )
+
+    fake_queue.enqueue.assert_not_called()

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1352,6 +1352,9 @@ def _patch_sweep(
 ):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.time.sleep", lambda *a, **k: None)
+    # Real DNS resolution has no place in a unit test - SSRF re-validation
+    # itself is covered by its own dedicated tests below.
+    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", lambda url: url)
     monkeypatch.setattr(
         "scan_worker.jobs.list_health_check_targets_all",
         lambda dsn: [
@@ -1764,6 +1767,7 @@ def test_sweep_isolates_one_targets_failure_from_others(monkeypatch):
     # take down the sweep for every other installation - this job runs
     # every HEALTH_SWEEP_INTERVAL_SECONDS for the whole customer base.
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", lambda url: url)
     monkeypatch.setattr(
         "scan_worker.jobs.list_health_check_targets_all",
         lambda dsn: [
@@ -1815,6 +1819,105 @@ def test_sweep_isolates_one_targets_failure_from_others(monkeypatch):
     # get_latest_evidence blowing up first in iteration order.
     assert len(inserted) == 1
     assert inserted[0][1] == 2
+
+
+def test_sweep_revalidates_target_url_before_every_fetch_and_skips_on_ssrf_failure(monkeypatch):
+    # A target that passed SSRF validation when it was saved (admin.py)
+    # must be re-checked on every sweep cycle, not trusted forever - DNS
+    # can be repointed at an internal/cloud-metadata address any time
+    # after that one-time save-time check.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_health_check_targets_all",
+        lambda dsn: [
+            {
+                "target_id": 1,
+                "installation_id": 1,
+                "repo_full_name": "acme/rebound",
+                "label": "Primary",
+                "base_url": "https://rebound.example.com",
+                "latency_threshold_ms": None,
+                "webhook_url": "https://hooks.slack.com/health",
+            }
+        ],
+    )
+
+    from app_server.url_validation import UnsafeURLError
+
+    def fake_validate(url):
+        raise UnsafeURLError(f"'{url}' now resolves to a disallowed address")
+
+    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", fake_validate)
+
+    evidence_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_latest_evidence",
+        lambda dsn, iid, repo: evidence_calls.append(True)
+        or {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
+    )
+    fetch_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.run_healthcheck",
+        lambda endpoints, base_url: fetch_calls.append(True)
+        or {"results": [{"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 1.0}]},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_endpoint_health", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: None)
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    # Rejected before ever touching evidence or making the actual request.
+    assert evidence_calls == []
+    assert fetch_calls == []
+
+
+def test_sweep_proceeds_when_target_url_still_passes_validation(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_health_check_targets_all",
+        lambda dsn: [
+            {
+                "target_id": 1,
+                "installation_id": 1,
+                "repo_full_name": "acme/fine",
+                "label": "Primary",
+                "base_url": "https://fine.example.com",
+                "latency_threshold_ms": None,
+                "webhook_url": "https://hooks.slack.com/health",
+            }
+        ],
+    )
+
+    validated_urls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.validate_external_https_url",
+        lambda url: validated_urls.append(url) or url,
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_latest_evidence",
+        lambda dsn, iid, repo: {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.run_healthcheck",
+        lambda endpoints, base_url: {
+            "results": [{"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 1.0}]
+        },
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_last_endpoint_health", lambda dsn, iid, repo, method, path, target_id=None: None
+    )
+    inserted = []
+    monkeypatch.setattr("scan_worker.jobs.insert_endpoint_health", lambda *a, **k: inserted.append(a))
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: None)
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert validated_urls == ["https://fine.example.com"]
+    assert len(inserted) == 1
 
 
 def test_sweep_threads_endpoint_source_location_into_alert(monkeypatch):
@@ -1888,6 +1991,7 @@ def test_sweep_checks_every_target_independently(monkeypatch):
     # one up - must each be checked and alerted on their own, not merged or
     # short-circuited after the first.
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", lambda url: url)
     monkeypatch.setattr(
         "scan_worker.jobs.list_health_check_targets_all",
         lambda dsn: [

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1092,6 +1092,44 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     assert recorded_spend == [0.0]
 
 
+def test_flash_review_job_posts_failure_comment_instead_of_raising(monkeypatch):
+    # Before this fix, any exception in the review body (LLM call, GitHub
+    # API, cache lookup) propagated straight out of the RQ job with zero
+    # customer-visible signal - the PR would just never get a comment, and
+    # nothing would tell the customer flash review had failed.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+
+    def _raise_diff_fetch(*a, **k):
+        raise RuntimeError("GitHub API timed out")
+
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", _raise_diff_fetch)
+
+    posted = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.upsert_pr_comment",
+        lambda client, token, repo_full_name, pr_number, body, **kwargs: posted.update(
+            body=body, marker=kwargs.get("marker")
+        ),
+    )
+    from scan_worker.jobs import FLASH_REVIEW_MARKER, run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert posted["marker"] == FLASH_REVIEW_MARKER
+    assert "couldn't complete this flash review" in posted["body"]
+    assert "GitHub API timed out" in posted["body"]
+
+
 def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkeypatch):
     # Real hallucination this exists to prevent: Flash Review claimed an
     # imported function needed `await`, citing "usage in admin.py", when

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1372,6 +1372,7 @@ def test_run_live_wiki_full_build_job_skips_model_call_on_cache_hit(monkeypatch)
     monkeypatch.setattr("scan_worker.jobs._live_wiki_full_build_writing_adapter", lambda plan: _SpyAdapter())
     monkeypatch.setattr("scan_worker.jobs._live_wiki_naming_adapter", lambda: _NamingAdapter())
     monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_wiki_build_status", lambda *a, **k: None)
 
     run_live_wiki_full_build_job(1, "octocat/hello-world")
 
@@ -2350,11 +2351,39 @@ def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
             records=records, commit=commit
         ),
     )
+    build_status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error=None: build_status_calls.append((status, error)),
+    )
 
     run_live_wiki_full_build_job(1, "octocat/hello-world")
 
     assert stored["records"] == [fake_record]
     assert stored["commit"] is None
+    assert build_status_calls == [("ready", None)]
+
+
+def test_run_live_wiki_full_build_job_records_failed_status_on_error(monkeypatch):
+    from scan_worker.jobs import run_live_wiki_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+
+    def _raise(*a, **k):
+        raise RuntimeError("model provider unavailable")
+
+    monkeypatch.setattr("scan_worker.jobs.live_wiki.generate_subsystems", _raise)
+    build_status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error=None: build_status_calls.append((status, error)),
+    )
+
+    run_live_wiki_full_build_job(1, "octocat/hello-world")
+
+    assert build_status_calls == [("failed", "model provider unavailable")]
 
 
 def test_real_line_count_fetcher_returns_none_when_token_setup_fails(monkeypatch):
@@ -2404,6 +2433,7 @@ def test_run_live_wiki_full_build_job_passes_fetch_line_count_through(monkeypatc
         "scan_worker.jobs._store_wiki_generation",
         lambda *a, **k: captured_store.update(k),
     )
+    monkeypatch.setattr("scan_worker.jobs.set_wiki_build_status", lambda *a, **k: None)
 
     run_live_wiki_full_build_job(1, "octocat/hello-world")
 

--- a/github-app/tests/test_managed_audit.py
+++ b/github-app/tests/test_managed_audit.py
@@ -19,7 +19,7 @@ def test_run_managed_audit_returns_report_text(tmp_path, monkeypatch):
 
     monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
 
-    assert "Real Report" in run_managed_audit(repo_path)
+    assert "Real Report" in run_managed_audit(repo_path, plan="air")
 
     adapter = captured_adapters[0]
     assert adapter.name == "DeepSeek"
@@ -45,7 +45,7 @@ def test_run_managed_audit_threads_on_usage_to_the_adapter(tmp_path, monkeypatch
     monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
 
     received = []
-    run_managed_audit(repo_path, on_usage=lambda p, c: received.append((p, c)))
+    run_managed_audit(repo_path, plan="air", on_usage=lambda p, c: received.append((p, c)))
 
     adapter = captured_adapters[0]
     assert adapter._on_usage is not None
@@ -138,7 +138,7 @@ def test_run_managed_audit_appends_llm_suggestion_section_when_available(tmp_pat
         lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
     )
 
-    result = run_managed_audit(repo_path)
+    result = run_managed_audit(repo_path, plan="air")
 
     assert "# Real Report" in result
     assert "LLM Based Suggestion (Not Evidence Backed)" in result

--- a/github-app/tests/test_paddle_webhook_verify.py
+++ b/github-app/tests/test_paddle_webhook_verify.py
@@ -40,3 +40,13 @@ def test_malformed_header_rejected():
     body = b'{"event_type": "subscription.created"}'
     assert verify_paddle_signature(body, "not-a-valid-header", SECRET) is False
     assert verify_paddle_signature(body, "", SECRET) is False
+
+
+def test_non_utf8_body_rejected_not_raised():
+    # Before this fix, raw_body.decode('utf-8') raised UnicodeDecodeError
+    # uncaught - any body containing invalid UTF-8 bytes crashed the whole
+    # request with a 500 instead of the intended 401.
+    body = b"\xff\xfe not valid utf-8"
+    ts = int(time.time())
+    header = f"ts={ts};h1=deadbeef"
+    assert verify_paddle_signature(body, header, SECRET) is False

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -82,6 +82,30 @@ async def test_invalid_signature_rejected_with_no_write(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_malformed_json_body_with_valid_signature_returns_401_not_500(pool, monkeypatch):
+    # Before this fix, a validly-signed but non-JSON body reached
+    # `await request.json()` uncaught - json.JSONDecodeError propagated as
+    # an unhandled 500 instead of the 401 every other verification failure
+    # in this handler returns.
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    body = b"not valid json at all"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_non_object_json_body_with_valid_signature_returns_401_not_500(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    body = b"[1, 2, 3]"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_missing_signature_header_rejected(pool):
     app.state.db_pool = pool
     body = json.dumps(_subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 102)).encode()

--- a/website/index.html
+++ b/website/index.html
@@ -284,7 +284,7 @@
               <div><dt>Commits analyzed</dt><dd>1,463,552</dd></div>
               <div><dt>License issues found</dt><dd>0</dd></div>
               <div><dt>Known vulnerabilities</dt><dd>0</dd></div>
-              <div><dt>Scan time</dt><dd>14m 8s</dd></div>
+              <div><dt>Scan time</dt><dd>4m 20s</dd></div>
               <div><dt>Evidence size</dt><dd>180MB &rarr; 74MB TOON</dd></div>
             </dl>
 

--- a/website/styles.css
+++ b/website/styles.css
@@ -1215,20 +1215,11 @@ pre {
 
 .pricing-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 24px;
-  max-width: 1180px;
+  max-width: 800px;
   margin: 0 auto;
   text-align: left;
-}
-
-/* Between the mobile breakpoint and where 4 columns fit comfortably,
-   auto-fit used to wrap the 4th card onto its own row alone - explicit
-   2x2 pairing looks intentional at every width in between instead. */
-@media (min-width: 761px) and (max-width: 1023px) {
-  .pricing-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
 }
 
 .price-card {


### PR DESCRIPTION
## Summary
Follow-up hardening pass after the AIR single-tier launch (#73, #74) - closes out every gap identified in the earlier security/billing/dashboard/reliability/onboarding audit that hadn't been fixed yet.

- **Scan-on-connect**: new installations/newly-added repos now get scanned immediately instead of waiting indefinitely for a PR (`run_initial_scan_job`, wired off both `installation` and `installation_repositories` webhooks).
- **SSRF re-validation**: health-check sweep re-validates each target URL immediately before every fetch, not just at save time.
- **Flash review silent failures**: exceptions now post a failure comment on the PR instead of the job just dying with no signal.
- **AIRview build failures**: new `wiki_build_status` table + dashboard surfacing - customers see an actual failure message instead of a permanently blank "hasn't been built yet" page.
- **Stale endpoints**: `stale_endpoints` was already computed server-side but never rendered - added a "Never reachable" section to the health page.
- **Paddle webhook 500s**: a malformed (non-UTF-8, or validly-signed-but-non-JSON) body could raise uncaught and 500 instead of the intended 401. Both paths now return 401.
- **Silent refresh failures**: `_try_refresh_session_token` now logs on failure instead of a bare `except Exception: return None`.
- **Dead `plan="pro"` default**: removed from `run_managed_audit` - not a real plan value since the single-tier rename, and both real callers always passed it explicitly anyway.
- **SESSION_SECRET key separation**: signing (session/oauth cookies) and encryption (stored GitHub tokens) now use independent HKDF-derived subkeys instead of reusing one secret for both purposes.
- Also includes the pricing-grid CSS centering fix from the AIR launch follow-up.

## Deploy note
The SESSION_SECRET change (last commit) means every existing signed session/oauth cookie stops verifying and every already-stored encrypted GitHub token in `sessions` stops decrypting under the new key on deploy. Self-healing (forces a one-time re-login) but truncating the `sessions` table on deploy is cleaner than letting it happen organically.

## Test plan
- [x] Full suite green: 666 passed, 7 skipped
- [x] New tests added for every fix (scan-on-connect enqueue behavior, flash review failure comment, wiki build status ready/failed, Paddle malformed-body 401s, refresh-failure logging, key derivation independence)