### PR TITLE
Harden and complete the AIR paid-tier feature set

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -34,6 +34,10 @@ from app_server.db import (
     set_webhook_url,
     update_session_tokens,
 )
+from app_server.paddle_client import PaddleAPIError
+from app_server.paddle_client import get_subscription as get_paddle_subscription
+from app_server.paddle_client import update_subscription_items as update_paddle_subscription_items
+from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
 from app_server.url_validation import UnsafeURLError, validate_external_https_url
 
 admin_router = APIRouter()
@@ -263,7 +267,8 @@ async def admin_page(org: str, repo: str, request: Request):
     tokens = await list_api_tokens(pool, installation_id)
     members = await list_installation_members(pool, installation_id)
     included_seats = INCLUDED_SEATS.get(installation["plan"], DEFAULT_SEAT_LIMIT)
-    seat_limit = included_seats + await get_extra_seats(pool, installation_id)
+    extra_seats = await get_extra_seats(pool, installation_id)
+    seat_limit = included_seats + extra_seats
     health_targets = await list_health_check_targets(pool, installation_id, repo_full_name)
     health_target_limit = INCLUDED_HEALTH_CHECK_TARGETS.get(installation["plan"], DEFAULT_HEALTH_CHECK_TARGET_LIMIT)
     return {
@@ -271,6 +276,7 @@ async def admin_page(org: str, repo: str, request: Request):
         "tokens": tokens,
         "members": members,
         "seat_limit": seat_limit,
+        "extra_seats": extra_seats,
         "health_targets": health_targets,
         "health_target_limit": health_target_limit,
         "public_status_url": f"/v1/health/{org}/{repo}",
@@ -292,11 +298,77 @@ async def add_member(org: str, repo: str, request: Request, body: AddMemberReque
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    f"seat limit reached ({seat_limit}) - additional seats need billing, "
-                    "which isn't wired up yet. Remove someone or check back soon."
+                    f"seat limit reached ({seat_limit}) - buy an extra seat in Settings "
+                    "($3.99/mo) or remove someone first."
                 ),
             )
         await add_installation_member(pool, installation_id, body.github_login, session["github_login"])
+    return {"ok": True}
+
+
+def _build_updated_seat_items(subscription_items: list[dict], delta: int) -> list[dict] | None:
+    # Paddle requires the complete item list on every subscription update -
+    # this rebuilds it with the extra-seat item's quantity adjusted by
+    # delta (adding the item at quantity 1 if it doesn't exist yet).
+    # Returns None if delta would take the seat item below zero.
+    items = []
+    seat_item_found = False
+    for item in subscription_items:
+        price_id = item["price"]["id"]
+        quantity = item["quantity"]
+        if price_id == EXTRA_SEAT_PRICE_ID:
+            seat_item_found = True
+            quantity += delta
+            if quantity < 0:
+                return None
+            if quantity == 0:
+                continue
+        items.append({"price_id": price_id, "quantity": quantity})
+    if not seat_item_found:
+        if delta <= 0:
+            return None
+        items.append({"price_id": EXTRA_SEAT_PRICE_ID, "quantity": delta})
+    return items
+
+
+@admin_router.post("/admin/{org}/{repo}/seats/buy")
+async def buy_extra_seat(org: str, repo: str, request: Request):
+    installation = await _require_admin_installation(request, org, repo)
+    subscription_id = installation.get("paddle_subscription_id")
+    if not subscription_id:
+        raise HTTPException(status_code=400, detail="no active subscription to add a seat to")
+
+    settings = get_settings()
+    try:
+        subscription = get_paddle_subscription(settings.paddle_api_key, subscription_id)
+        items = _build_updated_seat_items(subscription.get("items", []), delta=1)
+        update_paddle_subscription_items(settings.paddle_api_key, subscription_id, items, "prorated_immediately")
+    except PaddleAPIError as exc:
+        raise HTTPException(status_code=502, detail=f"could not update billing: {exc}") from exc
+
+    # extra_seats itself is reconciled from the resulting subscription.updated
+    # webhook, not set optimistically here - same pattern installations.plan
+    # already follows for the base subscription price.
+    return {"ok": True}
+
+
+@admin_router.post("/admin/{org}/{repo}/seats/remove")
+async def remove_extra_seat(org: str, repo: str, request: Request):
+    installation = await _require_admin_installation(request, org, repo)
+    subscription_id = installation.get("paddle_subscription_id")
+    if not subscription_id:
+        raise HTTPException(status_code=400, detail="no active subscription to remove a seat from")
+
+    settings = get_settings()
+    try:
+        subscription = get_paddle_subscription(settings.paddle_api_key, subscription_id)
+        items = _build_updated_seat_items(subscription.get("items", []), delta=-1)
+        if items is None:
+            raise HTTPException(status_code=409, detail="no extra seats to remove")
+        update_paddle_subscription_items(settings.paddle_api_key, subscription_id, items, "prorated_immediately")
+    except PaddleAPIError as exc:
+        raise HTTPException(status_code=502, detail=f"could not update billing: {exc}") from exc
+
     return {"ok": True}
 
 

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -348,6 +348,29 @@ async def set_webhook_url_route(org: str, repo: str, request: Request, body: Set
     return {"ok": True}
 
 
+@admin_router.post("/admin/{org}/{repo}/webhook-url/test")
+async def test_webhook_url_route(org: str, repo: str, request: Request):
+    # Without this, a customer has no way to confirm a webhook URL is
+    # correctly configured short of waiting for a real finding or
+    # incident to fire one - by then a typo or a dead/rotated URL has
+    # already meant silently missed alerts.
+    installation = await _require_admin_installation(request, org, repo)
+    webhook_url = installation.get("webhook_url")
+    if not webhook_url:
+        raise HTTPException(status_code=400, detail="no alert webhook is configured yet")
+
+    from scan_worker.slack import send_health_alert
+
+    try:
+        send_health_alert(
+            webhook_url,
+            {"text": f"*Aletheore*: test notification for `{org}/{repo}` - your alert webhook is configured correctly."},
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail=f"could not reach webhook: {exc}") from exc
+    return {"ok": True}
+
+
 @admin_router.post("/admin/{org}/{repo}/health-targets")
 async def add_health_check_target_route(org: str, repo: str, request: Request, body: AddHealthCheckTargetRequest):
     installation = await _require_admin_installation(request, org, repo)

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -18,6 +18,7 @@ class Settings:
     paddle_webhook_secret: str
     paddle_client_token: str
     paddle_environment: str
+    paddle_api_key: str | None
     github_app_slug: str
     github_demo_readonly_token: str | None
 
@@ -86,6 +87,12 @@ def get_settings() -> Settings:
         paddle_webhook_secret=_required_env("PADDLE_WEBHOOK_SECRET"),
         paddle_client_token=_paddle_client_token(paddle_environment),
         paddle_environment=paddle_environment,
+        # Optional, not required: the server ran fine before any code ever
+        # needed to call OUT to Paddle (webhooks only ever came in). Seat
+        # billing is the first feature that needs this - degrade that one
+        # feature gracefully rather than refusing to start over a key
+        # nothing else depends on.
+        paddle_api_key=os.environ.get("PADDLE_API_KEY", "").strip() or None,
         github_app_slug=_required_env("GITHUB_APP_SLUG"),
         # Only used to raise the rate limit on the pre-clone repo-size check
         # for the public demo (60/hr unauthenticated vs 5000/hr with a

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -125,6 +125,16 @@ async def list_my_repos(request: Request):
     result = []
     known_by_installation: dict[int, set[str]] = {}
     for row in repos:
+        known_by_installation.setdefault(row["installation_id"], set()).add(row["repo_full_name"])
+        # The hosted dashboard is an AIR (paid) feature. Community is free,
+        # self-service, and unmanaged by design - the CLI, the free GitHub
+        # Action, and free GitHub App usage are all meant to work without
+        # ever touching a shared web view. Listing a free installation's
+        # repos here would let every GitHub admin on that org click into a
+        # full managed dashboard for free - exactly the team-collaboration
+        # capability AIR itself sells.
+        if row["plan"] == "free":
+            continue
         # repo_full_name is the source of truth for the org/repo split used
         # in every /app/{org}/{repo} route - account_login is a display
         # value only and isn't guaranteed to match the org segment exactly.
@@ -138,17 +148,14 @@ async def list_my_repos(request: Request):
                 "initialized": True,
             }
         )
-        known_by_installation.setdefault(row["installation_id"], set()).add(row["repo_full_name"])
 
     for installation_id in administered_ids:
         installation = await get_installation(pool, installation_id)
-        if installation is None:
+        if installation is None or installation["plan"] == "free":
             continue
         known = known_by_installation.get(installation_id, set())
