### PR TITLE
feat(website): give the dogfooding writeup a nav slot

### DIFF
--- a/website/developers.html
+++ b/website/developers.html
@@ -32,7 +32,7 @@
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
         <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
@@ -258,7 +258,7 @@ aletheore dashboard .</code></pre>
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/developers.html
+++ b/website/developers.html
@@ -258,7 +258,7 @@ aletheore dashboard .</code></pre>
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="dogfooding.html">Proof</a>
+        <a href="terms.html">Terms</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/dogfooding.html
+++ b/website/dogfooding.html
@@ -217,7 +217,7 @@ aletheore scan flask</code></pre>
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="dogfooding.html">Proof</a>
+        <a href="terms.html">Terms</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/dogfooding.html
+++ b/website/dogfooding.html
@@ -32,7 +32,7 @@
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
         <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
@@ -217,7 +217,7 @@ aletheore scan flask</code></pre>
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -479,7 +479,7 @@
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="dogfooding.html">Proof</a>
+        <a href="terms.html">Terms</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/index.html
+++ b/website/index.html
@@ -74,7 +74,7 @@
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
         <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
@@ -479,7 +479,7 @@
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -101,7 +101,7 @@
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="dogfooding.html">Proof</a>
+        <a href="terms.html">Terms</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -25,7 +25,7 @@
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
         <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>
@@ -101,7 +101,7 @@
       </div>
       <div>
         <h4>Legal</h4>
-        <a href="terms.html">Terms</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -17,6 +17,7 @@
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
         <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>

--- a/website/refund.html
+++ b/website/refund.html
@@ -17,6 +17,7 @@
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
         <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>

--- a/website/terms.html
+++ b/website/terms.html
@@ -17,6 +17,7 @@
       <div class="nav-links">
         <a href="pricing.html">Pricing</a>
         <a href="developers.html">Developers</a>
+        <a href="dogfooding.html">Proof</a>
         <a href="https://github.com/Aletheore/Aletheore">GitHub</a>
         <a href="https://www.linkedin.com/company/aletheore">LinkedIn</a>
         <a href="https://app.aletheore.com/">Dashboard</a>


### PR DESCRIPTION
## Summary
Per feedback: the dogfooding page deserved a primary-nav slot rather than only a text link inside the homepage's PROOF section.

Swapped "Terms" for "Proof" (→ dogfooding.html) in the nav on every page — Terms is already fully reachable from the footer's Legal column on every page, and a proof-of-value page earns a nav slot more than legal boilerplate does. Used "Proof" rather than "Dogfooding" to match the homepage's existing PROOF section label.

The three legal pages (terms/privacy/refund) use a lighter nav with no Terms self-link to begin with, so Proof is inserted there rather than swapped for anything.

## Test plan
- [x] Verified all 7 pages now show a consistent nav
- [x] Visual check in a live browser tab
- [x] All linked files confirmed to exist