### PR TITLE
fix(flash-review): dedupe zero-grounded message in PR comment

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1256,9 +1256,10 @@ def _run_flash_review(
     # Surfaces the same verified-vs-proposed count that was previously only
     # ever logged (see flash_review.py's _validate_findings docstring on why
     # a silent drop is otherwise indistinguishable from "found nothing") -
-    # visible on every review with proposed findings, not just when
-    # something got dropped.
-    if proposed:
+    # only when there are findings to attach it to, since the elif proposed
+    # branch above already states the kept=0 case inline and a second line
+    # repeating the exact same ratio would just be noise.
+    if findings:
         body += f"\n\n_Grounding: {kept} of {proposed} proposed finding(s) held up against this diff._"
 
     upsert_pr_comment(client, token, repo_full_name, pr_number, body, marker=FLASH_REVIEW_MARKER)

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1355,6 +1355,9 @@ def test_flash_review_job_reports_zero_grounded_distinctly_from_no_issues_found(
 
     assert "No issues held up under verification (3 proposed, 0 grounded" in posted["body"]
     assert "No issues found in this diff." not in posted["body"]
+    # The line above already states the 0-grounded fact - a second
+    # "Grounding: 0 of 3..." footer would just repeat it.
+    assert "Grounding:" not in posted["body"]
 
 
 def test_flash_review_job_discloses_files_it_never_reviewed(monkeypatch):


### PR DESCRIPTION
## Summary
Minor follow-up from the audit-hardening recheck (#108). When a flash review's proposed findings all get filtered out by grounding, the PR comment stated the same "0 of N held up" fact twice - once inline ("No issues held up under verification (N proposed, 0 grounded in this diff)") and once more as a trailing "_Grounding: 0 of N proposed finding(s) held up_" footer. Only append the footer when there are findings to attach it to.

## Test plan
- [x] `test_flash_review_job_reports_zero_grounded_distinctly_from_no_issues_found` updated to assert the footer is now absent in the zero-grounded case
- [x] `test_flash_review_job_surfaces_grounding_result_in_pr_comment` (findings present, kept>0) still passes unchanged
- [x] github-app suite: 453 passed, 320 skipped (no local DB), 3 pre-existing errors requiring live Postgres - same baseline as master