### PR TITLE
feat: weekly usage digest email

### DIFF
--- a/github-app/app_server/email_templates.py
+++ b/github-app/app_server/email_templates.py
@@ -72,6 +72,66 @@ def payment_failed_email(account_login: str) -> dict:
     return {"subject": subject, "html": html, "text": text}
 
 
+def weekly_digest_email(
+    account_login: str,
+    scans_this_week: int,
+    endpoints_reachable: int,
+    endpoints_total: int,
+    llm_spend_month_to_date: float,
+    flash_reviews_month_to_date: int,
+) -> dict:
+    # Sent unconditionally to every paid installation, including quiet
+    # ones (see digest_sends' migration comment - this is meant to
+    # re-engage installs that have gone quiet, not just report on active
+    # ones), so every line needs copy that reads naturally at zero too.
+    if scans_this_week > 0:
+        scan_line = f"{scans_this_week} scan{'s' if scans_this_week != 1 else ''} run this week."
+    else:
+        scan_line = (
+            "No scans run this week - push to a repo, or run "
+            "`aletheore audit . --managed`, and it'll show up here next week."
+        )
+
+    if endpoints_total > 0:
+        health_line = f"Endpoint monitoring: {endpoints_reachable}/{endpoints_total} reachable right now."
+    else:
+        health_line = (
+            "No endpoints being monitored yet - add one in Settings to catch "
+            "outages before your users do."
+        )
+
+    review_word = "review" if flash_reviews_month_to_date == 1 else "reviews"
+    spend_line = (
+        f"${llm_spend_month_to_date:.2f} in AI spend this month, across "
+        f"{flash_reviews_month_to_date} automated PR {review_word}."
+    )
+
+    subject = f"Aletheore weekly digest for {account_login}"
+    text = (
+        f"Hi,\n\n"
+        f"Here's what happened on {account_login}'s Aletheore AIR this week:\n\n"
+        f"- {scan_line}\n"
+        f"- {health_line}\n"
+        f"- {spend_line}\n\n"
+        "Full details: https://app.aletheore.com/dashboard\n\n"
+        "Don't want these? Reply and let us know."
+        f"{_FOOTER_TEXT}"
+    )
+    html = (
+        "<p>Hi,</p>"
+        f"<p>Here's what happened on <strong>{account_login}</strong>'s Aletheore AIR this week:</p>"
+        "<ul>"
+        f"<li>{scan_line}</li>"
+        f"<li>{health_line}</li>"
+        f"<li>{spend_line}</li>"
+        "</ul>"
+        '<p>Full details: <a href="https://app.aletheore.com/dashboard">your dashboard</a>.</p>'
+        "<p>Don't want these? Reply and let us know.</p>"
+        f"{_FOOTER_HTML}"
+    )
+    return {"subject": subject, "html": html, "text": text}
+
+
 def subscription_canceled_email(account_login: str) -> dict:
     subject = "Sorry to see you go"
     text = (

--- a/github-app/migrations/031_weekly_digest.sql
+++ b/github-app/migrations/031_weekly_digest.sql
@@ -1,0 +1,10 @@
+-- Tracks the last time the weekly usage digest was sent per installation.
+-- Separate from docs_catchup_sweeps: that table is per-repo and gated on
+-- real activity since the last sweep (no point re-describing an unchanged
+-- repo); this is per-installation and unconditional - the digest is
+-- explicitly meant to re-engage installs that have gone quiet, so a week
+-- with nothing to report still gets an email, not silence.
+CREATE TABLE IF NOT EXISTS digest_sends (
+    installation_id  BIGINT PRIMARY KEY REFERENCES installations(installation_id) ON DELETE CASCADE,
+    last_sent_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -1014,3 +1014,102 @@ def record_sent_email(
                 (dedupe_key, template_name, recipient, installation_id, resend_message_id),
             )
         conn.commit()
+
+
+def list_paid_installations_due_for_digest(dsn: str, interval_seconds: int) -> list[int]:
+    """Paid installations due for the weekly usage digest - never sent
+    before, or sent more than interval_seconds ago. Unlike the docs
+    catch-up sweep, deliberately NOT gated on activity (see
+    digest_sends' migration comment) - a quiet installation still gets a
+    digest, just one that gently prompts re-engagement instead of listing
+    numbers.
+    """
+    import psycopg
+    import psycopg.rows
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+            cur.execute(
+                """
+                SELECT i.installation_id
+                FROM installations i
+                LEFT JOIN digest_sends d ON d.installation_id = i.installation_id
+                WHERE i.plan != 'free'
+                  AND (d.last_sent_at IS NULL OR d.last_sent_at <= now() - make_interval(secs => %s))
+                """,
+                (interval_seconds,),
+            )
+            return [row[0] for row in cur.fetchall()]
+
+
+def record_digest_sent(dsn: str, installation_id: int) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO digest_sends (installation_id, last_sent_at)
+                VALUES (%s, now())
+                ON CONFLICT (installation_id) DO UPDATE SET last_sent_at = now()
+                """,
+                (installation_id,),
+            )
+        conn.commit()
+
+
+def count_repo_scans_since(dsn: str, installation_id: int, since: datetime) -> int:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM repo_history WHERE installation_id = %s AND scanned_at >= %s",
+                (installation_id, since),
+            )
+            return cur.fetchone()[0]
+
+
+def get_endpoint_health_summary(dsn: str, installation_id: int, stale_after_seconds: int = 900) -> dict:
+    """Current live status - most-recent row per (method, path) within the
+    same 15-minute staleness window as the public status API
+    (dashboard.py's PUBLIC_HEALTH_STALE_AFTER), so the digest and the
+    status page never disagree about what's currently "up".
+    """
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT DISTINCT ON (endpoint_method, endpoint_path) reachable
+                FROM endpoint_health
+                WHERE installation_id = %s AND checked_at >= now() - make_interval(secs => %s)
+                ORDER BY endpoint_method, endpoint_path, checked_at DESC, id DESC
+                """,
+                (installation_id, stale_after_seconds),
+            )
+            rows = cur.fetchall()
+            return {"total": len(rows), "reachable": sum(1 for (reachable,) in rows if reachable)}
+
+
+def list_installation_member_emails(dsn: str, installation_id: int) -> list[str]:
+    """Sync (psycopg) counterpart to app_server.db.list_installation_member_emails
+    (asyncpg) - scan_worker jobs run outside the event loop, so they can't
+    share that pool. Same semantics: only members who've logged in at
+    least once (and so have a row in github_user_emails) get an email.
+    """
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT e.email
+                FROM installation_members m
+                JOIN github_user_emails e ON e.github_login = m.github_login
+                WHERE m.installation_id = %s
+                """,
+                (installation_id,),
+            )
+            return [row[0] for row in cur.fetchall()]

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -45,10 +45,12 @@ from scan_worker.db import (
     check_and_reserve_flash_review_attempt,
     check_and_reserve_managed_audit,
     check_and_reserve_monthly_repo_scan_slot,
+    count_repo_scans_since,
     delete_docs_symbols_not_in,
     delete_expired_sessions,
     delete_wiki_subsystems_not_in,
     email_already_sent,
+    get_endpoint_health_summary,
     get_extra_seats,
     get_flash_review_count_this_month,
     get_installation as get_installation_row,
@@ -63,10 +65,13 @@ from scan_worker.db import (
     installation_spend_lock,
     list_docs_symbols,
     list_health_check_targets_all,
+    list_installation_member_emails,
+    list_paid_installations_due_for_digest,
     list_paid_repos_due_for_docs_catchup,
     list_recent_endpoint_incidents,
     list_repos_for_installation,
     list_wiki_subsystems,
+    record_digest_sent,
     record_docs_catchup_swept,
     record_llm_spend,
     record_sent_email,
@@ -103,8 +108,10 @@ from scan_worker.github_api import (
 from app_server.email_templates import (
     payment_failed_email,
     subscription_canceled_email,
+    weekly_digest_email,
     welcome_email,
 )
+from app_server.email_queue import enqueue_transactional_email
 from scan_worker.email import send_transactional_email
 from scan_worker.managed_audit import run_managed_audit
 from scan_worker.model_tiers import PRO_MODEL, model_for_plan, writing_adapter_for_plan
@@ -1860,6 +1867,7 @@ _EMAIL_TEMPLATES = {
     "welcome": welcome_email,
     "payment_failed": payment_failed_email,
     "subscription_canceled": subscription_canceled_email,
+    "weekly_digest": weekly_digest_email,
 }
 
 
@@ -1867,7 +1875,7 @@ _EMAIL_TEMPLATES = {
 def send_transactional_email_job(
     dedupe_key: str,
     template_name: str,
-    template_arg: str,
+    template_arg: str | dict,
     to_email: str,
     installation_id: int | None = None,
 ) -> None:
@@ -1879,6 +1887,10 @@ def send_transactional_email_job(
     "payment_failed:{paddle_event_id}", "welcome:{github_login}") - Paddle
     webhooks are at-least-once delivery, so this is what stops a retried
     webhook from double-sending.
+
+    template_arg is a single positional string for the single-value
+    templates (welcome/payment_failed/subscription_canceled), or a dict of
+    keyword args for multi-value ones (weekly_digest).
     """
     dsn = get_settings().database_url
     logger = logging.getLogger("scan_worker.jobs")
@@ -1895,7 +1907,7 @@ def send_transactional_email_job(
         return
 
     render = _EMAIL_TEMPLATES[template_name]
-    message = render(template_arg)
+    message = render(**template_arg) if isinstance(template_arg, dict) else render(template_arg)
 
     result = send_transactional_email(
         settings.resend_api_key,
@@ -1910,6 +1922,66 @@ def send_transactional_email_job(
     record_sent_email(
         dsn, dedupe_key, template_name, to_email, installation_id, result.get("id")
     )
+
+
+WEEKLY_DIGEST_INTERVAL_SECONDS = 7 * 24 * 3600
+
+
+@log_job
+def run_weekly_digest_sweep_job() -> None:
+    """Runs on "scans" (see scheduler.py), same placement as the docs
+    catch-up sweep - a few hours of scheduling slop on a weekly cadence is
+    fine, this doesn't need "email" queue urgency. Gathers each due
+    installation's data here (cheap DB reads) and enqueues one send per
+    member onto "email" - not sent inline, so this sweep never blocks on
+    N sequential Resend calls.
+    """
+    dsn = get_settings().database_url
+    settings = get_settings()
+    logger = logging.getLogger("scan_worker.jobs")
+    since = datetime.now(timezone.utc) - timedelta(days=7)
+    week_key = datetime.now(timezone.utc).strftime("%G-W%V")
+
+    for installation_id in list_paid_installations_due_for_digest(dsn, WEEKLY_DIGEST_INTERVAL_SECONDS):
+        try:
+            installation = get_installation_row(dsn, installation_id)
+            if installation is None:
+                continue
+
+            context = {
+                "account_login": installation["account_login"],
+                "scans_this_week": count_repo_scans_since(dsn, installation_id, since),
+                "llm_spend_month_to_date": get_llm_spend_this_month(dsn, installation_id),
+                "flash_reviews_month_to_date": get_flash_review_count_this_month(dsn, installation_id),
+            }
+            endpoint_summary = get_endpoint_health_summary(dsn, installation_id)
+            context["endpoints_reachable"] = endpoint_summary["reachable"]
+            context["endpoints_total"] = endpoint_summary["total"]
+
+            for member_email in list_installation_member_emails(dsn, installation_id):
+                enqueue_transactional_email(
+                    settings.redis_url,
+                    dedupe_key=f"weekly_digest:{installation_id}:{week_key}:{member_email}",
+                    template_name="weekly_digest",
+                    template_arg=context,
+                    to_email=member_email,
+                    installation_id=installation_id,
+                )
+
+            # Recorded after enqueueing, not before: if this installation
+            # errors partway through, the next tick retries it from
+            # scratch - safe, since each individual send is separately
+            # deduped by sent_emails, so already-sent members are skipped
+            # rather than double-emailed.
+            record_digest_sent(dsn, installation_id)
+        except Exception:  # noqa: BLE001
+            # One installation's bad data (a missing row, a query hiccup)
+            # must not take down the digest for every other paying
+            # customer due this tick - matches the health sweep's own
+            # per-target isolation.
+            logger.warning(
+                "weekly digest sweep failed for installation=%s", installation_id, exc_info=True
+            )
 
 
 def _live_wiki_naming_adapter() -> OpenAICompatibleAdapter:

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -22,6 +22,11 @@ SESSION_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # above normal runtime for the rare tick where several repos are due at
 # once, same reasoning as HEALTH_SWEEP_JOB_TIMEOUT_SECONDS.
 DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS = 600
+# Reads the due list (a cheap join over installations/digest_sends), then
+# enqueues one send per recipient onto "email" rather than sending inline -
+# the actual Resend calls happen there, not in this job, so this stays
+# bounded even if many installations are due the same tick.
+WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS = 300
 
 SCANS_QUEUE_NAME = "scans"
 # The health sweep gets its own queue, consumed by a dedicated worker (see
@@ -57,6 +62,10 @@ def run_forever(
         scans_queue.enqueue(
             "scan_worker.jobs.run_live_docs_catchup_sweep_job",
             job_timeout=DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
+        )
+        scans_queue.enqueue(
+            "scan_worker.jobs.run_weekly_digest_sweep_job",
+            job_timeout=WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
         )
         iterations += 1
         if max_iterations is not None and iterations >= max_iterations:

--- a/github-app/tests/test_email_templates.py
+++ b/github-app/tests/test_email_templates.py
@@ -1,6 +1,7 @@
 from app_server.email_templates import (
     payment_failed_email,
     subscription_canceled_email,
+    weekly_digest_email,
     welcome_email,
 )
 
@@ -30,3 +31,50 @@ def test_subscription_canceled_email_names_account_and_lists_what_is_lost():
     assert "acme-corp" in message["html"]
     assert "AIRview" in message["text"]
     assert "pricing.html" in message["html"]
+
+
+def test_weekly_digest_email_reports_real_numbers_when_active():
+    message = weekly_digest_email(
+        account_login="acme-corp",
+        scans_this_week=3,
+        endpoints_reachable=4,
+        endpoints_total=5,
+        llm_spend_month_to_date=12.34,
+        flash_reviews_month_to_date=7,
+    )
+    assert "acme-corp" in message["text"]
+    assert "3 scans" in message["text"]
+    assert "4/5 reachable" in message["text"]
+    assert "$12.34" in message["text"]
+    assert "7 automated PR reviews" in message["text"]
+
+
+def test_weekly_digest_email_singular_scan_and_review_wording():
+    message = weekly_digest_email(
+        account_login="acme-corp",
+        scans_this_week=1,
+        endpoints_reachable=1,
+        endpoints_total=1,
+        llm_spend_month_to_date=0.5,
+        flash_reviews_month_to_date=1,
+    )
+    assert "1 scan run this week" in message["text"]
+    assert "1 automated PR review." in message["text"]
+
+
+def test_weekly_digest_email_reads_naturally_with_zero_activity():
+    # Sent unconditionally to re-engage quiet installs (see
+    # digest_sends' migration comment) - every field must degrade to
+    # something that reads as an invitation, not a broken report.
+    message = weekly_digest_email(
+        account_login="quiet-co",
+        scans_this_week=0,
+        endpoints_reachable=0,
+        endpoints_total=0,
+        llm_spend_month_to_date=0.0,
+        flash_reviews_month_to_date=0,
+    )
+    assert "No scans run this week" in message["text"]
+    assert "No endpoints being monitored yet" in message["text"]
+    assert "0/0 reachable" not in message["text"]
+    assert "$0.00" in message["text"]

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -10,10 +10,12 @@ from scan_worker.db import (
     check_and_reserve_flash_review_attempt,
     check_and_reserve_managed_audit,
     check_and_reserve_monthly_repo_scan_slot,
+    count_repo_scans_since,
     delete_docs_symbols_not_in,
     delete_expired_sessions,
     delete_wiki_subsystems_not_in,
     email_already_sent,
+    get_endpoint_health_summary,
     get_extra_seats,
     get_last_endpoint_health,
     get_last_reviewed_sha,
@@ -25,9 +27,12 @@ from scan_worker.db import (
     installation_spend_lock,
     list_health_check_targets_all,
     list_docs_symbols,
+    list_installation_member_emails,
+    list_paid_installations_due_for_digest,
     list_paid_repos_due_for_docs_catchup,
     list_repos_for_installation,
     list_wiki_subsystems,
+    record_digest_sent,
     record_docs_catchup_swept,
     record_llm_spend,
     record_sent_email,
@@ -847,3 +852,116 @@ async def test_record_sent_email_ignores_duplicate_dedupe_key(pool):
         "SELECT count(*) FROM sent_emails WHERE dedupe_key = $1", "payment_failed:evt_1:a@x.com"
     )
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_list_paid_installations_due_for_digest_excludes_free_plan(pool):
+    await _insert_installation(pool, 800, "paid-co", plan="indie")
+    await _insert_installation(pool, 801, "free-co", plan="free")
+
+    due = list_paid_installations_due_for_digest(TEST_DATABASE_URL, interval_seconds=7 * 86400)
+
+    assert 800 in due
+    assert 801 not in due
+
+
+@pytest.mark.asyncio
+async def test_list_paid_installations_due_for_digest_excludes_recently_sent(pool):
+    await _insert_installation(pool, 802, "paid-co", plan="indie")
+    record_digest_sent(TEST_DATABASE_URL, 802)
+
+    due = list_paid_installations_due_for_digest(TEST_DATABASE_URL, interval_seconds=7 * 86400)
+
+    assert 802 not in due
+
+
+@pytest.mark.asyncio
+async def test_list_paid_installations_due_for_digest_includes_installation_never_sent_to(pool):
+    await _insert_installation(pool, 803, "paid-co", plan="indie")
+
+    due = list_paid_installations_due_for_digest(TEST_DATABASE_URL, interval_seconds=7 * 86400)
+
+    assert 803 in due
+
+
+@pytest.mark.asyncio
+async def test_list_paid_installations_due_for_digest_includes_after_cooldown_elapses(pool):
+    await _insert_installation(pool, 804, "paid-co", plan="indie")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO digest_sends (installation_id, last_sent_at) VALUES ($1, now() - interval '8 days')",
+            804,
+        )
+
+    due = list_paid_installations_due_for_digest(TEST_DATABASE_URL, interval_seconds=7 * 86400)
+
+    assert 804 in due
+
+
+@pytest.mark.asyncio
+async def test_count_repo_scans_since_only_counts_recent_scans(pool):
+    await _insert_installation(pool, 805, "co")
+    insert_repo_history(
+        TEST_DATABASE_URL, 805, "co/repo", datetime.now(timezone.utc) - timedelta(days=10), {}
+    )
+    insert_repo_history(TEST_DATABASE_URL, 805, "co/repo", datetime.now(timezone.utc), {})
+
+    count = count_repo_scans_since(TEST_DATABASE_URL, 805, datetime.now(timezone.utc) - timedelta(days=7))
+
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_health_summary_counts_reachable_and_total(pool):
+    await _insert_installation(pool, 806, "co")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, status_code, latency_ms)
+            VALUES
+                (806, 'co/repo', 'GET', '/a', true, 200, 5.0),
+                (806, 'co/repo', 'GET', '/b', false, NULL, NULL)
+            """
+        )
+
+    summary = get_endpoint_health_summary(TEST_DATABASE_URL, 806)
+
+    assert summary == {"total": 2, "reachable": 1}
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_health_summary_excludes_stale_rows(pool):
+    await _insert_installation(pool, 807, "co")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, status_code, checked_at)
+            VALUES
+                (807, 'co/repo', 'GET', '/a', true, 200, now() - interval '1 hour')
+            """
+        )
+
+    summary = get_endpoint_health_summary(TEST_DATABASE_URL, 807, stale_after_seconds=900)
+
+    assert summary == {"total": 0, "reachable": 0}
+
+
+@pytest.mark.asyncio
+async def test_list_installation_member_emails_sync_matches_async_semantics(pool):
+    await _insert_installation(pool, 808, "co")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO installation_members (installation_id, github_login, added_by_github_login) "
+            "VALUES (808, 'alice', 'alice'), (808, 'bob', 'alice')"
+        )
+        await conn.execute(
+            "INSERT INTO github_user_emails (github_login, email) VALUES ('alice', 'alice@example.com')"
+        )
+        # bob was added by username but has never logged in - no email on
+        # file, deliberately excluded.
+
+    emails = list_installation_member_emails(TEST_DATABASE_URL, 808)
+
+    assert emails == ["alice@example.com"]

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -6,6 +6,7 @@ from scan_worker.scheduler import (
     HEALTH_SWEEP_JOB_TIMEOUT_SECONDS,
     SCANS_QUEUE_NAME,
     SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
+    WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
     run_forever,
 )
 
@@ -40,7 +41,7 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
 
-    assert scans_queue.enqueue.call_count == 6
+    assert scans_queue.enqueue.call_count == 9
     session_cleanup_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
@@ -49,11 +50,18 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_live_docs_catchup_sweep_job",)
     ]
+    weekly_digest_calls = [
+        c for c in scans_queue.enqueue.call_args_list
+        if c.args == ("scan_worker.jobs.run_weekly_digest_sweep_job",)
+    ]
     assert len(session_cleanup_calls) == 3
     assert len(docs_catchup_calls) == 3
+    assert len(weekly_digest_calls) == 3
     for call in session_cleanup_calls:
         assert call.kwargs == {"job_timeout": SESSION_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in docs_catchup_calls:
         assert call.kwargs == {"job_timeout": DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS}
+    for call in weekly_digest_calls:
+        assert call.kwargs == {"job_timeout": WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS}
     # Sleeps between iterations, not after the last one.
     assert sleeps == [42, 42]

--- a/github-app/tests/test_send_transactional_email_job.py
+++ b/github-app/tests/test_send_transactional_email_job.py
@@ -67,6 +67,43 @@ def test_sends_with_rendered_template_and_records_on_success(monkeypatch):
     assert record_calls == [("welcome:octocat", "welcome", "o@example.com", 42, "msg_abc")]
 
 
+def test_dict_template_arg_is_expanded_as_keyword_args(monkeypatch):
+    # weekly_digest needs several values, unlike the single-string
+    # templates (welcome/payment_failed/subscription_canceled) - a dict
+    # template_arg is expanded as **kwargs into the render function
+    # rather than passed positionally.
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: False)
+
+    send_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_transactional_email",
+        lambda api_key, from_addr, reply_to, to, subject, html, text: send_calls.append(
+            {"subject": subject, "text": text}
+        )
+        or {"id": "msg_digest"},
+    )
+    monkeypatch.setattr("scan_worker.jobs.record_sent_email", lambda *a, **k: None)
+
+    send_transactional_email_job(
+        "weekly_digest:1:2026-W32:o@example.com",
+        "weekly_digest",
+        {
+            "account_login": "acme",
+            "scans_this_week": 2,
+            "endpoints_reachable": 1,
+            "endpoints_total": 1,
+            "llm_spend_month_to_date": 1.0,
+            "flash_reviews_month_to_date": 1,
+        },
+        "o@example.com",
+    )
+
+    assert len(send_calls) == 1
+    assert "acme" in send_calls[0]["text"]
+    assert "2 scans" in send_calls[0]["text"]
+
+
 def test_unknown_template_name_raises(monkeypatch):
     monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
     monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: False)

