### PR TITLE
fix(github-app): three hosted-audit hardening findings from follow-up review

### DIFF
--- a/github-app/Dockerfile.demo-sandbox-runner
+++ b/github-app/Dockerfile.demo-sandbox-runner
@@ -1,0 +1,24 @@
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+
+WORKDIR /app
+
+# Docker CLI only (talks to the host daemon via the mounted socket at
+# runtime) - no daemon, no docker-in-docker, no redis/rq (this is a
+# stateless HTTP executor, not a queue consumer). This is the one service
+# in the whole stack with the socket mounted, so it deliberately carries
+# nothing else: no DB credentials, no GitHub App key, no LLM keys, and
+# none of the heavier scan_worker dependency tree (tree-sitter, lancedb,
+# model SDKs) that the trusted customer-scan path needs but this doesn't.
+# stdlib http.server covers the one internal endpoint this exposes, so
+# there is no web framework dependency to install either.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends docker-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY github-app/scan_worker/__init__.py scan_worker/__init__.py
+COPY github-app/scan_worker/demo_sandbox_runner.py scan_worker/demo_sandbox_runner.py
+
+# Runs as root deliberately - needs group access to the mounted
+# /var/run/docker.sock, whose group ownership is host-specific and not
+# knowable at image-build time.
+CMD ["python", "-m", "scan_worker.demo_sandbox_runner"]

--- a/github-app/Dockerfile.demo-scan-worker
+++ b/github-app/Dockerfile.demo-scan-worker
@@ -4,15 +4,15 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir "redis>=5.0.0" "rq>=1.16.0"
 
