### PR TITLE
fix(github-app): bump cryptography to close 3 pip-audit advisories

### DIFF
--- a/github-app/requirements.txt
+++ b/github-app/requirements.txt
@@ -7,4 +7,4 @@ rq>=1.16.0,<3.0
 httpx>=0.28.1,<1.0
 pyjwt[crypto]>=2.13.0,<3.0
 itsdangerous>=2.2.0,<3.0
-cryptography>=44.0.0,<49.0
+cryptography>=50.0.0,<51.0


### PR DESCRIPTION
## Summary
- `cryptography` was pinned `>=44.0.0,<49.0` (the `<49.0` cap came from a prior batch commit that applied an upper bound uniformly across all deps, not a cryptography-specific constraint)
- `pip-audit` flags 3 advisories against the installed `48.0.1`: `PYSEC-2026-3552` (fixed in 50.0.0), `PYSEC-2026-3553` and `PYSEC-2026-3554` (fixed in 49.0.0)
- Bumped to `>=50.0.0,<51.0`, which covers all three fixes
- `cryptography` backs Fernet/HKDF session encryption in `app_server/auth.py` and Ed25519 audit signing in `app_server/audit_signing.py`

## Test plan
- [x] Installed the bumped requirement set into an isolated venv (`pip install -r requirements.txt` + `requirements-dev.txt`), resolved cleanly
- [x] Ran the full github-app suite against `cryptography==50.0.0`: `468 passed, 320 skipped, 3 errors` — identical to the pre-bump baseline; the 3 errors are pre-existing `test_migrate.py` failures from no local test Postgres on `:55433`, unrelated to this change
- [x] Re-ran `pip-audit -r requirements.txt`: no known vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)