### PR TITLE
fix(website): add GitHub App install link, fix stale content gaps

### DIFF
--- a/website/developers.html
+++ b/website/developers.html
@@ -116,6 +116,7 @@ aletheore dashboard .</code></pre>
             <code>endpoints</code>
             <code>dead-code</code>
             <code>hotspots</code>
+            <code>layer-violations</code>
           </div>
           <div>
             <h3>Code intelligence</h3>
@@ -148,6 +149,20 @@ aletheore dashboard .</code></pre>
           <span>aletheore_imports</span>
           <span>aletheore_imported_by</span>
           <span>aletheore_symbols</span>
+          <span>aletheore_branch</span>
+          <span>aletheore_ownership</span>
+          <span>aletheore_secrets</span>
+          <span>aletheore_vulnerabilities</span>
+          <span>aletheore_licenses</span>
+          <span>aletheore_endpoints</span>
+          <span>aletheore_cluster</span>
+          <span>aletheore_layer_violations</span>
+          <span>aletheore_dead_code</span>
+          <span>aletheore_hotspots</span>
+          <span>aletheore_database</span>
+          <span>aletheore_infrastructure</span>
+          <span>aletheore_environment_variables</span>
+          <span>aletheore_changes</span>
           <span>aletheore_neighborhood</span>
           <span>aletheore_search</span>
           <span>aletheore_symbol_source</span>
@@ -155,6 +170,7 @@ aletheore dashboard .</code></pre>
           <span>aletheore_find_evidence_for_symbol</span>
           <span>aletheore_find_evidence_for_dependency</span>
           <span>aletheore_healthcheck</span>
+          <span>aletheore_index</span>
           <span>aletheore_search_codebase</span>
           <span>aletheore_answer</span>
           <span>aletheore_managed_audit</span>

--- a/website/index.html
+++ b/website/index.html
@@ -52,7 +52,7 @@
       "Database and infrastructure detection",
       "Local semantic code search via vector index",
       "MCP server for coding agents",
-      "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, Ollama)",
+      "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, DeepSeek, Ollama)",
       "GitHub App: automatic PR comments and branch-protection check runs",
       "AI-powered managed audit reports on pull requests, written by DeepSeek Pro",
       "Automatic Flash reviews on every pull request push",
@@ -237,8 +237,12 @@
           <p>Live endpoint checks alert on outages and latency regressions with source handler context.</p>
         </article>
       </div>
+      <div class="hero-actions" style="margin-top: 20px;">
+        <a class="btn btn-primary" href="https://github.com/apps/aletheore/installations/new" rel="noopener">Install the GitHub App</a>
+        <a class="btn btn-ghost" href="pricing.html">See Pricing</a>
+      </div>
       <p class="section-intro">
-        <a href="https://github.com/marketplace" rel="noopener">Coming soon to GitHub Marketplace</a> - the listing is submitted and under review. In the meantime, see <a href="pricing.html">Pricing</a>.
+        Installable today on any GitHub account or organization you administer - the public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find it for now.
       </p>
     </section>
 

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -71,8 +71,11 @@
           <button type="button" class="btn btn-primary" data-subscribe="air">Subscribe</button>
         </article>
       </div>
-      <p class="section-intro" style="margin-top: 28px;">
-        Also available as a GitHub App - <a href="https://github.com/marketplace" rel="noopener">listing submitted, currently under GitHub's review</a>.
+      <div class="hero-actions" style="margin-top: 28px;">
+        <a class="btn btn-secondary" href="https://github.com/apps/aletheore/installations/new" rel="noopener">Install the GitHub App</a>
+      </div>
+      <p class="section-intro">
+        Install it on your GitHub account or organization, then hit Subscribe above to activate AIR on that installation. The public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find and install it today.
       </p>
     </section>
   </div>


### PR DESCRIPTION
## Summary
- **The core gap**: there was no discoverable way to install the GitHub App anywhere on the marketing site - the only mention was "coming soon to GitHub Marketplace, listing under review." Since payment activation requires installing the app first (`/subscribe` prompts for install if none exists), this made the whole paid flow effectively undiscoverable outside people who already knew to click Subscribe. Added a direct `https://github.com/apps/aletheore/installations/new` install CTA on both the homepage's GitHub App section and the pricing page (next to Subscribe) - this works today regardless of Marketplace review status, verified the app page itself returns 200 and the slug (`aletheore`) matches production's `GITHUB_APP_SLUG`.
- **developers.html**: the MCP tool list documented only 14 of the 29 real tools the MCP server currently registers (missing `aletheore_index` and all 16 query-derived tools like `aletheore_secrets`, `aletheore_dead_code`, etc. - verified against `mcp_server.py`'s actual tool registrations). Also added `layer-violations`, missing from the CLI query-kind list.
- **index.html**: added DeepSeek to the supported-provider list (it's a real CLI adapter and already named elsewhere on the site as the managed-audit backend, just missing from this one list).

Also checked pricing.html, terms.html, privacy.html, and refund.html for pricing/tier consistency - all already match ($29.99/mo, $3.99/seat, Paddle as processor).

## Test plan
- [x] Verified `GITHUB_APP_SLUG=aletheore` against the production `.env`
- [x] Verified `https://github.com/apps/aletheore` returns 200
- [x] Verified the full real MCP tool list against `mcp_server.py`'s registration code
- [x] Verified "11 language ecosystems" claim against `graph.py`'s `LANGUAGE_BY_EXTENSION` (still accurate)
- [x] HTML parses cleanly (no unclosed tags) on all three edited pages