### PR TITLE
feat: build Regression Fencing - flag signature changes with unupdated callers

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -30,6 +30,7 @@ from aletheore.evidence_resolution import (
 from aletheore.history import compute_diff
 from aletheore.pr_comment import COMMENT_MARKER, format_diff_comment
 from aletheore.healthcheck import run_healthcheck
+from aletheore.signature_diff import find_regression_fence_violations
 from app_server.config import get_settings
 from app_server.db import MAX_SCANNED_REPOS_PER_MONTH
 from app_server.github_auth import generate_app_jwt, get_installation_token
@@ -525,6 +526,47 @@ def _maybe_create_regression_risk_check_run(
     )
 
 
+def _maybe_create_regression_fence_check_run(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    head_sha: str,
+    installation_id: int,
+    old_evidence: dict,
+    new_evidence: dict,
+    changed_files: list[str],
+) -> None:
+    settings = get_settings()
+    installation = get_installation_row(settings.database_url, installation_id)
+    if installation is None or installation["plan"] == "free":
+        return
+
+    violations = find_regression_fence_violations(old_evidence, new_evidence, changed_files)
+    if not violations:
+        return
+
+    lines = []
+    for v in violations:
+        callers = ", ".join(f"`{c}`" for c in v["untouched_callers"])
+        lines.append(
+            f"- `{v['function']}` in `{v['file']}`: `{v['old_params']}` -> `{v['new_params']}`, "
+            f"but these importers weren't updated in this PR: {callers}"
+        )
+    summary = (
+        "This PR changes a function signature without updating all known importers:\n"
+        + "\n".join(lines)
+    )
+    create_check_run(
+        client,
+        token,
+        repo_full_name,
+        head_sha,
+        "neutral",
+        summary,
+        name="Aletheore Regression Fence",
+    )
+
+
 async def _resolve_token(installation_id: int, app_jwt: str) -> str:
     result = get_installation_token(installation_id, app_jwt)
     if inspect.isawaitable(result):
@@ -660,6 +702,19 @@ def run_pr_scan_job(
                     repo_full_name,
                     head_sha,
                     installation_id,
+                    new,
+                    changed_files,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                _maybe_create_regression_fence_check_run(
+                    client,
+                    token,
+                    repo_full_name,
+                    head_sha,
+                    installation_id,
+                    old,
                     new,
                     changed_files,
                 )

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -523,6 +523,128 @@ def test_maybe_create_regression_risk_check_run_skips_free_plan(monkeypatch):
     assert touched_incidents == []
 
 
+def test_maybe_create_regression_fence_check_run_creates_neutral_check_run(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    created = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_check_run",
+        lambda client, token, repo, sha, conclusion, summary, name="Aletheore secrets check": created.append(
+            (conclusion, name, summary)
+        ),
+    )
+    old_evidence = {
+        "repository": {
+            "modules": [
+                {"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}},
+                {"path": "reports/export.py", "symbols": {"functions": []}},
+            ]
+        }
+    }
+    new_evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "billing.py",
+                    "symbols": {
+                        "functions": [{"name": "get_billing", "params": "(user_id, include_history)"}]
+                    },
+                    "imported_by": ["reports/export.py"],
+                },
+                {"path": "reports/export.py", "symbols": {"functions": []}},
+            ]
+        }
+    }
+
+    from scan_worker.jobs import _maybe_create_regression_fence_check_run
+
+    _maybe_create_regression_fence_check_run(
+        client=None,
+        token="tok",
+        repo_full_name="octocat/hello-world",
+        head_sha="sha1",
+        installation_id=1,
+        old_evidence=old_evidence,
+        new_evidence=new_evidence,
+        changed_files=["billing.py"],
+    )
+
+    assert len(created) == 1
+    assert created[0][0] == "neutral"
+    assert created[0][1] == "Aletheore Regression Fence"
+    assert "get_billing" in created[0][2]
+    assert "reports/export.py" in created[0][2]
+
+
+def test_maybe_create_regression_fence_check_run_skips_when_no_violations(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    created = []
+    monkeypatch.setattr("scan_worker.jobs.create_check_run", lambda *a, **k: created.append(True))
+    evidence = {
+        "repository": {
+            "modules": [
+                {"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}
+            ]
+        }
+    }
+
+    from scan_worker.jobs import _maybe_create_regression_fence_check_run
+
+    _maybe_create_regression_fence_check_run(
+        client=None,
+        token="tok",
+        repo_full_name="octocat/hello-world",
+        head_sha="sha1",
+        installation_id=1,
+        old_evidence=evidence,
+        new_evidence=evidence,
+        changed_files=["billing.py"],
+    )
+
+    assert created == []
+
+
+def test_maybe_create_regression_fence_check_run_skips_free_plan(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"})
+    created = []
+    monkeypatch.setattr("scan_worker.jobs.create_check_run", lambda *a, **k: created.append(True))
+    old_evidence = {
+        "repository": {
+            "modules": [
+                {"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}
+            ]
+        }
+    }
+    new_evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "billing.py",
+                    "symbols": {"functions": [{"name": "get_billing", "params": "(user_id, x)"}]},
+                    "imported_by": ["reports/export.py"],
+                }
+            ]
+        }
+    }
+
+    from scan_worker.jobs import _maybe_create_regression_fence_check_run
+
+    _maybe_create_regression_fence_check_run(
+        client=None,
+        token="tok",
+        repo_full_name="octocat/hello-world",
+        head_sha="sha1",
+        installation_id=1,
+        old_evidence=old_evidence,
+        new_evidence=new_evidence,
+        changed_files=["billing.py"],
+    )
+
+    assert created == []
+
+
 def test_managed_audit_api_job_returns_report_text(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -100,11 +100,37 @@ def _rel(repo_path: Path, path: Path) -> str | None:
         return None
 
 
+def _params_text(source: bytes, enclosing_node: Node) -> str | None:
+    """Raw source text of a function/method's parameter list, whitespace-
+    normalized so purely cosmetic reformatting (wrapping a long parameter
+    list across lines, extra spaces) doesn't look like a signature change.
+    None for symbols with no parameter list at all (classes, interfaces).
+
+    Every grammar checked (Python, JS/TS, Go, Rust, Java, Ruby, PHP, C#)
+    names this field "parameters" directly on the function/method node,
+    despite the node TYPE differing (parameters, formal_parameters,
+    parameter_list, method_parameters) - confirmed empirically per
+    language, not assumed. C/C++ is the one exception: the parameter list
+    hangs off a nested function_declarator ("declarator" field) rather
+    than the function_definition node directly.
+    """
+    params_node = enclosing_node.child_by_field_name("parameters")
+    if params_node is None:
+        declarator = enclosing_node.child_by_field_name("declarator")
+        if declarator is not None:
+            params_node = declarator.child_by_field_name("parameters")
+    if params_node is None:
+        return None
+    raw = source[params_node.start_byte:params_node.end_byte].decode()
+    return " ".join(raw.split())
+
+
 def _symbol_entry(source: bytes, name_node: Node, enclosing_node: Node) -> dict:
     return {
         "name": source[name_node.start_byte:name_node.end_byte].decode(),
         "start_line": enclosing_node.start_point[0] + 1,
         "end_line": enclosing_node.end_point[0] + 1,
+        "params": _params_text(source, enclosing_node),
     }
 
 
@@ -821,6 +847,7 @@ def _extract_c_family(node: Node, source: bytes) -> tuple[list[str], list[dict],
                                 "name": name,
                                 "start_line": n.start_point[0] + 1,
                                 "end_line": n.end_point[0] + 1,
+                                "params": _params_text(source, n),
                             }
                         )
             elif n.type in ("struct_specifier", "class_specifier", "union_specifier", "enum_specifier"):

