### PR TITLE
docs: fix MCP tool-count/deployment-verification drift

### DIFF
--- a/docs/operations/DEPLOYMENT-VERIFICATION.md
+++ b/docs/operations/DEPLOYMENT-VERIFICATION.md
@@ -5,6 +5,7 @@
 **Owner:** Arihant Kaul
 **Related Documents:** [README.md](README.md), [INCIDENT-RESPONSE.md](INCIDENT-RESPONSE.md), [../../github-app/README.md](../../github-app/README.md)
 **Last Updated:** 2026-07-23
+**Snapshot Freshness:** STALE as of 2026-08-04 - the recorded commit is 39 merged PRs behind `master` (verified via `git log ad4f3cdf..HEAD`). Do not treat the snapshot section as current; re-run the Required Checks below before citing any of it as live state.
 
 ## Purpose
 

--- a/website/developers.html
+++ b/website/developers.html
@@ -176,9 +176,10 @@ aletheore dashboard .</code></pre>
           <span>aletheore_healthcheck</span>
           <span>aletheore_index</span>
           <span>aletheore_search_codebase</span>
-          <span>aletheore_answer</span>
+          <span class="optional" title="Only registered when the MCP server is started with --agent">aletheore_answer*</span>
           <span>aletheore_managed_audit</span>
         </div>
+        <p class="mcp-tool-note">28 tools are always available. <code>aletheore_answer</code>* is registered only when the server is started with <code>--agent</code>.</p>
       </section>
 
       <section class="developer-section evidence-contract">

--- a/website/styles.css
+++ b/website/styles.css
@@ -733,6 +733,17 @@ pre {
   padding: 18px;
 }
 
+.mcp-tool-list span.optional {
+  border-style: dashed;
+  opacity: 0.85;
+}
+
+.mcp-tool-note {
+  margin-top: 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
 .evidence-contract {
   display: grid;
   grid-template-columns: minmax(0, 0.7fr) minmax(0, 1fr);


### PR DESCRIPTION
## Summary
Two Low-severity docs-drift findings from the audit:

1. **`website/developers.html`** listed all 29 MCP tools in one undifferentiated grid, while `src/README.md` explicitly documents `aletheore_answer` as optional (only registered when the MCP server is started with `--agent` - confirmed in `mcp_server.py`'s `build_server`/`_register_answer_tool`, which only wires it in when an `answer_adapter` is passed). A developer skimming the website would assume all 29 are always available. Marked the tile as optional (dashed border + tooltip) and added a one-line note matching the README's framing.
2. **`docs/operations/DEPLOYMENT-VERIFICATION.md`**'s snapshot (commit `ad4f3cdf`, 2026-07-23) is now 39 merged PRs behind `master` (`git log ad4f3cdf..HEAD | grep -cE '\(#[0-9]+\)$'`). Added an explicit "STALE" freshness marker above the snapshot so it can't be cited as current without re-running the Required Checks.

Re-running the actual checks against the production host requires SSH access this session doesn't have - the marker documents that the snapshot is stale rather than fabricating a fresh one.

## Test plan
- [x] `<div>` tag balance check on `developers.html` - unchanged (27/27)
- [x] CSS brace balance check on `styles.css` - balanced
- [x] Verified the 28/29 count against `mcp_server.py`: 16 dynamic query-wrapper tools + 12 always-registered explicit tools = 28, + optional `aletheore_answer` = 29

🤖 Generated with [Claude Code](https://claude.com/claude-code)