### PR TITLE
release: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Notable changes to Aletheore, by release. The working code lives in `src/` — s
   a deletion-only hunk's collapsed boundary was rejected before its content could be checked,
   silently turning a true positive into "No issues found."
 - Fixed Flash Review repeating the same zero-grounded-findings message twice in one comment.
+- Fixed `mcp-install` writing the bare command name `"aletheore"` into every coding-tool config
+  instead of an absolute path — silently broken whenever the launching tool's subprocess PATH
+  doesn't include wherever `aletheore` was actually installed (the common case for a
+  pip-installed-in-a-venv install launched by a GUI coding tool). Now resolves to the exact
+  install that ran `mcp-install`.
 - Three hosted-audit hardening fixes: a fail-closed collaborator permission check before running a
   triggered audit, credential stripping on reused checkouts, and Docker socket isolation via a
   narrow-purpose sidecar (verified live against production).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 Notable changes to Aletheore, by release. The working code lives in `src/` — see
 [`src/README.md`](src/README.md) for the full command reference.
 
+## 0.7.1 — 2026-08-07
+
+- Closed 3 known vulnerabilities (PYSEC-2026-3552/3553/3554) by bumping the `cryptography`
+  dependency.
+- Round-1 hardening from the internal audit report: local `aletheore audit` now runs the same
+  citation-verification path as the hosted managed audit (previously duplicated, now shared via
+  `aletheore.citation_verifier`); the git-history secret scan is now watchdog-bounded against
+  multi-minute hangs on large histories; a report is now clearly marked when it falls back to raw
+  agent output instead of silently presenting it as contract-compliant; a secret finding now
+  requires real value-shape evidence (entropy + placeholder markers), not just file path, before
+  being downgraded to a likely placeholder; production dependencies now have pinned upper bounds
+  and are split from test-only deps.
+- Enforced evidence schema-version compatibility on every CLI read path
+  (query/index/diff/healthcheck/verify), not just the MCP server — closing the gap left by the
+  same fix landing MCP-only in 0.7.0.
+- Fixed Flash Review discarding real findings about **deleted code**: a citation landing just past
+  a deletion-only hunk's collapsed boundary was rejected before its content could be checked,
+  silently turning a true positive into "No issues found."
+- Fixed Flash Review repeating the same zero-grounded-findings message twice in one comment.
+- Three hosted-audit hardening fixes: a fail-closed collaborator permission check before running a
+  triggered audit, credential stripping on reused checkouts, and Docker socket isolation via a
+  narrow-purpose sidecar (verified live against production).
+- Reworked the AIRview diagram zoom into a real pan/zoom toolbar, and polished the hosted
+  dashboard, pricing, and developers pages.
+- Routine dependency updates: GitHub Actions runners, `rq`, `psycopg`, `tree-sitter`, `typer`,
+  `pytest`, `pytest-asyncio`, `cspell`, `prettier`, `markdownlint-cli2`.
+
 ## 0.7.0 — 2026-07-31
 
 - Added **Regression Fencing**: flags a changed function signature when a real caller wasn't

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ PHP, C, C++, and C#**.
   `audit`.
 
 ```yaml
-- uses: Aletheore/Aletheore@v0.7.0
+- uses: Aletheore/Aletheore@v0.7.1
   with:
     fail-on-new-secrets: true
 ```

--- a/cspell.json
+++ b/cspell.json
@@ -102,6 +102,7 @@
     "tree-sitter",
     "unrecovered",
     "uvicorn",
+    "venv",
     "vport",
     "werkzeug",
     "worktree",

--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "Aletheore",
     "AIRview",
     "Arihant",
+    "asyncio",
     "BYOK",
     "CODEOWNERS",
     "DeepSeek",

--- a/src/README.md
+++ b/src/README.md
@@ -546,7 +546,7 @@ It only ever calls `aletheore scan` and `aletheore diff`, matching the reasoning
 something fast and deterministic, not a full agent-driven audit.
 
 ```yaml
-- uses: Aletheore/Aletheore@v0.6.0    # pin to a tagged release, not @master
+- uses: Aletheore/Aletheore@v0.7.1    # pin to a tagged release, not @master
   with:
     fail-on-new-secrets: true              # exit 1 if a new real (non-placeholder) secret appears
     fail-on-new-vulnerabilities: true      # exit 1 if a new dependency vulnerability appears

--- a/src/README.md
+++ b/src/README.md
@@ -16,8 +16,6 @@ This is the real, working CLI package — the same code that runs in CI (a real 
 1,600+ tests across this package and the hosted service) and in production behind the hosted
 GitHub App (see `../github-app/`). Full project overview: [`../README.md`](../README.md).
 
-## What this is
-
 ## Quickstart
 
 ```bash

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import socket
 import sys
 import threading
@@ -758,15 +759,40 @@ def _mcp(repo_path: str, forced_agent: str | None = None) -> int:
     return 0
 
 
