### PR TITLE
fix(cli): enforce evidence schema-version compatibility on every read path

### DIFF
--- a/github-app/tests/test_managed_audit.py
+++ b/github-app/tests/test_managed_audit.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from aletheore.citation_verifier import load_verifiable_evidence as _load_verifiable_evidence
 from aletheore.citation_verifier import local_line_count_fetcher as _local_line_count_fetcher
+from aletheore.evidence import EVIDENCE_VERSION
 from scan_worker.managed_audit import (
     _citation_verification_section,
     _llm_based_suggestion_section,
@@ -138,7 +139,10 @@ def _repo_with_evidence(tmp_path, files: dict[str, str]) -> Path:
         full = repo_path / path
         full.parent.mkdir(parents=True, exist_ok=True)
         full.write_text(content)
-    evidence = {"repository": {"modules": [{"path": p} for p in files]}}
+    evidence = {
+        "aletheore_version": EVIDENCE_VERSION,
+        "repository": {"modules": [{"path": p} for p in files]},
+    }
     (repo_path / ".aletheore" / "air.json").write_text(json.dumps(evidence))
     return repo_path
 
@@ -218,7 +222,10 @@ def test_citation_verification_section_does_not_claim_bounds_checking_it_could_n
     # exact overclaim this section exists to prevent.
     repo_path = tmp_path / "repo"
     (repo_path / ".aletheore").mkdir(parents=True)
-    evidence = {"repository": {"modules": [{"path": "app.py"}]}}
+    evidence = {
+        "aletheore_version": EVIDENCE_VERSION,
+        "repository": {"modules": [{"path": "app.py"}]},
+    }
     (repo_path / ".aletheore" / "air.json").write_text(json.dumps(evidence))
 
     section = _citation_verification_section("The bug is at `app.py:900`.", repo_path)

--- a/src/aletheore/citation_verifier.py
+++ b/src/aletheore/citation_verifier.py
@@ -33,6 +33,8 @@ import re
 from collections.abc import Callable
 from pathlib import Path
 
+from aletheore.evidence import is_evidence_version_compatible
+
 logger = logging.getLogger("aletheore.citation_verifier")
 
 # Matches file:line citations in report text, e.g. "server/routes/billing.ts:142"
@@ -206,6 +208,8 @@ def load_verifiable_evidence(repo_path: Path) -> dict | None:
     except (OSError, json.JSONDecodeError):
         return None
     if not isinstance(evidence, dict):
+        return None
+    if not is_evidence_version_compatible(evidence.get("aletheore_version")):
         return None
     if not evidence.get("repository", {}).get("modules"):
         return None

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -34,7 +34,13 @@ from aletheore.citation_verifier import (
 )
 from aletheore.credentials import get_api_key
 from aletheore.device_auth import infer_repo_full_name_from_cwd_git_remote
-from aletheore.evidence import scan_repository, write_evidence
+from aletheore.evidence import (
+    IncompatibleEvidenceVersionError,
+    load_evidence,
+    load_evidence_file,
+    scan_repository,
+    write_evidence,
+)
 from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE, GitAnalysisError
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
 from aletheore.history import compute_diff, list_snapshots, save_snapshot, to_sarif
@@ -443,12 +449,23 @@ def _query_changes(repo_path: str, full: bool) -> int:
         return 0
 
     try:
-        old = json.loads(snapshots[-2].read_text())
+        old = load_evidence_file(snapshots[-2])
     except json.JSONDecodeError:
         print(f"error: most recent snapshot is unreadable ({snapshots[-2]})")
         return 1
+    except IncompatibleEvidenceVersionError as exc:
+        print(f"error: {exc}")
+        return 1
 
-    new = json.loads(snapshots[-1].read_text())
+    try:
+        new = load_evidence_file(snapshots[-1])
+    except json.JSONDecodeError:
+        print(f"error: most recent snapshot is unreadable ({snapshots[-1]})")
+        return 1
+    except IncompatibleEvidenceVersionError as exc:
+        print(f"error: {exc}")
+        return 1
+
     diff = compute_diff(old, new, full=full)
     print(json.dumps(diff, indent=2))
     return 0
@@ -456,12 +473,14 @@ def _query_changes(repo_path: str, full: bool) -> int:
 
 def _index(repo_path: str) -> int:
     repo = Path(repo_path).resolve()
-    evidence_path = repo / ".aletheore" / "air.json"
-    if not evidence_path.exists():
-        console.print(f"[bold red]error:[/bold red] no evidence found at {evidence_path}")
-        console.print(f"Run 'aletheore scan {repo}' first.")
+    try:
+        evidence = load_evidence(repo)
+    except FileNotFoundError as exc:
+        console.print(f"[bold red]error:[/bold red] {exc}")
         return 1
-    evidence = json.loads(evidence_path.read_text())
+    except IncompatibleEvidenceVersionError as exc:
+        console.print(f"[bold red]error:[/bold red] {exc}")
+        return 1
     console.print(
         "Building semantic search index (embedding via local Ollama, "
         "falling back to OpenAI if unavailable)..."
@@ -541,17 +560,16 @@ def _query(
         return 0
 
     repo = Path(repo_path).resolve()
-    evidence_path = repo / ".aletheore" / "air.json"
-    if not evidence_path.exists():
-        print(f"error: no evidence found at {evidence_path}")
-        print(f"Run 'aletheore scan {repo}' first.")
+    try:
+        evidence = load_evidence(repo)
+    except (FileNotFoundError, IncompatibleEvidenceVersionError) as exc:
+        print(f"error: {exc}")
         return 1
 
     if kind == "symbol-source":
         if target is None or symbol is None:
             print("error: query type 'symbol-source' requires module and symbol arguments")
             return 1
-        evidence = json.loads(evidence_path.read_text())
         try:
             result = find_symbol_source(evidence, repo, target, symbol)
         except (ModuleNotFoundInEvidenceError, SymbolNotFoundInEvidenceError) as exc:
@@ -565,7 +583,6 @@ def _query(
         print(f"error: query type '{kind}' requires a target argument")
         return 1
 
-    evidence = json.loads(evidence_path.read_text())
     try:
         if kind in ("evidence-for-endpoint", "evidence-for-symbol", "evidence-for-dependency"):
             result = func(evidence, target, repo)
@@ -606,14 +623,20 @@ def _diff(
         return 1
 
     try:
-        old = json.loads(old_file.read_text())
+        old = load_evidence_file(old_file)
     except json.JSONDecodeError:
         print(f"error: {old_file} is not valid JSON")
         return 1
+    except IncompatibleEvidenceVersionError as exc:
+        print(f"error: {exc}")
+        return 1
     try:
-        new = json.loads(new_file.read_text())
+        new = load_evidence_file(new_file)
     except json.JSONDecodeError:
         print(f"error: {new_file} is not valid JSON")
+        return 1
+    except IncompatibleEvidenceVersionError as exc:
+        print(f"error: {exc}")
         return 1
 
     diff = compute_diff(old, new, full=full)
@@ -687,13 +710,12 @@ def _verify(report_path: str, repo_path: str) -> int:
 
 def _healthcheck(repo_path: str, base_url: str) -> int:
     repo = Path(repo_path).resolve()
-    evidence_path = repo / ".aletheore" / "air.json"
-    if not evidence_path.exists():
-        print(f"error: no evidence found at {evidence_path}")
-        print(f"Run 'aletheore scan {repo}' first.")
+    try:
+        evidence = load_evidence(repo)
+    except (FileNotFoundError, IncompatibleEvidenceVersionError) as exc:
+        print(f"error: {exc}")
         return 1
 
-    evidence = json.loads(evidence_path.read_text())
     endpoints = evidence["repository"].get("api_endpoints", {}).get("endpoints", [])
     result = run_healthcheck(endpoints, base_url)
     save_healthcheck(result, repo)

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -70,6 +70,42 @@ def is_evidence_version_compatible(version: object) -> bool:
     given = _version_compatibility_key(version)
     return current is not None and current == given
 
+
+class IncompatibleEvidenceVersionError(Exception):
+    pass
+
+
+def load_evidence_file(evidence_path: Path) -> dict:
+    """Reads and validates a raw air.json or snapshot file, refusing evidence
+    written by an incompatible schema version.
+
+    Every direct reader of an evidence file (CLI query/index/diff/healthcheck,
+    the MCP server) should route through this or load_evidence rather than a
+    bare json.loads - see is_evidence_version_compatible for why.
+    """
+    evidence = json.loads(evidence_path.read_text())
+    written_version = evidence.get("aletheore_version") if isinstance(evidence, dict) else None
+    if not is_evidence_version_compatible(written_version):
+        raise IncompatibleEvidenceVersionError(
+            f"{evidence_path} was written by aletheore_version={written_version!r}, which "
+            f"isn't compatible with this build's evidence schema ({EVIDENCE_VERSION}) - "
+            "re-run 'aletheore scan' to refresh it"
+        )
+    return evidence
+
+
+def load_evidence(repo_path: Path) -> dict:
+    """The repo's own .aletheore/air.json, validated for schema compatibility.
+
+    Raises FileNotFoundError if no evidence has been written yet.
+    """
+    evidence_path = repo_path / ".aletheore" / "air.json"
+    if not evidence_path.exists():
+        raise FileNotFoundError(
+            f"no evidence found at {evidence_path} - run 'aletheore scan {repo_path}' first"
+        )
+    return load_evidence_file(evidence_path)
+
 # Unset by default - a developer scanning their own repo locally wants full
 # history, and isn't running inside a memory-constrained container. The
 # hosted scan-worker sets this (see scan_worker/jobs.py's

--- a/src/tests/test_citation_verifier.py
+++ b/src/tests/test_citation_verifier.py
@@ -7,6 +7,7 @@ from aletheore.citation_verifier import (
     local_line_count_fetcher,
     verify_citations,
 )
+from aletheore.evidence import EVIDENCE_VERSION
 
 
 def make_evidence() -> dict:
@@ -195,7 +196,10 @@ def _repo_with_evidence(tmp_path, files: dict[str, str]):
     (repo_path / ".aletheore").mkdir(parents=True)
     for name, content in files.items():
         (repo_path / name).write_text(content)
-    evidence = {"repository": {"modules": [{"path": p} for p in files]}}
+    evidence = {
+        "aletheore_version": EVIDENCE_VERSION,
+        "repository": {"modules": [{"path": p} for p in files]},
+    }
     (repo_path / ".aletheore" / "air.json").write_text(json.dumps(evidence))
     return repo_path
 
@@ -215,6 +219,18 @@ def test_load_verifiable_evidence_rejects_evidence_with_no_file_inventory(tmp_pa
     repo_path = tmp_path / "repo"
     (repo_path / ".aletheore").mkdir(parents=True)
     (repo_path / ".aletheore" / "air.json").write_text(json.dumps({"managed_evidence": True}))
+
+    assert load_verifiable_evidence(repo_path) is None
+
+
+def test_load_verifiable_evidence_rejects_an_incompatible_schema_version(tmp_path):
+    repo_path = tmp_path / "repo"
+    (repo_path / ".aletheore").mkdir(parents=True)
+    evidence = {
+        "aletheore_version": "9.9.9",
+        "repository": {"modules": [{"path": "app.py"}]},
+    }
+    (repo_path / ".aletheore" / "air.json").write_text(json.dumps(evidence))
 
     assert load_verifiable_evidence(repo_path) is None
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -21,6 +21,7 @@ from aletheore.cli import (
     app,
 )
 from aletheore.device_auth import DeviceFlowError
+from aletheore.evidence import EVIDENCE_VERSION
 from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE, GitAnalysisError
 from aletheore.report import (
     AmbiguousAdapterError,
@@ -623,7 +624,7 @@ def test_verify_reports_verified_citations_and_exits_zero(tmp_path):
     repo = tmp_path
     (repo / "app.py").write_text("one\ntwo\nthree\n")
     (repo / ".aletheore").mkdir()
-    evidence = {"repository": {"modules": [{"path": "app.py"}]}}
+    evidence = {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": [{"path": "app.py"}]}}
     (repo / ".aletheore" / "air.json").write_text(json.dumps(evidence))
     report = repo / "report.md"
     report.write_text("The bug is at `app.py:2`.")
@@ -639,7 +640,7 @@ def test_verify_exits_nonzero_and_lists_unverified_citations(tmp_path):
     repo = tmp_path
     (repo / "app.py").write_text("one\n")
     (repo / ".aletheore").mkdir()
-    evidence = {"repository": {"modules": [{"path": "app.py"}]}}
+    evidence = {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": [{"path": "app.py"}]}}
     (repo / ".aletheore" / "air.json").write_text(json.dumps(evidence))
     report = repo / "report.md"
     report.write_text("See `ghost.py:1` for details.")
@@ -849,6 +850,18 @@ def test_index_command_fails_clearly_without_prior_scan(tmp_path):
     assert "scan" in result.output.lower()
 
 
+def test_index_command_rejects_evidence_from_an_incompatible_schema_version(tmp_path):
+    repo = tmp_path
+    (repo / ".aletheore").mkdir()
+    evidence = {"aletheore_version": "9.9.9", "repository": {"modules": []}}
+    (repo / ".aletheore" / "air.json").write_text(json.dumps(evidence))
+
+    result = runner.invoke(app, ["index", str(repo)])
+
+    assert result.exit_code == 1
+    assert "re-run" in result.output.lower() or "re-scan" in result.output.lower()
+
+
 def test_query_search_codebase_prints_toon_results(tmp_path):
     with patch(
         "aletheore.search_index.search_index",
@@ -982,6 +995,20 @@ def test_main_healthcheck_without_evidence_errors_clearly(tmp_path):
 
     assert result.exit_code == 1
     assert "aletheore scan" in result.output
+
+
+def test_main_healthcheck_rejects_evidence_from_an_incompatible_schema_version(tmp_path):
+    repo = tmp_path
+    (repo / ".aletheore").mkdir()
+    evidence = {"aletheore_version": "9.9.9", "repository": {}}
+    (repo / ".aletheore" / "air.json").write_text(json.dumps(evidence))
+
+    result = runner.invoke(
+        app, ["healthcheck", str(repo), "--base-url", "http://localhost:5000"]
+    )
+
+    assert result.exit_code == 1
+    assert "re-run" in result.output.lower()
 
 
 def test_login_saves_token_when_installation_auto_resolved(tmp_path, monkeypatch):
@@ -1272,6 +1299,18 @@ def test_main_query_without_evidence_errors_clearly(tmp_path):
     assert "aletheore scan" in result.output
 
 
+def test_main_query_rejects_evidence_from_an_incompatible_schema_version(tmp_path):
+    repo = tmp_path
+    (repo / ".aletheore").mkdir()
+    evidence = {"aletheore_version": "9.9.9", "repository": {"modules": []}}
+    (repo / ".aletheore" / "air.json").write_text(json.dumps(evidence))
+
+    result = runner.invoke(app, ["query", "ownership", "--path", str(repo)])
+
+    assert result.exit_code == 1
+    assert "re-run" in result.output.lower()
+
+
 def test_main_query_unknown_module_errors_clearly(tmp_path):
     repo = tmp_path
     (repo / "main.py").write_text("x = 1\n")
@@ -1299,6 +1338,7 @@ def make_evidence_file(
     layer_violations: list[dict] | None = None,
 ) -> Path:
     evidence = {
+        "aletheore_version": EVIDENCE_VERSION,
         "repository": {"modules": [], "dependency_graph": {"nodes": [], "edges": []}},
         "git": {"total_commits": 0},
         "security": {
@@ -1383,6 +1423,17 @@ def test_main_diff_rejects_unknown_format(tmp_path):
 
     assert result.exit_code == 1
     assert "unknown --format" in result.output
+
+
+def test_main_diff_rejects_an_evidence_file_from_an_incompatible_schema_version(tmp_path):
+    old_path = tmp_path / "old.json"
+    old_path.write_text(json.dumps({"aletheore_version": "9.9.9", "repository": {}}))
+    new_path = make_evidence_file(tmp_path / "new.json")
+
+    result = runner.invoke(app, ["diff", str(old_path), str(new_path)])
+
+    assert result.exit_code == 1
+    assert "re-run" in result.output.lower()
 
 
 def test_main_diff_full_flag_returns_raw_diff(tmp_path):
@@ -1621,6 +1672,24 @@ def test_main_query_changes_reports_corrupt_snapshot(tmp_path):
 
     assert result.exit_code == 1
     assert "unreadable" in result.output
+
+
+def test_main_query_changes_rejects_a_snapshot_from_an_incompatible_schema_version(tmp_path):
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+    runner.invoke(app, ["scan", str(repo), "--no-check-vulnerabilities"])
+    runner.invoke(app, ["scan", str(repo), "--no-check-vulnerabilities"])
+
+    history_dir = repo / ".aletheore" / "history"
+    oldest = sorted(history_dir.glob("*.json"))[0]
+    stale = json.loads(oldest.read_text())
+    stale["aletheore_version"] = "9.9.9"
+    oldest.write_text(json.dumps(stale))
+
+    result = runner.invoke(app, ["query", "changes", "--path", str(repo)])
+
+    assert result.exit_code == 1
+    assert "re-run" in result.output.lower()
 
 
 def test_main_query_changes_shows_a_real_diff_between_two_scans(tmp_path):

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -3,7 +3,15 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from aletheore.evidence import EVIDENCE_VERSION, is_evidence_version_compatible, scan_repository, write_evidence
+from aletheore.evidence import (
+    EVIDENCE_VERSION,
+    IncompatibleEvidenceVersionError,
+    is_evidence_version_compatible,
+    load_evidence,
+    load_evidence_file,
+    scan_repository,
+    write_evidence,
+)
 
 
 def run(repo: Path, *args: str):
@@ -42,6 +50,53 @@ def test_is_evidence_version_compatible_rejects_missing_or_malformed_versions():
     assert is_evidence_version_compatible("") is False
     assert is_evidence_version_compatible("not-a-version") is False
     assert is_evidence_version_compatible(1) is False
+
+
+def test_load_evidence_file_returns_a_compatible_evidence_dict(tmp_path):
+    evidence_path = tmp_path / "air.json"
+    evidence_path.write_text(json.dumps({"aletheore_version": EVIDENCE_VERSION, "repository": {}}))
+
+    assert load_evidence_file(evidence_path)["repository"] == {}
+
+
+def test_load_evidence_file_rejects_an_incompatible_version(tmp_path):
+    evidence_path = tmp_path / "air.json"
+    evidence_path.write_text(json.dumps({"aletheore_version": "9.9.9", "repository": {}}))
+
+    try:
+        load_evidence_file(evidence_path)
+        assert False, "expected IncompatibleEvidenceVersionError"
+    except IncompatibleEvidenceVersionError as exc:
+        assert "9.9.9" in str(exc)
+        assert "re-run" in str(exc)
+
+
+def test_load_evidence_file_rejects_a_missing_version(tmp_path):
+    evidence_path = tmp_path / "air.json"
+    evidence_path.write_text(json.dumps({"repository": {}}))
+
+    try:
+        load_evidence_file(evidence_path)
+        assert False, "expected IncompatibleEvidenceVersionError"
+    except IncompatibleEvidenceVersionError:
+        pass
+
+
+def test_load_evidence_raises_file_not_found_when_repo_never_scanned(tmp_path):
+    try:
+        load_evidence(tmp_path)
+        assert False, "expected FileNotFoundError"
+    except FileNotFoundError as exc:
+        assert "aletheore scan" in str(exc)
+
+
+def test_load_evidence_reads_the_repos_own_air_json(tmp_path):
+    (tmp_path / ".aletheore").mkdir()
+    (tmp_path / ".aletheore" / "air.json").write_text(
+        json.dumps({"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}})
+    )
+
+    assert load_evidence(tmp_path)["repository"]["modules"] == []
 
 
 def test_scan_repository_produces_full_schema(tmp_path):


### PR DESCRIPTION
## Summary
M1 (#108) added `is_evidence_version_compatible` and wired it into the MCP server's `read_evidence`, but every CLI path that reads an air.json or snapshot directly still did a bare `json.loads` - a schema change between the aletheore build that wrote a file and the one reading it back could silently misread fields or KeyError deep in a consumer instead of failing with a clear "re-scan" message.

Fixed call sites:
- `aletheore query <kind>` (and `query changes`)
- `aletheore index`
- `aletheore diff`
- `aletheore healthcheck`
- `citation_verifier.load_verifiable_evidence` - backs both `aletheore verify` and the hosted managed-audit citation-verification section (`scan_worker/managed_audit.py`)

## Approach
- Added `load_evidence(repo_path)` / `load_evidence_file(evidence_path)` to `evidence.py` as the shared, version-checked read path; CLI call sites now go through these instead of raw `json.loads`.
- `citation_verifier.load_verifiable_evidence` already had a "return None when evidence isn't usable" contract (for the no-file-inventory case) - extended that same contract to cover an incompatible schema version rather than introducing a different failure mode.
- Left `mcp_server.py`'s existing `read_evidence`/`IncompatibleEvidenceVersionError` untouched (it already enforced this correctly and has its own caching wrapper) to keep the change scoped to what was actually missing.

## Test plan
- [x] New unit tests: `load_evidence_file`/`load_evidence` accept-compatible/reject-incompatible/reject-missing-version, `load_verifiable_evidence` rejects an incompatible version
- [x] New CLI integration tests: `query`, `index`, `diff`, `healthcheck`, and `query changes` all exit 1 with a "re-run ... to refresh it" message when handed evidence stamped with an incompatible version
- [x] Updated existing hand-built evidence fixtures (`test_cli.py`, `test_citation_verifier.py`, `test_managed_audit.py`) to stamp the current `EVIDENCE_VERSION`, since they now flow through the new check
- [x] Full `src` suite: 873 passed (was 862 before this branch; +11 new tests, 0 regressions)
- [x] Full `github-app` suite: 468 passed, 320 skipped, 3 pre-existing errors (no local test Postgres) - unchanged baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)