### PR TITLE
feat: cache license/vulnerability registry lookups on disk

### DIFF
--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -1,6 +1,7 @@
 import json
 import re
 import ssl
+import time
 import tomllib
 import urllib.error
 import urllib.request
@@ -30,6 +31,17 @@ DEFAULT_TIMEOUT_SECONDS = 10
 # to blow the hosted worker's per-job timeout on its own. Bounded, not
 # unbounded, so this stays polite to registries under a large repo.
 LICENSE_CHECK_CONCURRENCY = 20
+
+# A registry lookup for one exact (ecosystem, name, version) triple returns
+# the same answer forever in the overwhelming majority of cases - a
+# published package version's license doesn't change - so every scan of
+# every repo on this machine re-paying the same network round-trip for the
+# same dependency is pure waste. Cached across repos and across
+# invocations, not per-scan. 30 days is defensive against the rare
+# corrected-metadata case, not a sign this data actually changes on that
+# timescale.
+DEFAULT_LICENSE_CACHE_PATH = Path.home() / ".cache" / "aletheore" / "license-cache.json"
+_LICENSE_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60
 
 # Same reasoning as vulnerabilities.py: certifi's CA bundle explicitly, since a
 # python.org macOS install commonly has no default CA bundle configured.
@@ -258,11 +270,57 @@ def _fetch_one_license(pin: tuple[str, str, str], timeout: int) -> str | None:
         return None
 
 
+def _license_cache_key(ecosystem: str, name: str, version: str) -> str:
+    return f"{ecosystem}|{name}|{version}"
+
+
+def _load_license_cache(cache_path: Path) -> dict[str, dict]:
+    try:
+        return json.loads(cache_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_license_cache(cache_path: Path, cache: dict[str, dict]) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(cache))
+    except OSError:
+        # Best-effort: a failure to persist the cache must never fail the
+        # license check itself - it only costs the next scan (of this or any
+        # other repo) its cache hit, not correctness.
+        pass
+
+
+def _fetch_one_license_cached(
+    pin: tuple[str, str, str], timeout: int, cache: dict[str, dict]
+) -> str | None:
+    name, version, ecosystem = pin
+    key = _license_cache_key(ecosystem, name, version)
+    cached = cache.get(key)
+    if cached is not None and time.time() - cached.get("cached_at", 0) < _LICENSE_CACHE_TTL_SECONDS:
+        return cached.get("license")
+
+    license_text = _fetch_one_license(pin, timeout)
+    # Safe to mutate from multiple worker threads: dict item assignment on
+    # distinct keys is atomic under the GIL, and every pin has its own
+    # distinct key here.
+    cache[key] = {"license": license_text, "cached_at": time.time()}
+    return license_text
+
+
 def check_dependency_licenses(
     repo_path: Path,
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
     on_progress: Callable[[int, int, str], None] | None = None,
+    cache_path: Path | None = None,
 ) -> dict:
