### PR TITLE
Close redirect-SSRF and queue-contention gaps in health monitoring

### DIFF
--- a/github-app/README.md
+++ b/github-app/README.md
@@ -112,8 +112,8 @@ checking out a previous commit and rebuilding from it.
    ```
 4. **Verify the rollback actually took**:
    - `docker compose ps` - all services `Up`, no restart loops.
-   - `docker compose logs --tail 50 app-server scan-worker scheduler` - clean
-     JSON startup lines, no tracebacks.
+   - `docker compose logs --tail 50 app-server scan-worker health-worker scheduler` -
+     clean JSON startup lines, no tracebacks.
    - `GET /v1/health/{org}/{repo}` for a known-good repo returns the expected
      endpoint statuses.
    - If `INTERNAL_METRICS_TOKEN` is set, `GET /v1/internal/queue-stats` shows

--- a/github-app/app_server/metrics.py
+++ b/github-app/app_server/metrics.py
@@ -19,11 +19,22 @@ async def queue_stats(request: Request):
         raise HTTPException(status_code=401, detail="missing or invalid token")
 
     redis_conn = Redis.from_url(settings.redis_url)
-    queue = Queue("scans", connection=redis_conn)
+    # "health" runs on its own queue/worker, separate from "scans" (see
+    # scan_worker/scheduler.py) so a slow AI job never delays the endpoint
+    # health sweep - reported separately here too, since a stat that only
+    # covered "scans" would be blind to the health queue backing up or its
+    # worker going down.
+    queues = {name: Queue(name, connection=redis_conn) for name in ("scans", "health")}
     return {
-        "queue_depth": queue.count,
-        "started_count": StartedJobRegistry(queue=queue).count,
-        "failed_count": FailedJobRegistry(queue=queue).count,
-        "finished_count": FinishedJobRegistry(queue=queue).count,
+        "queues": {
+            name: {
+                "queue_depth": queue.count,
+                "started_count": StartedJobRegistry(queue=queue).count,
+                "failed_count": FailedJobRegistry(queue=queue).count,
+                "finished_count": FinishedJobRegistry(queue=queue).count,
+                "worker_count": Worker.count(connection=redis_conn, queue=queue),
+            }
+            for name, queue in queues.items()
+        },
         "worker_count": Worker.count(connection=redis_conn),
     }

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -54,6 +54,35 @@ services:
     cpus: "1.0"
     mem_limit: 1g
 
+  # Consumes only the "health" queue (see scan_worker/scheduler.py and
+  # health_worker.py) - a dedicated worker so a long-running AI job on
+  # scan-worker's "scans" queue (Flash review, AIRview, managed audit) can
+  # never delay the ~3-minute endpoint health sweep behind it. Same image
+  # as scan-worker since run_health_check_sweep_job's failure-alert
+  # enrichment needs the same GitHub App credentials and LLM keys; no
+  # Ollama or persistent repo-checkout volume since health checks never do
+  # embeddings or local git work.
+  health-worker:
+    build:
+      context: ..
+      dockerfile: github-app/Dockerfile.scan-worker
+    restart: unless-stopped
+    command: ["python", "-m", "scan_worker.health_worker"]
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app-key.pem
+    volumes:
+      - ./app-private-key.pem:/run/secrets/github-app-key.pem:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    cpus: "0.5"
+    mem_limit: 512m
+
   # Never started via `up` - this service exists purely so `docker compose
   # build demo-sandbox` produces the aletheore-demo-sandbox:latest image on
   # the host daemon for demo-scan-worker (which has docker socket access)

--- a/github-app/scan_worker/health_worker.py
+++ b/github-app/scan_worker/health_worker.py
@@ -1,0 +1,14 @@
+import os
+
+from redis import Redis
+from rq import Worker
+
+from app_server.config import get_settings
+from app_server.logging_config import configure_json_logging
+
+
+if __name__ == "__main__":
+    configure_json_logging()
+    settings = get_settings()
+    redis_conn = Redis.from_url(os.environ.get("REDIS_URL", settings.redis_url))
+    Worker(["health"], connection=redis_conn).work()

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -23,24 +23,38 @@ SESSION_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # once, same reasoning as HEALTH_SWEEP_JOB_TIMEOUT_SECONDS.
 DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS = 600
 
