### PR TITLE
fix: MCP server tool docs, per-tool descriptions, credential parity, index tool, evidence caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ has full setup, every CLI command, the MCP tool list, and the dashboard.
   [`src/README.md`](src/README.md) for why.
 - **`aletheore query`** / **`aletheore diff`** — answer targeted questions or compare two scans
   from existing evidence, no re-scan or LLM call needed.
-- **`aletheore mcp`** — a stdio MCP server exposing 13 tools (module lookups, ownership,
-  clusters, full-text search, a compact scan trigger) so a coding agent can query a repo's
-  structure directly instead of shelling out or re-reading files.
+- **`aletheore mcp`** — a stdio MCP server exposing 28 tools (module/symbol/dependency
+  lookups, ownership, clusters, dead code, hotspots, full-text and semantic search, scan and
+  index triggers) so a coding agent can query a repo's structure directly instead of shelling
+  out or re-reading files. See [`src/README.md`](src/README.md) for the full tool list.
 - **`aletheore dashboard`** — a live local web UI: dependency graph, an Obsidian-style cluster
   graph, trend charts, MCP tool list.
 - **A GitHub Action** (`action.yml`) — scans a PR's base and head refs and posts a diff (new

--- a/src/README.md
+++ b/src/README.md
@@ -294,6 +294,7 @@ call.
 aletheore query imports app/routes.py --path .
 aletheore query imported-by app/routes.py --path .
 aletheore query symbols app/routes.py --path .
+aletheore query symbol-source app/routes.py handle_login --path .
 aletheore query branch main --path .
 aletheore query ownership --path .
 aletheore query secrets app/routes.py --path .        # findings within just that file
@@ -302,6 +303,14 @@ aletheore query licenses --path .
 aletheore query endpoints --path .
 aletheore query cluster app/routes.py --path .
 aletheore query layer-violations --path .
+aletheore query dead-code --path .
+aletheore query hotspots --path .                     # files with the most git churn/co-change
+aletheore query database --path .                     # detected ORMs, connection strings, migrations
+aletheore query infrastructure --path .                # detected Docker/CI/IaC config
+aletheore query environment-variables --path .
+aletheore query evidence-for-endpoint "GET /users/:id" --path .
+aletheore query evidence-for-symbol handle_login --path .
+aletheore query evidence-for-dependency requests --path .
 aletheore query changes --path .              # diff against the previous history snapshot
 aletheore query search-codebase "how does auth work?" --path .
 aletheore query answer "how does auth work?" --path . --agent ollama
