### PR TITLE
fix(regression-fence): don't flag additive, backward-compatible signature changes

### DIFF
--- a/src/aletheore/signature_diff.py
+++ b/src/aletheore/signature_diff.py
@@ -24,6 +24,80 @@ def _index_functions(evidence: dict) -> dict[tuple[str, str], str | None]:
     return index
 
 
+def _split_params(params: str) -> list[str]:
+    """Top-level comma-separated parameters from a raw parameter list.
+
+    Splits only at depth zero so a default value or generic type
+    containing commas - `Callable[[str], int | None] | None = None`,
+    `dict[str, int]`, `foo=(1, 2)` - stays a single parameter.
+    """
+    inner = params.strip()
+    if inner.startswith("(") and inner.endswith(")"):
+        inner = inner[1:-1]
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in inner:
+        if char in "([{<":
+            depth += 1
+        elif char in ")]}>":
+            depth -= 1
+        if char == "," and depth == 0:
+            parts.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    tail = "".join(current).strip()
+    if tail:
+        parts.append(tail)
+    return [p for p in parts if p]
+
+
+def _is_optional_param(param: str) -> bool:
+    """Whether an added parameter leaves existing callers working.
+
+    A default value (`x=1`, `int x = 5`, `$x = 5`), a TypeScript optional
+    (`x?: number`), and Python's keyword-only/positional-only markers
+    (`*`, `/`) all add nothing a caller must pass. Variadics (`*args`,
+    `**kwargs`, `...rest`) likewise. Languages without defaults - Go, Java,
+    Rust - simply never match here, so additions there stay flagged, which
+    is correct: they really do break callers.
+    """
+    if param in {"*", "/"}:
+        return True
+    if param.startswith(("*", "...")):
+        return True
+    if "=" in param:
+        return True
+    name = param.split(":", 1)[0].strip()
+    return name.endswith("?")
+
+
+def is_backward_compatible_change(old_params: str | None, new_params: str | None) -> bool:
+    """True when the new signature only appends parameters that callers can
+    keep omitting.
+
+    Found by dogfooding: the first real PR this feature ran on flagged a
+    function that had gained a keyword-only `context: str = "output"`
+    argument. No caller could possibly break, yet the check posted a
+    merge-blocking-eligible Check Run naming a file that merely imports the
+    module. Flagging additive, backward-compatible changes is noise, and
+    noise on a check people are told to require in branch protection is
+    worse than no check.
+    """
+    if old_params is None or new_params is None:
+        return False
+    old_parts = _split_params(old_params)
+    new_parts = _split_params(new_params)
+    if len(new_parts) < len(old_parts):
+        return False
+    # Everything the old signature had must still be there, unchanged and in
+    # order - a rename or reorder can break callers even with the same count.
+    if new_parts[: len(old_parts)] != old_parts:
+        return False
+    return all(_is_optional_param(p) for p in new_parts[len(old_parts) :])
+
+
 def find_changed_signatures(old_evidence: dict, new_evidence: dict) -> list[dict]:
     """Functions present in both snapshots whose params text differs.
 
@@ -31,16 +105,23 @@ def find_changed_signatures(old_evidence: dict, new_evidence: dict) -> list[dict
     that's a different, already-visible kind of edit (it shows up in the
     diff comment's added/removed symbols, not here). Only an existing
     function whose parameter list changed counts.
+
+    Purely additive changes that keep every existing caller working are
+    excluded too - see is_backward_compatible_change. A caller that cannot
+    break is not a caller that needs updating.
     """
     old_index = _index_functions(old_evidence)
     new_index = _index_functions(new_evidence)
     changed = []
     for (path, name), new_params in new_index.items():
         old_params = old_index.get((path, name))
-        if (path, name) in old_index and old_params != new_params and new_params is not None:
-            changed.append(
-                {"file": path, "function": name, "old_params": old_params, "new_params": new_params}
-            )
+        if (path, name) not in old_index or new_params is None or old_params == new_params:
+            continue
+        if is_backward_compatible_change(old_params, new_params):
+            continue
+        changed.append(
+            {"file": path, "function": name, "old_params": old_params, "new_params": new_params}
+        )
     return changed
 
 

--- a/src/tests/test_signature_diff.py
+++ b/src/tests/test_signature_diff.py
@@ -1,4 +1,8 @@
-from aletheore.signature_diff import find_changed_signatures, find_regression_fence_violations
+from aletheore.signature_diff import (
+    find_changed_signatures,
+    find_regression_fence_violations,
+    is_backward_compatible_change,
+)
 
 
 def _evidence(modules: list[dict]) -> dict:
@@ -192,10 +196,12 @@ def test_regression_fence_end_to_end_against_the_real_scanner(tmp_path):
         (root / "admin.py").write_text(
             "from billing import get_billing\n\ndef admin_view(uid):\n    return get_billing(uid)\n"
         )
+    # A genuinely breaking change: the new argument is required, so every
+    # existing call site really does need updating. (An additive
+    # `include_history=False` would be backward compatible and correctly
+    # produces nothing - see the additive tests above.)
     (base / "billing.py").write_text("def get_billing(user_id):\n    return {}\n")
-    (head / "billing.py").write_text(
-        "def get_billing(user_id, include_history=False):\n    return {}\n"
-    )
+    (head / "billing.py").write_text("def get_billing(user_id, tenant):\n    return {}\n")
 
     old, new = _scan(base), _scan(head)
 
