### PR TITLE
Exclude test files from the Docs feature

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -20,6 +20,7 @@ from app_server.audit_signing import content_hash, sign_report
 from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from aletheore.code_graph_diff import diff_endpoints, diff_modules
+from aletheore.dead_code import is_test_file
 from aletheore.evidence import write_evidence
 from aletheore.git_intel.analyzer import analyze_git, compute_hotspots
 from aletheore.evidence_resolution import (
@@ -2226,7 +2227,8 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
 
     candidate_modules = [
         m for m in evidence["repository"]["modules"]
-        if any(s.get("is_public", True) for s in m["symbols"]["functions"] + m["symbols"]["classes"])
+        if not is_test_file(m["path"])
+        and any(s.get("is_public", True) for s in m["symbols"]["functions"] + m["symbols"]["classes"])
     ]
     covered_by_module: dict[str, set[str]] = {}
     for row in list_docs_symbols(dsn, installation_id, repo_full_name):
@@ -2342,7 +2344,9 @@ def _maybe_update_live_docs(
         return
 
     modules_by_path = {m["path"]: m for m in evidence["repository"]["modules"]}
-    changed_modules = [modules_by_path[p] for p in changed_files if p in modules_by_path]
+    changed_modules = [
+        modules_by_path[p] for p in changed_files if p in modules_by_path and not is_test_file(p)
+    ]
     if not changed_modules:
         return
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3212,6 +3212,36 @@ def test_run_live_docs_full_build_job_skips_llm_setup_when_nothing_new(monkeypat
     assert status_calls == [("ready", None)]
 
 
+def test_run_live_docs_full_build_job_excludes_test_files_from_candidate_modules(monkeypatch):
+    from scan_worker.jobs import run_live_docs_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    # A test function is module-level and unprefixed, so is_public sees it
+    # as ordinary public API - dogfooding-confirmed real symptom: test_*.py
+    # functions were showing up as "generated" Docs entries. Only a test
+    # module exists here, so if it isn't excluded there's real work to do.
+    module = _docs_module(
+        "tests/test_a.py", functions=[{"name": "test_f_does_the_thing", "is_public": True, "docstring": None}]
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _docs_evidence([module]))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_docs_symbols", lambda *a, **k: [])
+    client_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs._github_client_and_token", lambda *a, **k: client_calls.append(1)
+    )
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_docs_build_status",
+        lambda dsn, iid, repo, status, error=None: status_calls.append((status, error)),
+    )
+
+    run_live_docs_full_build_job(1, "octocat/hello-world")
+
+    assert client_calls == []  # no GitHub/LLM setup - a test file is not real work
+    assert status_calls == [("ready", None)]
+
+
 def test_run_live_docs_full_build_job_survives_one_module_failing(monkeypatch):
     from scan_worker.jobs import run_live_docs_full_build_job
 
@@ -3321,3 +3351,37 @@ def test_maybe_update_live_docs_survives_one_module_failing(monkeypatch):
     assert status_calls[0][0] == "ready"
     assert "1/2 files processed" in status_calls[0][1]
     assert "rate limited" in status_calls[0][1]
+
+
+def test_maybe_update_live_docs_excludes_test_files_from_changed_modules(monkeypatch):
+    from scan_worker.jobs import _maybe_update_live_docs
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr(
+        "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
+    )
+    monkeypatch.setattr("scan_worker.jobs._live_docs_update_writing_adapter", lambda: object())
+
+    fetched_for = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_file_content",
+        lambda client, token, repo, path, ref: fetched_for.append(path) or "source",
+    )
+    monkeypatch.setattr("scan_worker.jobs._store_docs_generation_for_module", lambda *a, **k: None)
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_docs_build_status",
+        lambda dsn, iid, repo, status, error=None: status_calls.append((status, error)),
+    )
+
+    good = _docs_module("good.py")
+    test_module = _docs_module("tests/test_a.py")
+    evidence = _docs_evidence([good, test_module])
+
+    _maybe_update_live_docs(1, "octocat/hello-world", evidence, ["good.py", "tests/test_a.py"], "sha1")
+
+    # Only the real source file was ever fetched - the changed test file
+    # never reached the LLM at all, same as a full build's candidate filter.
+    assert fetched_for == ["good.py"]
+    assert status_calls == [("ready", None)]

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -89,7 +89,7 @@ def _html_script_entry_points(repo_path: Path) -> set[str]:
     return entry_points
 
 