@@ -346,25 +355,38 @@ Starts a stdio MCP server scoped to one repository, so a coding agent can query 
 directly instead of shelling out via Bash or re-reading files on every lookup. Every tool
 result is [TOON](https://toonformat.dev)-encoded rather than plain JSON — the calling agent's
 own token budget is what actually pays for reading these results, and evidence's shape (almost
-entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 17 tools
+entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 28 tools
 by default, plus one optional answer tool when started with `--agent`:
 
-- The 11 query kinds above as tools (`aletheore_imports`, `aletheore_imported_by`,
-  `aletheore_symbols`, `aletheore_branch`, `aletheore_ownership`, `aletheore_secrets`,
-  `aletheore_vulnerabilities`, `aletheore_licenses`, `aletheore_endpoints`, `aletheore_cluster`,
-  `aletheore_layer_violations`), plus `aletheore_changes`.
+- The 16 query kinds above as tools, each named `aletheore_<kind>` with underscores in place of
+  hyphens (`aletheore_imports`, `aletheore_imported_by`, `aletheore_symbols`, `aletheore_branch`,
+  `aletheore_ownership`, `aletheore_secrets`, `aletheore_vulnerabilities`, `aletheore_licenses`,
+  `aletheore_endpoints`, `aletheore_cluster`, `aletheore_layer_violations`, `aletheore_dead_code`,
+  `aletheore_hotspots`, `aletheore_database`, `aletheore_infrastructure`,
+  `aletheore_environment_variables`) — each tool's own description states what `target` expects
+  (a file path, a branch name, or that the tool takes no target at all).
+- `aletheore_changes(full=False)` — what changed between the two most recent scans.
 - `aletheore_neighborhood(target)` — a module's imports, dependents, and cluster in one call,
   instead of three round-trips.
 - `aletheore_search(pattern, regex=False, path_glob=None)` — literal or regex full-text search
   over tracked source files, capped at 200 matches.
-- `aletheore_search_codebase(query, k=10)` — semantic search over the local code index.
-- Optional: `aletheore_answer(question, k=5)` — available only when the MCP server is started
-  with `--agent`, answers from the semantic index using the selected provider.
-- `aletheore_scan()` — triggers a fresh deterministic scan and returns a compact summary (not
+- `aletheore_symbol_source(module, symbol)` — exact source text for one named function/class,
+  with resolved line bounds.
+- `aletheore_find_evidence_for_endpoint(method, path)`, `aletheore_find_evidence_for_symbol(symbol)`,
+  `aletheore_find_evidence_for_dependency(dependency)` — resolve an endpoint/symbol/dependency to
+  full source evidence: file, line, owner, commit, and (for endpoints) live-health risk.
+- `aletheore_scan(...)` — triggers a fresh deterministic scan and returns a compact summary (not
   the full evidence dump). Does **not** run the agent-driven `audit` report — see the note
   under `aletheore audit` above for why that's a deliberate boundary, not a gap.
 - `aletheore_healthcheck(base_url)` — runs the same GET-only live health check as the CLI and
   persists the result under `.aletheore/healthchecks/`.
+- `aletheore_index()` — builds the local semantic search index, same as `aletheore index`.
+- `aletheore_search_codebase(query, k=10)` — semantic search over the local code index.
+- `aletheore_managed_audit(token=None)` — runs a full managed audit report via Aletheore's
+  hosted service, resolving the token the same way `aletheore login` does: an explicit `token`
+  argument, then `ALETHEORE_API_TOKEN`, then the credential saved by `aletheore login`.
+- Optional: `aletheore_answer(question, k=5)` — available only when the MCP server is started
+  with `--agent`, answers from the semantic index using the selected provider.
 
 ```bash
 aletheore mcp .

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 
 from aletheore.adapters.base import AgentAdapter
 from aletheore.answer import answer_question
+from aletheore.credentials import get_api_key
 from aletheore.evidence import scan_repository, write_evidence
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
 from aletheore.history import compute_diff, list_snapshots, save_snapshot
@@ -26,6 +27,20 @@ from aletheore.search_index import search_index
 from aletheore.toon_encoding import to_toon
 
 
+# repo_path -> ((mtime, size) of the evidence file at load time, parsed
+# evidence dict). An MCP server process lives for the whole session, and
+# every tool call was re-reading and re-parsing the entire evidence file
+# from scratch - for a large repo (hundreds of MB of JSON) that's real,
+# entirely avoidable latency on every single tool call. Keyed by (mtime,
+# size) rather than unconditional for the process lifetime so a fresh
+# `aletheore scan` (or the aletheore_scan tool) invalidates it automatically
+# - mtime alone can be too coarse-grained on some filesystems to catch a
+# rewrite that lands in the same second, size is a cheap extra check from
+# the same stat() call. Nothing here ever mutates the returned dict, so
+# sharing one parsed copy across calls is safe.
+_evidence_cache: dict[Path, tuple[tuple[float, int], dict]] = {}
+
+
 def read_evidence(repo_path: Path) -> dict:
     evidence_path = repo_path / ".aletheore" / "air.json"
     if not evidence_path.exists():
@@ -33,7 +48,14 @@ def read_evidence(repo_path: Path) -> dict:
             f"no evidence found at {evidence_path} - run 'aletheore scan {repo_path}' first "
             "or call the aletheore_scan tool"
         )
-    return json.loads(evidence_path.read_text())
+    stat = evidence_path.stat()
+    cache_key = (stat.st_mtime, stat.st_size)
+    cached = _evidence_cache.get(repo_path)
+    if cached is not None and cached[0] == cache_key:
+        return cached[1]
+    evidence = json.loads(evidence_path.read_text())
+    _evidence_cache[repo_path] = (cache_key, evidence)
+    return evidence
 
 
 def _toon_result(data: object) -> str:
@@ -64,6 +86,31 @@ _TOOL_NAME_TO_QUERY_KIND = {
     "aletheore_environment_variables": "environment-variables",
 }
 
+# One real description per query kind, naming exactly what `target` expects
+# where the underlying query function actually takes one (see
+# QUERY_FUNCTIONS' requires_target flag in query.py) - a shared templated
+# docstring left every one of these indistinguishable to a calling LLM,
+# which had no way to tell "target is a file path" from "target is a
+# branch name" from "this tool takes no target at all".
+_QUERY_TOOL_DESCRIPTIONS = {
+    "imports": "This module's own list of imports. target: file path exactly as it appears in evidence (e.g. 'src/app.py').",
+    "imported-by": "Which modules import this one. target: file path exactly as it appears in evidence.",
+    "symbols": "This module's extracted functions and classes. target: file path exactly as it appears in evidence.",
+    "branch": "Git branch metadata (head commit, tracking info). target: branch name (e.g. 'main').",
+    "ownership": "Per-file code ownership derived from git blame history. Takes no target.",
+    "secrets": "Secret-scanner findings for one file. target: file path exactly as it appears in evidence.",
+    "vulnerabilities": "All dependency vulnerability findings for this repo. Takes no target.",
+    "licenses": "All dependency license findings for this repo. Takes no target.",
+    "endpoints": "All API endpoints mapped from source. Takes no target.",
+    "cluster": "The architecture cluster containing this module. target: file path exactly as it appears in evidence.",
+    "layer-violations": "Layer-convention violations detected in the architecture. Takes no target.",
+    "dead-code": "Unreferenced functions/classes and unused dependencies. Takes no target.",
+    "hotspots": "Files with the most git churn/co-change activity. Takes no target.",
+    "database": "Detected database usage - ORMs, connection strings, migrations. Takes no target.",
+    "infrastructure": "Detected infrastructure config - Docker, CI, IaC files. Takes no target.",
+    "environment-variables": "Environment variables referenced in the codebase. Takes no target.",
+}
+
 _SEARCH_MATCH_CAP = 200
 
 
@@ -88,7 +135,7 @@ def _register_query_wrapper_tools(mcp_instance: FastMCP, repo_path: Path) -> Non
 
         tool_func = make_tool()
         tool_func.__name__ = tool_name
-        tool_func.__doc__ = f"Query '{kind}' from the scanned repository's evidence."
+        tool_func.__doc__ = _QUERY_TOOL_DESCRIPTIONS[kind]
         mcp_instance.tool(name=tool_name)(tool_func)
 
 
@@ -249,6 +296,23 @@ def _register_healthcheck_tool(mcp_instance: FastMCP, repo_path: Path) -> None:
         return _toon_result(result)
 
 
+def _register_index_tool(mcp_instance: FastMCP, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_index")
+    def aletheore_index() -> str:
+        """Build the semantic search index this repo's evidence, required
+        before aletheore_search_codebase or aletheore_answer can be used.
+        Embeds via a local Ollama instance, falling back to OpenAI if
+        unavailable."""
+        from aletheore.search_index import build_index
+
+        evidence = read_evidence(repo_path)
+        try:
+            count = build_index(repo_path, evidence)
+        except Exception as exc:  # noqa: BLE001
+            return _toon_result({"error": str(exc)})
+        return _toon_result({"indexed_chunks": count})
+
+
 def _register_search_codebase_tool(mcp_instance: FastMCP, repo_path: Path) -> None:
     @mcp_instance.tool(name="aletheore_search_codebase")
     def aletheore_search_codebase(query: str, k: int = 10) -> str:
@@ -269,12 +333,19 @@ def _register_managed_audit_tool(mcp_instance: FastMCP, repo_path: Path) -> None
     @mcp_instance.tool(name="aletheore_managed_audit")
     def aletheore_managed_audit(token: str | None = None) -> str:
         """Run a full audit report using Aletheore's managed audit service."""
-        import os
-
-        resolved_token = token or os.environ.get("ALETHEORE_API_TOKEN")
+        # Same resolution the CLI's own `aletheore audit --managed` uses -
+        # before this fix, this only checked the raw env var, so a user who
+        # ran `aletheore login` (saved to the OS keychain/credentials file,
+        # no env var set) got a false "no token available" through MCP even
+        # though the CLI itself worked. prompt_fn is a no-op: an MCP tool
+        # call is driven by an agent, not a human at a terminal, and must
+        # never block waiting for interactive input.
+        resolved_token = token or get_api_key(
+            "ALETHEORE_API_TOKEN", "aletheore-managed-audit", prompt_fn=lambda _: ""
+        )
         if not resolved_token:
             return _toon_result(
-                {"error": "no managed-audit token available (set ALETHEORE_API_TOKEN or pass token)"}
+                {"error": "no managed-audit token available (run 'aletheore login', set ALETHEORE_API_TOKEN, or pass token)"}
             )
         evidence = read_evidence(repo_path)
         return _toon_result({"report": run_managed_audit_request(evidence, resolved_token)})
@@ -290,6 +361,7 @@ def build_server(repo_path: Path, answer_adapter: AgentAdapter | None = None) ->
     _register_code_evidence_tools(mcp_instance, repo_path)
     _register_scan_tool(mcp_instance, repo_path)
     _register_healthcheck_tool(mcp_instance, repo_path)
+    _register_index_tool(mcp_instance, repo_path)
     _register_search_codebase_tool(mcp_instance, repo_path)
     _register_managed_audit_tool(mcp_instance, repo_path)
     if answer_adapter is not None:

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -215,7 +215,7 @@ def test_api_graph_returns_shape(tmp_path):
     assert set(body.keys()) == {"nodes", "edges", "clusters"}
 
 
-def test_api_mcp_tools_returns_27_tools(tmp_path):
+def test_api_mcp_tools_returns_28_tools(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
     app = build_app(repo)
     client = TestClient(app)
@@ -224,10 +224,11 @@ def test_api_mcp_tools_returns_27_tools(tmp_path):
 
     assert response.status_code == 200
     tools = response.json()
-    assert len(tools) == 27
+    assert len(tools) == 28
     names = {t["name"] for t in tools}
     assert "aletheore_scan" in names
     assert "aletheore_search" in names
+    assert "aletheore_index" in names
     assert "aletheore_search_codebase" in names
     assert "aletheore_endpoints" in names
     assert "aletheore_healthcheck" in names

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -108,6 +108,46 @@ def make_repo_with_evidence(tmp_path: Path) -> Path:
     return repo
 
 
+def test_read_evidence_caches_parsed_result_until_the_file_changes(tmp_path, monkeypatch):
+    # Before this fix, every single MCP tool call re-read and re-parsed the
+    # whole evidence file from disk, with no caching across calls in the
+    # same long-lived MCP server process - real, entirely avoidable latency
+    # on a large repo's multi-hundred-MB evidence file.
+    import time
+
+    from aletheore.mcp_server import read_evidence
+
+    monkeypatch.setattr("aletheore.mcp_server._evidence_cache", {})
+    repo = make_repo_with_evidence(tmp_path)
+    evidence_path = repo / ".aletheore" / "air.json"
+
+    read_count = {"n": 0}
+    real_read_text = Path.read_text
+
+    def counting_read_text(self, *args, **kwargs):
+        if self == evidence_path:
+            read_count["n"] += 1
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+    first = read_evidence(repo)
+    second = read_evidence(repo)
+
+    assert read_count["n"] == 1
+    assert first is second
+
+    time.sleep(0.01)
+    updated = json.loads(real_read_text(evidence_path))
+    updated["scanned_at"] = "2026-07-16T00:00:00+00:00 - a longer value to change file size too"
+    evidence_path.write_text(json.dumps(updated))
+
+    third = read_evidence(repo)
+
+    assert read_count["n"] == 2
+    assert third["scanned_at"].startswith("2026-07-16")
+
+
 @pytest.mark.asyncio
 async def test_build_server_registers_expected_tools(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
@@ -139,6 +179,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_symbol_source",
         "aletheore_scan",
         "aletheore_healthcheck",
+        "aletheore_index",
         "aletheore_search_codebase",
         "aletheore_managed_audit",
         "aletheore_find_evidence_for_endpoint",
@@ -146,8 +187,48 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_find_evidence_for_dependency",
     }
     assert expected.issubset(names)
-    assert len(names) == 27
+    assert len(names) == 28
     assert "aletheore_answer" not in names
+
+
+@pytest.mark.asyncio
+async def test_dynamic_query_tools_have_distinct_non_generic_descriptions(tmp_path):
+    # Before this fix, every one of these 16 tools shared the same templated
+    # description ("Query 'X' from the scanned repository's evidence.") with
+    # no indication of what `target` means for that specific tool - an LLM
+    # caller had no way to tell "target is a file path" from "target is a
+    # branch name" from "this tool takes no target at all".
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    tools = await server.list_tools()
+    by_name = {t.name: t for t in tools}
+
+    dynamic_tool_names = [
+        "aletheore_imports",
+        "aletheore_imported_by",
+        "aletheore_symbols",
+        "aletheore_branch",
+        "aletheore_ownership",
+        "aletheore_secrets",
+        "aletheore_vulnerabilities",
+        "aletheore_licenses",
+        "aletheore_endpoints",
+        "aletheore_cluster",
+        "aletheore_layer_violations",
+        "aletheore_dead_code",
+        "aletheore_hotspots",
+        "aletheore_database",
+        "aletheore_infrastructure",
+        "aletheore_environment_variables",
+    ]
+    descriptions = [by_name[name].description for name in dynamic_tool_names]
+
+    assert len(set(descriptions)) == len(dynamic_tool_names)
+    assert not any(d.startswith("Query '") for d in descriptions)
+    assert "file path" in by_name["aletheore_imports"].description
+    assert "branch name" in by_name["aletheore_branch"].description
+    assert "Takes no target" in by_name["aletheore_vulnerabilities"].description
 
 
 @pytest.mark.asyncio
@@ -175,6 +256,36 @@ async def test_aletheore_search_codebase_returns_toon_results(tmp_path):
         )
 
     assert tool_result_body(result)["result"] == [{"module_path": "a.py", "symbol_name": "foo"}]
+
+
+@pytest.mark.asyncio
+async def test_aletheore_index_tool_builds_the_search_index(tmp_path):
+    # Before this fix, aletheore_search_codebase/aletheore_answer required
+    # .aletheore/index.lancedb, buildable only via the CLI's `aletheore
+    # index` command - no MCP tool existed to build it, forcing an agent
+    # using only MCP tools to shell out anyway.
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    with patch("aletheore.search_index.build_index", return_value=7) as mock_build_index:
+        result = await server.call_tool("aletheore_index", {})
+
+    assert tool_result_body(result)["result"] == {"indexed_chunks": 7}
+    mock_build_index.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_aletheore_index_tool_returns_error_instead_of_raising(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("no embedding provider available")
+
+    with patch("aletheore.search_index.build_index", side_effect=_raise):
+        result = await server.call_tool("aletheore_index", {})
+
+    assert tool_result_body(result)["result"] == {"error": "no embedding provider available"}
 
 
 @pytest.mark.asyncio
@@ -299,6 +410,36 @@ async def test_aletheore_managed_audit_tool_calls_client(tmp_path, monkeypatch):
 
     result = await server.call_tool("aletheore_managed_audit", {"token": "real-token"})
 
+    assert tool_result_body(result)["result"]["report"].startswith("# Report")
+
+
+@pytest.mark.asyncio
+async def test_aletheore_managed_audit_tool_falls_back_to_saved_credential(tmp_path, monkeypatch):
+    # Before this fix, this tool only checked os.environ.get("ALETHEORE_API_TOKEN")
+    # directly - a user who ran `aletheore login` (saved to the OS
+    # keychain/credentials file, no env var set) got a false "no token
+    # available" error through MCP even though the CLI's own `audit --managed`
+    # worked fine for the exact same saved credential.
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+    monkeypatch.delenv("ALETHEORE_API_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "aletheore.mcp_server.get_api_key",
+        lambda env_var, provider_name, **kwargs: "token-from-keychain",
+    )
+    captured = {}
+
+    def fake_run_managed_audit_request(evidence, token):
+        captured["token"] = token
+        return "# Report"
+
+    monkeypatch.setattr(
+        "aletheore.mcp_server.run_managed_audit_request", fake_run_managed_audit_request
+    )
+
+    result = await server.call_tool("aletheore_managed_audit", {})
+
+    assert captured["token"] == "token-from-keychain"
     assert tool_result_body(result)["result"]["report"].startswith("# Report")
 
 


### PR DESCRIPTION
## Summary
Five MCP-layer gaps from a deployment-readiness audit pass, all touching `mcp_server.py`:

- **Stale tool docs**: both READMEs claimed 13/17 MCP tools; the server actually registers 28 (dead-code, hotspots, database, infrastructure, environment-variables, symbol-source, 3 `find_evidence_for_*` tools, managed_audit - none were documented). Regenerated both READMEs' tool lists and the `query` command's example block (was missing 9 of 23 query kinds).
- **Generic tool descriptions**: all 16 dynamic query tools shared one templated docstring with no indication of what `target` means per tool. Each now has its own description.
- **`aletheore_managed_audit` credential mismatch**: only checked the raw env var, so a user who ran `aletheore login` (saved to the OS keychain/credentials file) got a false "no token available" through MCP even though the CLI itself worked. Now resolves through the same `credentials.get_api_key()` the CLI uses.
- **No MCP tool to build the semantic index**: `aletheore_search_codebase`/`aletheore_answer` require an index buildable only via the CLI's `aletheore index` - added `aletheore_index`.
- **No evidence caching**: `read_evidence()` re-read and re-parsed the whole evidence file from disk on every single tool call - real, avoidable latency on a large repo's multi-hundred-MB evidence file. Cached in-process, keyed by the file's `(mtime, size)` so a fresh scan invalidates it automatically.

## Test plan
- [x] Full suite green: 777 passed
- [x] New tests: per-tool description distinctness, managed-audit keychain fallback, index-tool success/error paths, evidence-cache hit/invalidation, updated tool-count assertions (27→28) in both `test_mcp_server.py` and `test_dashboard.py`