+def _aletheore_command() -> str:
+    # A bare "aletheore" only resolves if the launching process inherits the
+    # same PATH the install happened under - true for a terminal-launched
+    # coding tool, false for most GUI-launched ones (they don't source
+    # .zshrc/.bashrc, so a pip-installed-in-a-venv or pipx-installed
+    # aletheore silently isn't on PATH from the tool's point of view, and
+    # the MCP server fails to start with no explanation). Writing the
+    # already-resolved absolute path removes that dependency entirely.
+    #
+    # Prefer the console script sitting next to *this exact* interpreter
+    # (sys.executable) over a bare shutil.which() PATH search: which()
+    # returns whatever "aletheore" resolves to on the current PATH, which
+    # can be a different install than the one actually running this
+    # command right now (e.g. this venv's binary invoked by absolute path
+    # without activating the venv first, while some other aletheore sits
+    # earlier on PATH) - sys.executable is never ambiguous like that.
+    # Falls back to a PATH search, then the bare name, only if neither
+    # resolves - preserving today's behavior rather than writing something
+    # obviously broken.
+    sibling = Path(sys.executable).parent / "aletheore"
+    if sibling.exists():
+        return str(sibling)
+    return shutil.which("aletheore") or "aletheore"
+
+
 def _stdio_entry(repo_path: Path, include_type: bool) -> dict:
-    entry: dict = {"command": "aletheore", "args": ["mcp", str(repo_path)]}
+    entry: dict = {"command": _aletheore_command(), "args": ["mcp", str(repo_path)]}
     if include_type:
         entry = {"type": "stdio", **entry}
     return entry
 
 
 def _opencode_entry(repo_path: Path) -> dict:
-    return {"type": "local", "command": ["aletheore", "mcp", str(repo_path)], "enabled": True}
+    return {"type": "local", "command": [_aletheore_command(), "mcp", str(repo_path)], "enabled": True}
 
 
 _MCP_CLIENT_CONFIGS: dict[str, tuple[str, str, Callable[[Path], dict]]] = {
@@ -841,7 +867,7 @@ def _mcp_install(path: str, targets: list[str]) -> int:
     for target in selected:
         if target == "codex-cli":
             config_path = repo_path / ".codex" / "config.toml"
-            entry = {"command": "aletheore", "args": ["mcp", str(repo_path)]}
+            entry = {"command": _aletheore_command(), "args": ["mcp", str(repo_path)]}
             message = _write_toml_mcp_client_config(config_path, "mcp_servers", entry)
         else:
             relative_path, top_level_key, entry_builder = _MCP_CLIENT_CONFIGS[target]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aletheore"
-version = "0.7.0"
+version = "0.7.1"
 description = "Evidence-grounded repository audit CLI: deterministic scanner, MCP server, live dashboard, and a GitHub Action that posts PR diffs."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -11,6 +11,7 @@ import pytest
 from typer.testing import CliRunner
 
 from aletheore.cli import (
+    _aletheore_command,
     _ElapsedTicker,
     _MCP_CLIENT_CONFIGS,
     _make_progress_printer,
@@ -176,7 +177,45 @@ def test_mcp_client_configs_cover_the_five_json_targets():
     assert set(_MCP_CLIENT_CONFIGS.keys()) == {"claude-code", "cursor", "vscode", "kiro", "opencode"}
 
 
-def test_stdio_entry_includes_type_only_when_asked():
+def _no_command_resolvable(monkeypatch, tmp_path):
+    # Point sys.executable at a directory with no "aletheore" sibling, and
+    # make a PATH search fail too, so _aletheore_command() genuinely falls
+    # through both resolution strategies to the bare-name fallback -
+    # otherwise this venv's own real, installed aletheore (sitting right
+    # next to the real sys.executable running these tests) would resolve
+    # first and shadow whatever a test is trying to isolate.
+    monkeypatch.setattr("aletheore.cli.sys.executable", str(tmp_path / "python3"))
+    monkeypatch.setattr("aletheore.cli.shutil.which", lambda cmd: None)
+
+
+def test_aletheore_command_prefers_the_sibling_of_the_running_interpreter(monkeypatch, tmp_path):
+    interpreter_dir = tmp_path / "venv" / "bin"
+    interpreter_dir.mkdir(parents=True)
+    (interpreter_dir / "aletheore").write_text("#!/bin/sh\n")
+    monkeypatch.setattr("aletheore.cli.sys.executable", str(interpreter_dir / "python3"))
+    # A which() hit that disagrees with the interpreter sibling must lose -
+    # this is exactly the scenario the sibling-first order exists to avoid.
+    monkeypatch.setattr("aletheore.cli.shutil.which", lambda cmd: "/some/other/aletheore")
+
+    assert _aletheore_command() == str(interpreter_dir / "aletheore")
+
+
+def test_aletheore_command_falls_back_to_path_search_when_no_sibling(monkeypatch, tmp_path):
+    monkeypatch.setattr("aletheore.cli.sys.executable", str(tmp_path / "python3"))
+    monkeypatch.setattr("aletheore.cli.shutil.which", lambda cmd: "/usr/local/bin/aletheore")
+
+    assert _aletheore_command() == "/usr/local/bin/aletheore"
+
+
+def test_aletheore_command_falls_back_to_bare_name_when_not_resolvable(monkeypatch, tmp_path):
+    _no_command_resolvable(monkeypatch, tmp_path)
+
+    assert _aletheore_command() == "aletheore"
+
+
+def test_stdio_entry_includes_type_only_when_asked(monkeypatch, tmp_path):
+    _no_command_resolvable(monkeypatch, tmp_path)
+
     entry_with_type = _stdio_entry(Path("/repo"), include_type=True)
     entry_without_type = _stdio_entry(Path("/repo"), include_type=False)
 
@@ -184,7 +223,18 @@ def test_stdio_entry_includes_type_only_when_asked():
     assert entry_without_type == {"command": "aletheore", "args": ["mcp", "/repo"]}
 
 
-def test_opencode_entry_uses_single_command_array_not_command_plus_args():
+def test_stdio_entry_writes_resolved_absolute_path_when_found(monkeypatch, tmp_path):
+    monkeypatch.setattr("aletheore.cli.sys.executable", str(tmp_path / "python3"))
+    monkeypatch.setattr("aletheore.cli.shutil.which", lambda cmd: "/usr/local/bin/aletheore")
+
+    entry = _stdio_entry(Path("/repo"), include_type=False)
+
+    assert entry == {"command": "/usr/local/bin/aletheore", "args": ["mcp", "/repo"]}
+
+
+def test_opencode_entry_uses_single_command_array_not_command_plus_args(monkeypatch, tmp_path):
+    _no_command_resolvable(monkeypatch, tmp_path)
+
     entry = _opencode_entry(Path("/repo"))
 
     assert entry == {"type": "local", "command": ["aletheore", "mcp", "/repo"], "enabled": True}
@@ -363,22 +413,41 @@ def test_mcp_install_written_entry_points_at_the_resolved_repo_path(tmp_path):
     assert entry["args"] == ["mcp", str(tmp_path.resolve())]
 
 
-def test_mcp_install_opencode_entry_uses_command_array(tmp_path):
-    runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "opencode"])
+def test_mcp_install_opencode_entry_uses_command_array(tmp_path, monkeypatch):
+    install_target = tmp_path / "install-target"
+    install_target.mkdir()
+    _no_command_resolvable(monkeypatch, tmp_path)
+    runner.invoke(app, ["mcp-install", str(install_target), "--target", "opencode"])
 
