### PR TITLE
fix: two scanner-robustness crash/traversal bugs

### DIFF
--- a/src/aletheore/scanner/detect.py
+++ b/src/aletheore/scanner/detect.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tomllib
 from pathlib import Path
 
@@ -209,24 +210,37 @@ def _nested_git_roots(repo_path: Path) -> set[Path]:
     submodule checked out the classic way, and therefore a separate git
     working tree, not this repo's own source. Unlike cache/build dirs, these
     have no fixed name to add to IGNORED_DIRS - a real scan found one at
-    `.claude/worktrees/<name>/`, doubling every file inside it."""
-    return {
-        git_entry.parent
-        for git_entry in repo_path.rglob(".git")
-        if git_entry.parent != repo_path
-    }
+    `.claude/worktrees/<name>/`, doubling every file inside it.
+
+    os.walk(followlinks=False) rather than Path.rglob(".git") - a symlinked
+    directory shouldn't be descended into just to look for a nested repo.
+    """
+    roots = set()
+    for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
+        current_dir = Path(dirpath)
+        if current_dir != repo_path and (".git" in dirnames or ".git" in filenames):
+            roots.add(current_dir)
+    return roots
 
 
 def _iter_source_files(repo_path: Path):
+    # os.walk(followlinks=False) rather than Path.rglob("*") - a symlinked
+    # directory would otherwise have its contents walked and reported on as
+    # if they were part of this repo. followlinks only stops descent into
+    # symlinked *directories* - a symlinked file sitting directly in a real
+    # directory still needs its own is_symlink() check below.
     nested_git_roots = _nested_git_roots(repo_path)
-    for path in repo_path.rglob("*"):
-        if not path.is_file():
+    for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        current_dir = Path(dirpath)
+        if any(root in current_dir.parents or root == current_dir for root in nested_git_roots):
+            dirnames[:] = []
             continue
