### PR TITLE
Cache get_settings() instead of re-reading it on every call

### DIFF
--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from functools import lru_cache
 
 
 @dataclass(frozen=True)
@@ -70,7 +71,17 @@ def _paddle_client_token(environment: str) -> str:
     return token
 
 
+@lru_cache(maxsize=1)
 def get_settings() -> Settings:
+    # Called at the top of nearly every route and job (56 call sites) -
+    # without caching, every single one re-reads the mounted private-key
+    # file from disk and re-parses/re-validates every env var from scratch,
+    # every time. Safe to cache for a process's whole lifetime: env vars and
+    # mounted secret files are fixed at container start and don't change
+    # until the next deploy restarts the process anyway. Tests that rely on
+    # get_settings() reflecting their own monkeypatched env vars need
+    # get_settings.cache_clear() between tests - see conftest.py's autouse
+    # fixture for that.
     paddle_environment = _paddle_environment()
     return Settings(
         database_url=os.environ["DATABASE_URL"],

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -62,6 +62,22 @@ def redis_conn():
 
 
 @pytest.fixture(autouse=True)
+def _clear_settings_cache():
+    # get_settings() is @lru_cache'd for production (56 call sites, was
+    # re-reading the private-key file from disk on every single call) - but
+    # the test suite monkeypatches env vars per-test expecting get_settings()
+    # to reflect them fresh each time. Without this, whichever test happens
+    # to call get_settings() first in the whole pytest session would
+    # permanently pin every later test's settings to its own monkeypatched
+    # values for the rest of the run.
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
 def _no_real_paddle_ip_fetch(monkeypatch):
     # Without this, every full-route webhook test would make a real network
     # call to Paddle's /ips endpoint on the first request (module-level


### PR DESCRIPTION
## Summary
Found doing a follow-up audit pass: `get_settings()` is called at the top of nearly every route and job (56 call sites across `app_server` and `scan_worker`) and had no caching - every single call re-read the mounted GitHub App private-key file from disk and re-parsed/re-validated every env var from scratch, including the Paddle sandbox-vs-production token check.

Safe to cache for a process's whole lifetime: env vars and mounted secret files are fixed at container start and don't change until the next deploy restarts the process anyway - nothing in this codebase relies on settings changing mid-process.

The test suite monkeypatches env vars per-test and expects `get_settings()` to reflect them fresh each time, so a bare cache would pin every later test in the same pytest session to whichever test's settings got cached first. Added an autouse `conftest.py` fixture (matching the existing `_no_real_paddle_ip_fetch` pattern) that clears the cache before and after every test.

## Test plan
- [x] Full suite: 833 passed, 8 skipped, 0 failures - full test isolation preserved
- [x] Runtime dropped from ~180-260s to a consistent ~90s across two separate runs - real confirmation this was doing meaningful redundant work, not just a theoretical inefficiency

🤖 Generated with [Claude Code](https://claude.com/claude-code)