### PR TITLE
Offload blocking GitHub API calls off the single event loop

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -129,7 +129,7 @@ async def _repo_installation_id(pool, org: str, repo: str) -> int:
     return row["installation_id"]
 
 
-async def _administered_installation_ids(github_token: str) -> set[int]:
+def _fetch_administered_installation_ids(github_token: str) -> set[int]:
     response = _github_http_client().get(
         "/user/installations",
         headers={
@@ -139,6 +139,14 @@ async def _administered_installation_ids(github_token: str) -> set[int]:
     )
     response.raise_for_status()
     return {item["id"] for item in response.json().get("installations", [])}
+
+
+async def _administered_installation_ids(github_token: str) -> set[int]:
+    # This gates nearly every admin/dashboard route via
+    # _require_admin_installation - run off the event loop via
+    # asyncio.to_thread so one slow GitHub API round-trip can't stall
+    # every other in-flight request on this single-worker server.
+    return await asyncio.to_thread(_fetch_administered_installation_ids, github_token)
 
 
 async def _administered_installation_ids_or_401(github_token: str) -> set[int]:

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -61,6 +62,19 @@ def find_stale_endpoints(
     return stale
 
 
+def _fetch_uninitialized_repos_sync(installation_id: int, app_jwt: str) -> list[dict]:
+    token = get_installation_token(installation_id, app_jwt)
+    response = _github_http_client().get(
+        "/installation/repositories",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response.raise_for_status()
+    return response.json().get("repositories", [])
+
+
 async def _uninitialized_repos_for_installation(
     installation_id: int, plan: str, already_known: set[str], scan_limit_reached: bool = False
 ) -> list[dict]:
@@ -84,20 +98,14 @@ async def _uninitialized_repos_for_installation(
     try:
         settings = get_settings()
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
-        token = await get_installation_token(installation_id, app_jwt)
-        response = _github_http_client().get(
-            "/installation/repositories",
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
-            },
+        repositories = await asyncio.to_thread(
+            _fetch_uninitialized_repos_sync, installation_id, app_jwt
         )
-        response.raise_for_status()
     except Exception:
         return []
 
     result = []
-    for repo in response.json().get("repositories", []):
+    for repo in repositories:
         full_name = repo["full_name"]
         if full_name in already_known:
             continue

--- a/github-app/app_server/github_auth.py
+++ b/github-app/app_server/github_auth.py
@@ -14,7 +14,7 @@ def generate_app_jwt(app_id: str, private_key_pem: str) -> str:
     return jwt.encode(payload, private_key_pem, algorithm="RS256")
 
 
-async def get_installation_token(
+def get_installation_token(
     installation_id: int,
     app_jwt: str,
     http_client: httpx.Client | None = None,

--- a/github-app/app_server/webhooks/installation.py
+++ b/github-app/app_server/webhooks/installation.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import httpx
@@ -9,10 +10,8 @@ from app_server.github_auth import generate_app_jwt, get_installation_token
 logger = logging.getLogger(__name__)
 
 
-async def _fetch_all_installation_repo_full_names(installation_id: int) -> list[str]:
-    settings = get_settings()
-    app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
-    token = await get_installation_token(installation_id, app_jwt)
+def _fetch_installation_repos_sync(installation_id: int, app_jwt: str) -> list[str]:
+    token = get_installation_token(installation_id, app_jwt)
     response = httpx.Client(base_url="https://api.github.com").get(
         "/installation/repositories",
         headers={
@@ -22,6 +21,12 @@ async def _fetch_all_installation_repo_full_names(installation_id: int) -> list[
     )
     response.raise_for_status()
     return [repo["full_name"] for repo in response.json().get("repositories", [])]
+
+
+async def _fetch_all_installation_repo_full_names(installation_id: int) -> list[str]:
+    settings = get_settings()
+    app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+    return await asyncio.to_thread(_fetch_installation_repos_sync, installation_id, app_jwt)
 
 
 async def handle_installation_event(

--- a/github-app/app_server/webhooks/issue_comment.py
+++ b/github-app/app_server/webhooks/issue_comment.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from app_server.config import get_settings
@@ -12,6 +13,13 @@ AUDIT_COMMAND = "/aletheore audit"
 # exactly the set of people an outside PR commenter represents, which is
 # who this check exists to stop.
 AUTHORIZED_PERMISSIONS = ("admin", "write")
+
+
+def _verify_commenter_permission_sync(
+    installation_id: int, app_jwt: str, repo_full_name: str, commenter: str
+) -> str:
+    token = get_installation_token(installation_id, app_jwt)
+    return get_repo_permission_for_user(repo_full_name, commenter, token)
 
 
 async def handle_issue_comment_event(payload: dict, redis_url: str, queue=None) -> None:
@@ -29,8 +37,9 @@ async def handle_issue_comment_event(payload: dict, redis_url: str, queue=None) 
     settings = get_settings()
     try:
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
-        token = await get_installation_token(installation_id, app_jwt)
-        permission = get_repo_permission_for_user(repo_full_name, commenter, token)
+        permission = await asyncio.to_thread(
+            _verify_commenter_permission_sync, installation_id, app_jwt, repo_full_name, commenter
+        )
     except Exception:
         # Fail closed: an API hiccup here should silently drop a legitimate
         # trigger (the maintainer can just comment again), not let an

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -217,7 +217,7 @@ async def test_list_my_repos_includes_uninitialized_repos_with_no_scan_yet(pool,
 
     monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
 
-    async def fake_get_installation_token(installation_id, app_jwt, http_client=None):
+    def fake_get_installation_token(installation_id, app_jwt, http_client=None):
         return "fake-installation-token"
 
     monkeypatch.setattr("app_server.dashboard.get_installation_token", fake_get_installation_token)
@@ -279,7 +279,7 @@ async def test_list_my_repos_flags_uninitialized_repos_when_monthly_scan_cap_rea
 
     monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
 
-    async def fake_get_installation_token(installation_id, app_jwt, http_client=None):
+    def fake_get_installation_token(installation_id, app_jwt, http_client=None):
         return "fake-installation-token"
 
     monkeypatch.setattr("app_server.dashboard.get_installation_token", fake_get_installation_token)
@@ -339,7 +339,7 @@ async def test_list_my_repos_does_not_duplicate_already_scanned_repos(pool, monk
 
     monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
 
-    async def fake_get_installation_token(installation_id, app_jwt, http_client=None):
+    def fake_get_installation_token(installation_id, app_jwt, http_client=None):
         return "fake-installation-token"
 
     monkeypatch.setattr("app_server.dashboard.get_installation_token", fake_get_installation_token)
@@ -396,7 +396,7 @@ async def test_list_my_repos_ignores_github_failure_when_fetching_uninitialized_
 
     monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
 
-    async def fake_get_installation_token(installation_id, app_jwt, http_client=None):
+    def fake_get_installation_token(installation_id, app_jwt, http_client=None):
         raise httpx.HTTPStatusError(
             "boom",
             request=httpx.Request("POST", "https://api.github.com/x"),

--- a/github-app/tests/test_github_auth.py
+++ b/github-app/tests/test_github_auth.py
@@ -1,6 +1,5 @@
 import httpx
 import jwt
-import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -32,8 +31,7 @@ def test_generated_jwt_is_verifiable_with_public_key():
     assert decoded["iss"] == "12345"
 
 
-@pytest.mark.asyncio
-async def test_get_installation_token_returns_token_from_response():
+def test_get_installation_token_returns_token_from_response():
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/app/installations/999/access_tokens"
         assert request.headers["Authorization"] == "Bearer fake-jwt"
@@ -43,5 +41,5 @@ async def test_get_installation_token_returns_token_from_response():
         )
 
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
-    token = await get_installation_token(999, "fake-jwt", http_client=client)
+    token = get_installation_token(999, "fake-jwt", http_client=client)
     assert token == "ghs_faketoken123"

--- a/github-app/tests/test_issue_comment_webhook.py
+++ b/github-app/tests/test_issue_comment_webhook.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,7 +23,7 @@ def _mock_permission_check(monkeypatch, permission: str | None, raises: bool = F
         "app_server.webhooks.issue_comment.generate_app_jwt", lambda *a, **k: "fake-jwt"
     )
     monkeypatch.setattr(
-        "app_server.webhooks.issue_comment.get_installation_token", AsyncMock(return_value="fake-token")
+        "app_server.webhooks.issue_comment.get_installation_token", MagicMock(return_value="fake-token")
     )
     if raises:
 


### PR DESCRIPTION
## Summary
- `app-server` runs as a single uvicorn process with no `--workers` flag, so a synchronous `httpx.Client` call inside an `async def` route handler blocks the entire server for the round-trip duration - every other in-flight request (including a trivial `GET /`) queues behind it until it finishes.
- This is the root cause of Link Check's intermittent timeouts against `app.aletheore.com` in CI: real dashboard/webhook traffic occasionally lines up with the lychee probe while one of these blocking calls is in flight.
- Fixes the four remaining call sites with this pattern (an earlier pass already fixed `auth.py` correctly):
  - `admin.py`: `_administered_installation_ids`, which gates nearly every admin/dashboard route via `_require_admin_installation`
  - `dashboard.py`: the "Your repositories" enrichment, which made *two* sequential blocking GitHub calls on ordinary dashboard loads
  - `webhooks/installation.py`: fired on every installation webhook delivery
  - `webhooks/issue_comment.py`: fired on every issue-comment webhook delivery
- `github_auth.py`'s `get_installation_token` was `async def` but its body was always synchronous - changed to a plain `def`, matching its sibling functions in the same file, with each call site's actual work now wrapped in `asyncio.to_thread`, same pattern already proven correct in `auth.py`.

## Test plan
- [x] Targeted tests for all 4 touched files: 122 passed
- [x] Full `github-app` suite: 830 passed, 8 pre-existing skips, 0 failures (real test Postgres/Redis)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)