--- a/src/aletheore/signature_diff.py
+++ b/src/aletheore/signature_diff.py
@@ -1,0 +1,71 @@
+"""Detects exported function signature changes between two evidence
+snapshots (a PR's base and head scans), and cross-references the
+dependency graph's own imported_by data to find files that import the
+changed function's module but weren't touched in the same PR - the
+"you changed this signature, but N dependents weren't updated" gap
+Regression Fencing closes.
+
+Deliberately file/import-level, not a full call graph: a file being
+flagged here means it imports the module containing the changed
+function, not necessarily that it calls that specific function - no
+call-graph/reference tracking exists (or is planned) at that
+granularity. This matches what the dependency graph actually tracks
+today and is a genuine, real signal even at that coarser level.
+"""
+
+
+def _index_functions(evidence: dict) -> dict[tuple[str, str], str | None]:
+    """(file_path, function_name) -> params string, across the whole repo."""
+    index: dict[tuple[str, str], str | None] = {}
+    for module in evidence.get("repository", {}).get("modules", []):
+        path = module.get("path")
+        for fn in module.get("symbols", {}).get("functions", []):
+            index[(path, fn["name"])] = fn.get("params")
+    return index
+
+
+def find_changed_signatures(old_evidence: dict, new_evidence: dict) -> list[dict]:
+    """Functions present in both snapshots whose params text differs.
+
+    A function that's new or removed entirely isn't a "signature change" -
+    that's a different, already-visible kind of edit (it shows up in the
+    diff comment's added/removed symbols, not here). Only an existing
+    function whose parameter list changed counts.
+    """
+    old_index = _index_functions(old_evidence)
+    new_index = _index_functions(new_evidence)
+    changed = []
+    for (path, name), new_params in new_index.items():
+        old_params = old_index.get((path, name))
+        if (path, name) in old_index and old_params != new_params and new_params is not None:
+            changed.append(
+                {"file": path, "function": name, "old_params": old_params, "new_params": new_params}
+            )
+    return changed
+
+
+def find_regression_fence_violations(
+    old_evidence: dict, new_evidence: dict, changed_files: list[str]
+) -> list[dict]:
+    """Each changed_signatures entry, enriched with the subset of its
+    module's imported_by files that weren't touched in this PR. Only
+    signature changes with at least one such untouched dependent are
+    returned - a change where every importer was already updated in the
+    same PR isn't a violation."""
+    changed_files_set = set(changed_files)
+    changed_signatures = find_changed_signatures(old_evidence, new_evidence)
+    if not changed_signatures:
+        return []
+
+    module_imported_by = {
+        module.get("path"): module.get("imported_by") or []
+        for module in new_evidence.get("repository", {}).get("modules", [])
+    }
+
+    violations = []
+    for change in changed_signatures:
+        importers = module_imported_by.get(change["file"], [])
+        untouched = sorted(f for f in importers if f not in changed_files_set)
+        if untouched:
+            violations.append({**change, "untouched_callers": untouched})
+    return violations

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -43,10 +43,36 @@ def test_build_module_graph_records_symbol_line_bounds(tmp_path):
     login_fn = next(f for f in auth["symbols"]["functions"] if f["name"] == "login")
     assert login_fn["start_line"] == 4
     assert login_fn["end_line"] == 5
