### PR TITLE
fix: Flash review job_timeout too tight, silently killing most reviews

### DIFF
--- a/github-app/app_server/webhooks/pull_request.py
+++ b/github-app/app_server/webhooks/pull_request.py
@@ -1,5 +1,16 @@
 ENQUEUE_ACTIONS = ("opened", "reopened", "synchronize")
 
+PR_SCAN_JOB_TIMEOUT_SECONDS = 300
+# Flash review makes a real LLM call plus several sequential GitHub API
+# fetches (diff, changed files, per-symbol source) - a real run against a
+# ~10-file diff measured at 5m50s in production. The previous 180s value
+# was silently killing most non-trivial reviews: RQ's work-horse watchdog
+# SIGKILLs the job at job_timeout+60s (here, 240s), which is a hard kill
+# the job's own except block never sees, so no failure comment gets
+# posted and nothing gets logged - it just vanishes. Sized well above the
+# observed worst case, not the common case.
+FLASH_REVIEW_JOB_TIMEOUT_SECONDS = 900
+
 
 async def handle_pull_request_event(payload: dict, redis_url: str, queue=None) -> None:
     if payload.get("action") not in ENQUEUE_ACTIONS:
@@ -13,7 +24,7 @@ async def handle_pull_request_event(payload: dict, redis_url: str, queue=None) -
 
     queue.enqueue(
         "scan_worker.jobs.run_pr_scan_job",
-        job_timeout=300,
+        job_timeout=PR_SCAN_JOB_TIMEOUT_SECONDS,
         installation_id=payload["installation"]["id"],
         repo_full_name=payload["repository"]["full_name"],
         pr_number=payload["number"],
@@ -22,7 +33,7 @@ async def handle_pull_request_event(payload: dict, redis_url: str, queue=None) -
     )
     queue.enqueue(
         "scan_worker.jobs.run_flash_review_job",
-        job_timeout=180,
+        job_timeout=FLASH_REVIEW_JOB_TIMEOUT_SECONDS,
         installation_id=payload["installation"]["id"],
         repo_full_name=payload["repository"]["full_name"],
         pr_number=payload["number"],

--- a/github-app/tests/test_pull_request_webhook.py
+++ b/github-app/tests/test_pull_request_webhook.py
@@ -36,6 +36,20 @@ async def test_opened_enqueues_both_jobs():
 
 
 @pytest.mark.asyncio
+async def test_flash_review_job_timeout_has_real_margin():
+    # A real flash review (LLM call + several sequential GitHub API
+    # fetches) measured at 5m50s in production against a ~10-file diff -
+    # the previous 180s value silently killed most non-trivial reviews
+    # via RQ's work-horse SIGKILL watchdog (a hard kill the job's own
+    # except block never sees), leaving no error and no comment. This
+    # guards against that regressing back to something too tight.
+    fake_queue = MagicMock()
+    await handle_pull_request_event(_payload("opened"), "redis://unused", queue=fake_queue)
+    calls_by_job = {call.args[0]: call.kwargs for call in fake_queue.enqueue.call_args_list}
+    assert calls_by_job["scan_worker.jobs.run_flash_review_job"]["job_timeout"] >= 600
+
+
+@pytest.mark.asyncio
 async def test_synchronize_enqueues_both_jobs():
     fake_queue = MagicMock()
     await handle_pull_request_event(_payload("synchronize"), "redis://unused", queue=fake_queue)


### PR DESCRIPTION
## Summary
- Root cause of "Flash review isn't firing" (only the free deterministic scanner shows up on PRs): `run_flash_review_job` was enqueued with `job_timeout=180`, but a real review measured at **5m50s** in production against a ~10-file diff.
- RQ's work-horse watchdog hard-`SIGKILL`s the job at `job_timeout+60s` (240s here) - a kill the job's own `except` block never sees, so no failure comment posts and nothing gets logged. It just silently vanishes.
- Confirmed by reproducing on real PRs directly on prod, bypassing RQ's timeout: every "silent" PR completed and posted a real review once given enough time.
- Bumps the timeout to 900s (real margin over the observed worst case) and names both PR-webhook job timeouts as constants instead of inline numbers.
- Follow-up (separate PR, starting immediately after this ships): parallelize the sequential GitHub API fetches inside the review to bring actual latency down - this fix is what keeps the job alive to finish regardless of that.

## Test plan
- [x] New regression test: `test_flash_review_job_timeout_has_real_margin` asserts the timeout stays >= 600s
- [x] Full suite: `pytest tests/ -q` - 873 passed, 8 skipped
- [ ] CI checks
- [ ] Post-merge: deploy to prod (app-server, scan-worker), confirm a fresh PR gets a real Flash review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)