### PR TITLE
Fix Resend send timing out on httpx's 5s default

### DIFF
--- a/github-app/scan_worker/email.py
+++ b/github-app/scan_worker/email.py
@@ -19,7 +19,12 @@ def send_transactional_email(
     send_health_alert/send_slack_alert - the caller (the RQ job) is what
     decides retry/dedupe behavior, not this function.
     """
-    client = http_client or httpx.Client()
+    # httpx's 5s default (confirmed too tight against a real, otherwise-
+    # healthy Resend call in prod - a ReadTimeout on this container's
+    # first-ever request to a new external host, most likely DNS/TLS cold
+    # start) is a needless failure here: this runs in a background job,
+    # not a live request path, so there's no user waiting on the clock.
+    client = http_client or httpx.Client(timeout=15.0)
     response = client.post(
         RESEND_API_URL,
         headers={"Authorization": f"Bearer {api_key}"},


### PR DESCRIPTION
## Summary
Caught live during the real end-to-end welcome-email test for #133: the first request `health-worker` ever made to Resend's API (a brand-new external host for that container) hit httpx's 5s default timeout and raised `ReadTimeout`, failing the job. Set an explicit 15s timeout - this runs in a background job, not a live request path, so there's no reason to inherit a tight default.

## Test plan
- [x] `tests/test_email.py` - 2 passed, unaffected (tests inject their own mock client)
- [x] Will manually re-trigger the failed welcome-email job after this deploys to confirm delivery completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)