+    assert login_fn["params"] == "()"
 
     auth_error_cls = next(c for c in auth["symbols"]["classes"] if c["name"] == "AuthError")
     assert auth_error_cls["start_line"] == 8
     assert auth_error_cls["end_line"] == 9
+    # Classes have no parameter list - unlike functions, params is always
+    # None for them, not an empty string.
+    assert auth_error_cls["params"] is None
+
+
+def test_build_module_graph_normalizes_multiline_function_signatures(tmp_path):
+    # A signature reformatted across multiple lines (wrapped for length,
+    # extra indentation) must diff identically to its single-line
+    # equivalent - this is what makes "did the signature actually change"
+    # detection resilient to pure formatting changes.
+    repo = tmp_path / "repo"
+    app = repo / "app"
+    app.mkdir(parents=True)
+    (app / "__init__.py").write_text("")
+    (app / "billing.py").write_text(
+        "def get_billing(\n"
+        "    user_id: int,\n"
+        "    include_history: bool = False,\n"
+        ") -> dict:\n"
+        "    return {}\n"
+    )
+    modules, _, _ = build_module_graph(repo)
+    by_path = {m["path"]: m for m in modules}
+    billing_fn = next(f for f in by_path["app/billing.py"]["symbols"]["functions"] if f["name"] == "get_billing")
+    assert billing_fn["params"] == "( user_id: int, include_history: bool = False, )"
 
 
 def test_build_module_graph_dependency_edges(tmp_path):