+SCANS_QUEUE_NAME = "scans"
+# The health sweep gets its own queue, consumed by a dedicated worker (see
+# health_worker.py), instead of sharing "scans" with push-triggered Flash
+# reviews, AIRview builds, and managed audits. Those are real LLM calls
+# that can run for minutes; on a single shared queue, one long job delays
+# every health sweep enqueued behind it - observed live in prod, where one
+# Flash review run backed up three consecutive sweep ticks. Endpoint
+# monitoring needs to keep running on its own ~3-minute cadence regardless
+# of what the AI job queue is doing, especially now that the public status
+# API drops any endpoint not checked in the last 15 minutes.
+HEALTH_QUEUE_NAME = "health"
+
 
 def run_forever(
     interval_seconds: int = HEALTH_SWEEP_INTERVAL_SECONDS,
     max_iterations: int | None = None,
 ) -> None:
     settings = get_settings()
-    queue = Queue("scans", connection=Redis.from_url(settings.redis_url))
+    redis_conn = Redis.from_url(settings.redis_url)
+    scans_queue = Queue(SCANS_QUEUE_NAME, connection=redis_conn)
+    health_queue = Queue(HEALTH_QUEUE_NAME, connection=redis_conn)
     iterations = 0
     while max_iterations is None or iterations < max_iterations:
