### PR TITLE
fix(website): use support@aletheore.com on legal pages

### DIFF
--- a/website/privacy.html
+++ b/website/privacy.html
@@ -38,7 +38,7 @@
       <p>For paid installations: your GitHub account or organization identity, evidence snapshots from scans, and, if configured, a Slack/Teams webhook URL and health-check monitoring settings. We do not sell this data or share it beyond the service providers necessary to run Aletheore, including our LLM provider for managed audits and our payment provider for billing.</p>
 
       <h2>Contact</h2>
-      <p>Questions about this policy or a data deletion request: <a href="mailto:arihantkaul@outlook.com">arihantkaul@outlook.com</a></p>
+      <p>Questions about this policy or a data deletion request: <a href="mailto:support@aletheore.com">support@aletheore.com</a></p>
     </main>
   </div>
   <script src="vendor/motion.js"></script>

--- a/website/refund.html
+++ b/website/refund.html
@@ -35,7 +35,7 @@
       <p>Subscriptions can be cancelled at any time and will remain active until the end of the current billing period. We do not offer prorated refunds for partial months after the initial 14-day window, since the plan gives you continued access through the period you already paid for.</p>
 
       <h2>How to request one</h2>
-      <p>Email <a href="mailto:arihantkaul@outlook.com">arihantkaul@outlook.com</a> with your GitHub organization or account name. Refunds are processed through Paddle back to your original payment method.</p>
+      <p>Email <a href="mailto:support@aletheore.com">support@aletheore.com</a> with your GitHub organization or account name. Refunds are processed through Paddle back to your original payment method.</p>
     </main>
   </div>
   <script src="vendor/motion.js"></script>

--- a/website/terms.html
+++ b/website/terms.html
@@ -41,7 +41,7 @@
       <p>Aletheore is provided as-is. The deterministic scanner is unit-tested and evidence-grounded, but no software is guaranteed to catch every issue in every repository.</p>
 
       <h2>Contact</h2>
-      <p>Questions about these terms: <a href="mailto:arihantkaul@outlook.com">arihantkaul@outlook.com</a></p>
+      <p>Questions about these terms: <a href="mailto:support@aletheore.com">support@aletheore.com</a></p>
     </main>
   </div>
   <script src="vendor/motion.js"></script>


### PR DESCRIPTION
## Summary
- Terms, privacy, and refund pages linked directly to a personal Outlook address for customer contact / data-deletion requests. Swapped to the newly created support@aletheore.com.

## Test plan
- [x] Visual: mailto links now point to support@aletheore.com in all three files
- No behavior/logic change, static HTML only