### PR TITLE
Fix Express route false positives; add signed Audit Certificate check run

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -84,7 +84,10 @@ class AddMemberRequest(BaseModel):
 BRANCH_PROTECTION_DISCLOSURE = (
     "Aletheore reports a Check Run result on new secrets found - it does not and cannot "
     "unilaterally block a merge. To require it, mark \"Aletheore secrets check\" as a "
-    "required status check in this repository's branch protection settings."
+    "required status check in this repository's branch protection settings. Managed audits "
+    "(paid plans) also post an \"Aletheore Audit Certificate\" check with a cryptographically "
+    "signed (Ed25519), independently verifiable record of the audit - mark that as required "
+    "too to block merges lacking a valid, freshly-signed audit."
 )
 
 

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -127,6 +127,13 @@ async def verify_audit_report(verification_token: str, request: Request):
         "content_hash": report["content_hash"],
         "signed_at": report["created_at"].isoformat(),
         "verified": verified,
+        # Included so this is an actual verifiable certificate, not just an
+        # "our database says so" boolean - anyone can independently confirm
+        # signature over content_hash using this public key, without
+        # trusting this endpoint's own "verified" field.
+        "algorithm": "Ed25519",
+        "signature": report["signature"],
+        "public_key": public_key_hex,
     }
 
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -796,6 +796,16 @@ def _clone_pr_head(url: str, pr_number: int, dest: Path) -> None:
     subprocess.run(["git", "checkout", "-q", "FETCH_HEAD"], cwd=dest, check=True)
 
 
+def _git_rev_parse_head(repo_dir: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo_dir, check=True, capture_output=True, text=True
+        )
+        return result.stdout.strip()
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _sign_and_persist_audit_report(
     settings,
     installation_id: int,
@@ -822,6 +832,39 @@ def _sign_and_persist_audit_report(
             type(exc).__name__,
         )
         return None
+
+
+def _maybe_create_audit_certificate_check_run(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    head_sha: str | None,
+    verify_url: str,
+) -> None:
+    # Best-effort, like every other Check Run this codebase posts - a
+    # customer's actual audit result must never be blocked on GitHub's
+    # check-runs API being reachable. head_sha can be None if `git
+    # rev-parse` itself failed; there's nothing to attach a check run to
+    # in that case.
+    if head_sha is None:
+        return
+    try:
+        create_check_run(
+            client,
+            token,
+            repo_full_name,
+            head_sha,
+            "success",
+            "A cryptographically signed (Ed25519) record of this audit is available for "
+            f"independent verification: {verify_url}\n\n"
+            "Require this check in branch protection to block merges without a valid, "
+            "freshly-signed Aletheore audit certificate.",
+            name="Aletheore Audit Certificate",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "audit certificate check run failed for repo=%s (%s)", repo_full_name, exc,
+        )
 
 
 @log_job
@@ -888,6 +931,13 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                         body = (
                             f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
                             f"{report_text}\n\n[Verify this report]({verify_url})"
+                        )
+                        _maybe_create_audit_certificate_check_run(
+                            client,
+                            token,
+                            repo_full_name,
+                            _git_rev_parse_head(repo_dir),
+                            verify_url,
                         )
                     else:
                         body = f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n{report_text}"

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -741,6 +741,13 @@ def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_pat
             sig=sig,
         ),
     )
+    check_runs = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_check_run",
+        lambda client, token, repo, sha, conclusion, summary, name="Aletheore secrets check": check_runs.append(
+            {"repo": repo, "sha": sha, "conclusion": conclusion, "summary": summary, "name": name}
+        ),
+    )
 
     from scan_worker.jobs import run_managed_audit_pr_job
 
@@ -751,6 +758,67 @@ def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_pat
     assert stored["text"] == "the audit findings"
     assert len(stored["token"]) == 64
     assert stored["token"] in posted["body"]