-        queue.enqueue(
+        health_queue.enqueue(
             "scan_worker.jobs.run_health_check_sweep_job",
             job_timeout=HEALTH_SWEEP_JOB_TIMEOUT_SECONDS,
         )
-        queue.enqueue(
+        scans_queue.enqueue(
             "scan_worker.jobs.run_session_cleanup_job",
             job_timeout=SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
         )
-        queue.enqueue(
+        scans_queue.enqueue(
             "scan_worker.jobs.run_live_docs_catchup_sweep_job",
             job_timeout=DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
         )

--- a/github-app/tests/test_metrics.py
+++ b/github-app/tests/test_metrics.py
@@ -42,21 +42,45 @@ async def test_queue_stats_rejects_wrong_token(monkeypatch):
 async def test_queue_stats_returns_counts_for_valid_token(monkeypatch):
     monkeypatch.setenv("INTERNAL_METRICS_TOKEN", "secret-token")
 
-    fake_queue = MagicMock()
-    fake_queue.count = 3
+    # "scans" and "health" are separate queues (see scan_worker/scheduler.py)
+    # - this test uses distinct counts per queue to prove the response
+    # actually breaks stats down per queue rather than reporting "scans"
+    # twice under two names.
+    fake_queues = {}
+
+    def _fake_queue(name, **kwargs):
+        q = MagicMock()
+        q.count = {"scans": 3, "health": 1}[name]
+        fake_queues[name] = q
+        return q
+
+    def _by_queue(counts):
+        def _factory(*, queue):
+            name = next(n for n, q in fake_queues.items() if q is queue)
+            return MagicMock(count=counts[name])
+
+        return _factory
+
     monkeypatch.setattr("app_server.metrics.Redis.from_url", lambda url: MagicMock())
-    monkeypatch.setattr("app_server.metrics.Queue", lambda *a, **k: fake_queue)
+    monkeypatch.setattr("app_server.metrics.Queue", _fake_queue)
     monkeypatch.setattr(
-        "app_server.metrics.StartedJobRegistry", lambda *a, **k: MagicMock(count=1)
+        "app_server.metrics.StartedJobRegistry", _by_queue({"scans": 1, "health": 0})
     )
     monkeypatch.setattr(
-        "app_server.metrics.FailedJobRegistry", lambda *a, **k: MagicMock(count=2)
+        "app_server.metrics.FailedJobRegistry", _by_queue({"scans": 2, "health": 0})
     )
     monkeypatch.setattr(
-        "app_server.metrics.FinishedJobRegistry", lambda *a, **k: MagicMock(count=4)
+        "app_server.metrics.FinishedJobRegistry", _by_queue({"scans": 4, "health": 2})
     )
+
+    def _worker_count(connection=None, queue=None):
+        if queue is None:
+            return 6
+        name = next(n for n, q in fake_queues.items() if q is queue)
+        return {"scans": 5, "health": 1}[name]
+
     fake_worker = MagicMock()
-    fake_worker.count = MagicMock(return_value=5)
+    fake_worker.count = _worker_count
     monkeypatch.setattr("app_server.metrics.Worker", fake_worker)
 
     app.state.db_pool = object()
@@ -68,9 +92,21 @@ async def test_queue_stats_returns_counts_for_valid_token(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {
-        "queue_depth": 3,
-        "started_count": 1,
-        "failed_count": 2,
-        "finished_count": 4,
-        "worker_count": 5,
+        "queues": {
+            "scans": {
+                "queue_depth": 3,
+                "started_count": 1,
+                "failed_count": 2,
+                "finished_count": 4,
+                "worker_count": 5,
+            },
+            "health": {
+                "queue_depth": 1,
+                "started_count": 0,
+                "failed_count": 0,
+                "finished_count": 2,
+                "worker_count": 1,
+            },
+        },
+        "worker_count": 6,
     }

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -2,39 +2,55 @@ from unittest.mock import MagicMock
 
 from scan_worker.scheduler import (
     DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
+    HEALTH_QUEUE_NAME,
     HEALTH_SWEEP_JOB_TIMEOUT_SECONDS,
+    SCANS_QUEUE_NAME,
     SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
     run_forever,
 )
 
 
 def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration(monkeypatch):
-    fake_queue = MagicMock()
-    monkeypatch.setattr("scan_worker.scheduler.Queue", lambda *a, **k: fake_queue)
+    # Queue() is called once per queue name and reused across iterations -
+    # a dict keyed by the name argument stands in for both real Queue
+    # instances so scans_queue and health_queue resolve to two distinct
+    # fakes instead of collapsing into one.
+    fake_queues: dict[str, MagicMock] = {}
+
+    def _fake_queue(name, **kwargs):
+        return fake_queues.setdefault(name, MagicMock())
+
+    monkeypatch.setattr("scan_worker.scheduler.Queue", _fake_queue)
     monkeypatch.setattr("scan_worker.scheduler.Redis.from_url", lambda url: MagicMock())
     sleeps = []
     monkeypatch.setattr("scan_worker.scheduler.time.sleep", lambda seconds: sleeps.append(seconds))
 
     run_forever(interval_seconds=42, max_iterations=3)
 
-    assert fake_queue.enqueue.call_count == 9
-    health_sweep_calls = [
-        c for c in fake_queue.enqueue.call_args_list
-        if c.args == ("scan_worker.jobs.run_health_check_sweep_job",)
-    ]
+    assert set(fake_queues) == {SCANS_QUEUE_NAME, HEALTH_QUEUE_NAME}
+    health_queue = fake_queues[HEALTH_QUEUE_NAME]
+    scans_queue = fake_queues[SCANS_QUEUE_NAME]
+
+    # The health sweep must never land on the same queue as the AI jobs
+    # (Flash review, AIRview, managed audit) below - that's the entire
+    # point of the split, so this is checked on the queue object itself
+    # rather than just by job name.
+    assert health_queue.enqueue.call_count == 3
+    for call in health_queue.enqueue.call_args_list:
+        assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
+        assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
+
+    assert scans_queue.enqueue.call_count == 6
     session_cleanup_calls = [
-        c for c in fake_queue.enqueue.call_args_list
+        c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
     ]
     docs_catchup_calls = [
-        c for c in fake_queue.enqueue.call_args_list
+        c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_live_docs_catchup_sweep_job",)
     ]
-    assert len(health_sweep_calls) == 3
     assert len(session_cleanup_calls) == 3
     assert len(docs_catchup_calls) == 3
-    for call in health_sweep_calls:
-        assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
     for call in session_cleanup_calls:
         assert call.kwargs == {"job_timeout": SESSION_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in docs_catchup_calls:

--- a/src/aletheore/healthcheck.py
+++ b/src/aletheore/healthcheck.py
@@ -13,6 +13,28 @@ from aletheore.history import _save_json_with_rotation
 
 _SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    # Health checks must never follow a redirect: the destination hasn't
+    # gone through validate_external_https_url the way base_url has, so
+    # chasing it would let a monitored endpoint redirect this checker at an
+    # address it has no business reaching (scan_worker shares a network
+    # with postgres/redis/ollama). Returning None here makes the opener
+    # raise HTTPError for the 3xx instead of following it - the redirect
+    # response itself still proves the endpoint is up, which is all
+    # reachability monitoring claims to answer.
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+# A module-local opener, not the process-wide default - installing this
+# globally via urllib.request.install_opener() would also block the
+# legitimate redirect-following that other callers (licenses.py querying
+# PyPI, vulnerabilities.py querying OSV.dev) rely on.
+_NO_REDIRECT_OPENER = urllib.request.build_opener(
+    _NoRedirectHandler, urllib.request.HTTPSHandler(context=_SSL_CONTEXT)
+)
+
 _PATH_PARAM_PATTERNS = (
     re.compile(r"<[^>]+>"),
     re.compile(r"\{[^}]+\}"),
@@ -92,9 +114,7 @@ def run_healthcheck(endpoints: list[dict], base_url: str, timeout: float = 5.0) 
         start = time.monotonic()
         try:
             request = urllib.request.Request(url)
-            with urllib.request.urlopen(
-                request, timeout=timeout, context=_SSL_CONTEXT
-            ) as response:
+            with _NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:
                 entry["status_code"] = response.status
                 entry["reachable"] = True
                 entry["response_shape"] = None if reachability_only else _response_shape(response)

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -1047,7 +1047,7 @@ def test_main_healthcheck_reports_results(tmp_path):
     response.__enter__.return_value = response
     response.__exit__.return_value = False
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=response):
         result = runner.invoke(
             app, ["healthcheck", str(repo), "--base-url", "http://localhost:5000"]
         )

--- a/src/tests/test_healthcheck.py
+++ b/src/tests/test_healthcheck.py
@@ -27,7 +27,7 @@ def test_run_healthcheck_reports_reachable_get_endpoint():
         }
     ]
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=_mock_response(200)):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=_mock_response(200)):
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
     assert result["base_url"] == "http://localhost:5000"
@@ -52,7 +52,7 @@ def test_run_healthcheck_substitutes_path_params_and_notes_it():
     ]
 
     with patch(
-        "aletheore.healthcheck.urllib.request.urlopen", return_value=_mock_response(404)
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=_mock_response(404)
     ) as mock_urlopen:
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
@@ -77,7 +77,7 @@ def test_run_healthcheck_probes_non_get_methods_via_get_for_reachability_only():
     ]
 
     with patch(
-        "aletheore.healthcheck.urllib.request.urlopen",
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open",
         side_effect=urllib.error.HTTPError("url", 405, "method not allowed", {}, None),
     ) as mock_urlopen:
         result = run_healthcheck(endpoints, "http://localhost:5000")