@@ -77,6 +103,8 @@ def test_build_module_graph_extracts_javascript_imports(tmp_path):
     by_path = {m["path"]: m for m in modules}
     assert "index.js" in by_path
     assert "utils.js" in by_path["index.js"]["imports"]
+    add_fn = next(f for f in by_path["utils.js"]["symbols"]["functions"] if f["name"] == "add")
+    assert add_fn["params"] == "(a, b)"
     assert unparseable == []
 
 
@@ -169,6 +197,8 @@ def test_build_module_graph_extracts_typescript_imports(tmp_path):
     assert "index.ts" in by_path
     assert "utils.ts" in by_path["index.ts"]["imports"]
     assert "add" in symbol_names(by_path["utils.ts"]["symbols"]["functions"])
+    add_fn = next(f for f in by_path["utils.ts"]["symbols"]["functions"] if f["name"] == "add")
+    assert add_fn["params"] == "(a: number, b: number)"
     assert unparseable == []
 
 

--- a/src/tests/test_graph_cpp.py
+++ b/src/tests/test_graph_cpp.py
@@ -98,8 +98,13 @@ def test_build_module_graph_cpp_out_of_class_methods_are_extracted(tmp_path):
     assert "Handler" in symbol_names(handler_cpp["symbols"]["functions"])
     assert "getUser" in symbol_names(handler_cpp["symbols"]["functions"])
 
+    get_user_fn = next(f for f in handler_cpp["symbols"]["functions"] if f["name"] == "getUser")
+    assert get_user_fn["params"] == "(int id)"
+
     logger_cpp = by_path["src/logger.cpp"]
     assert "info" in symbol_names(logger_cpp["symbols"]["functions"])
+    info_fn = next(f for f in logger_cpp["symbols"]["functions"] if f["name"] == "info")
+    assert info_fn["params"] == "(const std::string& msg)"
 
 
 def test_build_module_graph_cpp_same_directory_include_resolves(tmp_path):

--- a/src/tests/test_graph_csharp.py
+++ b/src/tests/test_graph_csharp.py
@@ -86,6 +86,11 @@ def test_build_module_graph_extracts_csharp_symbols(tmp_path):
     assert "Handler" in symbol_names(handler["symbols"]["classes"])
     assert "GetUser" in symbol_names(handler["symbols"]["functions"])
 
+    get_user_fn = next(f for f in handler["symbols"]["functions"] if f["name"] == "GetUser")
+    assert get_user_fn["params"] == "(int id)"
+    handler_cls = next(c for c in handler["symbols"]["classes"] if c["name"] == "Handler")
+    assert handler_cls["params"] is None
+
     assert unparseable == []
 
 

--- a/src/tests/test_graph_go.py
+++ b/src/tests/test_graph_go.py
@@ -53,6 +53,11 @@ def test_build_module_graph_extracts_go_imports_and_symbols(tmp_path):
     assert "Hello" in symbol_names(service["symbols"]["functions"])
     assert "Greeter" in symbol_names(service["symbols"]["classes"])
 
+    hello_fn = next(f for f in service["symbols"]["functions"] if f["name"] == "Hello")
+    assert hello_fn["params"] == "()"
+    greeter_cls = next(c for c in service["symbols"]["classes"] if c["name"] == "Greeter")
+    assert greeter_cls["params"] is None
+
     assert unparseable == []
 
 

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -91,6 +91,11 @@ def test_build_module_graph_extracts_java_symbols(tmp_path):
     assert "Handler" in symbol_names(handler["symbols"]["classes"])
     assert "getUser" in symbol_names(handler["symbols"]["functions"])
 