-def _is_test_file(path: str) -> bool:
+def is_test_file(path: str) -> bool:
     return any(pattern.search(path) for pattern in TEST_PATH_PATTERNS)
 
 
@@ -126,7 +126,7 @@ def find_dead_code(repo_path: Path, modules: list[dict], config: dict | None) ->
         if _is_entry_point(path, custom_entry_points):
             entry_points_detected.append(path)
             continue
-        if _is_test_file(path):
+        if is_test_file(path):
             continue
         if not module.get("imported_by", []):
             if path in html_script_entry_points or _has_main_guard(repo_path, path):

--- a/src/aletheore/docs_reference.py
+++ b/src/aletheore/docs_reference.py
@@ -15,6 +15,8 @@ comments that were never written.
 
 import inspect
 
+from aletheore.dead_code import is_test_file
+
 UNDOCUMENTED = "*Undocumented - no docstring found.*"
 AI_GENERATED_MARKER = "*(AI-generated - no docstring found in source)*"
 AI_POLISHED_MARKER = "*(AI-polished from the original docstring)*"
@@ -112,6 +114,8 @@ def build_api_reference(
     """
     reference: dict[str, str] = {}
     for module in evidence["repository"]["modules"]:
+        if is_test_file(module["path"]):
+            continue
         has_public_symbol = any(
             symbol.get("is_public", True)
             for symbol in module["symbols"]["classes"] + module["symbols"]["functions"]

--- a/src/tests/test_docs_reference.py
+++ b/src/tests/test_docs_reference.py
@@ -93,6 +93,20 @@ def test_build_api_reference_returns_one_entry_per_module_with_at_least_one_publ
     assert "f" in refs["src/a.py"]
 
 
+def test_build_api_reference_excludes_test_files_even_with_public_symbols():
+    # Test functions are module-level and unprefixed, so is_public sees them
+    # as ordinary public API - but a Docs page documenting an app's public
+    # surface shouldn't include its own test suite, dogfooding-confirmed
+    # (test_dashboard.py functions showed up as "generated" API entries).
+    evidence = {"repository": {"modules": [
+        _module("src/a.py", [_symbol("f")]),
+        _module("tests/test_a.py", [_symbol("test_f_does_the_thing")]),
+        _module("src/a_test.py", [_symbol("test_g")]),
+    ]}}
+    refs = build_api_reference(evidence)
+    assert set(refs) == {"src/a.py"}
+
+
 def test_build_module_reference_renders_ai_generated_description_with_marker():
     evidence = {"repository": {"modules": [_module("src/a.py", [_symbol("f", docstring=None)])]}}
     md = build_module_reference(


### PR DESCRIPTION
## Summary
- Test functions are module-level and unprefixed, so `is_public` sees them as ordinary public API - dogfooding this feature against its own repo showed `test_dashboard.py` functions rendered as "generated" Docs entries (accurate descriptions, wrong scope).
- Reuses `dead_code.py`'s existing `TEST_PATH_PATTERNS` classifier (promoted `_is_test_file` -> public `is_test_file`) instead of inventing a new one - already correctly covers `test_*.py`, `*_test.py`, `*.test`/`*.spec` JS/TS, and `tests/`/`__tests__/` directories, and is already proven against this same codebase for dead-code detection.
- `docs_reference.py`: `build_api_reference` now skips test modules entirely, hiding them from the Docs page regardless of what's already in `docs_symbols` from before this fix - no data migration needed.
- `scan_worker/jobs.py`: both the full-build `candidate_modules` and the incremental-update `changed_modules` now skip test files, so the AI stops spending budget on them going forward.

## Test plan
- [x] `src` suite: 950 passed, 0 failures
- [x] `github-app` suite: 832 passed, 8 pre-existing skips, 0 failures
- [x] New tests cover: `build_api_reference` excludes test files even with public-looking symbols; `run_live_docs_full_build_job` treats a test-only repo as "nothing new to do" (no GitHub/LLM setup); `_maybe_update_live_docs` skips a changed test file while still processing a changed real file in the same push

🤖 Generated with [Claude Code](https://claude.com/claude-code)