@@ -204,7 +210,7 @@ def test_regression_fence_end_to_end_against_the_real_scanner(tmp_path):
             "file": "billing.py",
             "function": "get_billing",
             "old_params": "(user_id)",
-            "new_params": "(user_id, include_history=False)",
+            "new_params": "(user_id, tenant)",
         }
     ]
 
@@ -216,7 +222,7 @@ def test_regression_fence_end_to_end_against_the_real_scanner(tmp_path):
             "file": "billing.py",
             "function": "get_billing",
             "old_params": "(user_id)",
-            "new_params": "(user_id, include_history=False)",
+            "new_params": "(user_id, tenant)",
             "untouched_callers": ["admin.py"],
         }
     ]
@@ -242,3 +248,74 @@ def test_regression_fence_stays_silent_when_only_a_body_changes(tmp_path):
 
     assert find_changed_signatures(old, new) == []
     assert find_regression_fence_violations(old, new, ["billing.py"]) == []
+
+
+def test_is_backward_compatible_change_accepts_the_real_pr_97_signature():
+    # The first real PR Regression Fencing ran on flagged this: a
+    # keyword-only argument with a default was added, no caller could
+    # break, and it still posted a Check Run naming a file that merely
+    # imports the module.
+    old = "( parsed: dict | None, evidence: dict, fetch_line_count: Callable[[str], int | None] | None = None, )"
+    new = (
+        "( parsed: dict | None, evidence: dict, "
+        'fetch_line_count: Callable[[str], int | None] | None = None, *, context: str = "output", )'
+    )
+
+    assert is_backward_compatible_change(old, new) is True
+
+
+def test_is_backward_compatible_change_accepts_added_defaults_and_variadics():
+    assert is_backward_compatible_change("(a)", "(a, b=1)") is True
+    assert is_backward_compatible_change("(a)", "(a, *args)") is True
+    assert is_backward_compatible_change("(a)", "(a, **kwargs)") is True
+    assert is_backward_compatible_change("(a)", "(a, b?: number)") is True
+    # A default value containing a comma must not be split into two params.
+    assert is_backward_compatible_change("(a)", "(a, b=(1, 2))") is True
+
+
+def test_is_backward_compatible_change_rejects_anything_a_caller_can_trip_on():
+    assert is_backward_compatible_change("(a)", "(a, b)") is False        # new required arg
+    assert is_backward_compatible_change("(a, b)", "(a)") is False        # removed arg
+    assert is_backward_compatible_change("(a)", "(b)") is False           # renamed
+    assert is_backward_compatible_change("(a, b)", "(b, a)") is False     # reordered
+    # Go has no default arguments, so an addition really does break callers
+    # and must stay flagged.
+    assert is_backward_compatible_change("(a int)", "(a int, b string)") is False
+
+
+def test_is_backward_compatible_change_is_false_when_params_are_unknown():
+    assert is_backward_compatible_change(None, "(a)") is False
+    assert is_backward_compatible_change("(a)", None) is False
+
+
+def test_find_changed_signatures_ignores_a_purely_additive_change():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence(
+        [
+            {
+                "path": "billing.py",
+                "symbols": {"functions": [{"name": "get_billing", "params": "(user_id, verbose=False)"}]},
+            }
+        ]
+    )
+
+    assert find_changed_signatures(old, new) == []
+
+
+def test_find_regression_fence_violations_stays_silent_for_an_additive_change():
+    old = _evidence(
+        [{"path": "billing.py", "symbols": {"functions": [{"name": "get_billing", "params": "(user_id)"}]}}]
+    )
+    new = _evidence(
+        [
+            {
+                "path": "billing.py",
+                "symbols": {"functions": [{"name": "get_billing", "params": "(user_id, verbose=False)"}]},
+                "imported_by": ["reports/export.py"],
+            }
+        ]
+    )
+
+    assert find_regression_fence_violations(old, new, changed_files=["billing.py"]) == []


### PR DESCRIPTION
## Summary

Found by dogfooding. The first real PR Regression Fencing ever ran on was the grounding-audit PR (#97), and it flagged `_validate_written_output` for gaining a keyword-only `context: str = "output"` argument — naming a test file that imports the module but never calls that function.

Two things went wrong there:

- The **import-level rather than call-level** match is the documented, deliberate coarseness of this feature (there is no call graph). Not changed here.
- The **signature change itself could not break any caller** — and that part is straightforwardly fixable. A purely additive change, where every new parameter has a default, is variadic, or is a keyword-only marker, leaves every existing call site working. Flagging it is noise, and noise on a check users are told to require in branch protection is worse than no check at all.

`find_changed_signatures` now skips those. The comparison:
- splits parameters only at bracket depth zero, so a default or generic type containing commas (`Callable[[str], int | None] | None = None`, `b=(1, 2)`) stays one parameter;
- requires the pre-existing parameters to still be present, unchanged and **in order** — a rename or reorder can break callers even at identical count, so those stay flagged;
- never matches in languages without default arguments (Go, Java, Rust), which is correct — an added parameter there really does break callers.

## Test plan
- [x] Verified against the exact signature pair from the real PR #97 check run
- [x] Covered renames, reorders, removals, required additions, TypeScript optionals, `*args`/`**kwargs`, defaults containing commas, and a Go-style addition
- [x] `src/`: 829 passed (2 pre-existing unrelated `test_cli.py` failures)
- [x] `github-app/`: 764 passed, 7 skipped
- [x] The end-to-end scanner test now uses a genuinely breaking change (a new *required* argument), since its previous additive one is correctly silent under this fix