### PR TITLE
fix(flash-review): stop dropping correct findings during citation verification

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -227,7 +227,7 @@ def build_referenced_symbol_context(
 
 
 _QUOTED_STRING_RE = re.compile(r"'([^'\n]{8,})'|\"([^\"\n]{8,})\"")
-LINE_CITATION_CONTEXT_WINDOW = 2
+LINE_CITATION_CONTEXT_WINDOW = 8
 
 
 def _quoted_strings(text: str) -> list[str]:
@@ -258,6 +258,29 @@ def _line_citation_content_matches(finding: dict, file_contents: dict[str, str])
     the model invented passed that check. This proves the claimed
     content is actually near the claimed line, independent of diff shape.
 
+    The window is wider than the minimum needed to fix that one incident
+    (which was off by 237 lines) because a live re-run of the same case
+    through deepseek-v4-pro showed the model citing the correct line +/-1
+    to +/-3 across separate calls (797, 795, 800 for a bug actually at
+    798) - real, small line-counting variance distinct from the
+    237-line hallucination this check exists to catch, and worth
+    tolerating rather than dropping a correct finding over.
+
+    Only checks against `issue`'s quoted strings, not `suggestion`'s: a
+    suggestion is a proposed REPLACEMENT for the current code, so its
+    quoted text is what the code should become, not what it currently is
+    - checking it against the existing file content produces a false
+    negative whenever a finding's `issue` text is (correctly) abstract
+    with no literal quote of its own. Confirmed as a real, deterministic
+    drop via a live re-run of pr-review-benchmark case
+    016-flask-sql-injection-user-lookup through deepseek-v4-pro: the
+    model correctly found the real SQL-injection bug, described it in
+    `issue` with no quoted string (there's no single buggy literal to
+    quote - the bug is the concatenation pattern itself), and offered a
+    parameterized-query rewrite in `suggestion` - text that, by
+    definition, was never part of the original vulnerable code it was
+    replacing, so checking it against that code can never pass.
+
     Returns True (pass) when there's nothing to check: no real content
     was fetched for this file (e.g. it was skipped for size, or the fetch
     failed - this check only ever adds scrutiny, never rejects for a
@@ -271,7 +294,7 @@ def _line_citation_content_matches(finding: dict, file_contents: dict[str, str])
     line = finding["line"]
     if line < 1 or line > len(lines):
         return False
-    quoted = _quoted_strings(finding.get("issue") or "") + _quoted_strings(finding.get("suggestion") or "")
+    quoted = _quoted_strings(finding.get("issue") or "")
     if not quoted:
         return True
     window_start = max(0, line - 1 - LINE_CITATION_CONTEXT_WINDOW)

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -118,6 +118,43 @@ def test_line_citation_content_matches_false_when_line_out_of_bounds():
     assert _line_citation_content_matches(finding, file_contents) is False
 
 
+def test_line_citation_content_matches_tolerates_a_few_lines_of_miscount():
+    # Reproduces a real live re-run of pr-review-benchmark case
+    # 001-flask-cli-key-quote through deepseek-v4-pro: it correctly quoted
+    # the exact buggy string verbatim but cited line 795 in a file where
+    # that string actually sits at line 798 - a 3-line miscount, nothing
+    # like the 237-line hallucination this check exists to catch. The old
+    # +/-2 window rejected this correct finding; the widened window must
+    # tolerate it.
+    lines = ["filler"] * 20
+    lines[16] = "line 798-equivalent: a specific buggy string here"  # 0-indexed 16 -> line 17
+    finding = {"file": "a.py", "line": 14, "issue": "missing quote: 'a specific buggy string here'"}
+    file_contents = {"a.py": "\n".join(lines)}
+
+    assert _line_citation_content_matches(finding, file_contents) is True
+
+
+def test_line_citation_content_matches_ignores_suggestion_quoted_text():
+    # Reproduces the other half of the same live re-run, case
+    # 016-flask-sql-injection-user-lookup: the finding correctly described
+    # a SQL-injection vulnerability with no literal quote in `issue` (an
+    # appropriately abstract description), and its `suggestion` proposed a
+    # parameterized-query replacement - text that, by definition, was never
+    # part of the original vulnerable code being cited. Checking
+    # `suggestion`'s quoted text against the current file content produces
+    # a false rejection of exactly the findings with the most concrete,
+    # actionable fixes attached.
+    finding = {
+        "file": "a.py",
+        "line": 1,
+        "issue": "SQL injection: username is concatenated into the query without sanitization.",
+        "suggestion": "return 'SELECT id, username FROM users WHERE username = ?;'",
+    }
+    file_contents = {"a.py": "return \"SELECT id, username FROM users WHERE username = '\" + username + \"'\""}
+
+    assert _line_citation_content_matches(finding, file_contents) is True
+
+
 def test_validate_findings_drops_finding_whose_quoted_content_is_at_the_wrong_line():
     diff_lines = "\n".join(f" line{i}" for i in range(1, 21))
     diff_text = f"--- a.py ---\n@@ -1,20 +1,20 @@\n{diff_lines}"


### PR DESCRIPTION
## Summary
- The live pr-review-benchmark dry run showed Flash Review finding nothing on either real test case, while PR-Agent and DeepSource both caught the real SQL-injection bug.
- Reproduced both diffs directly against `deepseek-v4-pro`: the model correctly finds both bugs, but `_line_citation_content_matches` was dropping both findings as "unverified".
- Widened the citation window from +/-2 to +/-8 lines - across separate real calls the model cited the correct bug's line +/-1 to +/-3, real counting variance distinct from the 237-line hallucination this check was built to catch.
- Stopped checking a finding's `suggestion` text against the original file content - a suggestion is a proposed *replacement*, so it can never match what the code currently is. This was a deterministic false negative whenever `issue` itself had no literal quote (as with the SQL-injection case, which correctly described the vulnerability pattern rather than quoting a single buggy literal).

## Test plan
- [x] `github-app/`: 744 passed, 7 skipped (2 new regression tests reproducing both real scenarios)
- [x] Re-ran both real benchmark diffs against `deepseek-v4-pro` with the fix in place - both findings now survive citation verification