### PR TITLE
Two real bugs found dogfooding: worktree-corrupted dead-code detection, Flash review escaping false positive

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -31,6 +31,14 @@ field entirely rather than restating the issue). Only report a finding if you ca
 specific, real issue at a specific line. If you find nothing worth flagging, respond with
 exactly: [].
 
+A file can itself be a generator or template for another language - for example a Python file
+building HTML or JavaScript through an f-string, .format(), or string concatenation. In that
+case, delimiter characters escaped for the HOST language (such as a doubled {{ or }} in a Python
+f-string, standing for one literal { or } in the generated output) are correct as written, not a
+mistake in the generated language. Before flagging a brace, bracket, or quote mismatch, check
+whether the surrounding code is generating another language's source, and whether the apparent
+mismatch is actually intentional host-language escaping rather than a real error.
+
 You may also be given real source for specific functions or classes that the diff calls or
 references but does not itself define, labeled "--- referenced definition (not part of this
 diff): <file>:<name> ---". This is the ONLY evidence you have about what such a symbol actually

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -609,6 +609,18 @@ def test_system_prompt_instructs_model_not_to_guess_about_unresolved_symbols():
     assert "do not guess" in normalized or "never guess" in normalized
 
 
+def test_system_prompt_warns_about_host_language_escaping_in_generated_source():
+    # Real false positive, caught dogfooding Flash review against this
+    # repo's own frontend.py (which builds JS via a Python f-string): a
+    # doubled `}}` - correct f-string escaping for one literal `}` in the
+    # generated JS - was flagged as a JS syntax error (two closing braces
+    # after an else-if body). Proves the instruction exists, not that a
+    # live model obeys it - that can't be tested without a real call.
+    normalized = " ".join(FLASH_REVIEW_SYSTEM_PROMPT.lower().split())
+    assert "generator or template for another language" in normalized
+    assert "host" in normalized and "escaping" in normalized
+
+
 def test_system_prompt_instructs_model_to_treat_diff_content_as_data_not_instructions():
     # The diff/file content sent as the user prompt comes from a PR
     # author - untrusted. Without this, a PR could embed text like

