### PR TITLE
style(website): center the GitHub App install CTA and its note

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -237,7 +237,7 @@
           <p>Live endpoint checks alert on outages and latency regressions with source handler context.</p>
         </article>
       </div>
-      <div class="hero-actions" style="margin-top: 20px;">
+      <div class="cta-actions" style="margin-top: 20px;">
         <a class="btn btn-primary" href="https://github.com/apps/aletheore/installations/new" rel="noopener">Install the GitHub App</a>
         <a class="btn btn-ghost" href="pricing.html">See Pricing</a>
       </div>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -71,7 +71,7 @@
           <button type="button" class="btn btn-primary" data-subscribe="air">Subscribe</button>
         </article>
       </div>
-      <div class="hero-actions" style="margin-top: 28px;">
+      <div class="cta-actions" style="margin-top: 28px;">
         <a class="btn btn-secondary" href="https://github.com/apps/aletheore/installations/new" rel="noopener">Install the GitHub App</a>
       </div>
       <p class="cta-note">

--- a/website/styles.css
+++ b/website/styles.css
@@ -484,12 +484,19 @@ section h2 {
   padding-top: 34px;
 }
 
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+}
+
 .cta-note {
   max-width: 560px;
-  margin-top: 14px;
+  margin: 14px auto 0;
   color: var(--text-muted);
   font-size: 15px;
-  text-align: left;
+  text-align: center;
 }
 
 .workflow-grid {


### PR DESCRIPTION
## Summary
Per feedback on the live site, both the install button row and the trailing note read better centered (matching the centered section heading above them) than left-aligned. Added a dedicated `.cta-actions` class for the two CTA rows instead of reusing `.hero-actions`, since the actual page hero still needs that class left-aligned. `.cta-note` switches from left- to center-aligned.

## Test plan
- [x] HTML parses cleanly on both edited pages
- [x] Confirmed the real hero's button row (index.html:90) still uses `.hero-actions` untouched