### PR TITLE
Add transactional email (welcome, payment-failed, win-back) via Resend

### DIFF
--- a/github-app/.env.example
+++ b/github-app/.env.example
@@ -34,3 +34,12 @@ INTERNAL_METRICS_TOKEN=
 # Optional paid-tier endpoint health monitoring config is stored per
 # installation through the admin API. No global base URL or latency threshold is
 # read from this file.
+
+# Optional. Set to enable transactional email (welcome, payment-failed,
+# subscription-canceled). Missing key means send_transactional_email_job
+# logs and skips rather than failing - nothing else depends on outbound
+# mail actually working. from/reply-to both have sane defaults below if
+# left unset.
+RESEND_API_KEY=
+EMAIL_FROM_ADDRESS=Aletheore <hello@notify.aletheore.com>
+EMAIL_REPLY_TO_ADDRESS=support@aletheore.com

--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -14,7 +14,14 @@ from fastapi.responses import RedirectResponse
 from itsdangerous import BadSignature, URLSafeTimedSerializer
 
 from app_server.config import get_settings
-from app_server.db import create_session, delete_session, get_session, upsert_installation
+from app_server.db import (
+    create_session,
+    delete_session,
+    get_session,
+    upsert_github_user_email,
+    upsert_installation,
+)
+from app_server.email_queue import enqueue_transactional_email
 from app_server.github_auth import generate_app_jwt, get_installation_details
 
 SESSION_COOKIE_NAME = "session"
@@ -63,9 +70,29 @@ def _github_http_client() -> httpx.Client:
     return httpx.Client(base_url="https://api.github.com")
 
 
+def _fetch_primary_verified_email(access_token: str) -> str | None:
+    # /user's own "email" field only reflects a user's public-profile
+    # email setting (often unset) regardless of scope - the verified
+    # primary address needs user:email scope plus this separate call.
+    response = _github_http_client().get(
+        "/user/emails",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+    response.raise_for_status()
+    emails = response.json()
+    primary = next((e for e in emails if e.get("primary") and e.get("verified")), None)
+    if primary:
+        return primary["email"]
+    verified = next((e for e in emails if e.get("verified")), None)
+    return verified["email"] if verified else None
+
+
 def _exchange_code_and_fetch_user(
     code: str, client_id: str, client_secret: str
-) -> tuple[str, str | None, dict]:
+) -> tuple[str, str | None, dict, str | None]:
     # Synchronous httpx.Client calls, run off the event loop via
     # asyncio.to_thread by the caller - this whole function otherwise blocks
     # every other request the server is handling for its duration.
@@ -89,7 +116,19 @@ def _exchange_code_and_fetch_user(
         },
     )
     user_response.raise_for_status()
