### PR TITLE
fix(github-app): give scheduler the GitHub App private-key mount

### DIFF
--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -111,6 +111,10 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      - GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app-key.pem
+    volumes:
+      - ./app-private-key.pem:/run/secrets/github-app-key.pem:ro
     depends_on:
       redis:
         condition: service_started


### PR DESCRIPTION
## Summary
`scheduler.py` calls `app_server.config.get_settings()`, which unconditionally requires `GITHUB_APP_PRIVATE_KEY` (even though `scheduler` only ever reads `settings.redis_url`), but the `scheduler` service in `docker-compose.yml` never got the private-key volume/env mount that `app-server` and `scan-worker` both have. It crash-loops the moment the container is recreated - dormant while the container just keeps running, but hit for real during today's v0.6.0 production deploy (first recreate in 4 days).

## Test plan
- [x] Verified against production: applying the equivalent fix and recreating the `scheduler` container brings it back to a stable `Up` state (health-sweep/session-cleanup jobs resume).