@@ -107,7 +107,7 @@ def test_run_healthcheck_reports_non_get_endpoint_unreachable_on_connection_erro
     ]
 
     with patch(
-        "aletheore.healthcheck.urllib.request.urlopen",
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open",
         side_effect=urllib.error.URLError("connection refused"),
     ):
         result = run_healthcheck(endpoints, "http://localhost:5000")
@@ -130,7 +130,7 @@ def test_run_healthcheck_get_endpoint_is_not_marked_reachability_only():
         }
     ]
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=_mock_response(200)):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=_mock_response(200)):
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
     assert result["results"][0]["reachability_only"] is False
@@ -149,7 +149,7 @@ def test_run_healthcheck_treats_any_method_as_get_checkable():
         }
     ]
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=_mock_response(200)):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=_mock_response(200)):
         result = run_healthcheck(endpoints, "http://localhost:8000")
 
     assert result["results"][0].get("skipped") is not True
@@ -169,7 +169,7 @@ def test_run_healthcheck_skips_unresolved_indirection_entries():
         }
     ]
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen") as mock_urlopen:
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open") as mock_urlopen:
         result = run_healthcheck(endpoints, "http://localhost:8000")
 
     mock_urlopen.assert_not_called()
@@ -191,13 +191,56 @@ def test_run_healthcheck_reports_http_error_status_as_reachable():
     ]
 
     with patch(
-        "aletheore.healthcheck.urllib.request.urlopen",
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open",
         side_effect=urllib.error.HTTPError("url", 404, "not found", {}, None),
     ):
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
     assert result["results"][0]["status_code"] == 404
     assert result["results"][0]["reachable"] is True
