### PR TITLE
chore: CLI help text, flag-combo warnings, README gaps, Java/C# double-parse

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "Aletheore",
     "AIRview",
     "Arihant",
+    "BYOK",
     "CODEOWNERS",
     "DeepSeek",
     "FastAPI",

--- a/src/README.md
+++ b/src/README.md
@@ -16,6 +16,20 @@ convention violations, dependency licenses, and static API endpoint maps. Every 
 below is built on top of that same evidence and
 never states anything it can't cite back to a specific field in it.
 
+## Quickstart
+
+```bash
+pipx install aletheore
+aletheore scan .
+cat .aletheore/air.json   # the evidence everything else reads from
+```
+
+That's the whole deterministic path: no LLM call, no account, no network access beyond the
+dependency-vulnerability/license registry lookups (skip those with `--no-check-vulnerabilities
+--no-check-licenses` for a fully offline run). Everything below - the per-language import
+resolution details, `audit`'s LLM-written report, the MCP server, the dashboard - builds on
+top of that one `air.json` file.
+
 Secrets, git activity, and dependency-vulnerability checks are language-agnostic. The module
 dependency graph (imports, clusters, layer violations) currently understands **Python,
 JavaScript/JSX, TypeScript/TSX, Go, Rust, Java, Ruby, PHP, C, C++, and C#** — other languages
@@ -101,11 +115,15 @@ doesn't break reproducibility: same repo content in, same evidence out).
 {
   "layer_markers": { "biz": 1 },
   "cluster_resolution": 1.5,
+  "dead_code_entry_points": ["scripts/migrate.py"],
   "accepted_secrets": [
     { "path": "tests/fixtures/sample.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP" }
   ]
 }
 ```
+
+`aletheore init [path]` scaffolds this file with all four keys present (empty/default), plus
+a one-line explanation of each printed to the console.
 
 - `layer_markers` — extends/overrides the built-in folder-name -> layer-rank table used by
   layer-violation detection (e.g. a repo using a `biz/` folder that isn't one of the built-in
@@ -113,6 +131,10 @@ doesn't break reproducibility: same repo content in, same evidence out).
   for non-overlapping keys; only overlapping keys get overridden.
 - `cluster_resolution` — passed straight into the modularity-clustering algorithm (default
   `1.0`). Higher values favor more, smaller clusters; lower values favor fewer, larger ones.
+- `dead_code_entry_points` — extra file paths (beyond what's auto-detected: a framework's
+  `main.py`/`app.py`, test files, `__init__.py` re-exports) to treat as reachable roots when
+  computing unreferenced code - a script only ever invoked by a cron job or CI step, never
+  imported from anywhere else in the repo, would otherwise be flagged as dead code.
 - `accepted_secrets` — a baseline of reviewed, accepted secret findings (e.g. a genuinely
   fake key in a test fixture that will always match a pattern). Every secrets scanner needs
   this: without it, `--fail-on-new-secrets` has no escape hatch for a known false positive -
@@ -124,13 +146,23 @@ doesn't break reproducibility: same repo content in, same evidence out).
   `"accepted": true`/labeled "accepted (in .aletheore.json baseline)" - only the fail-gates and
   inline PR annotations skip them.
 
-All three keys are optional and independently defaulted/empty if the file is missing,
+All four keys are optional and independently defaulted/empty if the file is missing,
 malformed, or only sets some of them. `layer_markers`/`cluster_resolution` (or `null` if
 there's no config file at all) are recorded verbatim in `air.json` at
 `architecture.config_applied`, so a report can cite exactly what convention was in effect for
 that scan.
 
 ## Commands
+
+### `aletheore init [path]`
+
+Scaffolds a `.aletheore.json` at the repository root with all four Configuration keys above
+present (empty/default), refusing to overwrite an existing one. Entirely optional - `scan`/
+`audit` work identically with no config file at all.
+
+```bash
+aletheore init .
+```
 
 ### `aletheore scan [path]`
 
@@ -284,6 +316,41 @@ aletheore audit . --agent codex
 aletheore audit . --agent openai
 aletheore audit . --agent ollama
 ```