--- a/github-app/tests/test_weekly_digest_sweep_job.py
+++ b/github-app/tests/test_weekly_digest_sweep_job.py
@@ -1,0 +1,102 @@
+from scan_worker.jobs import run_weekly_digest_sweep_job
+
+
+def _patch_installation_data(monkeypatch, *, account_login="acme", emails=("alice@example.com",)):
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda dsn, iid: {"account_login": account_login})
+    monkeypatch.setattr("scan_worker.jobs.count_repo_scans_since", lambda dsn, iid, since: 3)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda dsn, iid: 5.5)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda dsn, iid: 2)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_summary", lambda dsn, iid: {"total": 3, "reachable": 3}
+    )
+    monkeypatch.setattr("scan_worker.jobs.list_installation_member_emails", lambda dsn, iid: list(emails))
+
+
+def test_processes_each_due_installation_and_enqueues_per_member(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.list_paid_installations_due_for_digest", lambda dsn, interval: [1])
+    _patch_installation_data(monkeypatch, emails=("alice@example.com", "bob@example.com"))
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+    recorded = []
+    monkeypatch.setattr("scan_worker.jobs.record_digest_sent", lambda dsn, iid: recorded.append(iid))
+
+    run_weekly_digest_sweep_job()
+
+    assert len(enqueue_calls) == 2
+    for call in enqueue_calls:
+        assert call["template_name"] == "weekly_digest"
+        assert call["installation_id"] == 1
+        assert call["template_arg"] == {
+            "account_login": "acme",
+            "scans_this_week": 3,
+            "llm_spend_month_to_date": 5.5,
+            "flash_reviews_month_to_date": 2,
+            "endpoints_reachable": 3,
+            "endpoints_total": 3,
+        }
+    emails = {c["to_email"] for c in enqueue_calls}
+    assert emails == {"alice@example.com", "bob@example.com"}
+    dedupe_keys = {c["dedupe_key"] for c in enqueue_calls}
+    assert all(k.startswith("weekly_digest:1:") for k in dedupe_keys)
+    # Distinct recipients must get distinct dedupe keys, or only one of
+    # them would ever actually receive the send.
+    assert len(dedupe_keys) == 2
+
+    assert recorded == [1]
+
+
+def test_missing_installation_is_skipped_without_error(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.list_paid_installations_due_for_digest", lambda dsn, interval: [1])
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda dsn, iid: None)
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError("should not enqueue for a missing installation")
+
+    monkeypatch.setattr("scan_worker.jobs.enqueue_transactional_email", _fail_if_called)
+
+    run_weekly_digest_sweep_job()  # must not raise
+
+
+def test_one_installation_failing_does_not_stop_the_others(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.list_paid_installations_due_for_digest", lambda dsn, interval: [1, 2])
+
+    def _get_installation(dsn, iid):
+        if iid == 1:
+            raise RuntimeError("boom")
+        return {"account_login": "acme-2"}
+
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", _get_installation)
+    monkeypatch.setattr("scan_worker.jobs.count_repo_scans_since", lambda dsn, iid, since: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda dsn, iid: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda dsn, iid: 0)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_summary", lambda dsn, iid: {"total": 0, "reachable": 0}
+    )
+    monkeypatch.setattr("scan_worker.jobs.list_installation_member_emails", lambda dsn, iid: ["m@example.com"])
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+    monkeypatch.setattr("scan_worker.jobs.record_digest_sent", lambda dsn, iid: None)
+
+    run_weekly_digest_sweep_job()  # installation 1 fails, installation 2 still processed
+
+    assert len(enqueue_calls) == 1
+    assert enqueue_calls[0]["template_arg"]["account_login"] == "acme-2"
+
+
+def test_no_installations_due_enqueues_nothing(monkeypatch):
+    monkeypatch.setattr("scan_worker.jobs.list_paid_installations_due_for_digest", lambda dsn, interval: [])
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError("should not enqueue when nothing is due")
+
+    monkeypatch.setattr("scan_worker.jobs.enqueue_transactional_email", _fail_if_called)
+
+    run_weekly_digest_sweep_job()


### PR DESCRIPTION
## Summary
- Fourth and final transactional email trigger (welcome, payment-failed, subscription-canceled already shipped): a weekly usage digest sent to every captured member email of each paid installation, on a 7-day cooldown, sent unconditionally (not activity-gated) to re-engage quiet installs.
- Content reports real trailing-7-day scan/health data, but honestly frames LLM spend and Flash review counts as month-to-date since those tables have no weekly granularity.
- `send_transactional_email_job`'s `template_arg` becomes `str | dict` so the multi-value digest template can reuse the existing single-arg send path without touching the 3 already-shipped templates.
- New `digest_sends` table for per-installation cooldown tracking.
- Scheduler enqueues the sweep on the `scans` queue every ~180s tick (batch/AI-adjacent, not time-sensitive).

## Test plan
- [x] Full suite: `python3 -m pytest tests/ -q` — 872 passed, 8 skipped
- [x] New/updated test files individually verified: `test_scan_worker_db.py`, `test_email_templates.py`, `test_weekly_digest_sweep_job.py`, `test_scheduler.py`, `test_send_transactional_email_job.py`
- [ ] CI checks (pytest ×3, dependency licenses, image scan ×2)
- [ ] Post-merge: deploy to prod (app-server, scan-worker, health-worker, scheduler), manually trigger `run_weekly_digest_sweep_job()` via SSH one-liner, confirm `digest_sends`/`sent_emails` rows and Resend delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)