+
+
+def test_no_redirect_handler_refuses_to_build_a_redirect_request():
+    from aletheore.healthcheck import _NoRedirectHandler
+
+    handler = _NoRedirectHandler()
+    # Returning None tells urllib's opener not to follow the redirect - it
+    # raises HTTPError for the 3xx instead. This is a direct check on that
+    # contract, independent of how the opener surfaces it.
+    assert (
+        handler.redirect_request(
+            MagicMock(), MagicMock(), 307, "temporary redirect", {}, "https://internal.example/secret"
+        )
+        is None
+    )
+
+
+def test_run_healthcheck_reports_redirect_as_reachable_without_following_it():
+    endpoints = [
+        {
+            "method": "GET",
+            "path": "/auth/login",
+            "framework": "fastapi",
+            "file": "auth.py",
+            "line": 1,
+            "handler": "login",
+            "unresolved": False,
+        }
+    ]
+
+    # A no-redirect opener raises HTTPError for a 3xx rather than chasing
+    # it - this is what stands between a monitored endpoint's redirect and
+    # this checker being made to probe wherever that redirect points.
+    with patch(
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open",
+        side_effect=urllib.error.HTTPError("url", 307, "temporary redirect", {}, None),
+    ) as mock_open:
+        result = run_healthcheck(endpoints, "http://localhost:5000")
+
+    mock_open.assert_called_once()
+    entry = result["results"][0]
+    assert entry["status_code"] == 307
+    assert entry["reachable"] is True
 
 
 def test_run_healthcheck_reports_unreachable_on_connection_error():
@@ -214,7 +257,7 @@ def test_run_healthcheck_reports_unreachable_on_connection_error():
     ]
 
     with patch(
-        "aletheore.healthcheck.urllib.request.urlopen",
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open",
         side_effect=urllib.error.URLError("connection refused"),
     ):
         result = run_healthcheck(endpoints, "http://localhost:9999")
@@ -242,7 +285,7 @@ def test_run_healthcheck_captures_response_shape_for_json_object():
         body=b'{"id": 1, "name": "Ada", "email": "ada@example.com"}',
     )
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=response):
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
     assert result["results"][0]["response_shape"] == ["email", "id", "name"]
@@ -267,7 +310,7 @@ def test_run_healthcheck_captures_response_shape_for_json_list_of_objects():
         body=b'[{"id": 1, "name": "Ada"}, {"id": 2, "name": "Bea"}]',
     )
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=response):
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
     assert result["results"][0]["response_shape"] == ["id", "name"]
@@ -288,7 +331,7 @@ def test_run_healthcheck_response_shape_is_none_for_non_json_content_type():
 
     response = _mock_response(200, headers={"Content-Type": "text/plain"}, body=b"OK")
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=response):
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
     assert result["results"][0]["response_shape"] is None
