### PR TITLE
feat(paddle): wire pwCustomer and IP-allowlist the live webhook

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -68,7 +68,7 @@ async def list_installations_for_ids(pool: asyncpg.Pool, installation_ids: list[
         return []
     rows = await pool.fetch(
         """
-        SELECT installation_id, account_login, plan
+        SELECT installation_id, account_login, plan, paddle_customer_id
         FROM installations
         WHERE installation_id = ANY($1::bigint[])
         ORDER BY account_login ASC

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1373,8 +1373,10 @@ def _subscribe_install_prompt_page(plan: str, next_path: str) -> str:
 
 
 def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]) -> str:
+    pw_customer_id: str | None = None
     if len(installations) == 1:
         installation = installations[0]
+        pw_customer_id = installation.get("paddle_customer_id")
         continue_attrs = f'data-installation-id="{installation["installation_id"]}"'
         body = f"""
         <h1>Subscribe to {escape(_plan_display_name(plan))}</h1>
@@ -1403,11 +1405,16 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
         """
 
     settings = get_settings()
+    # pwCustomer (Paddle Retain) only makes sense for a known, already-Paddle
+    # customer - only wireable here when there's exactly one installation to
+    # check out for, since Paddle.Initialize() runs once for the whole page,
+    # before the customer (if there's a choice) has picked which installation.
+    pw_customer_config = f', pwCustomer: {{ id: "{pw_customer_id}" }}' if pw_customer_id else ""
     return _subscribe_page("Subscribe", body) + f"""
 <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
 <script>
 Paddle.Environment.set("{settings.paddle_environment}");
-Paddle.Initialize({{ token: "{settings.paddle_client_token}" }});
+Paddle.Initialize({{ token: "{settings.paddle_client_token}"{pw_customer_config} }});
 document.getElementById("continue-checkout").addEventListener("click", (event) => {{
   const btn = event.currentTarget;
   const selected = document.querySelector('input[name="installation_id"]:checked');

--- a/github-app/app_server/paddle_ip_allowlist.py
+++ b/github-app/app_server/paddle_ip_allowlist.py
@@ -1,0 +1,67 @@
+import ipaddress
+import logging
+import time
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_PADDLE_IPS_URL = "https://api.paddle.com/ips"
+_CACHE_TTL_SECONDS = 3600.0
+
+# (fetched_at, networks) - module-level so the list is fetched at most once
+# per TTL across the whole process, not once per webhook request.
+_cache: tuple[float, list[ipaddress.IPv4Network]] | None = None
+
+
+async def _fetch_paddle_networks() -> list[ipaddress.IPv4Network] | None:
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(_PADDLE_IPS_URL, timeout=5.0)
+        response.raise_for_status()
+        cidrs = response.json()["data"]["ipv4_cidrs"]
+        return [ipaddress.ip_network(cidr) for cidr in cidrs]
+    except (httpx.HTTPError, KeyError, ValueError, TypeError) as exc:
+        logger.warning("failed to fetch Paddle's published IP list: %s", exc)
+        return None
+
+
+async def _cached_paddle_networks() -> list[ipaddress.IPv4Network] | None:
+    global _cache
+    now = time.monotonic()
+    if _cache is not None and now - _cache[0] < _CACHE_TTL_SECONDS:
+        return _cache[1]
+    networks = await _fetch_paddle_networks()
+    if networks is None:
+        # A transient fetch failure shouldn't turn into "reject every real
+        # webhook until the next successful fetch" - reuse the last known-good
+        # list (if any) rather than treating "couldn't reach Paddle's IP
+        # endpoint" as "no IPs are Paddle's".
+        return _cache[1] if _cache is not None else None
+    _cache = (now, networks)
+    return networks
+
+
+async def is_known_paddle_ip(ip: str) -> bool | None:
+    """True/False once checked against Paddle's published IP range, or None
+    if the range itself couldn't be fetched (fresh or cached) - callers
+    should treat None as "can't verify" rather than "reject", since webhook
+    signature verification remains the real security boundary and this is
+    defense-in-depth on top of it, not a replacement for it."""
+    networks = await _cached_paddle_networks()
+    if networks is None:
+        return None
+    try:
+        address = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return any(address in network for network in networks)
+
+
+def client_ip_from_forwarded_for(forwarded_for: str | None, fallback: str) -> str:
+    if not forwarded_for:
+        return fallback
+    # Caddy's reverse_proxy appends the real connecting peer's IP as the LAST
+    # entry in X-Forwarded-For - any earlier entries could be attacker-supplied
+    # on the original request before it ever reached Caddy.
+    return forwarded_for.split(",")[-1].strip()

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request, Response
 
 from app_server.config import get_settings
 from app_server.db import add_paddle_ids_to_installation, get_installation, set_installation_plan
+from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
 from app_server.paddle_pricing import resolve_plan_for_price_id
 from app_server.paddle_webhook_verify import verify_paddle_signature
 
@@ -94,6 +95,19 @@ async def handle_paddle_webhook(request: Request) -> Response:
     signature = request.headers.get("paddle-signature", "")
     settings = get_settings()
     if not signature or not verify_paddle_signature(raw_body, signature, settings.paddle_webhook_secret):
+        return Response(status_code=401)
+
+    # Defense-in-depth on top of signature verification, not a replacement
+    # for it: reject only when the source IP is definitively not one of
+    # Paddle's published addresses. A fetch failure returns None (can't
+    # verify) rather than False, so a transient outage reaching Paddle's own
+    # /ips endpoint can't turn into rejecting every real webhook.
+    client_ip = client_ip_from_forwarded_for(
+        request.headers.get("x-forwarded-for"),
+        request.client.host if request.client else "",
+    )
+    if await is_known_paddle_ip(client_ip) is False:
+        logger.warning("rejected webhook from non-Paddle IP %s despite a valid signature", client_ip)
         return Response(status_code=401)
 
     try:

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -61,6 +61,25 @@ def redis_conn():
     conn.close()
 
 
+@pytest.fixture(autouse=True)
+def _no_real_paddle_ip_fetch(monkeypatch):
+    # Without this, every full-route webhook test would make a real network
+    # call to Paddle's /ips endpoint on the first request (module-level
+    # cache miss) - slow and flaky in a sandboxed/offline CI runner. Default
+    # to "can't verify" (None), the same fail-open outcome a real fetch
+    # failure produces, so this doesn't change what any existing test
+    # asserts. Tests that need to exercise the actual allow/reject paths
+    # patch is_known_paddle_ip directly instead.
+    from app_server import paddle_ip_allowlist
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_cache", None)
+
+    async def _fake_fetch():
+        return None
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+
+
 def _make_git_repo(path: Path, files: dict[str, str]) -> str:
     path.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "-q"], cwd=path, check=True)

--- a/github-app/tests/test_frontend_subscribe.py
+++ b/github-app/tests/test_frontend_subscribe.py
@@ -5,7 +5,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app_server.auth import encrypt_access_token, sign_session_id
-from app_server.db import create_session, upsert_installation
+from app_server.db import add_paddle_ids_to_installation, create_session, upsert_installation
 from app_server.main import app
 
 
@@ -127,6 +127,22 @@ async def test_one_installation_shows_checkout_with_current_plan(pool, monkeypat
     assert "customData" in response.text
     assert "successUrl" in response.text and "dashboard" in response.text
     assert 'href="/dashboard"' in response.text
+    assert "pwCustomer" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_one_installation_with_existing_paddle_customer_wires_pw_customer(pool, monkeypatch):
+    # Before this fix, Paddle.Initialize() never passed pwCustomer at all, so
+    # Paddle Retain had no way to recognize a returning customer re-subscribing
+    # through this page - even though the installation already has a real
+    # Paddle customer ID from a previous subscription.
+    await upsert_installation(pool, 2004, "returning-corp")
+    await add_paddle_ids_to_installation(pool, 2004, "sub_existing", "ctm_existing123")
+    client = await _logged_in_client(pool, monkeypatch, [2004])
+    async with client:
+        response = await client.get("/subscribe?plan=air&interval=month")
+    assert response.status_code == 200
+    assert 'pwCustomer: { id: "ctm_existing123" }' in response.text
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_paddle_ip_allowlist.py
+++ b/github-app/tests/test_paddle_ip_allowlist.py
@@ -1,0 +1,103 @@
+import ipaddress
+
+import httpx
+import pytest
+
+from app_server import paddle_ip_allowlist
+from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
+
+
+@pytest.mark.asyncio
+async def test_is_known_paddle_ip_true_when_in_range(monkeypatch):
+    async def _fake_fetch():
+        return [ipaddress.ip_network("203.0.113.0/24")]
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_cache", None)
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+
+    assert await is_known_paddle_ip("203.0.113.42") is True
+
+
+@pytest.mark.asyncio
+async def test_is_known_paddle_ip_false_when_outside_range(monkeypatch):
+    async def _fake_fetch():
+        return [ipaddress.ip_network("203.0.113.0/24")]
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_cache", None)
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+
+    assert await is_known_paddle_ip("198.51.100.1") is False
+
+
+@pytest.mark.asyncio
+async def test_is_known_paddle_ip_none_when_fetch_fails(monkeypatch):
+    async def _fake_fetch():
+        return None
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_cache", None)
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+
+    assert await is_known_paddle_ip("203.0.113.42") is None
+
+
+@pytest.mark.asyncio
+async def test_is_known_paddle_ip_false_for_unparseable_ip(monkeypatch):
+    async def _fake_fetch():
+        return [ipaddress.ip_network("203.0.113.0/24")]
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_cache", None)
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+
+    assert await is_known_paddle_ip("not-an-ip") is False
+
+
+@pytest.mark.asyncio
+async def test_stale_cache_reused_when_refetch_fails(monkeypatch):
+    # A transient outage reaching Paddle's own /ips endpoint shouldn't turn
+    # into "reject every real webhook until the next successful fetch" -
+    # the last known-good list should keep being used.
+    call_count = 0
+
+    async def _fake_fetch():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [ipaddress.ip_network("203.0.113.0/24")]
+        return None
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_cache", None)
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+    monkeypatch.setattr(paddle_ip_allowlist, "_CACHE_TTL_SECONDS", -1.0)
+
+    assert await is_known_paddle_ip("203.0.113.42") is True
+    # TTL is negative, so this second call forces a re-fetch, which fails -
+    # the stale cached network list from the first call should still be used.
+    assert await is_known_paddle_ip("203.0.113.42") is True
+    assert call_count == 2
+
+
+def test_fetch_paddle_networks_handles_http_error(monkeypatch):
+    async def _raise(*args, **kwargs):
+        raise httpx.ConnectError("no network")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _raise)
+
+    import asyncio
+
+    result = asyncio.run(paddle_ip_allowlist._fetch_paddle_networks())
+    assert result is None
+
+
+def test_client_ip_from_forwarded_for_uses_last_entry():
+    # Caddy's reverse_proxy appends the real connecting peer as the LAST
+    # entry - earlier entries could be attacker-supplied on the original
+    # request before it ever reached Caddy.
+    assert client_ip_from_forwarded_for("1.2.3.4, 5.6.7.8", "9.9.9.9") == "5.6.7.8"
+
+
+def test_client_ip_from_forwarded_for_falls_back_when_header_absent():
+    assert client_ip_from_forwarded_for(None, "9.9.9.9") == "9.9.9.9"
+
+
+def test_client_ip_from_forwarded_for_falls_back_when_header_empty():
+    assert client_ip_from_forwarded_for("", "9.9.9.9") == "9.9.9.9"

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+import ipaddress
 import json
 import time
 from unittest.mock import MagicMock
@@ -7,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app_server import paddle_ip_allowlist
 from app_server.db import get_installation, upsert_installation
 from app_server.main import app
 from app_server.webhooks.paddle import handle_paddle_webhook_event
@@ -103,6 +105,54 @@ async def test_non_object_json_body_with_valid_signature_returns_401_not_500(poo
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_confirmed_non_paddle_ip_rejected_despite_valid_signature(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+
+    async def _fake_fetch():
+        return [ipaddress.ip_network("203.0.113.0/24")]
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+    app.state.db_pool = pool
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (106, 'acme', 'free')"
+    )
+    body = json.dumps(_subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 106)).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/paddle",
+            content=body,
+            headers={"paddle-signature": _sign(body), "x-forwarded-for": "198.51.100.1"},
+        )
+    assert response.status_code == 401
+    installation = await get_installation(pool, 106)
+    assert installation["plan"] == "free"
+
+
+@pytest.mark.asyncio
+async def test_confirmed_paddle_ip_accepted(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+
+    async def _fake_fetch():
+        return [ipaddress.ip_network("203.0.113.0/24")]
+
+    monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
+    app.state.db_pool = pool
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (107, 'acme', 'free')"
+    )
+    body = json.dumps(_subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 107)).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/paddle",
+            content=body,
+            headers={"paddle-signature": _sign(body), "x-forwarded-for": "10.0.0.1, 203.0.113.5"},
+        )
+    assert response.status_code == 200
+    installation = await get_installation(pool, 107)
+    assert installation["plan"] == "air"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Two remaining items from the live-Paddle-migration audit:

- **`pwCustomer`**: wired into `Paddle.Initialize()` for the single-installation checkout case when that installation already has a stored `paddle_customer_id`, enabling Paddle Retain for returning customers. Not wired for the multi-installation selector - `Paddle.Initialize()` runs once for the whole page, before the customer (if there's a choice) picks which installation, so there's no single correct customer ID to pass at that point.
- **Webhook IP allowlisting**: new `paddle_ip_allowlist.py` fetches Paddle's published IPs from `api.paddle.com/ips` (cached in-process, not hardcoded per Paddle's own guidance since the list can change) and rejects webhook requests from outside that range. This is defense-in-depth on top of the existing `paddle-signature` HMAC verification, not a replacement for it - fails open (treats "can't verify" the same as "not rejected") on a fetch failure or when no cached list exists yet, so a transient outage reaching Paddle's own IP endpoint can't turn into rejecting every real webhook.

Also: confirmed via the `paddle-live` MCP that `app.aletheore.com` (where checkout actually opens) is already covered by the approved `aletheore.com` domain - no action needed there.

## Test plan
- [x] Added `test_paddle_ip_allowlist.py` (in-range/out-of-range/unparseable-IP/fetch-failure/stale-cache-reuse cases)
- [x] Added webhook-route tests for confirmed-Paddle-IP (200) and confirmed-non-Paddle-IP (401) cases
- [x] Added checkout-page tests for `pwCustomer` present (known customer) and absent (new customer)
- [x] Added an autouse fixture so existing/new tests never make a real network call to Paddle's `/ips` endpoint
- [x] Full github-app suite: 678 passed, 7 skipped (pre-existing, unrelated)