### PR TITLE
Add a Contact section to the marketing site footer

### DIFF
--- a/website/developers.html
+++ b/website/developers.html
@@ -267,6 +267,10 @@ aletheore dashboard .</code></pre>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>
+      <div>
+        <h4>Contact</h4>
+        <a href="mailto:support@aletheore.com">support@aletheore.com</a>
+      </div>
     </div>
   </footer>
   <script src="vendor/motion.js"></script>

--- a/website/dogfooding.html
+++ b/website/dogfooding.html
@@ -221,6 +221,10 @@ aletheore scan flask</code></pre>
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>
+      <div>
+        <h4>Contact</h4>
+        <a href="mailto:support@aletheore.com">support@aletheore.com</a>
+      </div>
     </div>
   </footer>
   <script src="vendor/motion.js"></script>

--- a/website/index.html
+++ b/website/index.html
@@ -522,6 +522,10 @@
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>
+      <div>
+        <h4>Contact</h4>
+        <a href="mailto:support@aletheore.com">support@aletheore.com</a>
+      </div>
     </div>
   </footer>
   <script src="vendor/motion.js"></script>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -118,6 +118,10 @@
         <a href="privacy.html">Privacy</a>
         <a href="refund.html">Refund Policy</a>
       </div>
+      <div>
+        <h4>Contact</h4>
+        <a href="mailto:support@aletheore.com">support@aletheore.com</a>
+      </div>
     </div>
   </footer>
   <script src="vendor/motion.js"></script>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1686,7 +1686,7 @@ footer {
 
 .footer-grid {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
   gap: 32px;
 }
 


### PR DESCRIPTION
## Summary
- Adds a "Contact" column to every marketing page's footer (index, pricing, developers, dogfooding), pointing to `mailto:support@aletheore.com` - the mailbox is now confirmed live and already used on the legal pages (#127).
- The legal pages (terms/privacy/refund) have no nav footer, so this is scoped to the four pages that do.
- Widened `.footer-grid` from 4 to 5 columns; the existing mobile breakpoint already collapses it to a single column regardless of count, so no responsive changes needed.

## Test plan
- [x] Rendered all four pages in a real browser and confirmed the Contact heading + mailto link render correctly, in the right position, with no console errors
- No behavior/logic change, static HTML/CSS only

🤖 Generated with [Claude Code](https://claude.com/claude-code)