### PR TITLE
Surface partial-failure status in the Docs dashboard UI

### DIFF
--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1425,6 +1425,13 @@ async function loadDocs() {{
     staleBanner = '<div class="empty-state" style="color:var(--critical);margin-bottom:12px;">' +
       'The latest Docs update failed' + (data.build_error ? ': ' + escapeHtml(data.build_error) : '.') +
       ' Showing the last successful build below - it may be stale.</div>';
+  }} else if (data.build_error) {{
+    // A "ready" status with a build_error means a partial run: some files
+    // got documented, others didn't (a transient API error, mid-run). The
+    // ones below are real and current - this just says the rest is coming.
+    staleBanner = '<div class="empty-state" style="color:var(--warning);margin-bottom:12px;">' +
+      'The latest Docs update didn\\'t finish everything: ' + escapeHtml(data.build_error) +
+      ' It will pick up automatically on the next run.</div>';
   }}
   body.innerHTML = staleBanner;
   const list = document.createElement('div');


### PR DESCRIPTION
## Summary
- `docs_build_status` can be `"ready"` with a non-null `error_message` after a partial run (some files documented, others failed transiently) - the per-module resilience and 48h catch-up sweep already handle this correctly server-side, and the API route already returns `build_error` alongside a `"ready"` `build_status`, but the dashboard JS only ever checked `build_status === 'failed'`, so a partial failure was completely invisible to the customer.
- Adds a distinct warning-tier banner (amber `var(--warning)`, not the red `var(--critical)` used for a full build failure) shown whenever `build_error` is set but the build didn't outright fail. The already-documented modules render normally below it - they're real and current, this just says the rest is coming on the next run.
- No backend changes needed - `dashboard.py`'s `get_dashboard_docs` route already returns the right data; this is purely the missing frontend branch.

## Test plan
- [x] `test_frontend_js_syntax.py`: `DOCS_HTML`'s embedded script block still passes real `node --check`
- [x] Full `github-app` suite: 830 passed, 8 pre-existing skips, 0 failures
- [x] Rendered the real `DOCS_HTML` output with a mocked partial-failure API response in a browser and visually confirmed the correct banner text, amber (not red) color, and correct apostrophe escaping, with the already-documented module still rendering below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)