-    entry = json.loads((tmp_path / "opencode.json").read_text())["mcp"]["aletheore"]
-    assert entry["command"] == ["aletheore", "mcp", str(tmp_path.resolve())]
+    entry = json.loads((install_target / "opencode.json").read_text())["mcp"]["aletheore"]
+    assert entry["command"] == ["aletheore", "mcp", str(install_target.resolve())]
     assert "args" not in entry
 
 
-def test_mcp_install_writes_codex_cli_target(tmp_path):
-    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "codex-cli"])
+def test_mcp_install_writes_codex_cli_target(tmp_path, monkeypatch):
+    install_target = tmp_path / "install-target"
+    install_target.mkdir()
+    _no_command_resolvable(monkeypatch, tmp_path)
+    result = runner.invoke(app, ["mcp-install", str(install_target), "--target", "codex-cli"])
 
     assert result.exit_code == 0
-    config_path = tmp_path / ".codex" / "config.toml"
+    config_path = install_target / ".codex" / "config.toml"
     assert config_path.exists()
     entry = tomllib.loads(config_path.read_text())["mcp_servers"]["aletheore"]
-    assert entry == {"command": "aletheore", "args": ["mcp", str(tmp_path.resolve())]}
+    assert entry == {"command": "aletheore", "args": ["mcp", str(install_target.resolve())]}
+
+
+def test_mcp_install_writes_resolved_absolute_path_when_aletheore_is_on_path(tmp_path, monkeypatch):
+    install_target = tmp_path / "install-target"
+    install_target.mkdir()
+    monkeypatch.setattr("aletheore.cli.sys.executable", str(tmp_path / "python3"))
+    monkeypatch.setattr("aletheore.cli.shutil.which", lambda cmd: "/opt/venv/bin/aletheore")
+
+    result = runner.invoke(app, ["mcp-install", str(install_target), "--target", "claude-code"])
+
+    assert result.exit_code == 0
+    entry = json.loads((install_target / ".mcp.json").read_text())["mcpServers"]["aletheore"]
+    assert entry["command"] == "/opt/venv/bin/aletheore"
 
 
 def test_mcp_install_is_idempotent_and_does_not_duplicate_entries(tmp_path):


### PR DESCRIPTION
## Summary
Patch release covering everything merged since v0.7.0 (2026-07-31): a security fix, a full audit-hardening round, real Flash Review bug fixes, CLI schema-version enforcement, dashboard polish, and dependency updates. Full detail in CHANGELOG.md.

## Test plan
- [x] Local `src` + `github-app` suites pass (verified throughout the individual PRs this bundles)
- [x] CI will re-verify on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)