+    # Resolved inside the function body (not as the default argument value
+    # itself) so a test monkeypatching DEFAULT_LICENSE_CACHE_PATH actually
+    # takes effect - a default argument's value is bound once at function
+    # definition time, before any test ever runs.
+    if cache_path is None:
+        cache_path = DEFAULT_LICENSE_CACHE_PATH
     repo_license = detect_repo_license(repo_path)
     pins = (
         _parse_pip_pins(repo_path)
@@ -278,13 +336,16 @@ def check_dependency_licenses(
         return {"checked": True, "reason": None, "repo_license": repo_license, "findings": []}
 
     findings = []
+    cache = _load_license_cache(cache_path)
     # Each registry lookup is an independent blocking HTTP call - a thread
     # pool overlaps their network wait time instead of paying it serially.
     # executor.map (not as_completed) preserves pins' original order in the
     # results regardless of which thread finishes first, so progress
     # reporting and finding order both stay deterministic.
     with ThreadPoolExecutor(max_workers=LICENSE_CHECK_CONCURRENCY) as executor:
-        license_texts = executor.map(lambda pin: _fetch_one_license(pin, timeout), pins)
+        license_texts = executor.map(
+            lambda pin: _fetch_one_license_cached(pin, timeout, cache), pins
+        )
         for index, ((name, version, ecosystem), license_text) in enumerate(
             zip(pins, license_texts), start=1
         ):
@@ -302,5 +363,6 @@ def check_dependency_licenses(
                         "category": category,
                     }
                 )
+    _save_license_cache(cache_path, cache)
 
     return {"checked": True, "reason": None, "repo_license": repo_license, "findings": findings}

--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -1,6 +1,7 @@
 import json
 import re
 import ssl
+import time
 import tomllib
 import urllib.error
 import urllib.request
@@ -12,6 +13,15 @@ import certifi
 OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
 OSV_VULN_URL_TEMPLATE = "https://api.osv.dev/v1/vulns/{vuln_id}"
 DEFAULT_TIMEOUT_SECONDS = 10
+
+# Unlike a package's license (effectively invariant once published), new
+# vulnerabilities get disclosed against already-published old versions all
+# the time - a long cache here risks silently missing a newly-disclosed CVE.
+# Short enough that a day of repeated scans (of this or any other repo) on
+# the same machine doesn't re-pay the same OSV.dev round-trip for every one,
+# without letting real staleness accumulate for long.
+DEFAULT_VULNERABILITY_CACHE_PATH = Path.home() / ".cache" / "aletheore" / "vulnerability-cache.json"
+_VULNERABILITY_CACHE_TTL_SECONDS = 24 * 60 * 60
 
 # Use certifi's CA bundle explicitly rather than the system default SSL context.
 # On macOS, Python installed from python.org commonly has no default CA bundle
@@ -437,7 +447,37 @@ def _fetch_vuln_detail(vuln_id: str, timeout: int) -> dict:
         return json.loads(response.read())
 
 
-def check_vulnerabilities(repo_path: Path, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> dict:
+def _vulnerability_cache_key(ecosystem: str, name: str, version: str) -> str:
+    return f"{ecosystem}|{name}|{version}"
+
+
+def _load_vulnerability_cache(cache_path: Path) -> dict[str, dict]:
+    try:
+        return json.loads(cache_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_vulnerability_cache(cache_path: Path, cache: dict[str, dict]) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(cache))
+    except OSError:
+        # Best-effort: a failure to persist the cache must never fail the
+        # vulnerability check itself.
+        pass
+
+
+def check_vulnerabilities(
+    repo_path: Path,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    cache_path: Path | None = None,
+) -> dict:
+    # Resolved inside the function body so a test monkeypatching
+    # DEFAULT_VULNERABILITY_CACHE_PATH actually takes effect - see the
+    # matching comment in licenses.py's check_dependency_licenses.
+    if cache_path is None:
+        cache_path = DEFAULT_VULNERABILITY_CACHE_PATH
     pins = (
         _parse_pip_pins(repo_path)
         + _parse_npm_pins(repo_path)
@@ -451,14 +491,39 @@ def check_vulnerabilities(repo_path: Path, timeout: int = DEFAULT_TIMEOUT_SECOND
     if not pins:
         return {"checked": True, "reason": None, "findings": []}
 
-    try:
-        results = _query_batch(pins, timeout)
-    except (urllib.error.URLError, TimeoutError, OSError) as exc:
-        return {
-            "checked": False,
-            "reason": f"OSV.dev unreachable or timed out: {exc}",
-            "findings": [],
-        }
+    cache = _load_vulnerability_cache(cache_path)
+    now = time.time()
+
+    results: list[dict | None] = [None] * len(pins)
+    uncached_indices: list[int] = []
+    uncached_pins: list[tuple[str, str, str]] = []
+    for index, (name, version, ecosystem) in enumerate(pins):
+        key = _vulnerability_cache_key(ecosystem, name, version)
+        cached = cache.get(key)
+        if cached is not None and now - cached.get("cached_at", 0) < _VULNERABILITY_CACHE_TTL_SECONDS:
+            results[index] = cached["result"]
+        else:
+            uncached_indices.append(index)
+            uncached_pins.append((name, version, ecosystem))
+
+    if uncached_pins:
+        try:
+            fresh_results = _query_batch(uncached_pins, timeout)
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            return {
+                "checked": False,
+                "reason": f"OSV.dev unreachable or timed out: {exc}",
+                "findings": [],
+            }
+        for index, (name, version, ecosystem), result in zip(
+            uncached_indices, uncached_pins, fresh_results
+        ):
+            results[index] = result
+            cache[_vulnerability_cache_key(ecosystem, name, version)] = {
+                "result": result,
+                "cached_at": now,
+            }
+        _save_vulnerability_cache(cache_path, cache)
 
     findings = []
     for (name, version, ecosystem), result in zip(pins, results):

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -10,3 +10,19 @@ def _disable_cli_telemetry_in_tests(monkeypatch):
     locally via their own monkeypatch.delenv, same pattern as
     test_telemetry.py."""
     monkeypatch.setenv("ALETHEORE_TELEMETRY_DISABLED", "1")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_license_and_vulnerability_caches(tmp_path, monkeypatch):
+    """Global safety net: no test run should ever read or write this
+    machine's real ~/.cache/aletheore/ - a stale real-world cache entry
+    (from actually running the CLI by hand) silently swallowed a mocked
+    HTTP response and made an otherwise-correct test fail nondeterministically
+    depending on this machine's disk state, not the code under test."""
+    monkeypatch.setattr(
+        "aletheore.licenses.DEFAULT_LICENSE_CACHE_PATH", tmp_path / "license-cache.json"
+    )
+    monkeypatch.setattr(
+        "aletheore.vulnerabilities.DEFAULT_VULNERABILITY_CACHE_PATH",
+        tmp_path / "vulnerability-cache.json",
+    )

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -162,6 +162,56 @@ def test_check_dependency_licenses_no_pins_short_circuits_without_network_call(t
     assert result["findings"] == []
 
 
+def test_check_dependency_licenses_second_scan_skips_network_call_entirely(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("pyqt5==5.15.10\n")
+
+    response = _mock_response({"info": {"license": "GPL v3", "classifiers": []}})
+    with patch(
+        "aletheore.licenses.urllib.request.urlopen", return_value=response
+    ) as mock_urlopen:
+        first = check_dependency_licenses(repo)
+    assert mock_urlopen.call_count == 1
+
+    # A second scan of the same repo (or, since this is a global cache, any
+    # other repo pinning the same exact package+version) must reuse the
+    # cached license instead of paying another registry round-trip.
+    with patch(
+        "aletheore.licenses.urllib.request.urlopen",
+        side_effect=AssertionError("network must not be called on a cache hit"),
+    ) as mock_urlopen:
+        second = check_dependency_licenses(repo)
+
+    mock_urlopen.assert_not_called()
+    assert second == first
+
+
+def test_check_dependency_licenses_different_repo_reuses_the_same_global_cache(tmp_path):
+    # The license cache is keyed purely by (ecosystem, name, version), not
+    # by repo path - two entirely different repos pinning the same exact
+    # dependency version share one cached lookup.
+    repo_a = tmp_path / "repo_a"
+    repo_a.mkdir()
+    (repo_a / "requirements.txt").write_text("pyqt5==5.15.10\n")
+    repo_b = tmp_path / "repo_b"
+    repo_b.mkdir()
+    (repo_b / "requirements.txt").write_text("pyqt5==5.15.10\n")
+
+    response = _mock_response({"info": {"license": "GPL v3", "classifiers": []}})
+    with patch("aletheore.licenses.urllib.request.urlopen", return_value=response):
+        check_dependency_licenses(repo_a)
+
+    with patch(
+        "aletheore.licenses.urllib.request.urlopen",
+        side_effect=AssertionError("network must not be called on a cache hit"),
+    ) as mock_urlopen:
+        result = check_dependency_licenses(repo_b)
+
+    mock_urlopen.assert_not_called()
+    assert result["findings"][0]["package"] == "pyqt5"
+
+
 def test_check_dependency_licenses_reports_a_copyleft_pypi_dependency(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -95,6 +95,86 @@ def test_check_vulnerabilities_no_pins_short_circuits_without_network_call(tmp_p
     assert result == {"checked": True, "reason": None, "findings": []}
 
 
+def test_check_vulnerabilities_second_scan_skips_network_call_entirely(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("fastapi==0.100.0\n")
+
+    batch_response = _mock_response({"results": [{}]})
+    with patch(
+        "aletheore.vulnerabilities.urllib.request.urlopen", return_value=batch_response
+    ) as mock_urlopen:
+        first = check_vulnerabilities(repo)
+    assert mock_urlopen.call_count == 1
+
+    # Second scan of the same repo, same pin - the OSV.dev round-trip must
+    # not happen again within the cache's TTL, even if the mock would now
+    # error if called (proving it really isn't called, not just returning
+    # a stale-but-coincidentally-correct answer).
+    with patch(
+        "aletheore.vulnerabilities.urllib.request.urlopen",
+        side_effect=AssertionError("network must not be called on a cache hit"),
+    ) as mock_urlopen:
+        second = check_vulnerabilities(repo)
+
+    mock_urlopen.assert_not_called()
+    assert second == first
+
+
+def test_check_vulnerabilities_only_queries_the_uncached_subset(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("fastapi==0.100.0\n")
+    (repo / "package.json").write_text(
+        json.dumps({"dependencies": {"left-pad": "^1.3.0"}})
+    )
+
+    # First scan caches both pins.
+    batch_response = _mock_response({"results": [{}, {}]})
+    with patch("aletheore.vulnerabilities.urllib.request.urlopen", return_value=batch_response):
+        check_vulnerabilities(repo)
+
+    # Second scan adds a brand-new dependency - only that one should reach
+    # OSV.dev, cached fastapi/left-pad must not be re-queried.
+    (repo / "requirements.txt").write_text("fastapi==0.100.0\nrequests==2.31.0\n")
+    second_batch_response = _mock_response({"results": [{}]})
+    with patch(
+        "aletheore.vulnerabilities.urllib.request.urlopen", return_value=second_batch_response
+    ) as mock_urlopen:
+        check_vulnerabilities(repo)
+
+    sent_request = mock_urlopen.call_args[0][0]
+    sent_body = json.loads(sent_request.data)
+    queried_names = {q["package"]["name"] for q in sent_body["queries"]}
+    assert queried_names == {"requests"}
+
+
+def test_check_vulnerabilities_expired_cache_entry_is_requeried(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "requirements.txt").write_text("fastapi==0.100.0\n")
+
+    batch_response = _mock_response({"results": [{}]})
+    with patch("aletheore.vulnerabilities.urllib.request.urlopen", return_value=batch_response):
+        check_vulnerabilities(repo)
+
+    # Force every cache entry to look 25 hours old - past the 24h TTL.
+    import aletheore.vulnerabilities as vulnerabilities_module
+
+    cache_path = vulnerabilities_module.DEFAULT_VULNERABILITY_CACHE_PATH
+    cache = json.loads(cache_path.read_text())
+    for entry in cache.values():
+        entry["cached_at"] -= 25 * 60 * 60
+    cache_path.write_text(json.dumps(cache))
+
+    with patch(
+        "aletheore.vulnerabilities.urllib.request.urlopen", return_value=batch_response
+    ) as mock_urlopen:
+        check_vulnerabilities(repo)
+
+    mock_urlopen.assert_called_once()
+
+
 def test_parse_go_pins_reads_require_block(tmp_path):
     from aletheore.vulnerabilities import _parse_go_pins
 


### PR DESCRIPTION
## Summary
Both `check_dependency_licenses` and `check_vulnerabilities` re-issued a registry lookup for every pinned dependency on every single scan, even though a package version's published metadata is effectively static (license) or at least short-lived (vulnerabilities - new CVEs get disclosed against old versions, but not minute-to-minute). A repo with hundreds of pinned deps (real case: 441) took 3+ minutes on licenses alone.

Adds an on-disk cache keyed by `(ecosystem, name, version)`, shared **globally across every repo scanned on this machine**, not per-repo - the same exact dependency pinned in two different projects now costs one registry round-trip total, not one per project (covered by a dedicated test).

- **Licenses**: `~/.cache/aletheore/license-cache.json`, 30-day TTL - purely defensive against the rare corrected-metadata case, not a sign this data actually changes on that timescale.
- **Vulnerabilities**: `~/.cache/aletheore/vulnerability-cache.json`, 24-hour TTL - deliberately much shorter than licenses, since staleness here risks silently missing a newly-disclosed CVE. The existing single-batch-query design to OSV.dev is preserved: only the uncached subset of pins gets sent, and the network call is skipped entirely when every pin is already cached.

Both cache paths are resolved inside the function body rather than as default-argument values, so callers (and tests) can override them without hitting Python's once-at-definition-time default-argument binding.

## A bug this surfaced
While testing, a *real* cache entry left over from manually verifying #80's incremental-scan cache silently made two pre-existing `test_vulnerabilities.py` tests fail nondeterministically - they were reading this machine's actual `~/.cache/aletheore/` instead of the mocked HTTP response. Added an autouse `conftest.py` fixture isolating every test from the real cache location, matching the existing pattern for disabling real telemetry calls in tests.

## Test plan
- [x] 5 new tests: cache hit skips the network call entirely; only the uncached subset of pins gets queried on a partial cache hit; an expired entry gets requeried; a different repo pinning the identical dependency reuses the same global cache
- [x] Full suite green: 777 passed