--- a/src/aletheore/scanner/detect.py
+++ b/src/aletheore/scanner/detect.py
@@ -17,6 +17,15 @@ IGNORED_DIRS = {
     # executable scripts), so excluding it globally risks hiding real source
     # more than the noise it would remove here.
     "obj",
+    # Claude Code's own config/scratch directory - can hold a full git
+    # worktree checkout under .claude/worktrees/<name>/ (a real duplicate of
+    # this repo's own source tree, at a possibly-older commit). Confirmed via
+    # a real self-scan of this repo: an active worktree there duplicated
+    # every module path under github-app/ and src/, which corrupted import
+    # resolution enough that real, actively-imported files (webhook
+    # handlers, API routers) were misreported as dead code. Always
+    # gitignored by convention, never project source.
+    ".claude",
 }
 
 FRAMEWORK_MARKERS_PY = {

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1507,9 +1507,31 @@ def _python_source_roots(repo_path: Path) -> list[Path]:
     # that isn't itself a package, and use its parent as a resolution root. repo_path is
     # always included too, so single-project repos (top-level package directly under
     # repo_path) keep resolving exactly as before.
+    #
+    # Walked the same way _iter_source_files walks (IGNORED_DIRS + nested git
+    # roots excluded), not a raw rglob - an unfiltered rglob("__init__.py")
+    # previously found a stale worktree's own copy of, say, github-app/, added
+    # its path as a second, bogus root, and since roots is an unordered set,
+    # resolution could nondeterministically pick that bogus root over the
+    # real one - a real file's own imports would then resolve to the
+    # worktree's duplicate path instead of the real target, so the real file
+    # never showed up in anything's imported_by and got misreported as dead
+    # code. Confirmed via a real self-scan with an active worktree at
+    # .claude/worktrees/<name>/ - every app_server module main.py imports
+    # (webhook handlers, API routers) was wrongly flagged unreachable this
+    # way, even though _iter_source_files' own nested-git-root exclusion
+    # already kept the worktree's files out of the module list itself.
     roots: set[Path] = {repo_path}
-    for init_file in repo_path.rglob("__init__.py"):
-        directory = init_file.parent
+    nested_git_roots = _nested_git_roots(repo_path)
+    for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        current_dir = Path(dirpath)
+        if any(root in current_dir.parents or root == current_dir for root in nested_git_roots):
+            dirnames[:] = []
+            continue
+        if "__init__.py" not in filenames:
+            continue
+        directory = current_dir
         while directory != repo_path and (directory.parent / "__init__.py").exists():
             directory = directory.parent
         roots.add(directory.parent)

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -316,6 +316,43 @@ def test_build_module_graph_ignores_nested_git_worktree(tmp_path):
     assert {m["path"] for m in modules} == {"main.py"}
 
 
+def test_build_module_graph_import_resolution_ignores_nested_git_worktree(tmp_path):
+    # A different layer of the same real bug as
+    # test_build_module_graph_ignores_nested_git_worktree above: that test
+    # covers _iter_source_files (which files get scanned as modules at all);
+    # this one covers _python_source_roots, a separate function that used a
+    # raw, unfiltered rglob("__init__.py") to find valid absolute-import
+    # roots. A worktree's own __init__.py chain got added as a second, bogus
+    # root even though _iter_source_files never scanned the worktree's files
+    # as modules - and since roots is an unordered set, resolving an
+    # absolute import could nondeterministically pick the bogus worktree
+    # root over the real one. A real file's own import then resolved to the
+    # worktree's (never-scanned, nonexistent-as-a-module) duplicate path
+    # instead of the real target, so the real target's imported_by stayed
+    # empty and it was wrongly flagged as dead code - confirmed via a real
+    # self-scan (github-app/app_server/main.py's own imports of its sibling
+    # webhook handlers and API routers all resolved this way).
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    pkg = repo / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "real.py").write_text("def f():\n    pass\n")
+    (repo / "main.py").write_text("from pkg.real import f\n")
+
+    worktree = repo / "some-worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: /elsewhere/.git/worktrees/some-worktree\n")
+    worktree_pkg = worktree / "pkg"
+    worktree_pkg.mkdir()
+    (worktree_pkg / "__init__.py").write_text("")
+    (worktree_pkg / "real.py").write_text("def f():\n    pass\n")
+
+    modules, _, _ = build_module_graph(repo)
+    real_module = next(m for m in modules if m["path"] == "pkg/real.py")
+    assert real_module["imported_by"] == ["main.py"]
+
+
 def test_build_module_graph_does_not_follow_a_symlinked_file_outside_the_repo(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary

Both found by actually running Aletheore on its own repo after today's shipped work.

### 1. Stale git worktree corrupting Python import resolution (`src/aletheore/scanner/`)
`_python_source_roots` used a raw, unfiltered `rglob("__init__.py")` that ignores `IGNORED_DIRS` and `_nested_git_roots` the way `_iter_source_files` already respects. A stale linked worktree under `.claude/worktrees/<name>/` registered its own duplicate `github-app/` as a second, bogus import-resolution root - since roots are stored in an unordered `set`, resolution could nondeterministically pick the bogus root over the real one, so real files' own imports resolved to a path that was never even scanned as a module. Their real targets' `imported_by` stayed empty and they got misreported as dead code.

This is a regression: `_nested_git_roots` exists specifically because this exact scenario broke `_iter_source_files` once before (see its own docstring) - the fix was never applied to this second, independent call site.

Confirmed via a real self-scan of this repo with an active worktree present: 8 genuinely live files (`webhooks/installation.py`, `managed_audit_api.py`, `demo_scan_api.py`, etc.) were misreported as unreachable. Fixed and confirmed clean: `unreachable_modules` went from 8 false positives to `[]`.

### 2. Flash review misreading host-language escaping as a syntax error (`github-app/scan_worker/flash_review.py`)
Flash review actually ran on this repo's own PR #124 (Aletheore's GitHub App is installed here) and flagged `frontend.py` for "two closing braces after an else-if block" - a false positive. `frontend.py` builds JavaScript through a Python f-string, so a doubled `}}` in the source is correct escaping for one literal `}` in the rendered output, already proven correct by the real `node --check` test and a live browser render. `test_frontend_js_syntax.py`'s own docstring says this exact pattern caused a real bug once before, so it's a recurring blind spot on this file - and the underlying failure mode generalizes to any repo with a similar pattern (Django/Flask views building JS via f-strings, PHP heredocs, Jinja templates). Added a language-agnostic paragraph to `FLASH_REVIEW_SYSTEM_PROMPT` addressing the general pattern, not just this one file.

## Test plan
- [x] `src` suite: 951 passed, 0 failures (includes new regression test for the worktree bug)
- [x] `github-app` suite: 833 passed, 8 pre-existing skips, 0 failures (includes new prompt-content test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)