+
+    assert len(check_runs) == 1
+    assert check_runs[0]["name"] == "Aletheore Audit Certificate"
+    assert check_runs[0]["repo"] == "octocat/hello-world"
+    assert check_runs[0]["sha"] == head_sha
+    assert check_runs[0]["conclusion"] == "success"
+    assert stored["token"] in check_runs[0]["summary"]
+
+
+def test_managed_audit_pr_job_skips_check_run_when_signing_fails(monkeypatch, tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=work, check=True)
+    (work / "app.py").write_text("print('hello')\n")
+    subprocess.run(["git", "add", "."], cwd=work, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "commit"], cwd=work, check=True)
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(work), str(bare)], check=True)
+    subprocess.run(
+        ["git", "--git-dir", str(bare), "update-ref", "refs/pull/42/head", head_sha],
+        check=True,
+    )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.run_managed_audit", lambda *a, **k: "the audit findings")
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_managed_audit", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+
+    def _raise(*a, **k):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr("scan_worker.jobs.insert_audit_report", _raise)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    check_runs = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_check_run", lambda *a, **k: check_runs.append(True)
+    )
+
+    from scan_worker.jobs import run_managed_audit_pr_job
+
+    run_managed_audit_pr_job(1, "octocat/hello-world", 42)
+
+    # No certificate to point to if signing itself failed.
+    assert check_runs == []
 
 
 def test_managed_audit_pr_job_still_posts_report_when_signing_fails(monkeypatch, tmp_path):

--- a/github-app/tests/test_managed_audit_api.py
+++ b/github-app/tests/test_managed_audit_api.py
@@ -7,7 +7,7 @@ from httpx import ASGITransport, AsyncClient
 from app_server.db import create_api_token, set_installation_plan, upsert_installation
 from app_server.evidence_limits import MAX_EVIDENCE_BYTES
 from app_server.main import app
-from app_server.audit_signing import content_hash, sign_report
+from app_server.audit_signing import content_hash, public_key_hex_from_private, sign_report, verify_report
 from aletheore.toon_encoding import to_toon
 
 