-# Docker CLI only (talks to the host daemon via the mounted socket at
-# runtime) - no daemon, no docker-in-docker. This is the one service in
-# the whole stack with that socket mounted, so it deliberately carries
-# nothing else: no DB credentials, no GitHub App key, no LLM keys, and
-# none of the heavier scan_worker dependency tree (tree-sitter, lancedb,
-# model SDKs) that the trusted customer-scan path needs but this doesn't.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends docker-cli \
-    && rm -rf /var/lib/apt/lists/*
+# No Docker CLI, no socket mount - the actual `docker run` invocation
+# happens in the separate demo-sandbox-runner service (see
+# Dockerfile.demo-sandbox-runner), reached over the internal compose
+# network. This worker never touches the host Docker socket, so a bug in
+# its public-facing code path can never translate into Docker API access.
+# Still deliberately carries nothing else: no DB credentials, no GitHub
+# App key, no LLM keys, and none of the heavier scan_worker dependency
+# tree (tree-sitter, lancedb, model SDKs) that the trusted customer-scan
+# path needs but this doesn't.
 
 COPY github-app/app_server/__init__.py app_server/__init__.py
 COPY github-app/app_server/logging_config.py app_server/logging_config.py
@@ -20,7 +20,9 @@ COPY github-app/scan_worker/__init__.py scan_worker/__init__.py
 COPY github-app/scan_worker/demo_scan.py scan_worker/demo_scan.py
 COPY github-app/scan_worker/demo_scan_worker.py scan_worker/demo_scan_worker.py
 
-# Runs as root deliberately - needs group access to the mounted
-# /var/run/docker.sock, whose group ownership is host-specific and not
-# knowable at image-build time.
+# No longer needs root - that was only ever for the (now removed) docker
+# socket's host-specific group ownership.
+RUN groupadd --system worker && useradd --system --gid worker worker
+USER worker
+
 CMD ["python", "-m", "scan_worker.demo_scan_worker"]

--- a/github-app/app_server/github_auth.py
+++ b/github-app/app_server/github_auth.py
@@ -46,3 +46,29 @@ def get_installation_details(
     )
     response.raise_for_status()
     return response.json()
+
+
+def get_repo_permission_for_user(
+    repo_full_name: str,
+    username: str,
+    installation_token: str,
+    http_client: httpx.Client | None = None,
+) -> str:
+    """The caller's permission level on repo_full_name - "admin", "write",
+    "read", or "none". Gates any webhook-triggered action that should only
+    be available to someone who could already push to the repo: an issue
+    comment fires for anyone who can comment (on a public repo, anyone
+    with a GitHub account), which is a much wider set than anyone who
+    should be able to spend an installation's paid LLM budget or occupy
+    its managed-audit cooldown slot.
+    """
+    client = http_client or httpx.Client(base_url="https://api.github.com")
+    response = client.get(
+        f"/repos/{repo_full_name}/collaborators/{username}/permission",
+        headers={
+            "Authorization": f"token {installation_token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response.raise_for_status()
+    return response.json()["permission"]

--- a/github-app/app_server/webhooks/issue_comment.py
+++ b/github-app/app_server/webhooks/issue_comment.py
@@ -1,4 +1,17 @@
+import logging
+
+from app_server.config import get_settings
+from app_server.github_auth import generate_app_jwt, get_installation_token, get_repo_permission_for_user
+
+logger = logging.getLogger(__name__)
+
 AUDIT_COMMAND = "/aletheore audit"
+
+# Anyone who can push to the repo can already do everything a managed audit
+# does (read the code, spend the org's own compute) - "read" or below is
+# exactly the set of people an outside PR commenter represents, which is
+# who this check exists to stop.
+AUTHORIZED_PERMISSIONS = ("admin", "write")
 
 
 async def handle_issue_comment_event(payload: dict, redis_url: str, queue=None) -> None:
@@ -7,6 +20,37 @@ async def handle_issue_comment_event(payload: dict, redis_url: str, queue=None) 
     if "pull_request" not in payload.get("issue", {}):
         return
     if AUDIT_COMMAND not in payload.get("comment", {}).get("body", ""):
+        return
+
+    installation_id = payload["installation"]["id"]
+    repo_full_name = payload["repository"]["full_name"]
+    commenter = payload["comment"]["user"]["login"]
+
+    settings = get_settings()
+    try:
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        token = await get_installation_token(installation_id, app_jwt)
+        permission = get_repo_permission_for_user(repo_full_name, commenter, token)
+    except Exception:
+        # Fail closed: an API hiccup here should silently drop a legitimate
+        # trigger (the maintainer can just comment again), not let an
+        # unverified commenter through because the check itself errored.
+        logger.warning(
+            "failed to verify commenter permission for %s on %s; refusing to enqueue audit",
+            commenter,
+            repo_full_name,
+            exc_info=True,
+        )
+        return
+
+    if permission not in AUTHORIZED_PERMISSIONS:
+        logger.info(
+            "ignoring '%s' from %s on %s: permission=%r, need write or admin",
+            AUDIT_COMMAND,
+            commenter,
+            repo_full_name,
+            permission,
+        )
         return
 
     if queue is None:
@@ -18,7 +62,7 @@ async def handle_issue_comment_event(payload: dict, redis_url: str, queue=None) 
     queue.enqueue(
         "scan_worker.jobs.run_managed_audit_pr_job",
         job_timeout=900,
-        installation_id=payload["installation"]["id"],
-        repo_full_name=payload["repository"]["full_name"],
+        installation_id=installation_id,
+        repo_full_name=repo_full_name,
         pr_number=payload["issue"]["number"],
     )

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -74,17 +74,41 @@ services:
     env_file:
       - path: .env
         required: false
-    # The only service with the host's Docker socket - deliberately gets
-    # no DB credentials, no GitHub App key, no LLM keys (see
-    # Dockerfile.demo-scan-worker). Only consumes the demo_scan queue,
-    # completely separate from paying customers' real scan/audit jobs.
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - DEMO_SANDBOX_RUNNER_URL=http://demo-sandbox-runner:8090
+    # No Docker socket here - see Dockerfile.demo-scan-worker and
+    # scan_worker/demo_scan.py. Deliberately gets no DB credentials, no
+    # GitHub App key, no LLM keys either. Only consumes the demo_scan
+    # queue, completely separate from paying customers' real scan/audit
+    # jobs.
     depends_on:
       redis:
         condition: service_started
+      demo-sandbox-runner:
+        condition: service_started
     cpus: "1.0"
     mem_limit: 512m
+
+  demo-sandbox-runner:
+    build:
+      context: ..
+      dockerfile: github-app/Dockerfile.demo-sandbox-runner
+    restart: unless-stopped
+    # The only service with the host's Docker socket. Exposes exactly one
+    # internal-only operation (see scan_worker/demo_sandbox_runner.py) -
+    # "run this repo_url through the fixed sandbox command" - built
+    # entirely server-side from a validated repo_url, not a proxied
+    # Docker API. A tecnativa/docker-socket-proxy-style method/path
+    # allowlist was tested directly against this same daemon and does
+    # NOT close this: with only CONTAINERS+POST enabled, `docker run -v
+    # /:/hostfs alpine ls /hostfs` still succeeded, since POST=1
+    # (required for `docker run` to work at all) already allows an
+    # arbitrary bind mount in the request body. No host port published -
+    # only reachable from other containers on this compose network.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    cpus: "1.0"
+    mem_limit: 256m
 
   postgres:
     image: postgres:16

--- a/github-app/scan_worker/demo_sandbox_runner.py
+++ b/github-app/scan_worker/demo_sandbox_runner.py
@@ -1,0 +1,166 @@
+"""Internal-only sidecar that is the sole holder of the host Docker socket
+for the public, unauthenticated website demo.
+
+demo-scan-worker used to run `docker run --runtime=runsc ...` directly
+with the socket mounted into its own container - a compromise of that
+worker's process meant the full Docker API, and from there the host. A
+docker-socket-proxy (HAProxy-based method/path allowlisting) was tested
+directly against this repo's own production daemon as an alternative and
+does NOT close that: with only CONTAINERS+POST enabled (everything else,
+including VOLUMES, off), `docker run -v /:/hostfs alpine ls /hostfs`
+still succeeded and listed the real host filesystem - the proxy gates
+which endpoints are reachable, not what's inside a POST
+/containers/create body, so POST=1 (required for `docker run` to work at
+all) already allows an arbitrary bind mount.
+
+This service closes the hole instead of trying to filter it: it is the
+only container with real socket access, and it exposes exactly one
+operation - "run this repo_url through the fixed, hardcoded sandbox
+command" - over a narrow internal HTTP API. There is no field in that API
+a caller could use to inject a bind mount, an exec, or any other Docker
+API call: the actual `docker run` argv is built entirely server-side,
+from nothing but a validated repo_url string.
+"""
+
+import json
+import logging
+import re
+import subprocess
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+logger = logging.getLogger(__name__)
+
+DEMO_SANDBOX_IMAGE = "aletheore-demo-sandbox:latest"
+CONTAINER_TIMEOUT_SECONDS = 90
+PORT = 8090
+
+# Mirrors app_server.demo_scan_validation._REPO_URL_RE exactly. Re-checked
+# here rather than trusted from the caller: this process, not
+# demo-scan-worker, is the one thing standing between a string and a
+# real docker invocation, and RQ jobs can in principle be enqueued by
+# anything with access to the same Redis instance.
+_REPO_URL_RE = re.compile(
+    r"^https://github\.com/"
+    r"(?P<owner>[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))/"
+    r"(?P<repo>[A-Za-z0-9._-]{1,100}?)"
+    r"(?:\.git)?/?$"
+)
+
+# Mirrors aletheore.git_intel.analyzer.GIT_ANALYSIS_RESOURCE_EXIT_CODE.
+# Inlined for the same reason scan_worker.demo_scan does: this image
+# deliberately excludes the aletheore package and its dependency tree.
+GIT_ANALYSIS_RESOURCE_EXIT_CODE = 2
+
+
+class SandboxRunError(RuntimeError):
+    """reason is a stable code (see the raise sites below) - the HTTP
+    layer forwards it verbatim so the caller (scan_worker.demo_scan) can
+    reconstruct its own user-facing message without this service needing
+    to know anything about how that message should read."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def run_sandboxed_scan(repo_url: str) -> dict:
+    if not _REPO_URL_RE.match(repo_url.strip()):
+        raise SandboxRunError("invalid_repo_url")
+
+    container_name = f"demo-scan-{uuid.uuid4().hex}"
+    cmd = [
+        "docker",
+        "run",
+        "--name",
+        container_name,
+        "--rm",
+        "--runtime=runsc",
+        "--cpus=1",
+        "--memory=1g",
+        "--pids-limit=256",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        DEMO_SANDBOX_IMAGE,
+        repo_url,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CONTAINER_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # Killing the `docker run` CLI process (what subprocess's own
+        # timeout does) does not guarantee the container it started stops -
+        # the container is managed by the daemon, not the CLI. Force it
+        # explicitly so a slow/stuck clone can never linger past the
+        # timeout using resources or holding the untrusted repo on disk.
+        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True)
+        raise SandboxRunError("timeout") from exc
+
+    if result.returncode == GIT_ANALYSIS_RESOURCE_EXIT_CODE:
+        logger.info("demo scan hit the memory limit for %s", repo_url)
+        raise SandboxRunError("memory_limited")
+
+    if result.returncode != 0:
+        logger.warning(
+            "demo scan container exited %s for %s: %s",
+            result.returncode,
+            repo_url,
+            result.stderr[-2000:],
+        )
+        raise SandboxRunError("nonzero_exit")
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        logger.warning("demo scan produced non-JSON stdout for %s", repo_url)
+        raise SandboxRunError("non_json_output") from exc
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, format_str, *args):
+        logger.info("%s - %s", self.address_string(), format_str % args)
+
+    def do_POST(self):
+        if self.path != "/run":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        try:
+            body = json.loads(self.rfile.read(length) or b"{}")
+            repo_url = body["repo_url"]
+        except (json.JSONDecodeError, KeyError, UnicodeDecodeError):
+            self._send_json(400, {"error": "invalid_request_body"})
+            return
+
+        try:
+            evidence = run_sandboxed_scan(repo_url)
+        except SandboxRunError as exc:
+            self._send_json(422, {"error": exc.reason})
+            return
+
+        self._send_json(200, evidence)
+
+    def _send_json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), _Handler)
+    logger.info("demo sandbox runner listening on :%d", PORT)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/github-app/scan_worker/demo_scan.py
+++ b/github-app/scan_worker/demo_scan.py
@@ -1,33 +1,56 @@
 """RQ job for the public, unauthenticated "paste a repo" website demo.
 
 Runs on the dedicated `demo_scan` queue, consumed only by the
-demo-scan-worker compose service - the one component with access to the
-host's Docker socket, deliberately kept separate from the trusted
+demo-scan-worker compose service, kept separate from the trusted
 scan_worker.jobs path, which only ever touches repos from installed
 GitHub Apps. Every run is a single ephemeral gVisor-sandboxed container:
 the clone and the deterministic scan happen entirely inside it, and only
 a curated, public-safe summary of the results ever leaves - never the
 cloned source, never raw secret matches, never the full evidence.
+
+The actual `docker run` invocation happens in a separate process this
+one talks to over HTTP (see scan_worker.demo_sandbox_runner) - this
+worker itself never touches the host Docker socket, so a bug in the
+public-facing code path here can never translate into Docker API access.
 """
 
 import json
 import logging
-import subprocess
-import uuid
+import os
+import urllib.error
+import urllib.request
 
 logger = logging.getLogger(__name__)
 
-DEMO_SANDBOX_IMAGE = "aletheore-demo-sandbox:latest"
-CONTAINER_TIMEOUT_SECONDS = 90
 MAX_LISTED_ITEMS = 5
 
-# Mirrors aletheore.git_intel.analyzer.GIT_ANALYSIS_RESOURCE_EXIT_CODE.
-# Inlined rather than imported: this container deliberately excludes the
-# aletheore package and its dependency tree (see Dockerfile.demo-scan-worker)
-# - importing it here would crash this worker on startup with no aletheore
-# installed. The scan runs inside aletheore-demo-sandbox, which does have the
-# real package; only its exit code crosses the container boundary.
-GIT_ANALYSIS_RESOURCE_EXIT_CODE = 2
+DEMO_SANDBOX_RUNNER_URL = os.environ.get("DEMO_SANDBOX_RUNNER_URL", "http://demo-sandbox-runner:8090")
+# A little past the runner's own 90s container timeout, so a slow
+# container is what times this out, not this request racing it.
+REQUEST_TIMEOUT_SECONDS = 100
+
+_MEMORY_LIMITED_MESSAGE = (
+    "this repo needs more memory to scan than the live demo allows - install the "
+    "free CLI (`pip install aletheore`) and run `aletheore scan` locally, or "
+    "connect via MCP, with no size limit"
+)
+_GENERIC_FAILURE_MESSAGE = "scan failed - the repo may be invalid, private, or unparseable"
+
+# Maps scan_worker.demo_sandbox_runner.SandboxRunError's stable `reason`
+# codes to this module's own DemoScanError messages, so callers see
+# exactly the same user-facing text regardless of which process actually
+# ran the container.
+_REASON_MESSAGES = {
+    "timeout": "scan timed out",
+    # Confirmed directly: a full scan of the Linux kernel got OOM-killed
+    # under the runner's 1GB container limit. The demo's own 400MB
+    # repo-size cap makes this rare, but a pathologically dense repo
+    # could still hit it - when it does, say so plainly.
+    "memory_limited": _MEMORY_LIMITED_MESSAGE,
+    "nonzero_exit": _GENERIC_FAILURE_MESSAGE,
+    "non_json_output": "scan failed",
+    "invalid_repo_url": _GENERIC_FAILURE_MESSAGE,
+}
 
 
 class DemoScanError(RuntimeError):
@@ -35,65 +58,26 @@ class DemoScanError(RuntimeError):
 
 
 def _run_sandboxed_scan(repo_url: str) -> dict:
-    container_name = f"demo-scan-{uuid.uuid4().hex}"
-    cmd = [
-        "docker",
-        "run",
-        "--name",
-        container_name,
-        "--rm",
-        "--runtime=runsc",
-        "--cpus=1",
-        "--memory=1g",
-        "--pids-limit=256",
-        "--cap-drop=ALL",
-        "--security-opt=no-new-privileges",
-        DEMO_SANDBOX_IMAGE,
-        repo_url,
-    ]
+    request = urllib.request.Request(
+        f"{DEMO_SANDBOX_RUNNER_URL}/run",
+        data=json.dumps({"repo_url": repo_url}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=CONTAINER_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as exc:
-        # Killing the `docker run` CLI process (what subprocess's own
-        # timeout does) does not guarantee the container it started stops -
-        # the container is managed by the daemon, not the CLI. Force it
-        # explicitly so a slow/stuck clone can never linger past the
-        # timeout using resources or holding the untrusted repo on disk.
-        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True)
-        raise DemoScanError("scan timed out") from exc
-
-    if result.returncode == GIT_ANALYSIS_RESOURCE_EXIT_CODE:
-        # Confirmed directly: a full scan of the Linux kernel got OOM-killed
-        # under this same 1GB container limit. The demo's own 400MB repo-size
-        # cap makes this rare (400MB needs a small fraction of the memory
-        # Linux's 8.2GB needed), but a pathologically dense repo could still
-        # hit it - when it does, say so plainly instead of a generic failure.
-        logger.info("demo scan hit the memory limit for %s", repo_url)
-        raise DemoScanError(
-            "this repo needs more memory to scan than the live demo allows - install the "
-            "free CLI (`pip install aletheore`) and run `aletheore scan` locally, or "
-            "connect via MCP, with no size limit"
-        )
-
-    if result.returncode != 0:
-        logger.warning(
-            "demo scan container exited %s for %s: %s",
-            result.returncode,
-            repo_url,
-            result.stderr[-2000:],
-        )
-        raise DemoScanError("scan failed - the repo may be invalid, private, or unparseable")
-
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError as exc:
-        logger.warning("demo scan produced non-JSON stdout for %s", repo_url)
-        raise DemoScanError("scan failed") from exc
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        try:
+            reason = json.loads(exc.read() or b"{}").get("error", "")
+        except json.JSONDecodeError:
+            reason = ""
+        raise DemoScanError(_REASON_MESSAGES.get(reason, _GENERIC_FAILURE_MESSAGE)) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        # The runner process/network hop itself failed - distinct from
+        # any of the repo-shaped failures above, which all come back as a
+        # clean HTTP response from a runner that's up and running fine.
+        raise DemoScanError("demo scan is temporarily unavailable - please try again shortly") from exc
 
 
 def _summarize_for_public_display(evidence: dict) -> dict:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -11,6 +11,7 @@ import uuid
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from rq import get_current_job
@@ -166,6 +167,11 @@ def _clone_url(repo_full_name: str, token: str) -> str:
     return f"https://x-access-token:{token}@github.com/{repo_full_name}.git"
 
 
+def _url_without_credentials(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit(parts._replace(netloc=parts.hostname))
+
+
 def _clone_ref(url: str, ref: str, dest: Path) -> None:
     subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(dest)], check=True)
     subprocess.run(["git", "checkout", "-q", ref], cwd=dest, check=True)
@@ -205,16 +211,40 @@ def _ensure_persistent_checkout(url: str, checkout_sha: str, checkout_dir: Path)
     (see _clone_url - `url` always carries a fresh one) doesn't leave
     this checkout stuck fetching against a stale URL baked in at clone
     time.
+
+    That same `git remote set-url`/`git clone` call, though, is what
+    writes the token into checkout_dir/.git/config - and unlike the
+    ephemeral clones this function is an alternative to (deleted with
+    the whole job_dir within minutes), this checkout lives on a mounted,
+    reused-across-scans volume. Left as-is, a still-live installation
+    token would sit at rest on disk for as long as this checkout exists,
+    not just for the few seconds the fetch/clone needs it. Reset back to
+    a credential-less URL immediately after: this checkout's next reuse
+    calls `git remote set-url` again with a fresh token before it fetches.
     """
+    credential_free_url = _url_without_credentials(url)
     if (checkout_dir / ".git").exists():
         subprocess.run(["git", "remote", "set-url", "origin", url], cwd=checkout_dir, check=True)
-        subprocess.run(["git", "fetch", "-q", "origin"], cwd=checkout_dir, check=True)
-        subprocess.run(["git", "checkout", "-q", "-f", checkout_sha], cwd=checkout_dir, check=True)
-        subprocess.run(["git", "clean", "-q", "-fdx"], cwd=checkout_dir, check=True)
+        try:
+            subprocess.run(["git", "fetch", "-q", "origin"], cwd=checkout_dir, check=True)
+            subprocess.run(["git", "checkout", "-q", "-f", checkout_sha], cwd=checkout_dir, check=True)
+            subprocess.run(["git", "clean", "-q", "-fdx"], cwd=checkout_dir, check=True)
+        finally:
+            subprocess.run(
+                ["git", "remote", "set-url", "origin", credential_free_url], cwd=checkout_dir, check=True
+            )
     else:
         checkout_dir.mkdir(parents=True, exist_ok=True)
-        subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(checkout_dir)], check=True)
-        subprocess.run(["git", "checkout", "-q", checkout_sha], cwd=checkout_dir, check=True)
+        try:
+            subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(checkout_dir)], check=True)
+            subprocess.run(["git", "checkout", "-q", checkout_sha], cwd=checkout_dir, check=True)
+        finally:
+            if (checkout_dir / ".git").exists():
+                subprocess.run(
+                    ["git", "remote", "set-url", "origin", credential_free_url],
+                    cwd=checkout_dir,
+                    check=True,
+                )
 
 
 def _prepare_head_checkout(

--- a/github-app/tests/test_demo_sandbox_runner.py
+++ b/github-app/tests/test_demo_sandbox_runner.py
@@ -1,0 +1,100 @@
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from scan_worker.demo_sandbox_runner import SandboxRunError, run_sandboxed_scan
+
+
+def test_run_sandboxed_scan_invokes_docker_with_gvisor_runtime(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, timeout):
+        captured["cmd"] = cmd
+        captured["timeout"] = timeout
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout=json.dumps({"ok": True}), stderr="")
+
+    monkeypatch.setattr("scan_worker.demo_sandbox_runner.subprocess.run", fake_run)
+    result = run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+
+    assert result == {"ok": True}
+    cmd = captured["cmd"]
+    assert cmd[0:2] == ["docker", "run"]
+    assert "--runtime=runsc" in cmd
+    assert "--cap-drop=ALL" in cmd
+    assert "--rm" in cmd
+    assert cmd[-2] == "aletheore-demo-sandbox:latest"
+    assert cmd[-1] == "https://github.com/octocat/Hello-World.git"
+    assert captured["timeout"] == 90
+
+
+def test_run_sandboxed_scan_rejects_a_url_that_is_not_a_github_repo(monkeypatch):
+    # Defense in depth: app_server.demo_scan_validation already rejects this
+    # before a job is ever enqueued, but this process is the one thing that
+    # actually turns a string into a docker invocation, so it re-checks
+    # rather than trusting the caller.
+    called = []
+    monkeypatch.setattr(
+        "scan_worker.demo_sandbox_runner.subprocess.run", lambda *a, **k: called.append(1) or MagicMock()
+    )
+
+    with pytest.raises(SandboxRunError) as exc_info:
+        run_sandboxed_scan("https://evil.example.com/pwn")
+
+    assert exc_info.value.reason == "invalid_repo_url"
+    assert not called
+
+
+def test_run_sandboxed_scan_raises_on_nonzero_exit(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="clone failed")
+
+    monkeypatch.setattr("scan_worker.demo_sandbox_runner.subprocess.run", fake_run)
+    with pytest.raises(SandboxRunError) as exc_info:
+        run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+    assert exc_info.value.reason == "nonzero_exit"
+
+
+def test_run_sandboxed_scan_reports_memory_limit_distinctly(monkeypatch):
+    from scan_worker.demo_sandbox_runner import GIT_ANALYSIS_RESOURCE_EXIT_CODE
+
+    def fake_run(cmd, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=GIT_ANALYSIS_RESOURCE_EXIT_CODE, stdout="", stderr="")
+
+    monkeypatch.setattr("scan_worker.demo_sandbox_runner.subprocess.run", fake_run)
+    with pytest.raises(SandboxRunError) as exc_info:
+        run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+    assert exc_info.value.reason == "memory_limited"
+
+
+def test_run_sandboxed_scan_raises_on_non_json_stdout(monkeypatch):
+    def fake_run(cmd, capture_output, text, timeout):
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="not json", stderr="")
+
+    monkeypatch.setattr("scan_worker.demo_sandbox_runner.subprocess.run", fake_run)
+    with pytest.raises(SandboxRunError) as exc_info:
+        run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+    assert exc_info.value.reason == "non_json_output"
+
+
+def test_run_sandboxed_scan_force_removes_container_on_timeout(monkeypatch):
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        if args and args[0][0:2] == ["docker", "run"]:
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=90)
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr("scan_worker.demo_sandbox_runner.subprocess.run", fake_run)
+    with pytest.raises(SandboxRunError) as exc_info:
+        run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
+    assert exc_info.value.reason == "timeout"
+
+    assert len(calls) == 2
+    run_cmd = calls[0][0][0]
+    cleanup_cmd = calls[1][0][0]
+    assert cleanup_cmd[:3] == ["docker", "rm", "-f"]
+    container_name_index = run_cmd.index("--name") + 1
+    assert cleanup_cmd[3] == run_cmd[container_name_index]

--- a/github-app/tests/test_demo_scan.py
+++ b/github-app/tests/test_demo_scan.py
@@ -1,6 +1,6 @@
+import io
 import json
-import subprocess
-from unittest.mock import MagicMock
+import urllib.error
 
 import pytest
 
@@ -10,6 +10,36 @@ from scan_worker.demo_scan import (
     _summarize_for_public_display,
     run_demo_scan_job,
 )
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _fake_urlopen_returning(payload: dict):
+    def _fake(request, timeout):
+        return _FakeHTTPResponse(json.dumps(payload).encode())
+
+    return _fake
+
+
+def _fake_urlopen_raising_http_error(status: int, reason: str):
+    def _fake(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url, status, reason, {}, io.BytesIO(json.dumps({"error": reason}).encode())
+        )
+
+    return _fake
 
 
 def _fake_evidence(**overrides) -> dict:
@@ -66,88 +96,76 @@ def test_summarize_notes_osv_is_held_back():
     assert "OSV" in summary["held_back"]["vulnerabilities"]
 
 
-def test_run_sandboxed_scan_invokes_docker_with_gvisor_runtime(monkeypatch):
+def test_run_sandboxed_scan_posts_repo_url_to_the_runner_and_returns_its_json(monkeypatch):
     captured = {}
 
-    def fake_run(cmd, capture_output, text, timeout):
-        captured["cmd"] = cmd
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["body"] = json.loads(request.data)
         captured["timeout"] = timeout
-        return subprocess.CompletedProcess(cmd, returncode=0, stdout=json.dumps({"ok": True}), stderr="")
+        return _FakeHTTPResponse(json.dumps({"ok": True}).encode())
 
-    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    monkeypatch.setattr("scan_worker.demo_scan.urllib.request.urlopen", fake_urlopen)
     result = _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
 
     assert result == {"ok": True}
-    cmd = captured["cmd"]
-    assert cmd[0:2] == ["docker", "run"]
-    assert "--runtime=runsc" in cmd
-    assert "--rm" in cmd
-    assert cmd[-2] == "aletheore-demo-sandbox:latest"
-    assert cmd[-1] == "https://github.com/octocat/Hello-World.git"
-    assert captured["timeout"] == 90
+    assert captured["url"].endswith("/run")
+    assert captured["body"] == {"repo_url": "https://github.com/octocat/Hello-World.git"}
+    assert captured["timeout"] > 90  # past the runner's own container timeout
 
 
-def test_run_sandboxed_scan_raises_on_nonzero_exit(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="clone failed")
-
-    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+def test_run_sandboxed_scan_raises_on_nonzero_exit_reason(monkeypatch):
+    monkeypatch.setattr(
+        "scan_worker.demo_scan.urllib.request.urlopen", _fake_urlopen_raising_http_error(422, "nonzero_exit")
+    )
     with pytest.raises(DemoScanError):
         _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
 
 
 def test_run_sandboxed_scan_gives_a_specific_message_when_memory_limited(monkeypatch):
     # Confirmed directly: a full scan of the Linux kernel got OOM-killed
-    # under this same 1GB container limit, and the CLI (via GitAnalysisError)
-    # exits with GIT_ANALYSIS_RESOURCE_EXIT_CODE for exactly this case -
-    # the demo should say so plainly rather than a generic failure message.
-    from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE
-
-    def fake_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, returncode=GIT_ANALYSIS_RESOURCE_EXIT_CODE, stdout="", stderr="")
-
-    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    # under the runner's 1GB container limit, and the CLI (via
+    # GitAnalysisError) exits with GIT_ANALYSIS_RESOURCE_EXIT_CODE for
+    # exactly this case - the demo should say so plainly rather than a
+    # generic failure message.
+    monkeypatch.setattr(
+        "scan_worker.demo_scan.urllib.request.urlopen", _fake_urlopen_raising_http_error(422, "memory_limited")
+    )
     with pytest.raises(DemoScanError, match="pip install aletheore"):
         _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
 
 
-def test_run_sandboxed_scan_raises_on_non_json_stdout(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, returncode=0, stdout="not json", stderr="")
-
-    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+def test_run_sandboxed_scan_raises_on_non_json_output_reason(monkeypatch):
+    monkeypatch.setattr(
+        "scan_worker.demo_scan.urllib.request.urlopen", _fake_urlopen_raising_http_error(422, "non_json_output")
+    )
     with pytest.raises(DemoScanError):
         _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
 
 
-def test_run_sandboxed_scan_force_removes_container_on_timeout(monkeypatch):
-    calls = []
-
-    def fake_run(*args, **kwargs):
-        calls.append((args, kwargs))
-        if args and args[0][0:2] == ["docker", "run"]:
-            raise subprocess.TimeoutExpired(cmd=args[0], timeout=90)
-        return MagicMock(returncode=0)
-
-    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+def test_run_sandboxed_scan_raises_a_timed_out_message_on_timeout_reason(monkeypatch):
+    monkeypatch.setattr(
+        "scan_worker.demo_scan.urllib.request.urlopen", _fake_urlopen_raising_http_error(422, "timeout")
+    )
     with pytest.raises(DemoScanError, match="timed out"):
         _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
 
-    # First call was the (timed-out) docker run, second must be the forced
-    # cleanup - the container name from the failed call is what gets removed.
-    assert len(calls) == 2
-    run_cmd = calls[0][0][0]
-    cleanup_cmd = calls[1][0][0]
-    assert cleanup_cmd[:3] == ["docker", "rm", "-f"]
-    container_name_index = run_cmd.index("--name") + 1
-    assert cleanup_cmd[3] == run_cmd[container_name_index]
+
+def test_run_sandboxed_scan_reports_the_runner_being_unreachable_distinctly(monkeypatch):
+    # A network/connectivity failure to the runner itself is not a
+    # repo-shaped problem - the message should say so, not blame the repo.
+    def fake_urlopen(request, timeout):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("scan_worker.demo_scan.urllib.request.urlopen", fake_urlopen)
+    with pytest.raises(DemoScanError, match="temporarily unavailable"):
+        _run_sandboxed_scan("https://github.com/octocat/Hello-World.git")
 
 
 def test_run_demo_scan_job_returns_summarized_result(monkeypatch):
-    def fake_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, returncode=0, stdout=json.dumps(_fake_evidence()), stderr="")
-
-    monkeypatch.setattr("scan_worker.demo_scan.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "scan_worker.demo_scan.urllib.request.urlopen", _fake_urlopen_returning(_fake_evidence())
+    )
     result = run_demo_scan_job("https://github.com/octocat/Hello-World.git")
 
     assert result["secrets"]["finding_count"] == 1

--- a/github-app/tests/test_issue_comment_webhook.py
+++ b/github-app/tests/test_issue_comment_webhook.py
@@ -1,25 +1,46 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app_server.webhooks.issue_comment import handle_issue_comment_event
 
 
-def _payload(comment_body: str, has_pr: bool = True):
+def _payload(comment_body: str, has_pr: bool = True, commenter: str = "someuser"):
     payload = {
         "action": "created",
         "installation": {"id": 111},
         "repository": {"full_name": "octocat/hello-world"},
         "issue": {"number": 42},
-        "comment": {"body": comment_body},
+        "comment": {"body": comment_body, "user": {"login": commenter}},
     }
     if has_pr:
         payload["issue"]["pull_request"] = {"url": "https://api.github.com/..."}
     return payload
 
 
+def _mock_permission_check(monkeypatch, permission: str | None, raises: bool = False):
+    monkeypatch.setattr(
+        "app_server.webhooks.issue_comment.generate_app_jwt", lambda *a, **k: "fake-jwt"
+    )
+    monkeypatch.setattr(
+        "app_server.webhooks.issue_comment.get_installation_token", AsyncMock(return_value="fake-token")
+    )
+    if raises:
+
+        def _raise(*a, **k):
+            raise RuntimeError("GitHub API unavailable")
+
+        monkeypatch.setattr("app_server.webhooks.issue_comment.get_repo_permission_for_user", _raise)
+    else:
+        monkeypatch.setattr(
+            "app_server.webhooks.issue_comment.get_repo_permission_for_user",
+            lambda *a, **k: permission,
+        )
+
+
 @pytest.mark.asyncio
-async def test_audit_command_enqueues_managed_audit_job():
+async def test_audit_command_enqueues_managed_audit_job_for_a_write_collaborator(monkeypatch):
+    _mock_permission_check(monkeypatch, "write")
     fake_queue = MagicMock()
     await handle_issue_comment_event(_payload("/aletheore audit"), "redis://unused", queue=fake_queue)
     fake_queue.enqueue.assert_called_once()
@@ -34,14 +55,50 @@ async def test_audit_command_enqueues_managed_audit_job():
 
 
 @pytest.mark.asyncio
-async def test_non_audit_comment_does_not_enqueue():
+async def test_audit_command_enqueues_for_an_admin_too(monkeypatch):
+    _mock_permission_check(monkeypatch, "admin")
+    fake_queue = MagicMock()
+    await handle_issue_comment_event(_payload("/aletheore audit"), "redis://unused", queue=fake_queue)
+    fake_queue.enqueue.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_audit_command_from_a_read_only_commenter_does_not_enqueue(monkeypatch):
+    _mock_permission_check(monkeypatch, "read")
+    fake_queue = MagicMock()
+    await handle_issue_comment_event(_payload("/aletheore audit"), "redis://unused", queue=fake_queue)
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_audit_command_from_a_non_collaborator_does_not_enqueue(monkeypatch):
+    _mock_permission_check(monkeypatch, "none")
+    fake_queue = MagicMock()
+    await handle_issue_comment_event(_payload("/aletheore audit"), "redis://unused", queue=fake_queue)
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_audit_command_does_not_enqueue_when_permission_check_itself_fails(monkeypatch):
+    # Fails closed: an API error while verifying the commenter's permission
+    # must not be treated as authorization to proceed.
+    _mock_permission_check(monkeypatch, None, raises=True)
+    fake_queue = MagicMock()
+    await handle_issue_comment_event(_payload("/aletheore audit"), "redis://unused", queue=fake_queue)
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_audit_comment_does_not_enqueue(monkeypatch):
+    _mock_permission_check(monkeypatch, "write")
     fake_queue = MagicMock()
     await handle_issue_comment_event(_payload("regular comment"), "redis://unused", queue=fake_queue)
     fake_queue.enqueue.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_comment_on_plain_issue_not_pr_does_not_enqueue():
+async def test_comment_on_plain_issue_not_pr_does_not_enqueue(monkeypatch):
+    _mock_permission_check(monkeypatch, "write")
     fake_queue = MagicMock()
     await handle_issue_comment_event(
         _payload("/aletheore audit", has_pr=False),

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -177,6 +177,75 @@ def test_build_unchanged_scan_cache_returns_none_without_a_previous_sync(tmp_pat
     assert result is None
 
 
+def test_url_without_credentials_strips_embedded_token():
+    from scan_worker.jobs import _url_without_credentials
+
+    assert (
+        _url_without_credentials("https://x-access-token:sometoken@github.com/org/repo.git")
+        == "https://github.com/org/repo.git"
+    )
+
+
+def test_url_without_credentials_leaves_a_plain_local_path_unchanged():
+    from scan_worker.jobs import _url_without_credentials
+
+    assert _url_without_credentials("/tmp/some/bare-repo") == "/tmp/some/bare-repo"
+
+
+def test_ensure_persistent_checkout_does_not_leave_a_live_token_on_disk(tmp_path, monkeypatch):
+    # This checkout directory is a mounted, reused-across-scans volume in
+    # production (see _persistent_checkout_dir) - unlike the ephemeral
+    # per-job clones that get deleted within minutes, a token embedded in
+    # its .git/config would sit at rest on disk for as long as the
+    # checkout exists. _ensure_persistent_checkout must reset the remote
+    # back to a credential-free URL before returning, on both the
+    # fresh-clone and reused-checkout paths.
+    from scan_worker.jobs import _ensure_persistent_checkout
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            dest = args[-1]
+            os.makedirs(os.path.join(dest, ".git"), exist_ok=True)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    checkout_dir = tmp_path / "fresh"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    _ensure_persistent_checkout(credentialed_url, "somesha", checkout_dir)
+
+    set_url_calls = [c for c in calls if c[:3] == ["git", "remote", "set-url"]]
+    assert set_url_calls, "expected at least one 'git remote set-url' call"
+    # The LAST set-url call is what .git/config is left holding when this
+    # function returns - it must never be the credentialed URL.
+    assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
+    assert "livetoken" not in set_url_calls[-1][-1]
+
+
+def test_ensure_persistent_checkout_strips_credentials_on_reuse_path_too(tmp_path, monkeypatch):
+    from scan_worker.jobs import _ensure_persistent_checkout
+
+    checkout_dir = tmp_path / "existing"
+    (checkout_dir / ".git").mkdir(parents=True)
+
+    calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.subprocess.run",
+        lambda args, cwd=None, check=None: calls.append(args) or subprocess.CompletedProcess(args, 0),
+    )
+
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    _ensure_persistent_checkout(credentialed_url, "somesha", checkout_dir)
+
+    set_url_calls = [c for c in calls if c[:3] == ["git", "remote", "set-url"]]
+    assert len(set_url_calls) == 2  # once with the live token to fetch, once to strip it
+    assert set_url_calls[0][-1] == credentialed_url
+    assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
+
+
 def test_run_pr_scan_job_uses_persistent_checkout_and_unchanged_cache_for_head(
     bare_repo_with_two_commits, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Follow-up on the round-1 audit hardening (#108, #109) — an independent external audit flagged three additional issues in the hosted GitHub App infrastructure. All three verified against the actual current code/config before fixing, then verified live against the production server where relevant.

- **Audit-trigger permission bypass**: `issue_comment.py`'s webhook enqueued a managed audit job for *any* commenter, not just repo collaborators with write/admin access. Now calls GitHub's collaborator-permission endpoint and fails closed (no job enqueued) on any error or insufficient permission.
- **Credentials left in checkout `.git/config`**: `jobs.py`'s persistent per-repo checkout embeds a short-lived GitHub App installation token in the clone URL, then reuses that checkout across many scans. The token was never stripped afterward, leaving it on disk in `.git/config` for up to ~1hr (until token expiry) on every reused checkout. Now strips credentials via `git remote set-url` in a `try/finally` immediately after every fetch/clone.
- **Docker socket exposed to `demo-scan-worker`**: the public-demo scan worker had direct `/var/run/docker.sock` access to run untrusted repos through `docker run --runtime=runsc`. Live-tested a `tecnativa/docker-socket-proxy`-style method/path allowlist directly against the production daemon first — confirmed it does NOT close this, since an allowed `POST /containers/create` can still carry an arbitrary bind-mount in its body (`docker run -v /:/hostfs ...` succeeded through the proxy). Replaced with a dedicated internal-only sidecar (`demo_sandbox_runner.py`) that is the sole holder of the socket and exposes exactly one fixed operation (repo_url in, evidence out) over a minimal stdlib HTTP API — no field in that API can smuggle an unintended Docker parameter. `demo-scan-worker` now has no socket access and runs as a non-root user.

## Test plan

- Full `github-app` test suite: 468 passed.
- New/updated tests: `test_issue_comment_webhook.py` (7 tests covering write/admin enqueue, read/none block, fail-closed on permission-check error), `test_jobs.py` (credential-stripping on both fresh-clone and reuse paths), `test_demo_sandbox_runner.py` (6 tests for the new sidecar), `test_demo_scan.py` (rewritten to mock the sidecar HTTP call instead of subprocess).
- Live-verified the sidecar end-to-end against the actual production Docker daemon + gVisor runtime, in full isolation (separate network/container/image names, source copied via scp, live stack untouched): confirmed both the success path (valid repo_url → real evidence) and the rejection path (invalid repo_url → no container ever created), then cleaned up all test artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)