+
+#### `--managed`: BYOK vs. Aletheore's own key
+
+Everything above is **BYOK** (bring your own key) - `audit` uses whichever provider/CLI *you*
+already have configured, and the reasoning cost is yours. `aletheore audit . --managed` is the
+alternative: it runs the identical report against Aletheore's own hosted reasoning service
+instead, using a token tied to a paid GitHub App installation rather than any of your own
+provider credentials.
+
+```bash
+aletheore login             # GitHub device-flow auth, saves a managed-audit token
+aletheore audit . --managed
+aletheore status             # confirm login state and installed version
+aletheore logout             # clear the saved token
+```
+
+`--managed` reads the token from `ALETHEORE_API_TOKEN` first, then the credential
+`aletheore login` saved to `~/.config/aletheore/credentials.json` (`--token` overrides both,
+and only has any effect together with `--managed`). `--agent` is BYOK-only and has no effect
+with `--managed`, since there's no local/API provider selection to make.
+
+### `aletheore login`
+
+Authenticates with GitHub via device flow (prints a one-time code and a URL to enter it at),
+resolves which of your paid GitHub App installations to attach to (prompting if you have more
+than one), and saves a managed-audit API token locally. Replaces any previously saved token.
+
+### `aletheore logout`
+
+Clears the locally saved managed-audit token. Safe to run even if not currently logged in.
+
+### `aletheore status`
+
+Prints the installed version, whether a newer one is available on PyPI, and - if a
+managed-audit token is saved - who it's logged in as and which plan that installation is on.
 
 ### `aletheore query <kind> [target]`
 

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -820,7 +820,9 @@ def _main_callback(
 @app.command(help="audit a repository")
 def audit(
     path: str = typer.Argument(".", help="repository path"),
-    agent: Optional[str] = typer.Option(None, "--agent", help="force a specific agent adapter by name"),
+    agent: Optional[str] = typer.Option(
+        None, "--agent", help="force a specific agent adapter by name (ignored with --managed)"
+    ),
     managed: bool = typer.Option(
         False,
         "--managed",
@@ -829,7 +831,7 @@ def audit(
     token: Optional[str] = typer.Option(
         None,
         "--token",
-        help="managed-audit API token (or set ALETHEORE_API_TOKEN)",
+        help="managed-audit API token, or set ALETHEORE_API_TOKEN (only has effect with --managed)",
     ),
     check_vulnerabilities: bool = typer.Option(
         True,
@@ -853,6 +855,11 @@ def audit(
     ),
 ) -> None:
     if managed:
+        if agent is not None:
+            console.print(
+                "[bold yellow]warning:[/bold yellow] --agent has no effect with --managed "
+                "(the managed audit always uses Aletheore's own service, not a local agent) - ignored."
+            )
         raise typer.Exit(
             code=_managed_audit(
                 path,
@@ -862,6 +869,10 @@ def audit(
                 check_licenses,
                 map_endpoints,
             )
+        )
+    if token is not None:
+        console.print(
+            "[bold yellow]warning:[/bold yellow] --token has no effect without --managed - ignored."
         )
     raise typer.Exit(
         code=_audit(path, agent, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints)
@@ -922,7 +933,14 @@ def init(path: str = typer.Argument(".", help="repository path")) -> None:
     console.print("  accepted_secrets: baseline of reviewed secret findings to suppress (leave empty for now)")
 
 
-@app.command(help="build a local semantic search index over the repository's code")
+@app.command(
+    help=(
+        "build a local semantic search index over the repository's code "
+        "(requires a prior 'aletheore scan'; embeds via a local Ollama instance, "
+        "falling back to OpenAI if Ollama is unavailable - needed by 'query search-codebase'/"
+        "'query answer' and the aletheore_search_codebase/aletheore_answer MCP tools)"
+    )
+)
 def index(path: str = typer.Argument(".", help="repository path")) -> None:
     raise typer.Exit(code=_index(path))
 
@@ -987,7 +1005,10 @@ def mcp_install(
     target: list[str] = typer.Option(
         [],
         "--target",
-        help="which client(s) to configure (default: all)",
+        help=(
+            "which client(s) to configure (default: all); one of: "
+            f"{', '.join([*_MCP_CLIENT_CONFIGS.keys(), 'codex-cli'])}"
+        ),
     ),
 ) -> None:
     raise typer.Exit(code=_mcp_install(path, target))

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -12,7 +12,7 @@ import tree_sitter_python as tspython
 import tree_sitter_ruby as tsruby
 import tree_sitter_rust as tsrust
 import tree_sitter_typescript as tstypescript
-from tree_sitter import Language, Node, Parser
+from tree_sitter import Language, Node, Parser, Tree
 
 from aletheore.scanner.detect import IGNORED_DIRS, _nested_git_roots
 
@@ -1078,6 +1078,11 @@ def build_module_graph(
     # declaration implies about its directory, so every .java file needs a quick
     # pre-parse before any of them can have their imports resolved.
     java_source_roots: list[Path] = []
+    # Cached alongside the source root inference below so the main loop's
+    # own per-file parse doesn't read and re-parse every .java file a
+    # second time from scratch - this pre-pass already did the identical
+    # work once.
+    java_pre_parsed: dict[Path, tuple[bytes, Tree]] = {}
     pre_parser = Parser()
     pre_parser.language = JAVA_LANGUAGE
     for path in _iter_source_files(repo_path):
@@ -1085,6 +1090,7 @@ def build_module_graph(
             continue
         pre_source = path.read_bytes()
         tree = pre_parser.parse(pre_source)
+        java_pre_parsed[path] = (pre_source, tree)
         package = _extract_java_package(tree.root_node, pre_source)
         root = _java_source_root_for(path, package)
         if root is not None and root not in java_source_roots:
@@ -1098,6 +1104,7 @@ def build_module_graph(
     # (prefix -> root) map rather than a plain root list, PSR-4-style, to handle
     # <RootNamespace>'s implicit prefix (see _csharp_prefix_and_root_for).
     csharp_prefix_map: dict[str, Path] = {}
+    csharp_pre_parsed: dict[Path, tuple[bytes, Tree]] = {}
     cs_pre_parser = Parser()
     cs_pre_parser.language = CSHARP_LANGUAGE
     for path in _iter_source_files(repo_path):
@@ -1105,6 +1112,7 @@ def build_module_graph(
             continue
         pre_source = path.read_bytes()
         tree = cs_pre_parser.parse(pre_source)
+        csharp_pre_parsed[path] = (pre_source, tree)
         namespace = _extract_csharp_namespace(tree.root_node, pre_source)
         result = _csharp_prefix_and_root_for(path, namespace)
         if result is not None:
@@ -1133,9 +1141,14 @@ def build_module_graph(
             continue
 
         language_name, ts_language = language_info
-        parser.language = ts_language
-        source = path.read_bytes()
-        tree = parser.parse(source)
+        if language_name == "java" and path in java_pre_parsed:
+            source, tree = java_pre_parsed[path]
+        elif language_name == "csharp" and path in csharp_pre_parsed:
+            source, tree = csharp_pre_parsed[path]
+        else:
+            parser.language = ts_language
+            source = path.read_bytes()
+            tree = parser.parse(source)
 
         if language_name == "python":
             plain_imports, from_imports, functions, classes = _extract_python(

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -606,6 +606,47 @@ def test_main_audit_threads_no_check_licenses_flag(tmp_path):
     assert evidence["security"]["dependency_licenses"]["reason"] == "skipped (--no-check-licenses)"
 
 
+def test_audit_warns_when_token_passed_without_managed(tmp_path):
+    # --token only has any effect when --managed is also passed - passing
+    # it alone silently did nothing before this fix, with no indication to
+    # the user that the flag they set had no effect.
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+
+    with patch("aletheore.cli._audit", return_value=0):
+        result = runner.invoke(app, ["audit", str(repo), "--token", "sometoken"])
+
+    assert "--token has no effect without --managed" in result.stdout
+
+
+def test_audit_warns_when_agent_passed_with_managed(tmp_path):
+    # --agent is silently dropped when --managed is set (the managed
+    # branch never reads forced_agent) - before this fix, nothing told the
+    # user their --agent choice was being ignored.
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+
+    with patch("aletheore.cli._managed_audit", return_value=0):
+        result = runner.invoke(
+            app, ["audit", str(repo), "--managed", "--agent", "claude-code"]
+        )
+
+    assert "--agent has no effect with --managed" in result.stdout
+
+
+def test_audit_does_not_warn_when_flags_are_used_correctly(tmp_path):
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+
+    with patch("aletheore.cli._audit", return_value=0):
+        result = runner.invoke(app, ["audit", str(repo), "--agent", "claude-code"])
+    assert "has no effect" not in result.stdout
+
+    with patch("aletheore.cli._managed_audit", return_value=0):
+        result = runner.invoke(app, ["audit", str(repo), "--managed", "--token", "sometoken"])
+    assert "has no effect" not in result.stdout
+
+
 def test_main_scan_threads_no_check_licenses_flag(tmp_path):
     repo = tmp_path
     (repo / "main.py").write_text("x = 1\n")

--- a/src/tests/test_graph_csharp.py
+++ b/src/tests/test_graph_csharp.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 from aletheore.scanner.graph import build_module_graph
 from conftest import symbol_names
@@ -136,3 +137,25 @@ def test_build_module_graph_dotnet_obj_directory_is_excluded(tmp_path):
     modules, _, _ = build_module_graph(repo)
 
     assert [m["path"] for m in modules] == ["Program.cs"]
+
+
+def test_build_module_graph_reads_each_csharp_file_only_once(tmp_path):
+    # Before this fix, the namespace/root-inference pre-pass and the main
+    # extraction loop each independently read_bytes() and re-parsed every
+    # .cs file from scratch - a real, avoidable 2x tree-sitter parse cost
+    # per file.
+    repo = make_csharp_repo(tmp_path)
+
+    real_read_bytes = Path.read_bytes
+    read_counts: dict[str, int] = {}
+
+    def counting_read_bytes(self):
+        if self.suffix == ".cs":
+            read_counts[str(self)] = read_counts.get(str(self), 0) + 1
+        return real_read_bytes(self)
+
+    with patch.object(Path, "read_bytes", counting_read_bytes):
+        build_module_graph(repo)
+
+    assert read_counts
+    assert all(count == 1 for count in read_counts.values())

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 from aletheore.scanner.graph import build_module_graph
 from conftest import symbol_names
@@ -197,3 +198,25 @@ def test_build_module_graph_java_no_package_declaration_still_scans_the_file(tmp
     assert modules[0]["path"] == "Main.java"
     assert "Main" in symbol_names(modules[0]["symbols"]["classes"])
     assert unparseable == []
+
+
+def test_build_module_graph_reads_each_java_file_only_once(tmp_path):
+    # Before this fix, the source-root-inference pre-pass and the main
+    # extraction loop each independently read_bytes() and re-parsed every
+    # .java file from scratch - a real, avoidable 2x tree-sitter parse cost
+    # per file.
+    repo = make_java_repo(tmp_path)
+
+    real_read_bytes = Path.read_bytes
+    read_counts: dict[str, int] = {}
+
+    def counting_read_bytes(self):
+        if self.suffix == ".java":
+            read_counts[str(self)] = read_counts.get(str(self), 0) + 1
+        return real_read_bytes(self)
+
+    with patch.object(Path, "read_bytes", counting_read_bytes):
+        build_module_graph(repo)
+
+    assert read_counts
+    assert all(count == 1 for count in read_counts.values())


### PR DESCRIPTION
## Summary
Five small polish items from a deployment-readiness audit pass (all LOW severity, bundled into one PR):

- **`mcp-install --target` help** didn't enumerate valid client values inline (unlike `query KIND`'s help, which lists all valid kinds) - only surfaced after triggering an error with a bad value. Now lists them.
- **`audit --token`/`--agent` silent no-ops**: `--token` only has effect with `--managed`, and `--agent` is silently dropped when `--managed` is set - neither was flagged. Both now warn when the passed flag will be ignored, and the help text notes the dependency.
- **`index --help`** didn't mention it requires a prior `scan`, or that it calls out to Ollama (falling back to OpenAI) for embeddings.
- **README gaps**: no true one-command quickstart before the per-language import-resolution deep-dive; `init`/`login`/`logout`/`status` commands completely undocumented; `--managed`/BYOK distinction never explained despite `audit`'s whole BYOK-vs-managed design being a real behavioral fork; `dead_code_entry_points` config key undocumented despite `init` scaffolding it. (Note: the stale "13/17 tools" MCP count is already fixed in #79, not duplicated here to avoid a merge conflict.)
- **Java/C# double-parsing**: `build_module_graph`'s source-root-inference pre-pass and the main extraction loop each independently read and re-parsed every `.java`/`.cs` file from scratch. The pre-pass now caches its own parse result for the main loop to reuse, cutting the double tree-sitter parse cost in half for both languages.

## Test plan
- [x] 2 new tests proving each `.java`/`.cs` file is read exactly once during a scan (was 2x)
- [x] 3 new tests for the `--token`/`--agent` warnings (both directions, plus a "no warning when used correctly" check)
- [x] Full suite green: 777 passed
- [x] markdownlint clean on the README changes; added "BYOK" to the cspell dictionary defensively