-        if any(part in IGNORED_DIRS for part in path.parts):
-            continue
-        if any(root in path.parents for root in nested_git_roots):
-            continue
-        yield path
+        for filename in filenames:
+            path = current_dir / filename
+            if path.is_symlink() or not path.is_file():
+                continue
+            yield path
 
 
 def detect_languages(repo_path: Path) -> list[dict]:

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import tree_sitter_c as tsc
@@ -64,15 +65,25 @@ KNOWN_SOURCE_EXTENSIONS_WITHOUT_GRAMMAR = {
 
 
 def _iter_source_files(repo_path: Path):
+    # os.walk(followlinks=False) rather than Path.rglob("*") - a symlinked
+    # directory in the tree would otherwise have its contents walked and
+    # parsed as if they were part of this repo. followlinks only stops
+    # descent into symlinked *directories* - a symlinked file sitting
+    # directly in a real directory still needs its own is_symlink() check.
     nested_git_roots = _nested_git_roots(repo_path)
-    for path in sorted(repo_path.rglob("*")):
-        if not path.is_file():
+    paths = []
+    for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        current_dir = Path(dirpath)
+        if any(root in current_dir.parents or root == current_dir for root in nested_git_roots):
+            dirnames[:] = []
             continue
-        if any(part in IGNORED_DIRS for part in path.parts):
-            continue
-        if any(root in path.parents for root in nested_git_roots):
-            continue
-        yield path
+        for filename in filenames:
+            path = current_dir / filename
+            if path.is_symlink() or not path.is_file():
+                continue
+            paths.append(path)
+    yield from sorted(paths)
 
 
 def _rel(repo_path: Path, path: Path) -> str | None:

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -75,8 +75,18 @@ def _iter_source_files(repo_path: Path):
         yield path
 
 
-def _rel(repo_path: Path, path: Path) -> str:
-    return path.relative_to(repo_path).as_posix()
+def _rel(repo_path: Path, path: Path) -> str | None:
+    """None when path resolves outside repo_path entirely - a relative
+    import/include that climbs above the repo root (e.g. `#include
+    "../../../../etc/passwd"`, or excess `super::` segments in Rust)
+    resolves to a real file on disk that simply isn't part of this repo.
+    Treated the same as an unresolved/external import rather than letting
+    path.relative_to()'s ValueError crash the whole scan.
+    """
+    try:
+        return path.relative_to(repo_path).as_posix()
+    except ValueError:
+        return None
 
 
 def _symbol_entry(source: bytes, name_node: Node, enclosing_node: Node) -> dict:
@@ -1045,10 +1055,7 @@ def _resolve_js_import(repo_path: Path, from_file: Path, spec: str) -> str | Non
         candidates.append(base / f"index{ext}")
     for candidate in candidates:
         if candidate.exists() and candidate.is_file():
-            try:
-                return _rel(repo_path, candidate)
-            except ValueError:
-                return None
+            return _rel(repo_path, candidate)
     return None
 
 
@@ -1195,7 +1202,7 @@ def build_module_graph(
                     java_source_roots, dotted, is_static, is_wildcard
                 ):
                     target = _rel(repo_path, target_path)
-                    if target == rel_path:
+                    if target is None or target == rel_path:
                         continue
                     resolved_imports.append(target)
                     edges.append([rel_path, target])
@@ -1207,7 +1214,7 @@ def build_module_graph(
                 target_path = _resolve_ruby_require(repo_path, path, kind, spec)
                 if target_path is not None:
                     target = _rel(repo_path, target_path)
-                    if target != rel_path:
+                    if target is not None and target != rel_path:
                         resolved_imports.append(target)
                         edges.append([rel_path, target])
                         imported_by_map.setdefault(target, []).append(rel_path)
@@ -1222,7 +1229,7 @@ def build_module_graph(
                 )
                 if target_path is not None:
                     target = _rel(repo_path, target_path)
-                    if target != rel_path:
+                    if target is not None and target != rel_path:
                         resolved_imports.append(target)
                         edges.append([rel_path, target])
                         imported_by_map.setdefault(target, []).append(rel_path)
@@ -1233,7 +1240,7 @@ def build_module_graph(
                 target_path = _resolve_c_include(path, spec)
                 if target_path is not None:
                     target = _rel(repo_path, target_path)
-                    if target != rel_path:
+                    if target is not None and target != rel_path:
                         resolved_imports.append(target)
                         edges.append([rel_path, target])
                         imported_by_map.setdefault(target, []).append(rel_path)
@@ -1243,7 +1250,7 @@ def build_module_graph(
             for dotted in raw_imports:
                 for target_path in _resolve_csharp_using(csharp_prefix_map, dotted):
                     target = _rel(repo_path, target_path)
-                    if target == rel_path:
+                    if target is None or target == rel_path:
                         continue
                     resolved_imports.append(target)
                     edges.append([rel_path, target])

--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -53,14 +54,22 @@ SECRET_PATTERNS = [
 
 
 def iter_all_files(repo_path: Path):
-    for path in repo_path.rglob("*"):
-        if not path.is_file():
-            continue
-        if any(part in IGNORED_DIRS for part in path.parts):
-            continue
-        if path.suffix in BINARY_EXTENSIONS:
-            continue
-        yield path
+    # os.walk(followlinks=False) rather than Path.rglob("*") - a symlinked
+    # directory anywhere in the tree (real case: a monorepo tool, or an
+    # accidental symlink to something outside the checkout) would otherwise
+    # have its contents walked and reported on as if they were part of this
+    # repo. followlinks only stops descent into symlinked *directories* -
+    # a symlinked file sitting directly in a real directory still needs its
+    # own explicit is_symlink() check below.
+    for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if path.is_symlink() or not path.is_file():
+                continue
+            if path.suffix in BINARY_EXTENSIONS:
+                continue
+            yield path
 
 
 def _is_likely_placeholder(rel_path: str) -> bool:

--- a/src/tests/test_detect.py
+++ b/src/tests/test_detect.py
@@ -156,6 +156,31 @@ def test_detect_languages_ignores_nested_git_worktree(tmp_path):
     assert by_name["python"]["file_count"] == 1
 
 
+def test_detect_languages_does_not_follow_a_symlinked_file_outside_the_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.py").write_text("x = 1\n")
+    (repo / "linked.py").symlink_to(tmp_path / "outside.py")
+    (repo / "main.py").write_text("x = 1\n")
+
+    languages = detect_languages(repo)
+    by_name = {entry["name"]: entry for entry in languages}
+    assert by_name["python"]["file_count"] == 1
+
+
+def test_detect_languages_does_not_descend_into_a_symlinked_directory_outside_the_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside").mkdir()
+    (tmp_path / "outside" / "module.py").write_text("x = 1\n")
+    (repo / "linked_dir").symlink_to(tmp_path / "outside")
+    (repo / "main.py").write_text("x = 1\n")
+
+    languages = detect_languages(repo)
+    by_name = {entry["name"]: entry for entry in languages}
+    assert by_name["python"]["file_count"] == 1
+
+
 def test_detect_ai_usage_finds_a_provider_in_requirements_txt(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -124,6 +124,37 @@ def test_build_module_graph_ignores_nested_git_worktree(tmp_path):
     assert {m["path"] for m in modules} == {"main.py"}
 
 
+def test_build_module_graph_does_not_follow_a_symlinked_file_outside_the_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.py").write_text("def outside():\n    pass\n")
+    (repo / "linked.py").symlink_to(tmp_path / "outside.py")
+    (repo / "main.py").write_text("x = 1\n")
+
+    modules, _, unparseable = build_module_graph(repo)
+
+    assert unparseable == []
+    assert {m["path"] for m in modules} == {"main.py"}
+
+
+def test_build_module_graph_does_not_descend_into_a_symlinked_directory_outside_the_repo(tmp_path):
+    # A symlinked directory isn't itself is_file(), so a naive per-path check
+    # alone doesn't protect against it - Path.rglob("*") still recurses through
+    # a symlinked directory's contents by default, parsing real files outside
+    # the repo as if they were part of it.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside").mkdir()
+    (tmp_path / "outside" / "module.py").write_text("def outside():\n    pass\n")
+    (repo / "linked_dir").symlink_to(tmp_path / "outside")
+    (repo / "main.py").write_text("x = 1\n")
+
+    modules, _, unparseable = build_module_graph(repo)
+
+    assert unparseable == []
+    assert {m["path"] for m in modules} == {"main.py"}
+
+
 def test_build_module_graph_extracts_typescript_imports(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_graph_cpp.py
+++ b/src/tests/test_graph_cpp.py
@@ -180,3 +180,18 @@ def test_build_module_graph_c_file_with_deeply_nested_expression_does_not_crash(
 
     assert unparseable == []
     assert "f" in symbol_names(modules[0]["symbols"]["functions"])
+
+
+def test_build_module_graph_c_include_escaping_repo_root_does_not_crash(tmp_path):
+    # Before this fix, a quoted #include resolving above the repo root (a real
+    # file on disk, just outside repo_path) crashed the whole scan with an
+    # unhandled ValueError from path.relative_to().
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.h").write_text("int outside(void);\n")
+    (repo / "main.c").write_text('#include "../outside.h"\n\nint main(void) { return 0; }\n')
+
+    _, dependency_graph, unparseable = build_module_graph(repo)
+
+    assert dependency_graph["edges"] == []
+    assert unparseable == []

--- a/src/tests/test_graph_csharp.py
+++ b/src/tests/test_graph_csharp.py
@@ -136,3 +136,23 @@ def test_build_module_graph_dotnet_obj_directory_is_excluded(tmp_path):
     modules, _, _ = build_module_graph(repo)
 
     assert [m["path"] for m in modules] == ["Program.cs"]
+
+
+def test_build_module_graph_csharp_using_escaping_repo_root_does_not_crash(tmp_path):
+    # Before this fix, this crashed with an unhandled ValueError from
+    # path.relative_to(). A file directly at the repo root whose single-segment
+    # namespace matches the repo directory's own name (here "App") makes
+    # _csharp_prefix_and_root_for infer a resolution root one level ABOVE
+    # repo_path - a real coincidence for any project namespaced after its own
+    # folder. A "using" statement resolving relative to that escaped root can
+    # then fan out to real files genuinely outside repo_path.
+    repo = tmp_path / "App"
+    repo.mkdir()
+    (repo / "Foo.cs").write_text("namespace App;\n\nclass Foo {}\n")
+    (tmp_path / "Other").mkdir()
+    (tmp_path / "Other" / "Outside.cs").write_text("class Outside {}\n")
+    (repo / "Main.cs").write_text("using Other;\n\nclass Main {}\n")
+
+    _, dependency_graph, _ = build_module_graph(repo)
+
+    assert dependency_graph["edges"] == []

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -197,3 +197,23 @@ def test_build_module_graph_java_no_package_declaration_still_scans_the_file(tmp
     assert modules[0]["path"] == "Main.java"
     assert "Main" in symbol_names(modules[0]["symbols"]["classes"])
     assert unparseable == []
+
+
+def test_build_module_graph_java_import_escaping_repo_root_does_not_crash(tmp_path):
+    # Before this fix, this crashed with an unhandled ValueError from
+    # path.relative_to(). A file directly at the repo root whose package name's
+    # last segment matches the repo directory's own name (here "app") makes
+    # _java_source_root_for infer a source root one level ABOVE repo_path - a
+    # real, if unusual, coincidence, not a hypothetical. An import that then
+    # resolves relative to that escaped root can land on a real file genuinely
+    # outside repo_path.
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "Foo.java").write_text("package app;\n\nclass Foo {}\n")
+    (tmp_path / "other").mkdir()
+    (tmp_path / "other" / "Outside.java").write_text("class Outside {}\n")
+    (repo / "Main.java").write_text("import other.Outside;\n\nclass Main {}\n")
+
+    _, dependency_graph, _ = build_module_graph(repo)
+
+    assert dependency_graph["edges"] == []

--- a/src/tests/test_graph_php.py
+++ b/src/tests/test_graph_php.py
@@ -130,6 +130,20 @@ def test_build_module_graph_php_relative_require_resolves(tmp_path):
     assert ("main.php", "helper.php") in edges
 
 
+def test_build_module_graph_php_include_escaping_repo_root_does_not_crash(tmp_path):
+    # Before this fix, a require/include resolving above the repo root (a real
+    # file on disk, just outside repo_path) crashed the whole scan with an
+    # unhandled ValueError from path.relative_to().
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.php").write_text("<?php\nfunction outside() {}\n")
+    (repo / "main.php").write_text("<?php\nrequire '../outside.php';\n")
+
+    _, dependency_graph, _ = build_module_graph(repo)
+
+    assert dependency_graph["edges"] == []
+
+
 def test_build_module_graph_php_use_of_unmapped_namespace_does_not_resolve(tmp_path):
     repo = tmp_path / "repo"
     (repo / "src").mkdir(parents=True)

--- a/src/tests/test_graph_ruby.py
+++ b/src/tests/test_graph_ruby.py
@@ -131,6 +131,21 @@ def test_build_module_graph_ruby_require_relative_with_dot_prefix_resolves(tmp_p
     assert ("main.rb", "helper.rb") in edges
 
 
+def test_build_module_graph_ruby_require_relative_escaping_repo_root_does_not_crash(tmp_path):
+    # Before this fix, a require_relative resolving above the repo root (a real
+    # file on disk, just outside repo_path) crashed the whole scan with an
+    # unhandled ValueError from path.relative_to() - treated the same as any
+    # other unresolved/external require instead.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.rb").write_text("def outside\nend\n")
+    (repo / "main.rb").write_text('require_relative "../outside"\n')
+
+    _, dependency_graph, _ = build_module_graph(repo)
+
+    assert dependency_graph["edges"] == []
+
+
 def test_build_module_graph_ruby_method_call_with_receiver_is_not_mistaken_for_require(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -82,6 +82,37 @@ def test_find_secrets_no_matches_in_ordinary_file(tmp_path):
     assert result["scanned_files"] == 1
 
 
+def test_find_secrets_does_not_follow_a_symlinked_file_outside_the_repo(tmp_path):
+    # Before this fix, a symlinked file was still is_file() == True and got
+    # scanned/reported on even though it points outside the intended repo root.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside.py").write_text('AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    (repo / "linked.py").symlink_to(tmp_path / "outside.py")
+
+    result = find_secrets(repo)
+
+    assert result["findings"] == []
+    assert result["scanned_files"] == 0
+
+
+def test_find_secrets_does_not_descend_into_a_symlinked_directory_outside_the_repo(tmp_path):
+    # A symlinked directory isn't itself is_file(), so the first check alone
+    # doesn't protect against it - Path.rglob("*") still recurses through a
+    # symlinked directory's contents by default, scanning real files outside
+    # the repo as if they were part of it.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / "outside").mkdir()
+    (tmp_path / "outside" / "config.py").write_text('AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    (repo / "linked_dir").symlink_to(tmp_path / "outside")
+
+    result = find_secrets(repo)
+
+    assert result["findings"] == []
+    assert result["scanned_files"] == 0
+
+
 def test_find_secrets_generic_credential_preview_previews_the_value_not_the_keyword(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
Two HIGH-severity CLI scanner robustness bugs found in a deployment-readiness audit pass:

- **Crash: relative imports resolving outside the repo root.** `_rel()` (scanner/graph.py) called `path.relative_to(repo_path)` unguarded - raises an unhandled `ValueError` whenever a resolved import/include lands outside `repo_path` (a relative path climbing above the root via `../..`, or - for Java/C# - a source root inferred one level too high when a file's own package/namespace name coincidentally matches its containing directory name). JS's own resolver already guarded this exact case; the other 5 language resolvers (Ruby, PHP, C/C++, Java, C#) never got the same protection, so a single escaping import anywhere in a repo killed the entire `aletheore scan`. Fixed by moving the guard into `_rel()` itself so every caller gets it automatically.
- **Symlink traversal outside the repo root.** `secrets.py`, `scanner/graph.py`, and `scanner/detect.py` all walked the repo via `Path.rglob("*")`, which follows symlinked directories by default - a symlink anywhere in the tree let the secrets scanner and module walker read/report on real files genuinely outside the intended repo root. Fixed by switching all three full-repo walks to `os.walk(followlinks=False)` plus an explicit `is_symlink()` check per file.

## Test plan
- [x] 5 new regression tests (one per affected language), each confirmed via a direct interpreter probe *before* writing the test to actually reproduce the escaping-path scenario under the old code
- [x] 6 new regression tests for symlinked files/directories outside the repo (secrets scanner, module graph builder, language detector)
- [x] Full suite green: 783 passed