+    get_user_fn = next(f for f in handler["symbols"]["functions"] if f["name"] == "getUser")
+    assert get_user_fn["params"] == "(int id)"
+    handler_cls = next(c for c in handler["symbols"]["classes"] if c["name"] == "Handler")
+    assert handler_cls["params"] is None
+
     assert unparseable == []
 
 

--- a/src/tests/test_graph_php.py
+++ b/src/tests/test_graph_php.py
@@ -76,6 +76,11 @@ def test_build_module_graph_extracts_php_symbols(tmp_path):
     assert "Handler" in symbol_names(handler["symbols"]["classes"])
     assert "getUser" in symbol_names(handler["symbols"]["functions"])
 
+    get_user_fn = next(f for f in handler["symbols"]["functions"] if f["name"] == "getUser")
+    assert get_user_fn["params"] == "(int $id)"
+    handler_cls = next(c for c in handler["symbols"]["classes"] if c["name"] == "Handler")
+    assert handler_cls["params"] is None
+
     assert unparseable == []
 
 

--- a/src/tests/test_graph_ruby.py
+++ b/src/tests/test_graph_ruby.py
@@ -76,6 +76,11 @@ def test_build_module_graph_extracts_ruby_symbols(tmp_path):
     assert "Handler" in symbol_names(handler["symbols"]["classes"])
     assert "get_user" in symbol_names(handler["symbols"]["functions"])
 
+    get_user_fn = next(f for f in handler["symbols"]["functions"] if f["name"] == "get_user")
+    assert get_user_fn["params"] == "(id)"
+    handler_cls = next(c for c in handler["symbols"]["classes"] if c["name"] == "Handler")
+    assert handler_cls["params"] is None
+
     assert unparseable == []
 
 

--- a/src/tests/test_graph_rust.py
+++ b/src/tests/test_graph_rust.py
@@ -88,6 +88,11 @@ def test_build_module_graph_extracts_rust_symbols(tmp_path):
     assert "Handler" in symbol_names(handlers["symbols"]["classes"])
     assert "get_user" in symbol_names(handlers["symbols"]["functions"])
 
+    get_user_fn = next(f for f in handlers["symbols"]["functions"] if f["name"] == "get_user")
+    assert get_user_fn["params"] == "(&self, id: u32)"
+    handler_cls = next(c for c in handlers["symbols"]["classes"] if c["name"] == "Handler")
+    assert handler_cls["params"] is None
+
     store = by_path["src/store/mod.rs"]
     assert "User" in symbol_names(store["symbols"]["classes"])
     assert "Store" in symbol_names(store["symbols"]["classes"])

