### PR TITLE
fix(dashboard): stop leaking raw Paddle errors, explain API tokens, fix empty-label no-op

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -350,7 +350,20 @@ async def buy_extra_seat(org: str, repo: str, request: Request):
         items = _build_updated_seat_items(subscription.get("items", []), delta=1)
         update_paddle_subscription_items(settings.paddle_api_key, subscription_id, items, "prorated_immediately")
     except PaddleAPIError as exc:
-        raise HTTPException(status_code=502, detail=f"could not update billing: {exc}") from exc
+        # exc's message includes the raw Paddle response (URL, status code,
+        # docs link) - useful in a log, not something to hand an end user
+        # verbatim. Logged with the installation for whoever's debugging;
+        # the customer gets a message that tells them what to do next.
+        logger.error(
+            "seat purchase failed for installation %s (subscription %s): %s",
+            installation["installation_id"],
+            subscription_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Could not update billing right now - please try again, or contact support if this keeps happening.",
+        ) from exc
 
     # extra_seats itself is reconciled from the resulting subscription.updated
     # webhook, not set optimistically here - same pattern installations.plan
@@ -373,7 +386,16 @@ async def remove_extra_seat(org: str, repo: str, request: Request):
             raise HTTPException(status_code=409, detail="no extra seats to remove")
         update_paddle_subscription_items(settings.paddle_api_key, subscription_id, items, "prorated_immediately")
     except PaddleAPIError as exc:
-        raise HTTPException(status_code=502, detail=f"could not update billing: {exc}") from exc
+        logger.error(
+            "seat removal failed for installation %s (subscription %s): %s",
+            installation["installation_id"],
+            subscription_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Could not update billing right now - please try again, or contact support if this keeps happening.",
+        ) from exc
 
     return {"ok": True}
 

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1441,8 +1441,8 @@ async function addMember() {{
 async function generateToken() {{
   const input = document.getElementById('new-token-label');
   const label = input.value.trim();
-  if (!label) return;
   const out = document.getElementById('token-reveal');
+  if (!label) {{ out.innerHTML = '<div class="error-banner">Give the token a label first.</div>'; input.focus(); return; }}
   const res = await fetch(adminBase + '/tokens', {{
     method: 'POST', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify({{ label: label }}),
   }});
@@ -1551,6 +1551,7 @@ async function loadSettings() {{
           '<div class="form-row"><input class="field" id="new-token-label" placeholder="Token label, e.g. CI pipeline">' +
           '<button class="btn" onclick="generateToken()">Generate</button></div>' +
           '<div id="token-reveal"></div>' +
+          '<div class="settings-block-hint">Used to authenticate the CLI (<code>aletheore login</code> or <code>ALETHEORE_API_TOKEN</code>) and the MCP server\\'s <code>aletheore_managed_audit</code> tool against this installation\\'s hosted managed audits, and to send runtime events from your app into Aletheore. Give each token a label so you can tell them apart later, and revoke one any time without affecting the others.</div>' +
         '</div>' +
       '</div>' +
       '<div>' +

--- a/github-app/tests/test_frontend_js_syntax.py
+++ b/github-app/tests/test_frontend_js_syntax.py
@@ -15,7 +15,7 @@ from app_server import frontend
 # Python happily accepts it - the bug only shows up as broken JavaScript in
 # a real browser. Real bug, caught this way once already: see the commit
 # that added this test.
-_SCRIPT_BLOCK = re.compile(r"<script>(.*?)</script>", re.DOTALL)
+_SCRIPT_BLOCK = re.compile(r"<script>(.*?)</script>", re.DOTALL | re.IGNORECASE)
 
 _PAGE_CONSTANTS = [
     name

--- a/github-app/tests/test_frontend_js_syntax.py
+++ b/github-app/tests/test_frontend_js_syntax.py
@@ -1,0 +1,43 @@
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from app_server import frontend
+
+# Every dashboard page is a Python string constant with an embedded <script>
+# block, built out of ordinary '...' + '...' JavaScript string concatenation
+# - which means an apostrophe inside that JS text (a contraction, a
+# possessive) needs escaping at the JS level, not the Python one, since
+# these constants are plain triple-quoted Python strings, not raw strings.
+# Get that escaping wrong (one backslash instead of two, or vice versa) and
+# Python happily accepts it - the bug only shows up as broken JavaScript in
+# a real browser. Real bug, caught this way once already: see the commit
+# that added this test.
+_SCRIPT_BLOCK = re.compile(r"<script>(.*?)</script>", re.DOTALL)
+
+_PAGE_CONSTANTS = [
+    name
+    for name in dir(frontend)
+    if name.endswith("_HTML") and isinstance(getattr(frontend, name), str)
+]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available in this environment")
+@pytest.mark.parametrize("page_constant", _PAGE_CONSTANTS)
+def test_embedded_script_blocks_are_valid_javascript(page_constant, tmp_path):
+    html = getattr(frontend, page_constant)
+    scripts = _SCRIPT_BLOCK.findall(html)
+    if not scripts:
+        pytest.skip(f"{page_constant} has no <script> block")
+
+    for i, script in enumerate(scripts):
+        js_file = tmp_path / f"{page_constant}_{i}.js"
+        js_file.write_text(script)
+        result = subprocess.run(
+            ["node", "--check", str(js_file)], capture_output=True, text=True
+        )
+        assert result.returncode == 0, (
+            f"{page_constant}'s script block {i} is not valid JavaScript:\n{result.stderr}"
+        )


### PR DESCRIPTION
## Summary
Three real bugs found live on the Settings page:
- Buying/removing an extra seat leaked the raw internal `PaddleAPIError` text (URL, HTTP status, docs link) straight into the UI on failure. Now logs the real error server-side, returns a clean generic message.
- The API tokens section had zero explanation of what the tokens are actually for. Added a hint (CLI login/`ALETHEORE_API_TOKEN`, MCP `aletheore_managed_audit`, runtime event ingestion).
- `generateToken()` silently no-op'd with no feedback when the label field was empty. Now shows an inline error and focuses the field.

Also adds `test_frontend_js_syntax.py`, which runs `node --check` against every `<script>` block emitted by every dashboard page - added after catching a real self-inflicted JS-escaping bug while writing the API-tokens hint (embedded JS text inside a Python triple-quoted string needs the backslash escaped at the JS level *and* survive Python's own string parser, easy to get wrong, previously had zero automated coverage).

## Test plan
- [x] `github-app` suite: 475 passed (was 468), 0 regressions
- [x] Verified the seat-purchase code path and both configured Paddle price IDs are correct/live against the real API - the specific failure is stale billing data on one internal dogfooding installation, not a code bug (left as-is per instruction)
- [x] Verified the new JS-syntax test actually catches the escaping bug class by reproducing it standalone before fixing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)