### PR TITLE
fix(mcp): give search_codebase/answer an agent-appropriate no-index error

### DIFF
--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -23,7 +23,7 @@ from aletheore.query import (
     find_symbol_source,
 )
 from aletheore.secrets import iter_all_files
-from aletheore.search_index import search_index
+from aletheore.search_index import IndexNotFoundError, search_index
 from aletheore.toon_encoding import to_toon
 
 
@@ -313,11 +313,19 @@ def _register_index_tool(mcp_instance: FastMCP, repo_path: Path) -> None:
         return _toon_result({"indexed_chunks": count})
 
 
+_NO_INDEX_ERROR = {
+    "error": "no semantic index built yet for this repository - call the aletheore_index tool first"
+}
+
+
 def _register_search_codebase_tool(mcp_instance: FastMCP, repo_path: Path) -> None:
     @mcp_instance.tool(name="aletheore_search_codebase")
     def aletheore_search_codebase(query: str, k: int = 10) -> str:
         """Semantic search over the repository's indexed code."""
-        return _toon_result(search_index(repo_path, query, k=k))
+        try:
+            return _toon_result(search_index(repo_path, query, k=k))
+        except IndexNotFoundError:
+            return _toon_result(_NO_INDEX_ERROR)
 
 
 def _register_answer_tool(
@@ -326,7 +334,10 @@ def _register_answer_tool(
     @mcp_instance.tool(name="aletheore_answer")
     def aletheore_answer(question: str, k: int = 5) -> str:
         """Answer a natural-language question about this repository from the semantic index."""
-        return _toon_result(answer_question(repo_path, question, answer_adapter, k=k))
+        try:
+            return _toon_result(answer_question(repo_path, question, answer_adapter, k=k))
+        except IndexNotFoundError:
+            return _toon_result(_NO_INDEX_ERROR)
 
 
 def _register_managed_audit_tool(mcp_instance: FastMCP, repo_path: Path) -> None:

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -8,6 +8,7 @@ import toon
 from mcp.server.fastmcp.exceptions import ToolError
 
 from aletheore.mcp_server import build_server
+from aletheore.search_index import IndexNotFoundError
 
 
 def tool_result_body(result):
@@ -256,6 +257,43 @@ async def test_aletheore_search_codebase_returns_toon_results(tmp_path):
         )
 
     assert tool_result_body(result)["result"] == [{"module_path": "a.py", "symbol_name": "foo"}]
+
+
+@pytest.mark.asyncio
+async def test_aletheore_search_codebase_returns_friendly_error_when_index_not_built(tmp_path):
+    # Before this fix, this raised IndexNotFoundError straight through FastMCP's
+    # own exception wrapping, which reused the CLI's own message ("run
+    # 'aletheore index <path>' first") - correct advice for a human at a
+    # terminal, useless for an agent that only has MCP tools and can't run
+    # shell commands. It should be told to call aletheore_index instead.
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    with patch(
+        "aletheore.mcp_server.search_index",
+        side_effect=IndexNotFoundError("no index found"),
+    ):
+        result = await server.call_tool("aletheore_search_codebase", {"query": "where is foo"})
+
+    assert tool_result_body(result)["result"] == {
+        "error": "no semantic index built yet for this repository - call the aletheore_index tool first"
+    }
+
+
+@pytest.mark.asyncio
+async def test_aletheore_answer_returns_friendly_error_when_index_not_built(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo, answer_adapter=MagicMock())
+
+    with patch(
+        "aletheore.mcp_server.answer_question",
+        side_effect=IndexNotFoundError("no index found"),
+    ):
+        result = await server.call_tool("aletheore_answer", {"question": "what does foo do"})
+
+    assert tool_result_body(result)["result"] == {
+        "error": "no semantic index built yet for this repository - call the aletheore_index tool first"
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
`aletheore_search_codebase` and `aletheore_answer` both call through to `search_index()`/`answer_question()`, which raise `IndexNotFoundError` when `.aletheore/index.lancedb` doesn't exist yet. That error's own message tells the caller to run `aletheore index <path>` - correct for a human at a terminal (the CLI's own handling for the same case just prints that same message), but useless for an agent that only has MCP tools and can't run shell commands.

Neither tool caught this, so it propagated as a raw `ToolError` with that CLI-oriented text. `aletheore_index`'s own embedding-failure case and `aletheore_managed_audit`'s missing-token case already establish the pattern for this file - catch the expected failure, return a soft `{"error": ...}` TOON result instead of raising - so this brings both into line with that, pointing at the actual `aletheore_index` tool instead.

## Test plan
- [x] Reproduced the original raw message empirically before fixing (`ToolError: ... run 'aletheore index /tmp/...' first`)
- [x] Added `test_aletheore_search_codebase_returns_friendly_error_when_index_not_built` and `test_aletheore_answer_returns_friendly_error_when_index_not_built`
- [x] `pytest src/tests/test_mcp_server.py` (36 passed)
- [x] `pytest` full suite (804 passed)