### PR TITLE
fix(flash-review): stop discarding findings about deleted code

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -326,7 +326,24 @@ _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
 
 def _diff_valid_lines(diff_text: str) -> dict[str, set[int]]:
-    """Maps each file to new-file line numbers present in its diff hunks."""
+    """Maps each file to new-file line numbers its diff hunks touch.
+
+    A removed line has no new-file line of its own, but the position it was
+    removed *from* is still a real, reviewable location - "you deleted the
+    guard here" is a legitimate comment. So a deletion records the new-file
+    line it collapsed onto, without advancing the counter.
+
+    Without that, a deletion-only hunk shrank to just its context lines and
+    the natural place to comment on the removal fell outside the diff
+    entirely. Confirmed on a real PR: a pure-deletion hunk removing
+    `__reduce__` from a JSONDecodeError subclass produced valid lines
+    41-46, Flash Review correctly found the resulting unpicklable-exception
+    bug and cited line 47, and the finding was dropped as "outside the
+    diff" - reported to the customer as "No issues found in this diff".
+    Deleting a null check, a guard, or an override is an extremely common
+    real-world regression, so this silently suppressed a whole class of
+    true positives.
+    """
     valid_lines: dict[str, set[int]] = {}
     current_file: str | None = None
     current_line: int | None = None
@@ -345,11 +362,23 @@ def _diff_valid_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if current_file is None or current_line is None:
             continue
-        if line.startswith("-"):
-            continue
         valid_lines[current_file].add(current_line)
-        current_line += 1
+        if not line.startswith("-"):
+            current_line += 1
     return valid_lines
+
+
+# Findings are allowed to land near a hunk rather than exactly inside it.
+# This filter exists to catch a citation pointing at an unrelated part of
+# the file, not to police off-by-a-few line counting - that is what
+# _line_citation_content_matches does, with real file content, and it can
+# never run on a finding this filter has already discarded. Matches
+# LINE_CITATION_CONTEXT_WINDOW deliberately: one tolerance, one rationale.
+DIFF_LINE_TOLERANCE = LINE_CITATION_CONTEXT_WINDOW
+
+
+def _line_is_near_diff(line: int, valid: set[int]) -> bool:
+    return any(abs(line - candidate) <= DIFF_LINE_TOLERANCE for candidate in valid)
 
 
 def _validate_findings(
@@ -371,7 +400,7 @@ def _validate_findings(
     in_diff = []
     out_of_diff = []
     for finding in findings:
-        if finding["line"] in valid_lines.get(finding["file"], set()):
+        if _line_is_near_diff(finding["line"], valid_lines.get(finding["file"], set())):
             in_diff.append(finding)
         else:
             out_of_diff.append(finding)

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -23,10 +23,21 @@ def test_diff_valid_lines_maps_added_and_context_lines_by_file():
     assert _diff_valid_lines(diff_text) == {"a.py": {1, 2, 3}}
 
 
-def test_diff_valid_lines_excludes_removed_lines():
+def test_diff_valid_lines_does_not_let_a_removed_line_consume_a_new_file_number():
+    # The removal's *position* is recorded (it's a reviewable location), but
+    # it must not advance the new-file counter, or every line after a
+    # deletion would be numbered wrongly.
     diff_text = "--- a.py ---\n@@ -1,2 +1,1 @@\n-removed\n context"
 
     assert _diff_valid_lines(diff_text) == {"a.py": {1}}
+
+
+def test_diff_valid_lines_records_the_position_of_a_leading_deletion():
+    # A hunk that opens with deletions has no preceding context line, so
+    # without this the removal point would not be in the set at all.
+    diff_text = "--- a.py ---\n@@ -5,3 +5,1 @@\n-gone one\n-gone two\n kept"
+
+    assert _diff_valid_lines(diff_text) == {"a.py": {5}}
 
 
 def test_diff_valid_lines_tracks_multiple_files_separately():
@@ -778,3 +789,31 @@ def test_fetch_changed_file_contents_stops_at_max_files(monkeypatch):
     flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py", "b.py", "c.py", "d.py"], "sha")
 
     assert fetched == ["a.py", "b.py"]
+
+
+def test_validate_findings_keeps_a_finding_just_past_a_deletion_only_hunk():
+    # The real PR #223 case, reduced. A pure-deletion hunk collapses to its
+    # context lines (41-46 there); Flash Review correctly found the bug the
+    # deletion introduced and cited line 47, one past the boundary, and the
+    # finding was discarded and reported as "No issues found in this diff".
+    # Deleting a guard or an override is a very common real regression, so
+    # this suppressed an entire class of true positives.
+    diff_text = (
+        "--- a.py ---\n@@ -41,16 +41,6 @@\n"
+        " ctx one\n ctx two\n ctx three\n"
+        "-    def __reduce__(self):\n"
+        "-        return CompatJSONDecodeError.__reduce__(self)\n"
+        " ctx four\n ctx five\n ctx six\n"
+    )
+    finding = {"file": "a.py", "line": 47, "issue": "removal makes this unpicklable"}
+
+    assert _validate_findings([finding], diff_text) == [finding]
+
+
+def test_validate_findings_still_rejects_a_citation_far_from_any_hunk():
+    # The tolerance must not turn the range filter into a no-op: a citation
+    # pointing at an unrelated part of the file is exactly what it's for.
+    diff_text = "--- a.py ---\n@@ -41,3 +41,3 @@\n ctx\n+added\n ctx2"
+    finding = {"file": "a.py", "line": 900, "issue": "unrelated claim"}
+
+    assert _validate_findings([finding], diff_text) == []


### PR DESCRIPTION
## Summary
- A deletion-only hunk collapses to just its context lines, so the natural place to comment on removed code sits at or past that boundary — `_diff_valid_lines` rejected the finding before the content check could weigh in
- Caught on a real PR via grounding instrumentation: a finding about a deleted `__reduce__` making an exception unpicklable was thrown away for being 1 line off
- A removed line now records the new-file position it collapsed onto; citations are accepted within `DIFF_LINE_TOLERANCE` of a hunk instead of exactly inside it

## Test plan
- [x] `pytest github-app/tests/test_flash_review.py` — 64 passed
- [x] Verified against the live PR data that produced the original false negative