-    return access_token, refresh_token, user_response.json()
+    user = user_response.json()
+
+    email = None
+    try:
+        email = _fetch_primary_verified_email(access_token)
+    except httpx.HTTPStatusError:
+        # A pre-existing session predating the user:email scope (until the
+        # user next consents to it) or a transient GitHub API failure -
+        # sign-in must not break because email capture did. Retried
+        # automatically on the user's next login.
+        pass
+
+    return access_token, refresh_token, user, email
 
 
 def refresh_github_access_token(
@@ -223,7 +262,7 @@ async def callback(code: str, request: Request, state: str | None = None, instal
         if not expected_state or not state or not hmac.compare_digest(expected_state, state):
             raise HTTPException(status_code=400, detail="invalid oauth state")
 
-    access_token, refresh_token, user = await asyncio.to_thread(
+    access_token, refresh_token, user, email = await asyncio.to_thread(
         _exchange_code_and_fetch_user, code, settings.github_client_id, settings.github_client_secret
     )
 
@@ -239,6 +278,23 @@ async def callback(code: str, request: Request, state: str | None = None, instal
         if refresh_token
         else None,
     )
+
+    if email:
+        # Best-effort, same discipline as the installation upsert below:
+        # a captured email (or the welcome email itself) failing to save
+        # must never break sign-in, the critical path here.
+        try:
+            is_new_email = await upsert_github_user_email(request.app.state.db_pool, user["login"], email)
+            if is_new_email:
+                enqueue_transactional_email(
+                    settings.redis_url,
+                    dedupe_key=f"welcome:{user['login']}",
+                    template_name="welcome",
+                    template_arg=user["login"],
+                    to_email=email,
+                )
+        except Exception:
+            logger.warning("failed to capture email / enqueue welcome email for %s", user["login"], exc_info=True)
 
     if installation_id is not None:
         # A direct "Install" click lands here with installation_id already in

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -22,6 +22,9 @@ class Settings:
     paddle_api_key: str | None
     github_app_slug: str
     github_demo_readonly_token: str | None
+    resend_api_key: str | None
+    email_from_address: str
+    email_reply_to_address: str
 
 
 def _required_env(name: str) -> str:
@@ -110,4 +113,18 @@ def get_settings() -> Settings:
         # token) - a public_repo-scoped read-only PAT is enough, and the
         # demo works without one, just at a much lower shared ceiling.
         github_demo_readonly_token=os.environ.get("GITHUB_DEMO_READONLY_TOKEN", "").strip() or None,
+        # Optional, not required: transactional email is additive - a
+        # missing key means send_transactional_email_job logs and skips
+        # rather than the server refusing to start, since nothing else
+        # depends on outbound mail actually working.
+        resend_api_key=os.environ.get("RESEND_API_KEY", "").strip() or None,
+        # notify.aletheore.com is a dedicated sending-only subdomain (no
+        # receiving capability) so transactional volume never touches
+        # aletheore.com's own reputation or the Hostinger-hosted MX that
+        # support@aletheore.com actually receives on. Replies still need
+        # somewhere real to land, hence email_reply_to_address below.
+        email_from_address=os.environ.get(
+            "EMAIL_FROM_ADDRESS", "Aletheore <hello@notify.aletheore.com>"
+        ),
+        email_reply_to_address=os.environ.get("EMAIL_REPLY_TO_ADDRESS", "support@aletheore.com"),
     )

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -348,6 +348,26 @@ async def is_installation_member(pool: asyncpg.Pool, installation_id: int, githu
     return row is not None
 
 
+async def list_installation_member_emails(pool: asyncpg.Pool, installation_id: int) -> list[str]:
+    """Emails for every member of this installation who has logged in at
+    least once (and so has a captured row in github_user_emails). Members
+    added by username alone (see add_installation_member) but who've
+    never signed in have no email on file yet, by design - inviting a
+    not-yet-logged-in seat by email is an explicit v2, not v1, for
+    transactional email.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT e.email
+        FROM installation_members m
+        JOIN github_user_emails e ON e.github_login = m.github_login
+        WHERE m.installation_id = $1
+        """,
+        installation_id,
+    )
+    return [row["email"] for row in rows]
+
+
 # Health check targets live behind the same paid-plan gate as the rest of
 # Settings (_require_admin_installation rejects free plans before any of
 # this is ever reached), so there is no meaningful "free" entry here.
@@ -595,6 +615,28 @@ async def create_session(
         expires_at,
         refresh_token,
     )
+
+
+async def upsert_github_user_email(pool: asyncpg.Pool, github_login: str, email: str) -> bool:
+    """Upserts the email captured via GitHub's user:email OAuth scope on
+    every login - self-heals if the user's GitHub email changes, and
+    deliberately kept separate from sessions (which expire and get pruned
+    by run_session_cleanup_job) since transactional email needs an
+    address that outlives any one session. Returns True only the first
+    time an email is ever recorded for this login, which auth.py's
+    callback uses to decide whether to enqueue the one-time welcome email.
+    """
+    row = await pool.fetchrow(
+        """
+        INSERT INTO github_user_emails (github_login, email, updated_at)
+        VALUES ($1, $2, now())
+        ON CONFLICT (github_login) DO UPDATE SET email = $2, updated_at = now()
+        RETURNING (xmax = 0) AS inserted
+        """,
+        github_login,
+        email,
+    )
+    return row["inserted"]
 
 
 async def get_session(pool: asyncpg.Pool, session_id: str) -> dict | None:

--- a/github-app/app_server/email_queue.py
+++ b/github-app/app_server/email_queue.py
@@ -1,0 +1,28 @@
+"""Enqueues transactional email sends onto the "email" RQ queue (consumed
+by health-worker, see scan_worker/health_worker.py and jobs.py's
+send_transactional_email_job) - never inline in a request/webhook path,
+same reasoning as every other network call this codebase defers to a job.
+Shared by auth.py (welcome email) and webhooks/paddle.py (payment-failed,
+subscription-canceled).
+"""
+
+
+def enqueue_transactional_email(
+    redis_url: str,
+    dedupe_key: str,
+    template_name: str,
+    template_arg: str,
+    to_email: str,
+    installation_id: int | None = None,
+) -> None:
+    from redis import Redis
+    from rq import Queue
+
+    Queue("email", connection=Redis.from_url(redis_url)).enqueue(
+        "scan_worker.jobs.send_transactional_email_job",
+        dedupe_key=dedupe_key,
+        template_name=template_name,
+        template_arg=template_arg,
+        to_email=to_email,
+        installation_id=installation_id,
+    )

--- a/github-app/app_server/email_templates.py
+++ b/github-app/app_server/email_templates.py
@@ -1,0 +1,105 @@
+"""Transactional email copy. Plain functions returning
+{"subject", "html", "text"} - no templating engine, since these are a
+handful of developer-authored, mostly-static messages with a few
+interpolated variables, matching scan_worker/slack.py's format_* pattern
+rather than pulling in a new dependency for it.
+"""
+
+_FOOTER_TEXT = "\n\n---\nAletheore - evidence-grounded repository audits\nhttps://aletheore.com"
+_FOOTER_HTML = (
+    '<p style="margin-top:32px;padding-top:16px;border-top:1px solid #e5e0d5;'
+    'color:#8a8377;font-size:13px;">Aletheore - evidence-grounded repository audits'
+    '<br><a href="https://aletheore.com" style="color:#8a8377;">aletheore.com</a></p>'
+)
+
+
+def welcome_email(github_login: str) -> dict:
+    subject = "Welcome to Aletheore"
+    text = (
+        f"Hi {github_login},\n\n"
+        "You're in. Aletheore Community is free forever - run `aletheore scan .` "
+        "on any repo to get evidence-grounded secrets, vulnerability, dead-code, "
+        "and endpoint findings with no LLM involved.\n\n"
+        "If you install the GitHub App, Aletheore AIR adds managed AI audits, "
+        "AIRview architecture maps, automated PR reviews, and endpoint health "
+        "monitoring: https://aletheore.com/pricing.html\n\n"
+        "Questions or anything looks wrong - just reply to this email."
+        f"{_FOOTER_TEXT}"
+    )
+    html = (
+        f'<p>Hi {github_login},</p>'
+        '<p>You\'re in. Aletheore Community is free forever - run '
+        '<code>aletheore scan .</code> on any repo to get evidence-grounded '
+        'secrets, vulnerability, dead-code, and endpoint findings with no LLM '
+        'involved.</p>'
+        '<p>If you install the GitHub App, Aletheore AIR adds managed AI audits, '
+        'AIRview architecture maps, automated PR reviews, and endpoint health '
+        'monitoring: <a href="https://aletheore.com/pricing.html">see pricing</a>.</p>'
+        '<p>Questions or anything looks wrong - just reply to this email.</p>'
+        f"{_FOOTER_HTML}"
+    )
+    return {"subject": subject, "html": html, "text": text}
+
+
+def payment_failed_email(account_login: str) -> dict:
+    # Access is already fully revoked by the time this fires (see
+    # webhooks/paddle.py - there's no dunning-aware grace period, the
+    # subscription downgrades to free the moment Paddle reports
+    # past_due), so this can't honestly say "update your card before you
+    # lose access" - it's already lost. Resubscribing via checkout is the
+    # actual fix, not a customer-portal payment-method update.
+    subject = "Your Aletheore AIR payment failed"
+    text = (
+        f"Hi,\n\n"
+        f"A payment for {account_login}'s Aletheore AIR subscription failed, "
+        "and the account has been moved back to the free Community plan.\n\n"
+        "To restore AIR (managed audits, AIRview, automated PR reviews, endpoint "
+        "monitoring), resubscribe here: https://aletheore.com/pricing.html\n\n"
+        "If this seems wrong, just reply to this email and we'll sort it out."
+        f"{_FOOTER_TEXT}"
+    )
+    html = (
+        "<p>Hi,</p>"
+        f"<p>A payment for <strong>{account_login}</strong>'s Aletheore AIR "
+        "subscription failed, and the account has been moved back to the free "
+        "Community plan.</p>"
+        '<p>To restore AIR (managed audits, AIRview, automated PR reviews, '
+        'endpoint monitoring), '
+        '<a href="https://aletheore.com/pricing.html">resubscribe here</a>.</p>'
+        "<p>If this seems wrong, just reply to this email and we'll sort it out.</p>"
+        f"{_FOOTER_HTML}"
+    )
+    return {"subject": subject, "html": html, "text": text}
+
+
+def subscription_canceled_email(account_login: str) -> dict:
+    subject = "Sorry to see you go"
+    text = (
+        f"Hi,\n\n"
+        f"{account_login}'s Aletheore AIR subscription has been canceled and the "
+        "account is back on the free Community plan. Your scan history and "
+        "settings are still there if you come back.\n\n"
+        "What you're losing: managed AI audits, AIRview architecture maps, "
+        "AI-generated Docs, automated PR reviews, Slack/Teams alerts, and "
+        "endpoint health monitoring. Community still gets the full deterministic "
+        "CLI scanner, free forever.\n\n"
+        "If you canceled by mistake or something didn't work the way you "
+        "expected, just reply to this email - or resubscribe any time: "
+        "https://aletheore.com/pricing.html"
+        f"{_FOOTER_TEXT}"
+    )
+    html = (
+        "<p>Hi,</p>"
+        f"<p><strong>{account_login}</strong>'s Aletheore AIR subscription has "
+        "been canceled and the account is back on the free Community plan. Your "
+        "scan history and settings are still there if you come back.</p>"
+        "<p>What you're losing: managed AI audits, AIRview architecture maps, "
+        "AI-generated Docs, automated PR reviews, Slack/Teams alerts, and "
+        "endpoint health monitoring. Community still gets the full deterministic "
+        "CLI scanner, free forever.</p>"
+        "<p>If you canceled by mistake or something didn't work the way you "
+        "expected, just reply to this email - or "
+        '<a href="https://aletheore.com/pricing.html">resubscribe any time</a>.</p>'
+        f"{_FOOTER_HTML}"
+    )
+    return {"subject": subject, "html": html, "text": text}

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -3,7 +3,14 @@ import logging
 from fastapi import APIRouter, Request, Response
 
 from app_server.config import get_settings
-from app_server.db import add_paddle_ids_to_installation, get_installation, set_extra_seats, set_installation_plan
+from app_server.db import (
+    add_paddle_ids_to_installation,
+    get_installation,
+    list_installation_member_emails,
+    set_extra_seats,
+    set_installation_plan,
+)
+from app_server.email_queue import enqueue_transactional_email
 from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
 from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID, resolve_plan_for_price_id
 from app_server.paddle_webhook_verify import verify_paddle_signature
@@ -118,6 +125,35 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
             job_timeout=60,
             installation_id=installation_id,
         )
+
+    # payment_failed and subscription_canceled emails, gated on an actual
+    # paid -> free transition (not "was already free") so a webhook for an
+    # installation that was never paid, or one already downgraded by a
+    # prior event, doesn't send anything. Distinguished by event_type +
+    # status since both land here as plan == "free": a card decline
+    # (subscription.updated, status=past_due - no dunning-aware grace
+    # period exists, see _ACTIVE_SUBSCRIPTION_STATUSES above, so access is
+    # already fully revoked by the time this fires) gets different copy
+    # from an actual cancellation (subscription.canceled).
+    if previous_plan != "free" and plan == "free":
+        event_id = payload.get("event_id")
+        template_name = None
+        if event_type == "subscription.updated" and data.get("status") == "past_due":
+            template_name = "payment_failed"
+        elif event_type == "subscription.canceled":
+            template_name = "subscription_canceled"
+
+        if template_name and event_id:
+            account_login = previous["account_login"] if previous is not None else str(installation_id)
+            for member_email in await list_installation_member_emails(pool, installation_id):
+                enqueue_transactional_email(
+                    redis_url,
+                    dedupe_key=f"{template_name}:{event_id}:{member_email}",
+                    template_name=template_name,
+                    template_arg=account_login,
+                    to_email=member_email,
+                    installation_id=installation_id,
+                )
 
 
 @paddle_webhook_router.post("/webhooks/paddle")

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -54,14 +54,15 @@ services:
     cpus: "1.0"
     mem_limit: 1g
 
-  # Consumes only the "health" queue (see scan_worker/scheduler.py and
-  # health_worker.py) - a dedicated worker so a long-running AI job on
+  # Consumes the "health" and "email" queues (see scan_worker/scheduler.py
+  # and health_worker.py) - a dedicated worker so a long-running AI job on
   # scan-worker's "scans" queue (Flash review, AIRview, managed audit) can
-  # never delay the ~3-minute endpoint health sweep behind it. Same image
-  # as scan-worker since run_health_check_sweep_job's failure-alert
-  # enrichment needs the same GitHub App credentials and LLM keys; no
-  # Ollama or persistent repo-checkout volume since health checks never do
-  # embeddings or local git work.
+  # never delay the ~3-minute endpoint health sweep, or a time-sensitive
+  # transactional email, behind it. Same image as scan-worker since
+  # run_health_check_sweep_job's failure-alert enrichment needs the same
+  # GitHub App credentials and LLM keys; RESEND_API_KEY comes from the
+  # same env_file. No Ollama or persistent repo-checkout volume since
+  # neither health checks nor email sends do embeddings or local git work.
   health-worker:
     build:
       context: ..

--- a/github-app/migrations/030_transactional_email.sql
+++ b/github-app/migrations/030_transactional_email.sql
@@ -1,0 +1,29 @@
+-- Captured via the GitHub OAuth user:email scope on every login (see
+-- auth.py's callback), keyed by github_login rather than stored on
+-- sessions - sessions expire and get pruned by run_session_cleanup_job,
+-- but transactional email (welcome, payment-failed, weekly digest) needs
+-- an address that outlives any one session, and self-heals if someone's
+-- GitHub email changes since it's upserted on every login.
+CREATE TABLE IF NOT EXISTS github_user_emails (
+    github_login  TEXT PRIMARY KEY,
+    email         TEXT NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Paddle webhooks are at-least-once delivery, so dedupe_key (e.g.
+-- "payment_failed:{paddle_event_id}") has a UNIQUE constraint - a
+-- retried webhook enqueuing the same email job twice can't double-send.
+-- The row is only inserted after a successful Resend call (not before,
+-- as a "claim"), so a transient send failure doesn't permanently block
+-- a legitimate retry. Doubles as the send log; resend_message_id lets a
+-- future delivery-status webhook (bounce/complaint) correlate back to
+-- what was actually sent.
+CREATE TABLE IF NOT EXISTS sent_emails (
+    id                 BIGSERIAL PRIMARY KEY,
+    dedupe_key         TEXT NOT NULL UNIQUE,
+    template_name      TEXT NOT NULL,
+    recipient          TEXT NOT NULL,
+    installation_id    BIGINT REFERENCES installations(installation_id) ON DELETE SET NULL,
+    resend_message_id  TEXT,
+    sent_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -977,3 +977,40 @@ def record_flash_review_cache_hit(dsn: str, row_id: int) -> None:
                 (row_id,),
             )
         conn.commit()
+
+
+def email_already_sent(dsn: str, dedupe_key: str) -> bool:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM sent_emails WHERE dedupe_key = %s", (dedupe_key,))
+            return cur.fetchone() is not None
+
+
+def record_sent_email(
+    dsn: str,
+    dedupe_key: str,
+    template_name: str,
+    recipient: str,
+    installation_id: int | None,
+    resend_message_id: str | None,
+) -> None:
+    # Only ever called after a successful Resend call (see
+    # send_transactional_email_job) - inserting this as a "claim" before
+    # sending would let a transient send failure permanently block a
+    # legitimate future retry, since dedupe_key is UNIQUE.
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO sent_emails
+                    (dedupe_key, template_name, recipient, installation_id, resend_message_id)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (dedupe_key) DO NOTHING
+                """,
+                (dedupe_key, template_name, recipient, installation_id, resend_message_id),
+            )
+        conn.commit()

--- a/github-app/scan_worker/email.py
+++ b/github-app/scan_worker/email.py
@@ -1,0 +1,36 @@
+import httpx
+
+RESEND_API_URL = "https://api.resend.com/emails"
+
+
+def send_transactional_email(
+    api_key: str,
+    from_address: str,
+    reply_to: str,
+    to: str,
+    subject: str,
+    html: str,
+    text: str,
+    http_client: httpx.Client | None = None,
+) -> dict:
+    """Sends one email via Resend's API. Returns the parsed JSON response
+    (contains "id", Resend's message id, stored on sent_emails for future
+    delivery-status correlation). Raises on any non-2xx, same as
+    send_health_alert/send_slack_alert - the caller (the RQ job) is what
+    decides retry/dedupe behavior, not this function.
+    """
+    client = http_client or httpx.Client()
+    response = client.post(
+        RESEND_API_URL,
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={
+            "from": from_address,
+            "to": [to],
+            "reply_to": reply_to,
+            "subject": subject,
+            "html": html,
+            "text": text,
+        },
+    )
+    response.raise_for_status()
+    return response.json()

--- a/github-app/scan_worker/health_worker.py
+++ b/github-app/scan_worker/health_worker.py
@@ -11,4 +11,10 @@ if __name__ == "__main__":
     configure_json_logging()
     settings = get_settings()
     redis_conn = Redis.from_url(os.environ.get("REDIS_URL", settings.redis_url))
-    Worker(["health"], connection=redis_conn).work()
+    # "health" is checked first (RQ's priority order), but this worker is
+    # otherwise mostly idle between the ~3-minute sweep ticks, so it also
+    # takes "email" - transactional sends are single fast HTTP calls, not
+    # the multi-minute AI jobs "scans" carries, so this doesn't reintroduce
+    # the contention problem "health" was split out to fix in the first
+    # place.
+    Worker(["health", "email"], connection=redis_conn).work()

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -48,6 +48,7 @@ from scan_worker.db import (
     delete_docs_symbols_not_in,
     delete_expired_sessions,
     delete_wiki_subsystems_not_in,
+    email_already_sent,
     get_extra_seats,
     get_flash_review_count_this_month,
     get_installation as get_installation_row,
@@ -68,6 +69,7 @@ from scan_worker.db import (
     list_wiki_subsystems,
     record_docs_catchup_swept,
     record_llm_spend,
+    record_sent_email,
     set_docs_build_status,
     set_last_reviewed_sha,
     set_wiki_build_status,
@@ -98,6 +100,12 @@ from scan_worker.github_api import (
     fetch_pr_diff,
     upsert_pr_comment,
 )
+from app_server.email_templates import (
+    payment_failed_email,
+    subscription_canceled_email,
+    welcome_email,
+)
+from scan_worker.email import send_transactional_email
 from scan_worker.managed_audit import run_managed_audit
 from scan_worker.model_tiers import PRO_MODEL, model_for_plan, writing_adapter_for_plan
 from scan_worker.packet_cache import lookup_cached_result, store_result
@@ -1842,6 +1850,65 @@ def run_session_cleanup_job() -> None:
     deleted = delete_expired_sessions(dsn)
     logging.getLogger("scan_worker.jobs").info(
         "session cleanup completed", extra={"deleted_count": deleted}
+    )
+
+
+# Each template function takes exactly one positional string arg
+# (github_login for welcome, account_login for the Paddle-triggered ones)
+# and returns {"subject", "html", "text"} - see app_server/email_templates.py.
+_EMAIL_TEMPLATES = {
+    "welcome": welcome_email,
+    "payment_failed": payment_failed_email,
+    "subscription_canceled": subscription_canceled_email,
+}
+
+
+@log_job
+def send_transactional_email_job(
+    dedupe_key: str,
+    template_name: str,
+    template_arg: str,
+    to_email: str,
+    installation_id: int | None = None,
+) -> None:
+    """Runs on the "email" queue (see scheduler.py/health_worker.py), never
+    "scans" - same reasoning as the health sweep's own queue split: a slow
+    AI job must never delay a time-sensitive email like payment-failed.
+
+    dedupe_key must be globally unique per logical send (e.g.
+    "payment_failed:{paddle_event_id}", "welcome:{github_login}") - Paddle
+    webhooks are at-least-once delivery, so this is what stops a retried
+    webhook from double-sending.
+    """
+    dsn = get_settings().database_url
+    logger = logging.getLogger("scan_worker.jobs")
+
+    if email_already_sent(dsn, dedupe_key):
+        logger.info("email already sent, skipping", extra={"dedupe_key": dedupe_key})
+        return
+
+    settings = get_settings()
+    if not settings.resend_api_key:
+        logger.warning(
+            "RESEND_API_KEY not configured, skipping email", extra={"dedupe_key": dedupe_key}
+        )
+        return
+
+    render = _EMAIL_TEMPLATES[template_name]
+    message = render(template_arg)
+
+    result = send_transactional_email(
+        settings.resend_api_key,
+        settings.email_from_address,
+        settings.email_reply_to_address,
+        to_email,
+        message["subject"],
+        message["html"],
+        message["text"],
+    )
+
+    record_sent_email(
+        dsn, dedupe_key, template_name, to_email, installation_id, result.get("id")
     )
 
 

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -41,7 +41,8 @@ async def pool():
         for migration in sorted(migrations_dir.glob("*.sql")):
             await conn.execute(migration.read_text())
         await conn.execute(
-            "TRUNCATE installations, sessions, demo_scan_rate_limits, cli_telemetry_events CASCADE"
+            "TRUNCATE installations, sessions, demo_scan_rate_limits, cli_telemetry_events, "
+            "github_user_emails, sent_emails CASCADE"
         )
     yield p
     await p.close()

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -492,3 +492,123 @@ def test_refresh_github_access_token_raises_when_github_reports_an_error(monkeyp
 
     with pytest.raises(RuntimeError):
         refresh_github_access_token("ghr_deadrefresh", "client-id", "client-secret")
+
+
+def _mock_github_clients(monkeypatch, handler):
+    monkeypatch.setattr(
+        "app_server.auth._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    monkeypatch.setattr(
+        "app_server.auth._github_oauth_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://github.com"),
+    )
+
+
+def _handler_with_emails(emails: list[dict]):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/login/oauth/access_token":
+            return httpx.Response(200, json={"access_token": "gho_faketoken"})
+        if request.url.path == "/user":
+            return httpx.Response(200, json={"id": 42, "login": "octocat"})
+        if request.url.path == "/user/emails":
+            return httpx.Response(200, json=emails)
+        return httpx.Response(404)
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_callback_captures_email_and_enqueues_welcome_on_first_login(pool, monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    _mock_github_clients(
+        monkeypatch,
+        _handler_with_emails(
+            [
+                {"email": "old@example.com", "primary": False, "verified": True},
+                {"email": "octocat@example.com", "primary": True, "verified": True},
+            ]
+        ),
+    )
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.auth.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        login_response = await client.get("/auth/login", follow_redirects=False)
+        state = login_response.headers["location"].split("state=")[1]
+        response = await client.get(
+            f"/auth/callback?code=fake-code&state={state}", follow_redirects=False
+        )
+
+    assert response.status_code == 307
+    row = await pool.fetchrow("SELECT email FROM github_user_emails WHERE github_login = 'octocat'")
+    assert row["email"] == "octocat@example.com"
+
+    assert len(enqueue_calls) == 1
+    assert enqueue_calls[0]["dedupe_key"] == "welcome:octocat"
+    assert enqueue_calls[0]["template_name"] == "welcome"
+    assert enqueue_calls[0]["template_arg"] == "octocat"
+    assert enqueue_calls[0]["to_email"] == "octocat@example.com"
+
+
+@pytest.mark.asyncio
+async def test_callback_does_not_reenqueue_welcome_on_second_login(pool, monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    _mock_github_clients(
+        monkeypatch,
+        _handler_with_emails([{"email": "octocat@example.com", "primary": True, "verified": True}]),
+    )
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.auth.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        for _ in range(2):
+            login_response = await client.get("/auth/login", follow_redirects=False)
+            state = login_response.headers["location"].split("state=")[1]
+            await client.get(f"/auth/callback?code=fake-code&state={state}", follow_redirects=False)
+
+    assert len(enqueue_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_callback_degrades_gracefully_when_email_permission_not_granted(pool, monkeypatch):
+    # The GitHub App's "Email addresses" account permission (see auth.py's
+    # _fetch_primary_verified_email comment) not yet granted for this user
+    # surfaces as a 403 on /user/emails - sign-in must still succeed.
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/login/oauth/access_token":
+            return httpx.Response(200, json={"access_token": "gho_faketoken"})
+        if request.url.path == "/user":
+            return httpx.Response(200, json={"id": 42, "login": "octocat"})
+        if request.url.path == "/user/emails":
+            return httpx.Response(403, json={"message": "missing permission"})
+        return httpx.Response(404)
+
+    _mock_github_clients(monkeypatch, handler)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        login_response = await client.get("/auth/login", follow_redirects=False)
+        state = login_response.headers["location"].split("state=")[1]
+        response = await client.get(
+            f"/auth/callback?code=fake-code&state={state}", follow_redirects=False
+        )
+
+    assert response.status_code == 307
+    row = await pool.fetchrow("SELECT 1 FROM github_user_emails WHERE github_login = 'octocat'")
+    assert row is None

--- a/github-app/tests/test_db.py
+++ b/github-app/tests/test_db.py
@@ -25,6 +25,7 @@ from app_server.db import (
     is_installation_member,
     list_api_tokens,
     list_health_check_targets,
+    list_installation_member_emails,
     list_installation_members,
     remove_health_check_target,
     remove_installation_member,
@@ -33,6 +34,7 @@ from app_server.db import (
     set_installation_plan,
     set_webhook_url,
     touch_api_token,
+    upsert_github_user_email,
     upsert_installation,
 )
 
@@ -300,3 +302,37 @@ async def test_remove_health_check_target_is_scoped_to_installation_and_repo(poo
     # A different installation cannot delete someone else's target by id.
     await remove_health_check_target(pool, 701, "octocat/repo1", target_id)
     assert await count_health_check_targets(pool, 700, "octocat/repo1") == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_github_user_email_returns_true_only_on_first_capture(pool):
+    is_new_first = await upsert_github_user_email(pool, "octocat", "octocat@example.com")
+    is_new_second = await upsert_github_user_email(pool, "octocat", "octocat@example.com")
+
+    assert is_new_first is True
+    assert is_new_second is False
+
+
+@pytest.mark.asyncio
+async def test_upsert_github_user_email_self_heals_on_email_change(pool):
+    await upsert_github_user_email(pool, "octocat", "old@example.com")
+    await upsert_github_user_email(pool, "octocat", "new@example.com")
+
+    row = await pool.fetchrow(
+        "SELECT email FROM github_user_emails WHERE github_login = $1", "octocat"
+    )
+    assert row["email"] == "new@example.com"
+
+
+@pytest.mark.asyncio
+async def test_list_installation_member_emails_only_includes_members_who_have_logged_in(pool):
+    await upsert_installation(pool, 700, "acme")
+    await add_installation_member(pool, 700, "alice", "alice")
+    await add_installation_member(pool, 700, "bob", "alice")
+    # bob was added by username but has never logged in, so has no
+    # captured email - this is deliberate v1 scope, not a bug.
+    await upsert_github_user_email(pool, "alice", "alice@example.com")
+
+    emails = await list_installation_member_emails(pool, 700)
+
+    assert emails == ["alice@example.com"]

--- a/github-app/tests/test_email.py
+++ b/github-app/tests/test_email.py
@@ -1,0 +1,59 @@
+import json
+
+import httpx
+import pytest
+
+from scan_worker.email import send_transactional_email
+
+
+def test_send_transactional_email_posts_expected_payload():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json={"id": "msg_123"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    result = send_transactional_email(
+        "re_test_key",
+        "Aletheore <hello@notify.aletheore.com>",
+        "support@aletheore.com",
+        "octocat@example.com",
+        "Welcome",
+        "<p>hi</p>",
+        "hi",
+        http_client=client,
+    )
+
+    assert result == {"id": "msg_123"}
+    assert len(calls) == 1
+    request = calls[0]
+    assert str(request.url) == "https://api.resend.com/emails"
+    assert request.headers["authorization"] == "Bearer re_test_key"
+    body = json.loads(request.content)
+    assert body == {
+        "from": "Aletheore <hello@notify.aletheore.com>",
+        "to": ["octocat@example.com"],
+        "reply_to": "support@aletheore.com",
+        "subject": "Welcome",
+        "html": "<p>hi</p>",
+        "text": "hi",
+    }
+
+
+def test_send_transactional_email_raises_on_error_response():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(422, json={"message": "invalid"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    with pytest.raises(httpx.HTTPStatusError):
+        send_transactional_email(
+            "re_test_key",
+            "Aletheore <hello@notify.aletheore.com>",
+            "support@aletheore.com",
+            "bad@",
+            "Welcome",
+            "<p>hi</p>",
+            "hi",
+            http_client=client,
+        )

--- a/github-app/tests/test_email_templates.py
+++ b/github-app/tests/test_email_templates.py
@@ -1,0 +1,32 @@
+from app_server.email_templates import (
+    payment_failed_email,
+    subscription_canceled_email,
+    welcome_email,
+)
+
+
+def test_welcome_email_greets_by_login_and_includes_pricing_link():
+    message = welcome_email("octocat")
+    assert "octocat" in message["text"]
+    assert "octocat" in message["html"]
+    assert "pricing.html" in message["html"]
+    for key in ("subject", "html", "text"):
+        assert message[key]
+
+
+def test_payment_failed_email_names_account_and_does_not_promise_a_grace_period():
+    message = payment_failed_email("acme-corp")
+    assert "acme-corp" in message["text"]
+    assert "acme-corp" in message["html"]
+    # Access is already fully revoked by the time this fires (no dunning
+    # grace period) - the copy must say so, not imply access is still on.
+    assert "resubscribe" in message["text"].lower()
+    assert "pricing.html" in message["html"]
+
+
+def test_subscription_canceled_email_names_account_and_lists_what_is_lost():
+    message = subscription_canceled_email("acme-corp")
+    assert "acme-corp" in message["text"]
+    assert "acme-corp" in message["html"]
+    assert "AIRview" in message["text"]
+    assert "pricing.html" in message["html"]

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -13,6 +13,7 @@ from scan_worker.db import (
     delete_docs_symbols_not_in,
     delete_expired_sessions,
     delete_wiki_subsystems_not_in,
+    email_already_sent,
     get_extra_seats,
     get_last_endpoint_health,
     get_last_reviewed_sha,
@@ -29,6 +30,7 @@ from scan_worker.db import (
     list_wiki_subsystems,
     record_docs_catchup_swept,
     record_llm_spend,
+    record_sent_email,
     set_last_reviewed_sha,
     upsert_docs_symbol,
     upsert_wiki_overview,
@@ -819,3 +821,29 @@ async def test_record_docs_catchup_swept_upserts_on_conflict(pool):
     )
     assert count == 1
     assert second >= first
+
+
+@pytest.mark.asyncio
+async def test_email_already_sent_is_false_until_recorded(pool):
+    await _insert_installation(pool, 601, "f")
+
+    assert email_already_sent(TEST_DATABASE_URL, "welcome:octocat") is False
+
+    record_sent_email(TEST_DATABASE_URL, "welcome:octocat", "welcome", "o@example.com", 601, "msg_1")
+
+    assert email_already_sent(TEST_DATABASE_URL, "welcome:octocat") is True
+
+
+@pytest.mark.asyncio
+async def test_record_sent_email_ignores_duplicate_dedupe_key(pool):
+    await _insert_installation(pool, 602, "g")
+
+    record_sent_email(TEST_DATABASE_URL, "payment_failed:evt_1:a@x.com", "payment_failed", "a@x.com", 602, "msg_1")
+    # Same dedupe_key again - must not raise (ON CONFLICT DO NOTHING), and
+    # must not create a second row.
+    record_sent_email(TEST_DATABASE_URL, "payment_failed:evt_1:a@x.com", "payment_failed", "a@x.com", 602, "msg_2")
+
+    count = await pool.fetchval(
+        "SELECT count(*) FROM sent_emails WHERE dedupe_key = $1", "payment_failed:evt_1:a@x.com"
+    )
+    assert count == 1

--- a/github-app/tests/test_send_transactional_email_job.py
+++ b/github-app/tests/test_send_transactional_email_job.py
@@ -1,0 +1,77 @@
+from scan_worker.jobs import send_transactional_email_job
+
+
+def test_skips_when_already_sent(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: True)
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError("should not attempt to send an already-sent email")
+
+    monkeypatch.setattr("scan_worker.jobs.send_transactional_email", _fail_if_called)
+
+    send_transactional_email_job("welcome:octocat", "welcome", "octocat", "o@example.com")
+
+
+def test_skips_when_resend_api_key_not_configured(monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: False)
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError("should not attempt to send without a configured API key")
+
+    monkeypatch.setattr("scan_worker.jobs.send_transactional_email", _fail_if_called)
+
+    send_transactional_email_job("welcome:octocat", "welcome", "octocat", "o@example.com")
+
+
+def test_sends_with_rendered_template_and_records_on_success(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: False)
+
+    send_calls = []
+
+    def _fake_send(api_key, from_addr, reply_to, to, subject, html, text):
+        send_calls.append(
+            {
+                "api_key": api_key,
+                "from_addr": from_addr,
+                "reply_to": reply_to,
+                "to": to,
+                "subject": subject,
+                "html": html,
+                "text": text,
+            }
+        )
+        return {"id": "msg_abc"}
+
+    monkeypatch.setattr("scan_worker.jobs.send_transactional_email", _fake_send)
+
+    record_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.record_sent_email",
+        lambda dsn, dedupe_key, template_name, recipient, installation_id, resend_message_id: record_calls.append(
+            (dedupe_key, template_name, recipient, installation_id, resend_message_id)
+        ),
+    )
+
+    send_transactional_email_job(
+        "welcome:octocat", "welcome", "octocat", "o@example.com", installation_id=42
+    )
+
+    assert len(send_calls) == 1
+    assert send_calls[0]["api_key"] == "re_test_key"
+    assert send_calls[0]["to"] == "o@example.com"
+    assert "octocat" in send_calls[0]["html"]
+
+    assert record_calls == [("welcome:octocat", "welcome", "o@example.com", 42, "msg_abc")]
+
+
+def test_unknown_template_name_raises(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: False)
+
+    import pytest
+
+    with pytest.raises(KeyError):
+        send_transactional_email_job("x:1", "not_a_real_template", "octocat", "o@example.com")

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -9,7 +9,13 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app_server import paddle_ip_allowlist
-from app_server.db import get_extra_seats, get_installation, upsert_installation
+from app_server.db import (
+    add_installation_member,
+    get_extra_seats,
+    get_installation,
+    upsert_github_user_email,
+    upsert_installation,
+)
 from app_server.main import app
 from app_server.webhooks.paddle import handle_paddle_webhook_event
 
@@ -410,3 +416,126 @@ async def test_unhandled_event_type_is_ignored(pool):
 
     installation = await get_installation(pool, 305)
     assert installation["plan"] == "air"
+
+
+@pytest.mark.asyncio
+async def test_past_due_from_paid_enqueues_payment_failed_email_to_members(pool, monkeypatch):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (700, 'acme', 'air')"
+    )
+    await add_installation_member(pool, 700, "alice", "alice")
+    await upsert_github_user_email(pool, "alice", "alice@example.com")
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    payload = _subscription_event_payload("subscription.updated", "past_due", 700)
+    payload["event_id"] = "evt_past_due_1"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert len(enqueue_calls) == 1
+    call = enqueue_calls[0]
+    assert call["template_name"] == "payment_failed"
+    assert call["template_arg"] == "acme"
+    assert call["to_email"] == "alice@example.com"
+    assert call["dedupe_key"] == "payment_failed:evt_past_due_1:alice@example.com"
+    assert call["installation_id"] == 700
+
+
+@pytest.mark.asyncio
+async def test_canceled_from_paid_enqueues_win_back_email(pool, monkeypatch):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (701, 'acme', 'air')"
+    )
+    await add_installation_member(pool, 701, "alice", "alice")
+    await upsert_github_user_email(pool, "alice", "alice@example.com")
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 701)
+    payload["event_id"] = "evt_canceled_1"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert len(enqueue_calls) == 1
+    assert enqueue_calls[0]["template_name"] == "subscription_canceled"
+    assert enqueue_calls[0]["dedupe_key"] == "subscription_canceled:evt_canceled_1:alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_no_email_enqueued_when_installation_was_already_free(pool, monkeypatch):
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 702, "acme")  # defaults to plan='free'
+    await add_installation_member(pool, 702, "alice", "alice")
+    await upsert_github_user_email(pool, "alice", "alice@example.com")
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    payload = _subscription_event_payload("subscription.updated", "past_due", 702)
+    payload["event_id"] = "evt_already_free"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert enqueue_calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_email_enqueued_for_members_who_have_never_logged_in(pool, monkeypatch):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (703, 'acme', 'air')"
+    )
+    # bob was added by username but has never logged in - no captured
+    # email, so no row to send to. Deliberate v1 scope, not a bug.
+    await add_installation_member(pool, 703, "bob", "bob")
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 703)
+    payload["event_id"] = "evt_no_email_on_file"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert enqueue_calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_email_enqueued_without_event_id(pool, monkeypatch):
+    # No event_id means no safe dedupe_key - skip rather than risk a
+    # duplicate send on a retried webhook that somehow lacks one.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (704, 'acme', 'air')"
+    )
+    await add_installation_member(pool, 704, "alice", "alice")
+    await upsert_github_user_email(pool, "alice", "alice@example.com")
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    payload = _subscription_event_payload("subscription.updated", "past_due", 704)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert enqueue_calls == []


### PR DESCRIPTION
## Summary
Stands up transactional email from scratch — there was no SMTP/Resend/SendGrid wiring anywhere in the app, and no email address stored for anyone, free or paid.

- **Provider**: Resend, sending from a dedicated `notify.aletheore.com` subdomain — separate SPF/DKIM from the root domain, so this never touches `support@aletheore.com`'s Hostinger-hosted receiving or the site's own reputation. Domain is verified, API key provisioned and already deployed to prod's `.env`.
- **Email source**: captured via GitHub's `/user/emails` on every login, in a new `github_user_emails` table keyed by `github_login` (not `sessions`, which get pruned). **Note**: this needs the GitHub App's "Email addresses" account permission enabled in the App's own settings — there's no runtime OAuth scope for GitHub Apps the way there is for legacy OAuth Apps. (Already done by the repo owner as of this PR.)
- **Delivery**: RQ jobs on a new `email` queue, consumed by `health-worker` (not `scan-worker`'s `scans`) — same reasoning as the earlier health-sweep queue split: a slow AI job must never delay a payment-failed email behind it.
- **Idempotency**: `sent_emails` table with a `UNIQUE dedupe_key`, since Paddle webhooks are at-least-once delivery.

Three triggers, built to be extended incrementally:
1. `welcome` — first login ever for a `github_login`.
2. `payment_failed` — `subscription.updated` + `status=past_due` from a previously-paid installation. No dunning grace period exists in this product (access is cut immediately on a failed payment), so the copy says "resubscribe," not "update your card before you lose access."
3. `subscription_canceled` — win-back copy on `subscription.canceled`.

Both Paddle triggers fan out to every installation member who's logged in at least once, not just the original purchaser. Members added by username who've never logged in have no email on file yet — that (an invite-by-email flow) and a weekly usage digest are explicit v2s, not this PR.

## Test plan
- [x] Full `github-app/` suite: 856 passed (was 834 before this branch), including new `test_email.py`, `test_email_templates.py`, `test_send_transactional_email_job.py`, plus new coverage in `test_auth.py`, `test_db.py`, `test_scan_worker_db.py`, `test_webhooks_paddle.py`
- [x] `src/` suite unaffected (904 passed, 1 pre-existing unrelated local-env failure)
- [x] Confirmed all 27 existing Paddle webhook tests and all 26 existing auth tests still pass unmodified in behavior — the new email capture/trigger paths degrade gracefully (try/except, matching this codebase's existing best-effort pattern for non-critical-path side effects) rather than being load-bearing for sign-in or billing
- [ ] Real end-to-end verification (an actual login producing a real welcome email) after this deploys — done separately post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)