@@ -42,6 +42,14 @@ async def test_verify_audit_report_returns_verified_true_for_untampered_report(p
     assert body["repo_full_name"] == "octocat/hello-world"
     assert body["content_hash"] == content_hash(report_text)
     assert "report_text" not in body
+    assert body["algorithm"] == "Ed25519"
+    assert body["signature"] == signature
+    assert body["public_key"] == public_key_hex_from_private("11" * 32)
+    # The point of returning signature + public_key is that a caller who
+    # already has the report text (e.g. from the PR comment it was posted
+    # alongside) can verify authenticity themselves, without trusting this
+    # endpoint's own "verified" boolean.
+    assert verify_report(report_text, body["signature"], body["public_key"]) is True
 
 
 @pytest.mark.asyncio

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -226,6 +226,18 @@ def _express_handler_label(node: Node | None, source: bytes) -> str:
     return "<inline handler>"
 
 
+def _looks_like_express_path(path: str) -> bool:
+    # `.get(...)`/`.post(...)`/`.use(...)` are extremely common method names
+    # on plain objects, Maps, and third-party libraries that have nothing to
+    # do with Express (e.g. a Motion/animation library's internal state
+    # getters: e.get("stroke-dasharray"), e.get("transformOrigin")). Without
+    # this, any such call with a string literal first argument gets
+    # misidentified as a registered route. A real Express path always
+    # starts with "/" (or is the "*" wildcard) - this cheaply rejects the
+    # overwhelming majority of false positives with no risk to real routes.
+    return path == "*" or path.startswith("/")
+
+
 def _extract_express_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
@@ -242,37 +254,38 @@ def _extract_express_routes(root: Node, source: bytes, rel_path: str) -> list[di
                     named = args.named_children
                     if named and named[0].type == "string":
                         path = _js_string_literal_text(named[0], source)
-                        line = n.start_point[0] + 1
-                        handler_node = named[1] if len(named) > 1 else None
+                        if _looks_like_express_path(path):
+                            line = n.start_point[0] + 1
+                            handler_node = named[1] if len(named) > 1 else None
 
-                        if method_name in _EXPRESS_ROUTE_METHODS:
-                            entries.append(
-                                {
-                                    "method": (
-                                        "ANY" if method_name == "all" else method_name.upper()
-                                    ),
-                                    "path": path,
-                                    "framework": "express",
-                                    "file": rel_path,
-                                    "line": line,
-                                    "handler": _express_handler_label(handler_node, source),
-                                    "unresolved": False,
-                                    "note": None,
-                                }
-                            )
-                        elif method_name == "use":
-                            entries.append(
-                                {
-                                    "method": None,
-                                    "path": path,
-                                    "framework": "express",
-                                    "file": rel_path,
-                                    "line": line,
-                                    "handler": "app.use(...)",
-                                    "unresolved": True,
-                                    "note": None,
-                                }
-                            )
+                            if method_name in _EXPRESS_ROUTE_METHODS:
+                                entries.append(
+                                    {
+                                        "method": (
+                                            "ANY" if method_name == "all" else method_name.upper()
+                                        ),
+                                        "path": path,
+                                        "framework": "express",
+                                        "file": rel_path,
+                                        "line": line,
+                                        "handler": _express_handler_label(handler_node, source),
+                                        "unresolved": False,
+                                        "note": None,
+                                    }
+                                )
+                            elif method_name == "use":
+                                entries.append(
+                                    {
+                                        "method": None,
+                                        "path": path,
+                                        "framework": "express",
+                                        "file": rel_path,
+                                        "line": line,
+                                        "handler": "app.use(...)",
+                                        "unresolved": True,
+                                        "note": None,
+                                    }
+                                )
         for child in n.children:
             walk(child)
 

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -275,6 +275,32 @@ def test_extract_express_ignores_unrelated_method_calls():
     assert entries == []
 
 
+def test_extract_express_ignores_non_path_get_calls():
+    # Regression test: a bare .get("key")/.set("key") on a Map-like object
+    # (e.g. an animation library's internal state, or any generic getter)
+    # must not be misidentified as an Express route just because the method
+    # name matches and the first argument is a string literal. Real
+    # production false positive: a vendored Motion library's
+    # e.get("stroke-dasharray") / e.get("transformOrigin") state getters.
+    root, source = parse_js(
+        'e.get("stroke-dasharray");\n'
+        'e.get("transformOrigin");\n'
+        'e.get("transform");\n'
+    )
+
+    entries = _extract_express_routes(root, source, "vendor/motion.js")
+
+    assert entries == []
+
+
+def test_extract_express_accepts_wildcard_path():
+    root, source = parse_js('app.get("*", catchAll);\n')
+
+    entries = _extract_express_routes(root, source, "server.js")
+
+    assert entries[0]["path"] == "*"
+
+
 def test_map_api_endpoints_combines_all_frameworks(tmp_path):
     (tmp_path / "app").mkdir()
     (tmp_path / "app" / "routes.py").write_text(


### PR DESCRIPTION
## Summary

Two changes, bundled here since both landed on the same branch:

**1. Fix Express route false positives**
- `_extract_express_routes` matched any call shaped like `x.get("string", ...)` or `x.use("string", ...)` and recorded it as a registered Express route, with no check that `x` was actually an Express app/router.
- Found dogfooding the endpoint-health-history feature against Aletheore's own AIRview: the health page showed "stroke-dasharray", "transform", "transformOrigin", "transformBox" as monitored GET endpoints - these come from `website/vendor/motion.js`'s internal state getters, not routes.
- Fix: require the matched string to actually look like an Express path (`/`-prefixed, or the `*` wildcard) before recording it as a route.

**2. Formalize signed audit reports into a real "certificate"**
- Aletheore already signs every managed audit report (Ed25519) and exposes a public verify endpoint, but nothing let an org actually gate on it - the signature was only ever a link in a PR comment, and GitHub branch protection can only require named Check Runs, not comments.
- Adds an "Aletheore Audit Certificate" Check Run posted on the PR's real head SHA whenever a managed audit is successfully signed, so an org can mark it required in branch protection and genuinely block merges lacking a valid, freshly-signed audit.
- Enriches the public verify endpoint with the signature and public key, not just a `verified: true/false` boolean - a caller who already has the report text (posted alongside the link) can independently verify authenticity themselves.

## Test plan
- [x] New regression tests for the Express false positive (real vendor motion.js patterns) and the wildcard path case
- [x] New tests for the audit certificate check run (created on success, skipped when signing fails) and independent verification via signature + public key
- [x] Full test suite passes (both src/ and github-app/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)