-        scan_limit_reached = False
-        if installation["plan"] != "free":
-            scanned_this_month = await count_monthly_scanned_repos(pool, installation_id)
-            scan_limit_reached = scanned_this_month >= MAX_SCANNED_REPOS_PER_MONTH
+        scanned_this_month = await count_monthly_scanned_repos(pool, installation_id)
+        scan_limit_reached = scanned_this_month >= MAX_SCANNED_REPOS_PER_MONTH
         result.extend(
             await _uninitialized_repos_for_installation(
                 installation_id, installation["plan"], known, scan_limit_reached
@@ -174,6 +181,8 @@ async def _require_dashboard_installation(request: Request, org: str, repo: str)
 
     installation = await get_installation(pool, installation_id)
     if installation is not None:
+        if installation["plan"] == "free":
+            raise HTTPException(status_code=402, detail="the managed dashboard requires a paid plan")
         await _require_seat_if_paid(pool, installation, session["github_login"])
 
     return installation_id

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -15,8 +15,10 @@ from app_server.config import get_settings
 from app_server.db import (
     MAX_SCANNED_REPOS_PER_MONTH,
     count_monthly_scanned_repos,
-    get_installation,
+    get_endpoint_health_history,
     get_endpoint_health_summary_since,
+    get_endpoint_uptime_pct_since,
+    get_installation,
     get_latest_evidence,
     get_recent_endpoint_health,
     get_recent_history,
@@ -237,6 +239,39 @@ async def get_dashboard_health(org: str, repo: str, request: Request):
     }
 
 
+@dashboard_router.get("/app/{org}/{repo}/health/history")
+async def get_dashboard_health_history(
+    org: str,
+    repo: str,
+    request: Request,
+    method: str,
+    path: str,
+    target_id: int | None = None,
+    limit: int = 50,
+):
+    installation_id = await _require_dashboard_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    repo_full_name = f"{org}/{repo}"
+
+    rows = await get_endpoint_health_history(
+        pool, installation_id, repo_full_name, target_id, method, path, limit
+    )
+    return {
+        "repo_full_name": repo_full_name,
+        "method": method,
+        "path": path,
+        "checks": [
+            {
+                "reachable": row["reachable"],
+                "status_code": row["status_code"],
+                "latency_ms": float(row["latency_ms"]) if row["latency_ms"] is not None else None,
+                "checked_at": row["checked_at"].isoformat(),
+            }
+            for row in rows
+        ],
+    }
+
+
 @dashboard_router.get("/app/{org}/{repo}/wiki")
 async def get_dashboard_wiki(org: str, repo: str, request: Request):
     installation = await _require_admin_installation(request, org, repo)
@@ -304,6 +339,13 @@ async def get_public_health(org: str, repo: str, request: Request, response: Res
             headers={"Access-Control-Allow-Origin": "*"},
         )
 
+    # An aggregate 7-day uptime percentage, not raw history - this is a
+    # public, unauthenticated, CORS-open endpoint, so it gets a trend
+    # signal without handing out granular check-by-check timing data to
+    # anyone who asks (the authenticated dashboard endpoint has that).
+    since = datetime.now(timezone.utc) - timedelta(days=7)
+    uptime_by_endpoint = await get_endpoint_uptime_pct_since(request.app.state.db_pool, repo_full_name, since)
+
     return {
         "repo_full_name": repo_full_name,
         "endpoints": [
@@ -314,6 +356,7 @@ async def get_public_health(org: str, repo: str, request: Request, response: Res
                 "status_code": row["status_code"],
                 "latency_ms": float(row["latency_ms"]) if row["latency_ms"] is not None else None,
                 "checked_at": row["checked_at"].isoformat(),
+                "uptime_pct_7d": uptime_by_endpoint.get((row["endpoint_method"], row["endpoint_path"])),
             }
             for row in rows
         ],

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, HTTPException, Request, Response
@@ -318,9 +319,49 @@ async def get_dashboard_wiki_subsystem(org: str, repo: str, subsystem_id: str, r
     return {"repo_full_name": repo_full_name, "subsystem": subsystem}
 
 
+PUBLIC_HEALTH_RATE_LIMIT = 60
+PUBLIC_HEALTH_RATE_LIMIT_WINDOW_SECONDS = 60
+
+
 @dashboard_router.get("/v1/health/{org}/{repo}")
 async def get_public_health(org: str, repo: str, request: Request, response: Response):
     response.headers["Access-Control-Allow-Origin"] = "*"
+
+    from redis import Redis
+
+    from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for
+    from app_server.rate_limit import is_rate_limited
+
+    client_ip = client_ip_from_forwarded_for(
+        request.headers.get("x-forwarded-for"),
+        request.client.host if request.client else "",
+    )
+    try:
+        rate_limited = is_rate_limited(
+            Redis.from_url(get_settings().redis_url),
+            f"ratelimit:public_health:{client_ip}",
+            PUBLIC_HEALTH_RATE_LIMIT,
+            PUBLIC_HEALTH_RATE_LIMIT_WINDOW_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # A Redis outage should degrade this endpoint's abuse protection,
+        # not take down the public status API itself - fail open, same as
+        # the Paddle IP allowlist does when it can't reach Paddle's /ips.
+        logging.getLogger("app_server.dashboard").warning(
+            "public health rate limit check failed (%s); allowing request", exc
+        )
+        rate_limited = False
+
+    if rate_limited:
+        raise HTTPException(
+            status_code=429,
+            detail="too many requests",
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Retry-After": str(PUBLIC_HEALTH_RATE_LIMIT_WINDOW_SECONDS),
+            },
+        )
+
     repo_full_name = f"{org}/{repo}"
     rows = await request.app.state.db_pool.fetch(
         """

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -279,6 +279,18 @@ async def get_extra_seats(pool: asyncpg.Pool, installation_id: int) -> int:
     return row["extra_seats"] if row else 0
 
 
+async def set_extra_seats(pool: asyncpg.Pool, installation_id: int, extra_seats: int) -> None:
+    # The Paddle subscription's extra-seat line item quantity is the source
+    # of truth, reconciled here from webhook events - never set directly by
+    # the buy/remove-seat button, the same pattern installations.plan
+    # already follows for the base subscription price.
+    await pool.execute(
+        "UPDATE installations SET extra_seats = $2 WHERE installation_id = $1",
+        installation_id,
+        extra_seats,
+    )
+
+
 INCLUDED_SEATS = {"air": 5}
 DEFAULT_SEAT_LIMIT = 5
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -473,6 +473,69 @@ async def get_recent_endpoint_health(
     return [dict(row) for row in rows]
 
 
+MAX_ENDPOINT_HEALTH_HISTORY_ROWS = 100
+
+
+async def get_endpoint_health_history(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    repo_full_name: str,
+    target_id: int | None,
+    endpoint_method: str,
+    endpoint_path: str,
+    limit: int = 50,
+) -> list[dict]:
+    # Every sweep persists a row per (target, endpoint) check, but until
+    # this every read path only ever surfaced the single latest one -
+    # a customer paying for "endpoint health monitoring" had no way to
+    # see a trend, only a live dot. target_id can legitimately be NULL
+    # (rows written before multi-target support existed), so this can't
+    # just be "= $3" - IS NOT DISTINCT FROM treats two NULLs as equal.
+    limit = min(max(limit, 1), MAX_ENDPOINT_HEALTH_HISTORY_ROWS)
+    rows = await pool.fetch(
+        """
+        SELECT reachable, status_code, latency_ms, checked_at
+        FROM endpoint_health
+        WHERE installation_id = $1 AND repo_full_name = $2
+          AND target_id IS NOT DISTINCT FROM $3
+          AND endpoint_method = $4 AND endpoint_path = $5
+        ORDER BY checked_at DESC, id DESC
+        LIMIT $6
+        """,
+        installation_id,
+        repo_full_name,
+        target_id,
+        endpoint_method,
+        endpoint_path,
+        limit,
+    )
+    return [dict(row) for row in rows]
+
+
+async def get_endpoint_uptime_pct_since(
+    pool: asyncpg.Pool,
+    repo_full_name: str,
+    since: datetime,
+) -> dict[tuple[str, str], float]:
+    # Backs the public status API's trend signal. Deliberately an
+    # aggregate percentage rather than the raw per-check history exposed
+    # on the authenticated dashboard endpoint - an unauthenticated,
+    # CORS-open route shouldn't hand out granular check-by-check timing
+    # data to anyone who asks.
+    rows = await pool.fetch(
+        """
+        SELECT endpoint_method, endpoint_path,
+               (count(*) FILTER (WHERE reachable))::float / count(*) AS uptime_pct
+        FROM endpoint_health
+        WHERE repo_full_name = $1 AND checked_at >= $2
+        GROUP BY endpoint_method, endpoint_path
+        """,
+        repo_full_name,
+        since,
+    )
+    return {(row["endpoint_method"], row["endpoint_path"]): row["uptime_pct"] for row in rows}
+
+
 async def get_endpoint_health_summary_since(
     pool: asyncpg.Pool,
     installation_id: int,

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -226,6 +226,9 @@ table.findings tr:last-child td { border-bottom: none; }
 .health-target-group { margin-bottom: 1.2rem; }
 .health-target-group:last-child { margin-bottom: 0; }
 .health-target-group-label { font-size: 12px; font-weight: 500; margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.health-history { grid-column: 1 / -1; background: var(--slate-50); border-radius: 8px; padding: 8px 10px; margin: -4px 0 4px; }
+.health-history-list { display: flex; flex-direction: column; gap: 5px; }
+.health-history-row { display: flex; align-items: center; gap: 10px; font-size: 11.5px; }
 
 .wiki-banner { display: flex; align-items: center; justify-content: space-between; gap: 1rem; background: var(--accent-soft); border-radius: 10px; padding: 12px 15px; margin: 10px 0 14px; flex-wrap: wrap; }
 .wiki-banner-text { font-size: 12.5px; color: var(--accent-strong); line-height: 1.5; max-width: 46ch; }
@@ -907,6 +910,8 @@ async function loadResults() {{
     (groups[key] = groups[key] || []).push(e);
   }});
   let html = '';
+  let rowIndex = 0;
+  const rowMeta = {{}};
   Object.keys(groups).sort().forEach(function (label) {{
     const rows = groups[label];
     const up = rows.filter(function (e) {{ return e.reachable; }}).length;
@@ -914,14 +919,20 @@ async function loadResults() {{
       '<span class="chip ' + (up === rows.length ? 'success' : 'critical') + '">' + up + ' of ' + rows.length + ' up</span></div>' +
       '<div class="health-grid">';
     rows.forEach(function (e) {{
-      html += '<div class="health-row"><span class="health-status ' + (e.reachable ? 'up' : 'down') + '"></span>' +
+      const rowId = 'health-row-' + rowIndex;
+      rowMeta[rowId] = {{ target_id: e.target_id, method: e.method, path: e.path }};
+      html += '<div class="health-row" id="' + rowId + '" style="cursor:pointer;" onclick="toggleEndpointHistory(\\'' + rowId + '\\')">' +
+        '<span class="health-status ' + (e.reachable ? 'up' : 'down') + '"></span>' +
         '<span class="health-endpoint">' + escapeHtml(e.method) + ' ' + escapeHtml(e.path) + '</span>' +
         '<span class="health-latency"' + (e.reachable ? '' : ' style="color:var(--critical);"') + '>' + (e.reachable ? Math.round(e.latency_ms) + 'ms' : (e.status_code || 'unreachable')) + '</span>' +
-        '<span class="health-checked">' + relativeTime(e.checked_at) + '</span></div>';
+        '<span class="health-checked">' + relativeTime(e.checked_at) + '</span></div>' +
+        '<div class="health-history" id="' + rowId + '-history" style="display:none;"></div>';
+      rowIndex += 1;
     }});
     html += '</div></div>';
   }});
   body.innerHTML = html;
+  window._healthRowMeta = rowMeta;
 
   const staleEndpoints = data.stale_endpoints || [];
   const staleSection = document.getElementById('stale-endpoints-section');
@@ -941,6 +952,35 @@ async function loadResults() {{
     staleHtml += '</div>';
     staleBody.innerHTML = staleHtml;
   }}
+}}
+
+async function toggleEndpointHistory(rowId) {{
+  const panel = document.getElementById(rowId + '-history');
+  if (!panel) return;
+  if (panel.style.display !== 'none') {{ panel.style.display = 'none'; return; }}
+
+  const meta = (window._healthRowMeta || {{}})[rowId];
+  if (!meta) return;
+  panel.style.display = '';
+  panel.innerHTML = '<div class="empty-state">Loading&hellip;</div>';
+
+  const params = new URLSearchParams({{ method: meta.method, path: meta.path }});
+  if (meta.target_id !== null && meta.target_id !== undefined) {{ params.set('target_id', meta.target_id); }}
+  const res = await apiGet(base + '/health/history?' + params.toString());
+  if (!res || !res.ok) {{ panel.innerHTML = '<div class="empty-state">History unavailable.</div>'; return; }}
+  const data = await res.json();
+  const checks = data.checks || [];
+  if (checks.length === 0) {{ panel.innerHTML = '<div class="empty-state">No history yet.</div>'; return; }}
+
+  let html = '<div class="health-history-list">';
+  checks.forEach(function (c) {{
+    html += '<div class="health-history-row"><span class="health-status ' + (c.reachable ? 'up' : 'down') + '"></span>' +
+      '<span class="health-latency"' + (c.reachable ? '' : ' style="color:var(--critical);"') + '>' +
+      (c.reachable ? Math.round(c.latency_ms) + 'ms' : (c.status_code || 'unreachable')) + '</span>' +
+      '<span class="health-checked">' + relativeTime(c.checked_at) + '</span></div>';
+  }});
+  html += '</div>';
+  panel.innerHTML = html;
 }}
 
 loadTargets();

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -359,7 +359,7 @@ PICKER_HTML = f"""<!DOCTYPE html>
   if (!res) return;
   const data = await res.json();
   if (data.repos.length === 0) {{
-    body.innerHTML = '<div class="empty-state">No repositories yet. Install the Aletheore GitHub App on an organization to get started.</div>';
+    body.innerHTML = '<div class="empty-state">No managed repositories yet. Aletheore Community (free) runs self-service - the CLI, the free GitHub Action, and free GitHub App usage all work without a hosted dashboard, so a free installation won\\'t appear here. Install the Aletheore GitHub App on an organization and subscribe to AIR to get a managed dashboard.</div>';
     return;
   }}
   const byOrg = {{}};

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1282,6 +1282,16 @@ async function saveWebhook() {{
   status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
 }}
 
+async function sendTestNotification() {{
+  const status = document.getElementById('webhook-status');
+  status.textContent = 'Sending...';
+  status.style.color = 'var(--slate-600)';
+  const res = await fetch(adminBase + '/webhook-url/test', {{ method: 'POST' }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  status.textContent = res.ok ? 'Test notification sent.' : (data.detail || 'Could not send test notification.');
+  status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
+}}
+
 async function loadSettings() {{
   const body = document.getElementById('settings-body');
   const res = await apiGet(adminBase);
@@ -1323,9 +1333,9 @@ async function loadSettings() {{
       '<div>' +
         '<div class="settings-block">' +
           '<div class="settings-block-label">Alert webhook</div>' +
-          '<input class="field" id="webhook-url-input" placeholder="https://hooks.slack.com/..." value="' + escapeHtml(installation.webhook_url || '') + '">' +
-          '<div class="form-row"><button class="btn" onclick="saveWebhook()">Save</button><span id="webhook-status" class="settings-block-hint"></span></div>' +
-          '<div class="settings-block-hint">New critical findings are posted here shortly after a scan finishes.</div>' +
+          '<input class="field" id="webhook-url-input" placeholder="Slack or Teams webhook URL" value="' + escapeHtml(installation.webhook_url || '') + '">' +
+          '<div class="form-row"><button class="btn" onclick="saveWebhook()">Save</button><button class="btn" onclick="sendTestNotification()" style="margin-left:6px;">Send test</button><span id="webhook-status" class="settings-block-hint"></span></div>' +
+          '<div class="settings-block-hint">New critical findings are posted here shortly after a scan finishes. Paste a Slack incoming-webhook URL or a Teams workflow webhook URL - both are auto-detected.</div>' +
         '</div>' +
         '<div class="settings-block">' +
           '<div class="settings-block-label">Endpoint health targets</div>' +

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1123,7 +1123,18 @@ async function loadWiki() {{
     }}
     return;
   }}
-  let html = '<div class="wiki-banner"><div class="wiki-banner-text"><b>Built once by a frontier model, kept current by a fast one.</b> Every diagram edge below is a real import in this repo, never inferred.</div></div>' +
+  // A failed status here means a later incremental update broke, not the
+  // first build (which is what the branch above handles) - without this,
+  // the customer just sees increasingly stale content with zero signal
+  // that anything is wrong.
+  let staleBanner = '';
+  if (data.build_status === 'failed') {{
+    staleBanner = '<div class="empty-state" style="color:var(--critical);margin-bottom:12px;">' +
+      'The latest AIRview update failed' + (data.build_error ? ': ' + escapeHtml(data.build_error) : '.') +
+      ' Showing the last successful build below - it may be stale.</div>';
+  }}
+  let html = staleBanner +
+    '<div class="wiki-banner"><div class="wiki-banner-text"><b>Built once by a frontier model, kept current by a fast one.</b> Every diagram edge below is a real import in this repo, never inferred.</div></div>' +
     '<div class="diagram-wrap"><div class="mermaid" id="overview-diagram"></div></div>' +
     '<div class="subsystem-grid" id="subsystem-grid"></div>';
   body.innerHTML = html;

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1332,6 +1332,38 @@ async function sendTestNotification() {{
   status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
 }}
 
+async function buySeat() {{
+  const status = document.getElementById('seat-billing-status');
+  status.textContent = 'Updating billing...';
+  status.style.color = 'var(--slate-600)';
+  const res = await fetch(adminBase + '/seats/buy', {{ method: 'POST' }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  if (res.ok) {{
+    status.textContent = 'Seat added - billing updated. Refreshing...';
+    status.style.color = 'var(--success)';
+    loadSettings();
+  }} else {{
+    status.textContent = data.detail || 'Could not buy a seat.';
+    status.style.color = 'var(--critical)';
+  }}
+}}
+
+async function removeSeat() {{
+  const status = document.getElementById('seat-billing-status');
+  status.textContent = 'Updating billing...';
+  status.style.color = 'var(--slate-600)';
+  const res = await fetch(adminBase + '/seats/remove', {{ method: 'POST' }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  if (res.ok) {{
+    status.textContent = 'Seat removed - billing updated. Refreshing...';
+    status.style.color = 'var(--success)';
+    loadSettings();
+  }} else {{
+    status.textContent = data.detail || 'Could not remove a seat.';
+    status.style.color = 'var(--critical)';
+  }}
+}}
+
 async function loadSettings() {{
   const body = document.getElementById('settings-body');
   const res = await apiGet(adminBase);
@@ -1350,6 +1382,15 @@ async function loadSettings() {{
   }}
   const data = await res.json();
   const installation = data.installation;
+  window._hasActiveSubscription = !!installation.paddle_subscription_id;
+  window._extraSeats = data.extra_seats || 0;
+
+  const seatBillingHtml = window._hasActiveSubscription
+    ? '<div class="form-row">' +
+      '<button class="btn" onclick="buySeat()">Buy extra seat ($3.99/mo)</button>' +
+      (window._extraSeats > 0 ? '<button class="btn" onclick="removeSeat()" style="margin-left:6px;">Remove a seat</button>' : '') +
+      '</div><div id="seat-billing-status" class="settings-block-hint"></div>'
+    : '<div class="settings-block-hint">Extra seats need an active subscription - subscribe first to buy one.</div>';
 
   body.innerHTML =
     '<div class="settings-grid">' +
@@ -1360,7 +1401,7 @@ async function loadSettings() {{
           '<div class="form-row"><input class="field" id="new-member-login" placeholder="GitHub username">' +
           '<button class="btn" onclick="addMember()">Add</button></div>' +
           '<div id="member-status" class="settings-block-hint"></div>' +
-          '<div class="settings-block-hint">Extra seats beyond the plan\\'s limit aren\\'t billable yet - adding past the cap is blocked for now.</div>' +
+          seatBillingHtml +
         '</div>' +
         '<div class="settings-block">' +
           '<div class="settings-block-label">API tokens</div>' +

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -139,6 +139,10 @@ async def webhook(request: Request):
         from app_server.webhooks.pull_request import handle_pull_request_event
 
         await handle_pull_request_event(payload, settings.redis_url)
+    elif event == "push":
+        from app_server.webhooks.push import handle_push_event
+
+        await handle_push_event(payload, settings.redis_url)
     elif event == "issue_comment":
         from app_server.webhooks.issue_comment import handle_issue_comment_event
 

--- a/github-app/app_server/paddle_client.py
+++ b/github-app/app_server/paddle_client.py
@@ -1,0 +1,50 @@
+import httpx
+
+_PADDLE_API_BASE = "https://api.paddle.com"
+
+
+class PaddleAPIError(Exception):
+    pass
+
+
+class PaddleAPINotConfigured(PaddleAPIError):
+    pass
+
+
+def _headers(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def get_subscription(api_key: str | None, subscription_id: str) -> dict:
+    if not api_key:
+        raise PaddleAPINotConfigured("PADDLE_API_KEY is not configured")
+    try:
+        response = httpx.get(f"{_PADDLE_API_BASE}/subscriptions/{subscription_id}", headers=_headers(api_key))
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise PaddleAPIError(f"could not fetch subscription {subscription_id}: {exc}") from exc
+    return response.json()["data"]
+
+
+def update_subscription_items(
+    api_key: str | None,
+    subscription_id: str,
+    items: list[dict],
+    proration_billing_mode: str,
+) -> dict:
+    if not api_key:
+        raise PaddleAPINotConfigured("PADDLE_API_KEY is not configured")
+    # Paddle requires the COMPLETE item list on every update, not just the
+    # items being changed - omitting an existing item removes it from the
+    # subscription. Callers must fetch the current subscription first and
+    # build the full list; this function does not merge for them.
+    try:
+        response = httpx.patch(
+            f"{_PADDLE_API_BASE}/subscriptions/{subscription_id}",
+            headers=_headers(api_key),
+            json={"items": items, "proration_billing_mode": proration_billing_mode},
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise PaddleAPIError(f"could not update subscription {subscription_id}: {exc}") from exc
+    return response.json()["data"]

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -1,5 +1,11 @@
 """Paddle price ID to Aletheore plan mapping."""
 
+# The AIR add-on for a seat beyond the plan's included count ($3.99/mo,
+# pricing.html's "+$3.99/mo per additional team member"). Added as a second
+# line item (by quantity) on a customer's existing AIR subscription, not a
+# separate subscription of its own.
+EXTRA_SEAT_PRICE_ID = "pri_01kym2q99kevmdg7h71nwpm4ej"
+
 PADDLE_PRICE_TO_PLAN: dict[str, str] = {
     "pri_01kyhevc8bkcghfpwjymz16y2h": "air",
     "pri_01kyhevc9xn6z2nghmy8057jvp": "air",

--- a/github-app/app_server/rate_limit.py
+++ b/github-app/app_server/rate_limit.py
@@ -21,3 +21,16 @@ def cooldown_seconds_for_loc(total_loc: int) -> int:
 def total_loc_from_evidence(evidence: dict) -> int:
     languages = evidence.get("repository", {}).get("languages", [])
     return sum(language.get("lines", 0) for language in languages)
+
+
+def is_rate_limited(redis_conn, key: str, limit: int, window_seconds: int) -> bool:
+    # Fixed-window counter, not a token bucket - simple and sufficient for
+    # an abuse guard on a public, unauthenticated endpoint. NX on the
+    # EXPIRE call means only the first request in a window sets the TTL,
+    # so a burst of concurrent requests can't each reset the window and
+    # make the limit unenforceable.
+    pipe = redis_conn.pipeline()
+    pipe.incr(key)
+    pipe.expire(key, window_seconds, nx=True)
+    count, _ = pipe.execute()
+    return count > limit

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -3,9 +3,9 @@ import logging
 from fastapi import APIRouter, Request, Response
 
 from app_server.config import get_settings
-from app_server.db import add_paddle_ids_to_installation, get_installation, set_installation_plan
+from app_server.db import add_paddle_ids_to_installation, get_installation, set_extra_seats, set_installation_plan
 from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
-from app_server.paddle_pricing import resolve_plan_for_price_id
+from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID, resolve_plan_for_price_id
 from app_server.paddle_webhook_verify import verify_paddle_signature
 
 paddle_webhook_router = APIRouter()
@@ -50,13 +50,22 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         logger.warning("%s missing installation_id in custom_data", event_type)
         return
 
+    items = data.get("items") or []
     if data.get("status") in _ACTIVE_SUBSCRIPTION_STATUSES:
-        items = data.get("items") or []
-        price_id = items[0].get("price", {}).get("id") if items else None
-        plan = resolve_plan_for_price_id(price_id) if price_id else None
+        # The base plan price is whichever item resolves to a known plan -
+        # not necessarily items[0], since the extra-seat add-on can be
+        # either item once seats are involved.
+        plan = next(
+            (
+                resolved
+                for item in items
+                if (resolved := resolve_plan_for_price_id((item.get("price") or {}).get("id")))
+            ),
+            None,
+        )
         if not plan:
             logger.warning(
-                "%s has an active status but no resolvable price id: price_id=%s", event_type, price_id
+                "%s has an active status but no resolvable plan price id in items", event_type
             )
             return
     else:
@@ -68,6 +77,21 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     await set_installation_plan(pool, installation_id, plan)
     if "id" in data and "customer_id" in data:
         await add_paddle_ids_to_installation(pool, installation_id, data["id"], data["customer_id"])
+
+    # The extra-seat line item's quantity is the source of truth for billed
+    # seats - reconciled here, the same way the plan itself is, rather than
+    # trusting the buy/remove-seat button's own optimism about what Paddle
+    # actually charged.
+    extra_seats = (
+        sum(
+            item.get("quantity", 0)
+            for item in items
+            if (item.get("price") or {}).get("id") == EXTRA_SEAT_PRICE_ID
+        )
+        if plan != "free"
+        else 0
+    )
+    await set_extra_seats(pool, installation_id, extra_seats)
 
     # One-time Live Wiki build, mirroring the GitHub Marketplace path in
     # webhooks/marketplace.py - fires exactly once, on the free -> paid

--- a/github-app/app_server/webhooks/push.py
+++ b/github-app/app_server/webhooks/push.py
@@ -1,0 +1,33 @@
+async def handle_push_event(payload: dict, redis_url: str, queue=None) -> None:
+    # Every branch/tag push fires this event - only a push that actually
+    # lands on the repository's default branch is "what's on main" for
+    # AIRview's purposes. Branch deletions carry after == "0000...0" and
+    # have nothing to scan.
+    if payload.get("deleted"):
+        return
+
+    ref = payload.get("ref", "")
+    default_branch = payload.get("repository", {}).get("default_branch", "")
+    if ref != f"refs/heads/{default_branch}":
+        return
+
+    changed_files: set[str] = set()
+    for commit in payload.get("commits", []):
+        changed_files.update(commit.get("added", []))
+        changed_files.update(commit.get("removed", []))
+        changed_files.update(commit.get("modified", []))
+
+    if queue is None:
+        from redis import Redis
+        from rq import Queue
+
+        queue = Queue("scans", connection=Redis.from_url(redis_url))
+
+    queue.enqueue(
+        "scan_worker.jobs.run_push_scan_job",
+        job_timeout=300,
+        installation_id=payload["installation"]["id"],
+        repo_full_name=payload["repository"]["full_name"],
+        head_sha=payload["after"],
+        changed_files=sorted(changed_files),
+    )

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -629,8 +629,11 @@ def run_pr_scan_job(
         # comment we already posted with a generic failure message.
         try:
             _maybe_send_slack_alert(installation_id, repo_full_name, pr_number, diff)
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger("scan_worker.jobs").warning(
+                "alert webhook send failed for installation=%s repo=%s (%s)",
+                installation_id, repo_full_name, exc,
+            )
         try:
             _maybe_create_check_run(client, token, repo_full_name, head_sha, installation_id, diff)
         except Exception:  # noqa: BLE001
@@ -642,8 +645,14 @@ def run_pr_scan_job(
         if changed_files is not None:
             try:
                 _maybe_update_live_wiki(installation_id, repo_full_name, new, changed_files, head_sha)
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception as exc:  # noqa: BLE001
+                # _maybe_update_live_wiki already records failures to
+                # wiki_build_status itself; this only catches something
+                # failing before that handling could run (e.g. get_settings).
+                logging.getLogger("scan_worker.jobs").warning(
+                    "live wiki incremental update failed for installation=%s repo=%s (%s)",
+                    installation_id, repo_full_name, exc,
+                )
             try:
                 _maybe_create_regression_risk_check_run(
                     client,
@@ -1741,22 +1750,36 @@ def _maybe_update_live_wiki(
         return
 
     dsn = settings.database_url
-    naming_adapter = _live_wiki_naming_adapter()
-    writing_adapter = _live_wiki_update_writing_adapter()
-    fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
-    records = live_wiki.generate_subsystems(
-        evidence,
-        naming_adapter,
-        writing_adapter,
-        cluster_ids=cluster_ids,
-        cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
-        cache_write=lambda packet, output, used: store_result(
-            dsn, installation_id, repo_full_name, packet, output, used
-        ),
-        model_used=live_wiki.UPDATE_MODEL,
-        fetch_line_count=fetch_line_count,
-    )
-    _store_wiki_generation(
-        settings.database_url, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
-        fetch_line_count=fetch_line_count,
-    )
+    try:
+        naming_adapter = _live_wiki_naming_adapter()
+        writing_adapter = _live_wiki_update_writing_adapter()
+        fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
+        records = live_wiki.generate_subsystems(
+            evidence,
+            naming_adapter,
+            writing_adapter,
+            cluster_ids=cluster_ids,
+            cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
+            cache_write=lambda packet, output, used: store_result(
+                dsn, installation_id, repo_full_name, packet, output, used
+            ),
+            model_used=live_wiki.UPDATE_MODEL,
+            fetch_line_count=fetch_line_count,
+        )
+        _store_wiki_generation(
+            dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
+            fetch_line_count=fetch_line_count,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Without this, a failed incremental update just leaves stale
+        # content in place with zero signal - the customer (and
+        # wiki_build_status) has no way to tell "stale" apart from
+        # "current", especially once a first full build has already
+        # succeeded and populated an overview.
+        logging.getLogger("scan_worker.jobs").warning(
+            "live wiki incremental update failed for installation=%s repo=%s (%s)",
+            installation_id, repo_full_name, exc,
+        )
+        set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+        return
+    set_wiki_build_status(dsn, installation_id, repo_full_name, "ready")

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -731,6 +731,61 @@ def run_initial_scan_job(installation_id: int, repo_full_name: str) -> None:
         shutil.rmtree(job_dir, ignore_errors=True)
 
 
+@log_job
+def run_push_scan_job(
+    installation_id: int, repo_full_name: str, head_sha: str, changed_files: list[str]
+) -> None:
+    """Re-scans a repo's default branch after a direct push or a PR merge,
+    and reconciles AIRview against that scan.
+
+    Before this job existed, AIRview only ever updated off pull_request
+    events using the PR's *head* SHA - proposed, possibly-unmerged code -
+    via _maybe_update_live_wiki inside run_pr_scan_job. Nothing ever
+    re-scanned the actual default branch after the fact, so a merge could
+    leave the wiki describing the PR's pre-merge state indefinitely, and a
+    PR closed without merging left the wiki describing abandoned branch
+    content forever. Routing every push to main through the same
+    incremental update path used for PRs means merges (and direct pushes)
+    become the recurring correction against real merged code.
+    """
+    settings = get_settings()
+
+    installation = get_installation_row(settings.database_url, installation_id)
+    if installation is not None and installation["plan"] != "free":
+        if not check_and_reserve_monthly_repo_scan_slot(
+            settings.database_url, installation_id, repo_full_name, MAX_SCANNED_REPOS_PER_MONTH
+        ):
+            return
+
+    job_dir = _job_temp_dir()
+    try:
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        token = _token_sync(installation_id, app_jwt)
+        clone_url = _clone_url(repo_full_name, token)
+        repo_dir = _prepare_head_checkout(clone_url, head_sha, installation_id, repo_full_name, job_dir / "repo")
+
+        evidence_path = _run_scan(repo_dir)
+        evidence = json.loads(evidence_path.read_text())
+        evidence = _sync_persistent_git_graph(installation_id, repo_full_name, repo_dir, evidence)
+        _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
+        _insert_history(installation_id, repo_full_name, evidence)
+
+        if installation is not None and installation["plan"] != "free":
+            try:
+                _maybe_update_live_wiki(installation_id, repo_full_name, evidence, changed_files, head_sha)
+            except Exception as exc:  # noqa: BLE001
+                logging.getLogger("scan_worker.jobs").warning(
+                    "live wiki reconciliation after push failed for installation=%s repo=%s (%s)",
+                    installation_id, repo_full_name, exc,
+                )
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "push scan job failed for installation=%s repo=%s (%s)", installation_id, repo_full_name, exc,
+        )
+    finally:
+        shutil.rmtree(job_dir, ignore_errors=True)
+
+
 def _clone_pr_head(url: str, pr_number: int, dest: Path) -> None:
     subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(dest)], check=True)
     subprocess.run(

--- a/github-app/scan_worker/slack.py
+++ b/github-app/scan_worker/slack.py
@@ -1,4 +1,62 @@
+import re
+
 import httpx
+
+
+def _detect_platform(webhook_url: str) -> str:
+    # Slack incoming webhooks are always hooks.slack.com. Modern Teams
+    # webhooks are Power Automate "Workflows" (logic.azure.com); the
+    # classic Office 365 Connector webhooks (webhook.office.com) were
+    # retired by Microsoft in 2024 but are matched too in case a customer
+    # still has one working. Anything unrecognized defaults to Slack's
+    # plain {"text": ...} shape, since that's the only format this
+    # webhook field has ever actually sent.
+    url_lower = webhook_url.lower()
+    if "logic.azure.com" in url_lower or "office.com" in url_lower or "teams.microsoft.com" in url_lower:
+        return "teams"
+    return "slack"
+
+
+def _slack_markdown_to_adaptive_card_markdown(text: str) -> str:
+    # Slack mrkdwn uses single-asterisk bold (*bold*); Adaptive Cards use
+    # CommonMark-style double-asterisk (**bold**). Backtick code spans and
+    # newlines already mean the same thing in both, so only bold needs
+    # translating.
+    return re.sub(r"(?<!\*)\*([^*\n]+)\*(?!\*)", r"**\1**", text)
+
+
+def _to_teams_payload(message: dict) -> dict:
+    # Classic Teams "Incoming Webhook" connectors (MessageCard payloads)
+    # were retired by Microsoft in 2024 in favor of Power Automate
+    # "Workflows" webhooks, which expect this envelope - a message
+    # containing an Adaptive Card attachment - rather than a bare
+    # MessageCard or Slack-shaped {"text": ...} body.
+    return {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": [
+                        {
+                            "type": "TextBlock",
+                            "text": _slack_markdown_to_adaptive_card_markdown(message.get("text", "")),
+                            "wrap": True,
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+
+def _render_payload(webhook_url: str, message: dict) -> dict:
+    if _detect_platform(webhook_url) == "teams":
+        return _to_teams_payload(message)
+    return message
 
 
 def _format_list(value) -> str | None:
@@ -77,7 +135,8 @@ def send_slack_alert(
     if not _has_new_findings(diff):
         return
     client = http_client or httpx.Client()
-    response = client.post(webhook_url, json=format_slack_message(diff, repo_full_name, pr_number))
+    payload = _render_payload(webhook_url, format_slack_message(diff, repo_full_name, pr_number))
+    response = client.post(webhook_url, json=payload)
     response.raise_for_status()
 
 
@@ -199,5 +258,6 @@ def send_health_alert(
     http_client: httpx.Client | None = None,
 ) -> None:
     client = http_client or httpx.Client()
-    response = client.post(webhook_url, json=message)
+    payload = _render_payload(webhook_url, message)
+    response = client.post(webhook_url, json=payload)
     response.raise_for_status()

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -6,9 +6,10 @@ import pytest
 from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
-from app_server.admin import _administered_installation_ids_for_session_or_401
+from app_server.admin import _administered_installation_ids_for_session_or_401, _build_updated_seat_items
 from app_server.auth import decrypt_access_token, encrypt_access_token, sign_session_id
 from app_server.db import (
+    add_paddle_ids_to_installation,
     create_session,
     get_max_tokens,
     get_session,
@@ -17,6 +18,8 @@ from app_server.db import (
     upsert_installation,
 )
 from app_server.main import app
+from app_server.paddle_client import PaddleAPIError
+from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
 
 
 async def _logged_in_client(pool, monkeypatch, installation_id=100, plan="air"):
@@ -721,6 +724,167 @@ async def test_add_member_enforces_seat_cap(pool, monkeypatch):
         response = await client.post("/admin/octocat/hello-world/members", json={"github_login": "erin"})
     assert response.status_code == 409
     assert "seat limit reached" in response.json()["detail"]
+
+
+def test_build_updated_seat_items_adds_new_seat_item_when_none_exists():
+    items = _build_updated_seat_items(
+        [{"price": {"id": "pri_base"}, "quantity": 1}], delta=1
+    )
+    assert {"price_id": "pri_base", "quantity": 1} in items
+    assert {"price_id": EXTRA_SEAT_PRICE_ID, "quantity": 1} in items
+
+
+def test_build_updated_seat_items_increments_existing_seat_item():
+    items = _build_updated_seat_items(
+        [
+            {"price": {"id": "pri_base"}, "quantity": 1},
+            {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 2},
+        ],
+        delta=1,
+    )
+    assert {"price_id": EXTRA_SEAT_PRICE_ID, "quantity": 3} in items
+
+
+def test_build_updated_seat_items_decrements_and_drops_item_at_zero():
+    items = _build_updated_seat_items(
+        [
+            {"price": {"id": "pri_base"}, "quantity": 1},
+            {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 1},
+        ],
+        delta=-1,
+    )
+    assert items == [{"price_id": "pri_base", "quantity": 1}]
+
+
+def test_build_updated_seat_items_returns_none_when_nothing_to_remove():
+    assert _build_updated_seat_items([{"price": {"id": "pri_base"}, "quantity": 1}], delta=-1) is None
+
+
+@pytest.mark.asyncio
+async def test_buy_extra_seat_requires_active_subscription(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/seats/buy")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_buy_extra_seat_degrades_gracefully_without_api_key_configured(pool, monkeypatch):
+    # Real-world current state until PADDLE_API_KEY is added to the server's
+    # env - must fail as a clean 502, not crash the request with a 500.
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test_seat", "ctm_test_seat")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/seats/buy")
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_buy_extra_seat_updates_paddle_subscription(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test_seat", "ctm_test_seat")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    monkeypatch.setattr(
+        "app_server.admin.get_paddle_subscription",
+        lambda api_key, sub_id: {"items": [{"price": {"id": "pri_base"}, "quantity": 1}]},
+    )
+    captured = {}
+
+    def fake_update(api_key, sub_id, items, proration_billing_mode):
+        captured["sub_id"] = sub_id
+        captured["items"] = items
+        captured["mode"] = proration_billing_mode
+        return {}
+
+    monkeypatch.setattr("app_server.admin.update_paddle_subscription_items", fake_update)
+
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/seats/buy")
+
+    assert response.status_code == 200
+    assert captured["sub_id"] == "sub_test_seat"
+    assert {"price_id": EXTRA_SEAT_PRICE_ID, "quantity": 1} in captured["items"]
+    assert captured["mode"] == "prorated_immediately"
+
+
+@pytest.mark.asyncio
+async def test_buy_extra_seat_reports_paddle_api_failure(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test_seat", "ctm_test_seat")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    def _boom(api_key, sub_id):
+        raise PaddleAPIError("could not fetch subscription")
+
+    monkeypatch.setattr("app_server.admin.get_paddle_subscription", _boom)
+
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/seats/buy")
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_remove_extra_seat_requires_active_subscription(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/seats/remove")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_remove_extra_seat_returns_409_when_no_seats_to_remove(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test_seat", "ctm_test_seat")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    monkeypatch.setattr(
+        "app_server.admin.get_paddle_subscription",
+        lambda api_key, sub_id: {"items": [{"price": {"id": "pri_base"}, "quantity": 1}]},
+    )
+    called = []
+    monkeypatch.setattr(
+        "app_server.admin.update_paddle_subscription_items",
+        lambda *a, **k: called.append(True),
+    )
+
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/seats/remove")
+
+    assert response.status_code == 409
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_remove_extra_seat_updates_paddle_subscription(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test_seat", "ctm_test_seat")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    monkeypatch.setattr(
+        "app_server.admin.get_paddle_subscription",
+        lambda api_key, sub_id: {
+            "items": [
+                {"price": {"id": "pri_base"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 2},
+            ]
+        },
+    )
+    captured = {}
+    monkeypatch.setattr(
+        "app_server.admin.update_paddle_subscription_items",
+        lambda api_key, sub_id, items, proration_billing_mode: captured.update(items=items),
+    )
+
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/seats/remove")
+
+    assert response.status_code == 200
+    assert {"price_id": EXTRA_SEAT_PRICE_ID, "quantity": 1} in captured["items"]
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -304,6 +304,64 @@ async def test_set_webhook_url(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_test_notification_requires_a_saved_webhook(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/webhook-url/test")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_test_notification_posts_to_saved_webhook(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    sent = []
+
+    def fake_send_health_alert(webhook_url, message, http_client=None):
+        sent.append((webhook_url, message))
+
+    monkeypatch.setattr("scan_worker.slack.send_health_alert", fake_send_health_alert)
+    async with client:
+        put_response = await client.put(
+            "/admin/octocat/hello-world/webhook-url",
+            json={"webhook_url": "https://hooks.slack.com/services/x"},
+        )
+        assert put_response.status_code == 200
+        response = await client.post("/admin/octocat/hello-world/webhook-url/test")
+
+    assert response.status_code == 200
+    assert len(sent) == 1
+    assert sent[0][0] == "https://hooks.slack.com/services/x"
+    assert "octocat/hello-world" in sent[0][1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_test_notification_reports_delivery_failure(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+
+    def fake_send_health_alert(webhook_url, message, http_client=None):
+        raise httpx.HTTPStatusError("bad gateway", request=None, response=httpx.Response(502))
+
+    monkeypatch.setattr("scan_worker.slack.send_health_alert", fake_send_health_alert)
+    async with client:
+        await client.put(
+            "/admin/octocat/hello-world/webhook-url",
+            json={"webhook_url": "https://hooks.slack.com/services/x"},
+        )
+        response = await client.post("/admin/octocat/hello-world/webhook-url/test")
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_send_test_notification_requires_login(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/admin/octocat/hello-world/webhook-url/test")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_add_health_check_target(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch, installation_id=100)
     async with client:

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -829,6 +829,35 @@ async def test_dashboard_wiki_surfaces_failed_build_status(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_wiki_surfaces_failed_status_alongside_existing_overview(pool, monkeypatch):
+    # A later incremental update can fail after the first full build already
+    # succeeded - the API must keep reporting that failure (not silently
+    # drop it just because an overview now exists), so the dashboard can
+    # tell the customer their AIRview content may be stale.
+    await upsert_installation(pool, 606, "octocat")
+    await set_installation_plan(pool, 606, "indie")
+    await insert_repo_history(
+        pool,
+        606,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {"repository": {"modules": []}},
+    )
+    await _seed_wiki_overview(pool, 606, "octocat/hello-world")
+    await _seed_wiki_build_status(pool, 606, "octocat/hello-world", "failed", "LLM API unavailable")
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[606])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/wiki")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["overview"] is not None
+    assert body["build_status"] == "failed"
+    assert body["build_error"] == "LLM API unavailable"
+
+
+@pytest.mark.asyncio
 async def test_dashboard_wiki_subsystem_requires_login(pool):
     app.state.db_pool = pool
     transport = ASGITransport(app=app)

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -526,6 +526,98 @@ async def test_public_health_uptime_pct_excludes_checks_older_than_7_days(pool):
 
 
 @pytest.mark.asyncio
+async def test_public_health_rate_limits_after_threshold(pool, monkeypatch, redis_conn):
+    from app_server import dashboard
+
+    await upsert_installation(pool, 508, "octocat")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES (508, 'octocat/hello-world', 'GET', '/api/users', true)
+            """
+        )
+
+    monkeypatch.setattr(dashboard, "PUBLIC_HEALTH_RATE_LIMIT", 2)
+    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    headers = {"x-forwarded-for": "203.0.113.50"}
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get("/v1/health/octocat/hello-world", headers=headers)
+        second = await client.get("/v1/health/octocat/hello-world", headers=headers)
+        third = await client.get("/v1/health/octocat/hello-world", headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429
+    assert third.headers["access-control-allow-origin"] == "*"
+    assert "retry-after" in third.headers
+
+
+@pytest.mark.asyncio
+async def test_public_health_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis_conn):
+    from app_server import dashboard
+
+    await upsert_installation(pool, 509, "octocat")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES (509, 'octocat/hello-world', 'GET', '/api/users', true)
+            """
+        )
+
+    monkeypatch.setattr(dashboard, "PUBLIC_HEALTH_RATE_LIMIT", 1)
+    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get(
+            "/v1/health/octocat/hello-world", headers={"x-forwarded-for": "1.1.1.1"}
+        )
+        second_same_ip = await client.get(
+            "/v1/health/octocat/hello-world", headers={"x-forwarded-for": "1.1.1.1"}
+        )
+        first_other_ip = await client.get(
+            "/v1/health/octocat/hello-world", headers={"x-forwarded-for": "2.2.2.2"}
+        )
+
+    assert first.status_code == 200
+    assert second_same_ip.status_code == 429
+    assert first_other_ip.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_public_health_fails_open_when_redis_is_unreachable(pool, monkeypatch):
+    await upsert_installation(pool, 510, "octocat")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES (510, 'octocat/hello-world', 'GET', '/api/users', true)
+            """
+        )
+
+    def _boom(url):
+        raise ConnectionError("redis unreachable")
+
+    monkeypatch.setattr("redis.Redis.from_url", _boom)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/health/octocat/hello-world")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_public_health_404s_with_no_data(pool):
     app.state.db_pool = pool
     transport = ASGITransport(app=app)

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -484,6 +484,9 @@ async def test_public_health_returns_latest_per_endpoint(pool):
     assert endpoints[("GET", "/api/users")]["latency_ms"] == 88.0
     assert endpoints[("GET", "/api/orders")]["reachable"] is False
     assert endpoints[("GET", "/api/orders")]["status_code"] is None
+    # /api/users: 2 of 2 checks reachable; /api/orders: 0 of 1.
+    assert endpoints[("GET", "/api/users")]["uptime_pct_7d"] == 1.0
+    assert endpoints[("GET", "/api/orders")]["uptime_pct_7d"] == 0.0
     for endpoint in endpoints.values():
         assert set(endpoint.keys()) == {
             "method",
@@ -492,7 +495,34 @@ async def test_public_health_returns_latest_per_endpoint(pool):
             "status_code",
             "latency_ms",
             "checked_at",
+            "uptime_pct_7d",
         }
+
+
+@pytest.mark.asyncio
+async def test_public_health_uptime_pct_excludes_checks_older_than_7_days(pool):
+    await upsert_installation(pool, 507, "octocat")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path,
+                 reachable, status_code, latency_ms, checked_at)
+            VALUES
+                (507, 'octocat/hello-world', 'GET', '/api/users', false, 500, 90.5, now() - interval '10 days'),
+                (507, 'octocat/hello-world', 'GET', '/api/users', true, 200, 88.0, now())
+            """
+        )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/health/octocat/hello-world")
+
+    assert response.status_code == 200
+    endpoints = {(e["method"], e["path"]): e for e in response.json()["endpoints"]}
+    # Only the recent, reachable check falls inside the 7-day window.
+    assert endpoints[("GET", "/api/users")]["uptime_pct_7d"] == 1.0
 
 
 @pytest.mark.asyncio
@@ -558,6 +588,104 @@ async def test_dashboard_health_keeps_results_separate_per_target(pool, monkeypa
     by_label = {e["target_label"]: e for e in endpoints}
     assert by_label["Staging"]["reachable"] is True
     assert by_label["Production"]["reachable"] is False
+
+
+@pytest.mark.asyncio
+async def test_dashboard_health_history_requires_login(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/app/octocat/hello-world/health/history", params={"method": "GET", "path": "/api/users"}
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_dashboard_health_history_returns_checks_newest_first(pool, monkeypatch):
+    await upsert_installation(pool, 504, "octocat")
+    await insert_repo_history(
+        pool, 504, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+    async with pool.acquire() as conn:
+        target_id = await conn.fetchval(
+            """
+            INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url)
+            VALUES (504, 'octocat/hello-world', 'Production', 'https://prod.example.com') RETURNING id
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path,
+                 reachable, status_code, latency_ms, checked_at, target_id)
+            VALUES
+                (504, 'octocat/hello-world', 'GET', '/api/users', true, 200, 80.0, now() - interval '2 minutes', $1),
+                (504, 'octocat/hello-world', 'GET', '/api/users', false, 500, NULL, now() - interval '1 minute', $1),
+                (504, 'octocat/hello-world', 'GET', '/api/users', true, 200, 95.0, now(), $1)
+            """,
+            target_id,
+        )
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[504])
+    async with client:
+        response = await client.get(
+            "/app/octocat/hello-world/health/history",
+            params={"method": "GET", "path": "/api/users", "target_id": target_id},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    checks = body["checks"]
+    assert len(checks) == 3
+    # Newest first.
+    assert checks[0]["reachable"] is True
+    assert checks[0]["latency_ms"] == 95.0
+    assert checks[1]["reachable"] is False
+    assert checks[1]["status_code"] == 500
+    assert checks[2]["latency_ms"] == 80.0
+
+
+@pytest.mark.asyncio
+async def test_dashboard_health_history_respects_limit(pool, monkeypatch):
+    await upsert_installation(pool, 505, "octocat")
+    await insert_repo_history(
+        pool, 505, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+    async with pool.acquire() as conn:
+        for i in range(5):
+            await conn.execute(
+                """
+                INSERT INTO endpoint_health
+                    (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, checked_at)
+                VALUES (505, 'octocat/hello-world', 'GET', '/api/users', true, now() - ($1 || ' minutes')::interval)
+                """,
+                str(i),
+            )
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[505])
+    async with client:
+        response = await client.get(
+            "/app/octocat/hello-world/health/history",
+            params={"method": "GET", "path": "/api/users", "limit": 2},
+        )
+
+    assert response.status_code == 200
+    assert len(response.json()["checks"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_dashboard_health_history_rejects_unadministered_installation(pool, monkeypatch):
+    await upsert_installation(pool, 506, "octocat")
+    await insert_repo_history(
+        pool, 506, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[])
+    async with client:
+        response = await client.get(
+            "/app/octocat/hello-world/health/history", params={"method": "GET", "path": "/api/users"}
+        )
+    assert response.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -98,6 +98,7 @@ async def test_list_my_repos_requires_login(pool):
 @pytest.mark.asyncio
 async def test_list_my_repos_returns_repos_across_administered_installations(pool, monkeypatch):
     await upsert_installation(pool, 701, "octocat")
+    await set_installation_plan(pool, 701, "indie")
     await upsert_installation(pool, 702, "another-org")
     await set_installation_plan(pool, 702, "indie")
     await insert_repo_history(
@@ -123,8 +124,27 @@ async def test_list_my_repos_returns_repos_across_administered_installations(poo
     by_name = {r["repo_full_name"]: r for r in repos}
     assert by_name["octocat/hello-world"]["org"] == "octocat"
     assert by_name["octocat/hello-world"]["repo"] == "hello-world"
-    assert by_name["octocat/hello-world"]["plan"] == "free"
+    assert by_name["octocat/hello-world"]["plan"] == "indie"
     assert by_name["another-org/service-b"]["plan"] == "indie"
+
+
+@pytest.mark.asyncio
+async def test_list_my_repos_excludes_free_plan_installations(pool, monkeypatch):
+    # The hosted dashboard is an AIR (paid) feature - Community is free,
+    # self-service, and unmanaged by design. Listing a free installation's
+    # repos here would let every GitHub admin on that org click into a full
+    # managed dashboard for free, without anyone paying for it.
+    await upsert_installation(pool, 704, "octocat")  # defaults to plan='free'
+    await insert_repo_history(
+        pool, 704, "octocat/free-repo", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[704])
+    async with client:
+        response = await client.get("/app/repos")
+
+    assert response.status_code == 200
+    assert response.json()["repos"] == []
 
 
 @pytest.mark.asyncio
@@ -254,6 +274,7 @@ async def test_list_my_repos_does_not_duplicate_already_scanned_repos(pool, monk
     # "uninitialized" duplicate just because it's still covered by the
     # installation's real GitHub repo list.
     await upsert_installation(pool, 802, "some-user")
+    await set_installation_plan(pool, 802, "team")
     await insert_repo_history(
         pool, 802, "some-user/already-scanned", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -301,7 +322,7 @@ async def test_list_my_repos_does_not_duplicate_already_scanned_repos(pool, monk
         "org": "some-user",
         "repo": "already-scanned",
         "repo_full_name": "some-user/already-scanned",
-        "plan": "free",
+        "plan": "team",
         "initialized": True,
     }]
 
@@ -313,6 +334,7 @@ async def test_list_my_repos_ignores_github_failure_when_fetching_uninitialized_
     # still see their already-scanned repos rather than getting a 502 for
     # the whole page over a "nice to have" enrichment.
     await upsert_installation(pool, 803, "some-user")
+    await set_installation_plan(pool, 803, "team")
 
     monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
 
@@ -436,8 +458,37 @@ async def test_dashboard_rejects_unadministered_installation(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_requires_paid_plan(pool, monkeypatch):
+    # Community is free, self-service, and unmanaged by design - the hosted
+    # dashboard (scan history, health monitoring, AIRview) is an AIR-only
+    # feature. Without this, any GitHub admin on a free-plan org could click
+    # into a full managed dashboard for free.
+    await upsert_installation(pool, 511, "octocat")  # defaults to plan='free'
+    await insert_repo_history(
+        pool, 511, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[511])
+    async with client:
+        response = await client.get("/app/octocat/hello-world")
+    assert response.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_dashboard_health_requires_paid_plan(pool, monkeypatch):
+    await upsert_installation(pool, 512, "octocat")  # defaults to plan='free'
+    await insert_repo_history(
+        pool, 512, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[512])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/health")
+    assert response.status_code == 402
+
+
+@pytest.mark.asyncio
 async def test_dashboard_returns_data_for_known_repo(pool, monkeypatch):
     await upsert_installation(pool, 1, "octocat")
+    await set_installation_plan(pool, 1, "indie")
     await insert_repo_history(
         pool,
         1,
@@ -642,6 +693,7 @@ async def test_dashboard_health_keeps_results_separate_per_target(pool, monkeypa
     # targets checking the exact same method+path collapse into one row
     # and one target's result silently vanishes.
     await upsert_installation(pool, 503, "octocat")
+    await set_installation_plan(pool, 503, "indie")
     await insert_repo_history(
         pool, 503, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -696,6 +748,7 @@ async def test_dashboard_health_history_requires_login(pool):
 @pytest.mark.asyncio
 async def test_dashboard_health_history_returns_checks_newest_first(pool, monkeypatch):
     await upsert_installation(pool, 504, "octocat")
+    await set_installation_plan(pool, 504, "indie")
     await insert_repo_history(
         pool, 504, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -741,6 +794,7 @@ async def test_dashboard_health_history_returns_checks_newest_first(pool, monkey
 @pytest.mark.asyncio
 async def test_dashboard_health_history_respects_limit(pool, monkeypatch):
     await upsert_installation(pool, 505, "octocat")
+    await set_installation_plan(pool, 505, "indie")
     await insert_repo_history(
         pool, 505, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -807,6 +861,7 @@ async def test_dashboard_health_rejects_unadministered_installation(pool, monkey
 @pytest.mark.asyncio
 async def test_dashboard_health_includes_evidence_resolution(pool, monkeypatch):
     await upsert_installation(pool, 502, "octocat")
+    await set_installation_plan(pool, 502, "indie")
     await insert_repo_history(
         pool,
         502,
@@ -853,6 +908,7 @@ async def test_dashboard_health_includes_evidence_resolution(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
     await upsert_installation(pool, 504, "octocat")
+    await set_installation_plan(pool, 504, "indie")
     await insert_repo_history(
         pool,
         504,
@@ -903,6 +959,7 @@ async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_health_omits_stale_endpoints_with_recent_success(pool, monkeypatch):
     await upsert_installation(pool, 505, "octocat")
+    await set_installation_plan(pool, 505, "indie")
     await insert_repo_history(
         pool,
         505,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2282,6 +2282,113 @@ def test_run_pr_scan_job_logs_slack_alert_failure_instead_of_swallowing_it(
     )
 
 
+def test_run_push_scan_job_scans_and_reconciles_wiki(bare_repo_with_two_commits, monkeypatch):
+    from scan_worker.jobs import run_push_scan_job
+
+    bare_path, _base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+
+    called = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs._maybe_update_live_wiki",
+        lambda installation_id, repo_full_name, evidence, changed_files, head_sha: called.update(
+            installation_id=installation_id,
+            repo_full_name=repo_full_name,
+            changed_files=changed_files,
+            head_sha=head_sha,
+        ),
+    )
+
+    run_push_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        head_sha=head_sha,
+        changed_files=["app.py"],
+    )
+
+    assert called["installation_id"] == 1
+    assert called["repo_full_name"] == "octocat/hello-world"
+    assert called["changed_files"] == ["app.py"]
+    assert called["head_sha"] == head_sha
+
+
+def test_run_push_scan_job_skips_wiki_update_for_free_plan(bare_repo_with_two_commits, monkeypatch):
+    from scan_worker.jobs import run_push_scan_job
+
+    bare_path, _base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"})
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+    called = []
+    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: called.append(True))
+
+    run_push_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        head_sha=head_sha,
+        changed_files=["app.py"],
+    )
+
+    assert called == []
+
+
+def test_run_push_scan_job_skips_paid_repo_past_monthly_scan_cap(bare_repo_with_two_commits, monkeypatch):
+    from scan_worker.jobs import run_push_scan_job
+
+    bare_path, _base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: False)
+    cloned = []
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: cloned.append(True))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+
+    run_push_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        head_sha=head_sha,
+        changed_files=["app.py"],
+    )
+
+    assert cloned == []
+
+
+def test_run_push_scan_job_logs_and_does_not_raise_on_scan_failure(bare_repo_with_two_commits, monkeypatch, caplog):
+    from scan_worker.jobs import run_push_scan_job
+
+    _bare_path, _base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+
+    def _boom(*a, **k):
+        raise RuntimeError("clone failed")
+
+    monkeypatch.setattr("scan_worker.jobs._clone_url", _boom)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+
+    with caplog.at_level("WARNING", logger="scan_worker.jobs"):
+        run_push_scan_job(
+            installation_id=1,
+            repo_full_name="octocat/hello-world",
+            head_sha=head_sha,
+            changed_files=["app.py"],
+        )
+
+    assert any("push scan job failed" in record.message for record in caplog.records)
+
+
 def test_run_pr_scan_job_skips_paid_repo_past_monthly_scan_cap(bare_repo_with_two_commits, monkeypatch):
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2170,11 +2170,41 @@ def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monke
             records=records, commit=commit
         ),
     )
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error_message=None: status_calls.append(status),
+    )
 
     _maybe_update_live_wiki(1, "octocat/hello-world", _wiki_evidence(), ["auth/login.py"], "sha1")
 
     assert stored["records"] == [fake_record]
     assert stored["commit"] == "sha1"
+    assert status_calls == ["ready"]
+
+
+def test_maybe_update_live_wiki_records_failure_status_on_exception(monkeypatch):
+    from scan_worker.jobs import _maybe_update_live_wiki
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+
+    def _boom(*a, **k):
+        raise RuntimeError("LLM API unavailable")
+
+    monkeypatch.setattr("scan_worker.jobs.live_wiki.generate_subsystems", _boom)
+
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error_message=None: status_calls.append((status, error_message)),
+    )
+
+    # Must not raise - a failed incremental update is a recorded status,
+    # not a crash that would take down the rest of run_pr_scan_job.
+    _maybe_update_live_wiki(1, "octocat/hello-world", _wiki_evidence(), ["auth/login.py"], "sha1")
+
+    assert status_calls == [("failed", "LLM API unavailable")]
 
 
 def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_with_two_commits, monkeypatch):
@@ -2214,6 +2244,42 @@ def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_wit
     assert called["repo_full_name"] == "octocat/hello-world"
     assert called["changed_files"] == ["app.py"]
     assert called["head_sha"] == head_sha
+
+
+def test_run_pr_scan_job_logs_slack_alert_failure_instead_of_swallowing_it(
+    bare_repo_with_two_commits, monkeypatch, caplog
+):
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+
+    def _boom(*a, **k):
+        raise RuntimeError("Slack API error: invalid_token")
+
+    monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", _boom)
+    monkeypatch.setattr("scan_worker.jobs._maybe_create_check_run", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: None)
+
+    with caplog.at_level("WARNING", logger="scan_worker.jobs"):
+        # Must not raise - a dead/wrong webhook must never take down the
+        # rest of the PR scan (the diff comment is already posted by now).
+        run_pr_scan_job(
+            installation_id=1,
+            repo_full_name="octocat/hello-world",
+            pr_number=7,
+            base_sha=base_sha,
+            head_sha=head_sha,
+        )
+
+    assert any(
+        "alert webhook send failed" in record.message and "octocat/hello-world" in record.message
+        for record in caplog.records
+    )
 
 
 def test_run_pr_scan_job_skips_paid_repo_past_monthly_scan_cap(bare_repo_with_two_commits, monkeypatch):
@@ -2459,6 +2525,7 @@ def test_maybe_update_live_wiki_passes_fetch_line_count_through(monkeypatch):
         "scan_worker.jobs._store_wiki_generation",
         lambda *a, **k: captured_store.update(k),
     )
+    monkeypatch.setattr("scan_worker.jobs.set_wiki_build_status", lambda *a, **k: None)
 
     _maybe_update_live_wiki(1, "octocat/hello-world", _wiki_evidence(), ["auth/login.py"], "sha1")
 

--- a/github-app/tests/test_main.py
+++ b/github-app/tests/test_main.py
@@ -67,6 +67,41 @@ async def test_webhook_dispatches_pull_request_enqueue(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_webhook_dispatches_push_enqueue(monkeypatch):
+    app.state.db_pool = object()
+    payload = {
+        "ref": "refs/heads/main",
+        "after": "def456",
+        "installation": {"id": 123},
+        "repository": {"full_name": "octocat/hello-world", "default_branch": "main"},
+        "commits": [],
+    }
+    body = json.dumps(payload).encode()
+    called = {}
+
+    async def fake_handle(payload_arg, redis_url):
+        called["payload"] = payload_arg
+        called["redis_url"] = redis_url
+
+    monkeypatch.setattr("app_server.webhooks.push.handle_push_event", fake_handle)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-Hub-Signature-256": _signature(body, settings.github_webhook_secret),
+                "X-GitHub-Event": "push",
+            },
+        )
+
+    assert response.status_code == 200
+    assert called["payload"]["after"] == "def456"
+    assert called["redis_url"] == settings.redis_url
+
+
+@pytest.mark.asyncio
 async def test_healthz_returns_200_when_dependencies_are_healthy(monkeypatch):
     app.state.db_pool = MagicMock()
     app.state.db_pool.fetchval = AsyncMock(return_value=1)

--- a/github-app/tests/test_paddle_client.py
+++ b/github-app/tests/test_paddle_client.py
@@ -1,0 +1,86 @@
+import httpx
+import pytest
+
+from app_server.paddle_client import (
+    PaddleAPIError,
+    PaddleAPINotConfigured,
+    get_subscription,
+    update_subscription_items,
+)
+
+
+def test_get_subscription_requires_api_key():
+    with pytest.raises(PaddleAPINotConfigured):
+        get_subscription(None, "sub_123")
+
+
+def test_update_subscription_items_requires_api_key():
+    with pytest.raises(PaddleAPINotConfigured):
+        update_subscription_items(None, "sub_123", [], "prorated_immediately")
+
+
+def test_get_subscription_returns_data_field(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/subscriptions/sub_123"
+        assert request.headers["authorization"] == "Bearer test_key"
+        return httpx.Response(200, json={"data": {"id": "sub_123", "status": "active"}})
+
+    monkeypatch.setattr(httpx, "get", lambda url, headers: httpx.Client(transport=httpx.MockTransport(handler)).get(url, headers=headers))
+
+    result = get_subscription("test_key", "sub_123")
+    assert result == {"id": "sub_123", "status": "active"}
+
+
+def test_get_subscription_wraps_http_errors(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "not found"})
+
+    monkeypatch.setattr(httpx, "get", lambda url, headers: httpx.Client(transport=httpx.MockTransport(handler)).get(url, headers=headers))
+
+    with pytest.raises(PaddleAPIError):
+        get_subscription("test_key", "sub_123")
+
+
+def test_update_subscription_items_sends_patch_with_items_and_proration(monkeypatch):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        import json
+
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"data": {"id": "sub_123"}})
+
+    monkeypatch.setattr(
+        httpx,
+        "patch",
+        lambda url, headers, json: httpx.Client(transport=httpx.MockTransport(handler)).patch(
+            url, headers=headers, json=json
+        ),
+    )
+
+    items = [{"price_id": "pri_base", "quantity": 1}, {"price_id": "pri_seat", "quantity": 2}]
+    result = update_subscription_items("test_key", "sub_123", items, "prorated_immediately")
+
+    assert result == {"id": "sub_123"}
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/subscriptions/sub_123"
+    assert captured["body"]["items"] == items
+    assert captured["body"]["proration_billing_mode"] == "prorated_immediately"
+
+
+def test_update_subscription_items_wraps_http_errors(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"error": "bad request"})
+
+    monkeypatch.setattr(
+        httpx,
+        "patch",
+        lambda url, headers, json: httpx.Client(transport=httpx.MockTransport(handler)).patch(
+            url, headers=headers, json=json
+        ),
+    )
+
+    with pytest.raises(PaddleAPIError):
+        update_subscription_items("test_key", "sub_123", [], "prorated_immediately")

--- a/github-app/tests/test_push_webhook.py
+++ b/github-app/tests/test_push_webhook.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from app_server.webhooks.push import handle_push_event
+
+
+def _payload(ref="refs/heads/main", default_branch="main", deleted=False, after="head123", commits=None):
+    return {
+        "ref": ref,
+        "after": after,
+        "deleted": deleted,
+        "installation": {"id": 111},
+        "repository": {"full_name": "octocat/hello-world", "default_branch": default_branch},
+        "commits": commits
+        if commits is not None
+        else [
+            {"added": ["new.py"], "removed": [], "modified": ["app.py"]},
+            {"added": [], "removed": ["old.py"], "modified": ["app.py"]},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_push_to_default_branch_enqueues_scan_job():
+    fake_queue = MagicMock()
+    await handle_push_event(_payload(), "redis://unused", queue=fake_queue)
+
+    fake_queue.enqueue.assert_called_once()
+    args, kwargs = fake_queue.enqueue.call_args
+    assert args[0] == "scan_worker.jobs.run_push_scan_job"
+    assert kwargs["installation_id"] == 111
+    assert kwargs["repo_full_name"] == "octocat/hello-world"
+    assert kwargs["head_sha"] == "head123"
+    assert kwargs["changed_files"] == ["app.py", "new.py", "old.py"]
+    assert kwargs["job_timeout"] > 0
+
+
+@pytest.mark.asyncio
+async def test_push_to_non_default_branch_does_not_enqueue():
+    fake_queue = MagicMock()
+    await handle_push_event(
+        _payload(ref="refs/heads/feature-x", default_branch="main"), "redis://unused", queue=fake_queue
+    )
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_branch_deletion_does_not_enqueue():
+    fake_queue = MagicMock()
+    await handle_push_event(_payload(deleted=True), "redis://unused", queue=fake_queue)
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_push_with_no_file_changes_enqueues_empty_changed_files():
+    fake_queue = MagicMock()
+    await handle_push_event(_payload(commits=[]), "redis://unused", queue=fake_queue)
+
+    fake_queue.enqueue.assert_called_once()
+    _, kwargs = fake_queue.enqueue.call_args
+    assert kwargs["changed_files"] == []

--- a/github-app/tests/test_rate_limit.py
+++ b/github-app/tests/test_rate_limit.py
@@ -1,4 +1,4 @@
-from app_server.rate_limit import cooldown_seconds_for_loc, total_loc_from_evidence
+from app_server.rate_limit import cooldown_seconds_for_loc, is_rate_limited, total_loc_from_evidence
 
 
 def test_cooldown_seconds_for_loc_small_repo_is_three_hours():
@@ -36,3 +36,23 @@ def test_total_loc_from_evidence_sums_all_languages():
 def test_total_loc_from_evidence_handles_missing_sections():
     assert total_loc_from_evidence({}) == 0
     assert total_loc_from_evidence({"repository": {}}) == 0
+
+
+def test_is_rate_limited_allows_calls_under_the_limit(redis_conn):
+    key = "test:ratelimit:under"
+    for _ in range(5):
+        assert is_rate_limited(redis_conn, key, limit=5, window_seconds=60) is False
+
+
+def test_is_rate_limited_blocks_calls_over_the_limit(redis_conn):
+    key = "test:ratelimit:over"
+    for _ in range(3):
+        assert is_rate_limited(redis_conn, key, limit=3, window_seconds=60) is False
+    assert is_rate_limited(redis_conn, key, limit=3, window_seconds=60) is True
+
+
+def test_is_rate_limited_keys_are_independent(redis_conn):
+    for _ in range(3):
+        is_rate_limited(redis_conn, "test:ratelimit:a", limit=3, window_seconds=60)
+    # A different key starts its own fresh window.
+    assert is_rate_limited(redis_conn, "test:ratelimit:b", limit=3, window_seconds=60) is False

--- a/github-app/tests/test_slack.py
+++ b/github-app/tests/test_slack.py
@@ -1,6 +1,11 @@
+import json
+
 import httpx
 
 from scan_worker.slack import (
+    _detect_platform,
+    _slack_markdown_to_adaptive_card_markdown,
+    _to_teams_payload,
     format_latency_alert,
     format_reachability_alert,
     format_runtime_error_alert,
@@ -211,3 +216,97 @@ def test_format_runtime_error_alert_handles_missing_method_and_path():
 
     assert "ValueError" in body["text"]
     assert "app/handler.py:10" in body["text"]
+
+
+def test_detect_platform_recognizes_slack_url():
+    assert _detect_platform("https://hooks.slack.com/services/T00/B00/xyz") == "slack"
+
+
+def test_detect_platform_recognizes_teams_workflow_url():
+    assert _detect_platform("https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual") == "teams"
+
+
+def test_detect_platform_recognizes_classic_teams_connector_url():
+    assert _detect_platform("https://outlook.office.com/webhook/abc") == "teams"
+
+
+def test_detect_platform_defaults_to_slack_for_unknown_url():
+    assert _detect_platform("https://example.com/my-webhook") == "slack"
+
+
+def test_slack_markdown_to_adaptive_card_markdown_converts_bold():
+    assert _slack_markdown_to_adaptive_card_markdown("*Aletheore*: new findings") == "**Aletheore**: new findings"
+
+
+def test_slack_markdown_to_adaptive_card_markdown_leaves_code_spans_alone():
+    text = "Secret: `a.py:1` (aws_key)"
+    assert _slack_markdown_to_adaptive_card_markdown(text) == text
+
+
+def test_to_teams_payload_wraps_text_in_adaptive_card():
+    payload = _to_teams_payload({"text": "*Aletheore*: new findings on `octocat/hello-world` PR #42"})
+
+    assert payload["type"] == "message"
+    card = payload["attachments"][0]["content"]
+    assert payload["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
+    assert card["type"] == "AdaptiveCard"
+    body_text = card["body"][0]["text"]
+    assert "**Aletheore**" in body_text
+    assert "octocat/hello-world" in body_text
+
+
+def test_send_slack_alert_sends_adaptive_card_to_teams_webhook():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content))
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    send_slack_alert(
+        "https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual",
+        _diff_with_new_secret(),
+        "octocat/hello-world",
+        42,
+        http_client=client,
+    )
+    assert len(calls) == 1
+    assert calls[0]["type"] == "message"
+    assert calls[0]["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
+
+
+def test_send_slack_alert_sends_plain_text_to_slack_webhook():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content))
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    send_slack_alert(
+        "https://hooks.slack.com/services/x",
+        _diff_with_new_secret(),
+        "octocat/hello-world",
+        42,
+        http_client=client,
+    )
+    assert len(calls) == 1
+    assert "text" in calls[0]
+    assert "attachments" not in calls[0]
+
+
+def test_send_health_alert_sends_adaptive_card_to_teams_webhook():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content))
+        return httpx.Response(200)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    send_health_alert(
+        "https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual",
+        {"text": "*Aletheore*: endpoint down"},
+        http_client=client,
+    )
+    assert len(calls) == 1
+    assert calls[0]["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -9,7 +9,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app_server import paddle_ip_allowlist
-from app_server.db import get_installation, upsert_installation
+from app_server.db import get_extra_seats, get_installation, upsert_installation
 from app_server.main import app
 from app_server.webhooks.paddle import handle_paddle_webhook_event
 
@@ -314,6 +314,66 @@ async def test_subscription_updated_refreshes_plan_without_retriggering_wiki_bui
     # Paid-to-paid change (e.g. switching monthly <-> annual) must not
     # re-trigger the one-time wiki build.
     fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_reconciles_extra_seats_from_items(pool):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+        "VALUES (305, 'acme', 'air', 0)"
+    )
+    payload = {
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_123",
+            "customer_id": "ctm_test_456",
+            "status": "active",
+            "custom_data": {"installation_id": "305"},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": "pri_01kym2q99kevmdg7h71nwpm4ej"}, "quantity": 3},
+            ],
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 305)
+    assert installation["plan"] == "air"
+    assert await get_extra_seats(pool, 305) == 3
+
+
+@pytest.mark.asyncio
+async def test_subscription_canceled_resets_extra_seats_to_zero(pool):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+        "VALUES (306, 'acme', 'air', 3)"
+    )
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 306)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 306)
+    assert installation["plan"] == "free"
+    assert await get_extra_seats(pool, 306) == 0
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_with_no_extra_seat_item_resets_to_zero(pool):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+        "VALUES (307, 'acme', 'air', 3)"
+    )
+    payload = _subscription_event_payload(
+        "subscription.updated", "active", 307, price_id="pri_01kyhevc8bkcghfpwjymz16y2h"
+    )
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_extra_seats(pool, 307) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

An audit of every feature promised on `pricing.html` for the AIR tier found gaps ranging from silent failures to features that were sold but never actually worked. This closes all of them, broken into 6 commits:

1. **Silent failure fixes** - a dead alert webhook on a PR scan failed with zero log line; an AIRview incremental update failing after a first success left `wiki_build_status` untouched forever; a failed status was never shown once an overview already existed.
2. **AIRview reconciliation** - AIRview only ever updated off `pull_request` events using the *proposed* head SHA, never the actual merged default branch. Adds a `push` webhook handler that reconciles AIRview against real merged code on every push to main.
3. **Real Microsoft Teams support** - pricing sold "Slack / Teams alerts," but only a Slack-format payload existed, which breaks against a real (post-2024) Teams webhook. Sends a proper Adaptive Card to Teams now, detected from the webhook URL. Also adds a "Send test" button so a webhook URL can be verified without waiting for a real finding.
4. **Endpoint health history** - every check was persisted but only ever the *latest* was ever shown, dashboard or public API. Adds a history endpoint + trend view, and a 7-day uptime aggregate on the public status API.
5. **Public status API rate limiting** - `/v1/health/{org}/{repo}` was unauthenticated, CORS-open, and had zero rate limiting anywhere in the stack. Adds a Redis-backed limiter, fails open on a Redis outage.
6. **Real per-seat billing** - pricing sold "+$3.99/mo per additional team member," but the product hard-blocked adding seats past the cap with an explicit "billing isn't wired up yet" error. Creates a real Paddle price and wires buy/remove-seat endpoints against the live subscription, reconciled via webhook.

## Deployment follow-ups (not code)

- The GitHub App needs the **`push` webhook event** subscribed in its settings for AIRview push reconciliation to actually fire.
- **`PADDLE_API_KEY`** needs to be created in the Paddle dashboard (a new API key with subscription write access) and added to production `.env` for seat billing to work - it degrades gracefully (502) without it, doesn't crash.

## Test plan
- [x] Full test suite passes locally (735 passed, 7 skipped)
- [ ] Deploy, confirm `push` webhook subscription enabled, confirm `PADDLE_API_KEY` set, smoke-test buy-seat flow against a real subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)