@@ -313,7 +356,7 @@ def test_run_healthcheck_response_shape_is_none_for_malformed_json():
         body=b"not actually json",
     )
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=response):
         result = run_healthcheck(endpoints, "http://localhost:5000")
 
     assert result["results"][0]["response_shape"] is None
@@ -333,7 +376,7 @@ def test_run_healthcheck_response_shape_is_none_on_unreachable():
     ]
 
     with patch(
-        "aletheore.healthcheck.urllib.request.urlopen",
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open",
         side_effect=urllib.error.URLError("connection refused"),
     ):
         result = run_healthcheck(endpoints, "http://localhost:9999")

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -759,7 +759,7 @@ async def test_aletheore_healthcheck_tool_returns_results(tmp_path):
     response.__enter__.return_value = response
     response.__exit__.return_value = False
 
-    with patch("aletheore.healthcheck.urllib.request.urlopen", return_value=response):
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=response):
         result = await server.call_tool(
             "aletheore_healthcheck", {"base_url": "http://localhost:5000"}
         )

--- a/website/status.html
+++ b/website/status.html
@@ -35,7 +35,7 @@
     </nav>
 
     <main>
-      <section class="developer-hero">
+      <section class="developer-hero status-hero">
         <div>
           <p class="eyebrow">Dogfooding, not a third-party status page</p>
           <h1>Aletheore's own status, monitored by Aletheore.</h1>
@@ -47,7 +47,7 @@
         </div>
       </section>
 
-      <section class="developer-section">
+      <section class="developer-section status-section">
         <div id="status-banner" class="status-banner is-loading">
           <span class="status-banner-dot"></span>
           <div>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1861,6 +1861,14 @@ footer a:hover {
 
 /* Status page */
 
+.status-hero {
+  padding-bottom: 8px;
+}
+
+.status-section {
+  padding-top: 0;
+}
+
 .status-banner {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Follow-up to #131, closing the two findings flagged there rather than fixed silently:

- **Redirect-following / SSRF-adjacent gap**: `healthcheck.py`'s probe followed redirects via urllib's default opener. `validate_external_https_url` only checks a target's initial `base_url`, never a redirect's destination — `scan_worker` shares a docker network with `postgres`/`redis`/`ollama`, so a monitored endpoint that redirected could make the checker request an address it has no business reaching. Now uses a module-local opener with redirects disabled (scoped to this module only — `licenses.py`/`vulnerabilities.py` still need real redirect-following for PyPI/OSV.dev); a 3xx is now reported as reachable without ever being followed.
- **Health-sweep queue contention**: health sweeps and AI jobs (Flash review, AIRview, managed audits) shared one serial `scans` queue. Watched it happen live: one Flash review run backed up 3 consecutive sweep ticks — which directly undermines #131's 15-minute staleness filter (a backed-up AI queue could make genuinely-up endpoints look down). Health sweeps now run on their own `health` queue + dedicated `health-worker` container. `/v1/internal/queue-stats` now reports both queues separately.
- Small layout tweak on `website/status.html` per live feedback while testing (tightened the gap under the intro paragraph), scoped so it doesn't affect `developers.html`/`dogfooding.html`.

## Test plan
- [x] `src/tests/test_healthcheck.py` — updated redirect-related test patches to the new call site, added 2 new tests for the no-redirect opener (905 total local tests, 1 pre-existing unrelated failure from a missing local `mcp` package)
- [x] `github-app/tests/` — full suite, 834 passed, including updated `test_scheduler.py` (verifies health sweep lands on a distinct queue from session-cleanup/docs-catchup) and `test_metrics.py` (verifies per-queue breakdown)
- [x] `docker-compose.yml` validated as parseable YAML; new `health-worker` service reuses the existing `Dockerfile.scan-worker` image, so no new image-scan CI job is needed

**Not deploying this to prod yet** — merging to master now, deploy to follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)