### PR TITLE
fix(github-app): catch the exception psycopg actually raises when test Postgres is unavailable

### DIFF
--- a/github-app/tests/test_migrate.py
+++ b/github-app/tests/test_migrate.py
@@ -31,7 +31,7 @@ def fresh_database():
             with conn.cursor() as cur:
                 cur.execute(f"DROP DATABASE IF EXISTS {db_name}")
                 cur.execute(f"CREATE DATABASE {db_name}")
-    except OSError as exc:
+    except (OSError, psycopg.OperationalError) as exc:
         pytest.skip(f"test Postgres unavailable: {exc}")
 
     yield _dsn_for(db_name)


### PR DESCRIPTION
## Summary
`test_migrate.py`'s `fresh_database` fixture wraps its connection attempt in `except OSError` to skip cleanly when no local test Postgres is running. `psycopg.OperationalError` (raised on connection refused) does not inherit from `OSError` (`psycopg.OperationalError` -> `psycopg.DatabaseError` -> `psycopg.Error` -> `Exception`), so the except clause never triggered - the three migration tests errored out instead of skipping, which is what every prior audit run against this repo has been observing as "3 pre-existing errors" without a test Postgres available.

## Fix
Catch `(OSError, psycopg.OperationalError)` instead of just `OSError`.

## Test plan
- [x] With no local test Postgres running: all three tests now skip cleanly with "test Postgres unavailable: ..." instead of erroring
- [x] Full `github-app` suite: 468 passed, 323 skipped, **0 errors** (previously 468 passed, 320 skipped, 3 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)