### PR TITLE
fix(website): stop reusing centered .section-intro for left-aligned CTA notes

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -241,7 +241,7 @@
         <a class="btn btn-primary" href="https://github.com/apps/aletheore/installations/new" rel="noopener">Install the GitHub App</a>
         <a class="btn btn-ghost" href="pricing.html">See Pricing</a>
       </div>
-      <p class="section-intro">
+      <p class="cta-note">
         Installable today on any GitHub account or organization you administer - the public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find it for now.
       </p>
     </section>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -74,7 +74,7 @@
       <div class="hero-actions" style="margin-top: 28px;">
         <a class="btn btn-secondary" href="https://github.com/apps/aletheore/installations/new" rel="noopener">Install the GitHub App</a>
       </div>
-      <p class="section-intro">
+      <p class="cta-note">
         Install it on your GitHub account or organization, then hit Subscribe above to activate AIR on that installation. The public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find and install it today.
       </p>
     </section>

--- a/website/styles.css
+++ b/website/styles.css
@@ -484,6 +484,14 @@ section h2 {
   padding-top: 34px;
 }
 
+.cta-note {
+  max-width: 560px;
+  margin-top: 14px;
+  color: var(--text-muted);
+  font-size: 15px;
+  text-align: left;
+}
+
 .workflow-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
The trailing note under the new GitHub App install buttons (added in #86) was reusing `.section-intro`, a class styled for centered intro text under a centered `.section-heading` at the top of a section. Bottom-of-section, left-aligned content doesn't belong centered - most visible now with a left-aligned button row directly above it (confirmed via screenshot on the live site). Added a dedicated `.cta-note` class (left-aligned, muted, smaller) and swapped both occurrences (index.html and pricing.html) over to it.

## Test plan
- [x] HTML parses cleanly on both edited pages
- [x] Verified `.pricing-hero`'s inherited `text-align: center` is correctly overridden by the new class's own `text-align: left` (same pattern `.pricing-grid` already uses)