--- a/src/tests/test_signature_diff.py
+++ b/src/tests/test_signature_diff.py
@@ -1,0 +1,156 @@
+from aletheore.signature_diff import find_changed_signatures, find_regression_fence_violations
+
+
+def _evidence(modules: list[dict]) -> dict:
+    return {"repository": {"modules": modules}}
+
+
+def test_find_changed_signatures_detects_a_changed_parameter_list():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence(
+        [
+            {
+                "path": "billing.py",
+                "symbols": {"functions": [{"name": "get_billing", "params": "(user_id, include_history)"}]},
+            }
+        ]
+    )
+
+    changed = find_changed_signatures(old, new)
+
+    assert changed == [
+        {
+            "file": "billing.py",
+            "function": "get_billing",
+            "old_params": "(user_id)",
+            "new_params": "(user_id, include_history)",
+        }
+    ]
+
+
+def test_find_changed_signatures_ignores_unchanged_functions():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+
+    assert find_changed_signatures(old, new) == []
+
+
+def test_find_changed_signatures_ignores_newly_added_functions():
+    # A brand-new function isn't a "signature change" - there's no prior
+    # signature to compare against, and it shows up in the diff comment's
+    # own added-symbols section instead.
+    old = _evidence([{"path": "billing.py", "symbols": {"functions": []}}])
+    new = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+
+    assert find_changed_signatures(old, new) == []
+
+
+def test_find_changed_signatures_ignores_removed_functions():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence([{"path": "billing.py", "symbols": {"functions": []}}])
+
+    assert find_changed_signatures(old, new) == []
+
+
+def test_find_changed_signatures_ignores_a_different_file_with_the_same_function_name():
+    old = _evidence(
+        [{"path": "a.py", "symbols": {"functions": [{"name": "run", "params": "(x)"}]}}]
+    )
+    new = _evidence(
+        [
+            {"path": "a.py", "symbols": {"functions": [{"name": "run", "params": "(x)"}]}},
+            {"path": "b.py", "symbols": {"functions": [{"name": "run", "params": "(x, y)"}]}},
+        ]
+    )
+
+    assert find_changed_signatures(old, new) == []
+
+
+def test_find_regression_fence_violations_flags_untouched_importers():
+    old = _evidence(
+        [
+            {"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}},
+            {"path": "auth/login.py", "symbols": {"functions": []}},
+            {"path": "reports/export.py", "symbols": {"functions": []}},
+        ]
+    )
+    new = _evidence(
+        [
+            {
+                "path": "billing.py",
+                "symbols": {"functions": [{"name": "get_billing", "params": "(user_id, include_history)"}]},
+                "imported_by": ["auth/login.py", "reports/export.py"],
+            },
+            {"path": "auth/login.py", "symbols": {"functions": []}},
+            {"path": "reports/export.py", "symbols": {"functions": []}},
+        ]
+    )
+
+    violations = find_regression_fence_violations(old, new, changed_files=["billing.py", "auth/login.py"])
+
+    assert violations == [
+        {
+            "file": "billing.py",
+            "function": "get_billing",
+            "old_params": "(user_id)",
+            "new_params": "(user_id, include_history)",
+            "untouched_callers": ["reports/export.py"],
+        }
+    ]
+
+
+def test_find_regression_fence_violations_empty_when_all_importers_touched():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence(
+        [
+            {
+                "path": "billing.py",
+                "symbols": {"functions": [{"name": "get_billing", "params": "(user_id, include_history)"}]},
+                "imported_by": ["auth/login.py"],
+            }
+        ]
+    )
+
+    violations = find_regression_fence_violations(old, new, changed_files=["billing.py", "auth/login.py"])
+
+    assert violations == []
+
+
+def test_find_regression_fence_violations_empty_when_no_signature_changed():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence(
+        [
+            {
+                "path": "billing.py",
+                "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]},
+                "imported_by": ["auth/login.py"],
+            }
+        ]
+    )
+
+    assert find_regression_fence_violations(old, new, changed_files=["billing.py"]) == []
+
+
+def test_find_regression_fence_violations_handles_missing_imported_by_key():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id, x)"}]}}]
+    )
+
+    assert find_regression_fence_violations(old, new, changed_files=["billing.py"]) == []


### PR DESCRIPTION
## Summary
- Scanner now captures each function's normalized parameter-list text (`params`) across every supported language, using each tree-sitter grammar's `parameters` field (C/C++ nests it under `declarator` instead).
- New `aletheore.signature_diff` module diffs a PR's base/head evidence to find functions whose signature changed, then cross-references the existing `imported_by` graph data to find importers of the changed module that weren't touched in the same PR.
- `run_pr_scan_job` now posts an "Aletheore Regression Fence" GitHub Check Run (neutral conclusion, paid plans only) listing any such violations, alongside the existing regression-risk and secrets check runs.
- Deliberately file/import-level, not a full call graph: a flagged file imports the module containing the changed function, not necessarily that specific function - matches what the dependency graph actually tracks today.

## Test plan
- [x] `src/`: 814/816 passing (2 pre-existing, unrelated failures in `test_cli.py`)
- [x] `github-app/`: 742 passed, 7 skipped
- [x] New tests for `signature_diff.py` (9 tests) and the new check-run helper (3 tests) in `test_jobs.py`
- [x] Per-language `params` field assertions added across all existing graph-extraction tests (Python, JS, TS, Go, Java, Ruby, PHP, Rust, C#, C++)