### PR TITLE
perf: stop double-fetching Flash review file content, fetch concurrently

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
 from aletheore.evidence_resolution import (
     attach_dependency_evidence,
@@ -59,8 +60,8 @@ def files_missing_from_review_context(
 ) -> list[str]:
     """Changed files whose real content never reached the review.
 
-    gather_file_context and fetch_changed_file_contents both stop at
-    MAX_CONTEXT_FILES and skip anything over MAX_CONTEXT_FILE_BYTES, so on
+    fetch_review_file_context stops at MAX_CONTEXT_FILES and skips anything
+    over MAX_CONTEXT_FILE_BYTES, so on
     a PR touching more than 15 files - or any file over 40KB - the excess
     is invisible to the model *and* to the citation check, which passes any
     finding whose file content it doesn't have (see
@@ -72,49 +73,67 @@ def files_missing_from_review_context(
     return [path for path in changed_files if path not in file_contents]
 
 
-def gather_file_context(
+MAX_FILE_FETCH_WORKERS = 8
+
+
+def fetch_review_file_context(
     client,
     token: str,
     repo_full_name: str,
     changed_files: list[str],
     head_ref: str,
-) -> str:
+) -> tuple[str, dict[str, str]]:
+    """One fetch pass over changed_files[:MAX_CONTEXT_FILES], producing both
+    the formatted prompt blob (file_context, capped by
+    MAX_CONTEXT_TOTAL_BYTES and truncated in original diff order once that
+    budget is hit) and the structured path->content lookup used by
+    _line_citation_content_matches for verification (file_contents, capped
+    only per-file - no total budget, since a citation check needs the real
+    content of every file that was actually read regardless of whether it
+    made it into the prompt).
+
+    This used to be two separate functions (gather_file_context,
+    fetch_changed_file_contents) that each looped over the same file list
+    and issued their own GET per file - fetching every changed file's
+    content from GitHub twice for no reason. Fetched once here, concurrently
+    (httpx.Client is safe for concurrent use across threads), since on a
+    real PR this pair of loops was a measurable chunk of Flash review's
+    end-to-end latency (a single review was clocked at 5m50s in production,
+    well past the job's old 180s timeout - see FLASH_REVIEW_JOB_TIMEOUT_SECONDS
+    in app_server/webhooks/pull_request.py)."""
+    paths = changed_files[:MAX_CONTEXT_FILES]
+    raw_contents: dict[str, str] = {}
+    if paths:
+        with ThreadPoolExecutor(max_workers=min(MAX_FILE_FETCH_WORKERS, len(paths))) as pool:
+            futures = {
+                pool.submit(fetch_file_content, client, token, repo_full_name, path, head_ref): path
+                for path in paths
+            }
+            for future, path in futures.items():
+                content = future.result()
+                if content is not None:
+                    raw_contents[path] = content
+
+    file_contents = {
+        path: content
+        for path, content in raw_contents.items()
+        if len(content.encode("utf-8")) <= MAX_CONTEXT_FILE_BYTES
+    }
+
     parts = []
     total_bytes = 0
-    for path in changed_files[:MAX_CONTEXT_FILES]:
-        content = fetch_file_content(client, token, repo_full_name, path, head_ref)
+    for path in paths:
+        content = file_contents.get(path)
         if content is None:
             continue
         encoded_len = len(content.encode("utf-8"))
-        if encoded_len > MAX_CONTEXT_FILE_BYTES:
-            continue
         if total_bytes + encoded_len > MAX_CONTEXT_TOTAL_BYTES:
             break
         parts.append(f"--- full content: {path} ---\n{content}")
         total_bytes += encoded_len
-    return "\n\n".join(parts)
+    file_context = "\n\n".join(parts)
 
-
-def fetch_changed_file_contents(
-    client,
-    token: str,
-    repo_full_name: str,
-    changed_files: list[str],
-    head_ref: str,
-) -> dict[str, str]:
-    """Structured file->content lookup for _line_citation_content_matches -
-    a parallel fetch to gather_file_context's formatted prompt blob, since
-    that function's return type (one joined string) can't answer "what's
-    the real content of this specific file" for verification."""
-    contents = {}
-    for path in changed_files[:MAX_CONTEXT_FILES]:
-        content = fetch_file_content(client, token, repo_full_name, path, head_ref)
-        if content is None:
-            continue
-        if len(content.encode("utf-8")) > MAX_CONTEXT_FILE_BYTES:
-            continue
-        contents[path] = content
-    return contents
+    return file_context, file_contents
 
 
 def build_code_evidence_context(evidence: dict | None, changed_files: list[str]) -> str:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -85,9 +85,8 @@ from scan_worker.db import (
 from scan_worker.flash_review import (
     build_code_evidence_context,
     build_referenced_symbol_context,
-    fetch_changed_file_contents,
+    fetch_review_file_context,
     files_missing_from_review_context,
-    gather_file_context,
     is_non_substantive_diff,
     review_diff,
 )
@@ -1218,8 +1217,9 @@ def _run_flash_review(
     if is_non_substantive_diff(changed_files):
         findings: list[dict] = []
     else:
-        file_context = gather_file_context(client, token, repo_full_name, changed_files, head_sha)
-        file_contents = fetch_changed_file_contents(client, token, repo_full_name, changed_files, head_sha)
+        file_context, file_contents = fetch_review_file_context(
+            client, token, repo_full_name, changed_files, head_sha
+        )
         skipped_files = files_missing_from_review_context(changed_files, file_contents)
         if skipped_files:
             logging.getLogger("scan_worker.jobs").info(

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -696,7 +696,11 @@ def test_review_diff_ignores_unexpected_fields_on_a_finding(mock_adapter_class):
     assert findings == [{"file": "a.py", "line": 3, "issue": "real issue"}]
 
 
-def test_gather_file_context_stops_at_max_files(monkeypatch):
+def test_fetch_review_file_context_stops_at_max_files(monkeypatch):
+    # fetch_review_file_context fetches concurrently (see its docstring -
+    # this replaced two functions that each looped over the same file list
+    # and fetched every file twice), so which of the eligible paths starts
+    # first is not deterministic - only the eligible *set* is.
     from scan_worker import flash_review
 
     monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILES", 2)
@@ -708,12 +712,14 @@ def test_gather_file_context_stops_at_max_files(monkeypatch):
 
     monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
 
-    flash_review.gather_file_context(None, "tok", "o/r", ["a.py", "b.py", "c.py", "d.py"], "sha")
+    flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["a.py", "b.py", "c.py", "d.py"], "sha"
+    )
 
-    assert fetched == ["a.py", "b.py"]
+    assert set(fetched) == {"a.py", "b.py"}
 
 
-def test_gather_file_context_skips_oversized_files(monkeypatch):
+def test_fetch_review_file_context_skips_oversized_files_from_both_outputs(monkeypatch):
     from scan_worker import flash_review
 
     monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILE_BYTES", 5)
@@ -723,12 +729,21 @@ def test_gather_file_context_skips_oversized_files(monkeypatch):
 
     monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
 
-    result = flash_review.gather_file_context(None, "tok", "o/r", ["a.py"], "sha")
+    file_context, file_contents = flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["a.py"], "sha"
+    )
 
-    assert "a.py" not in result
+    assert "a.py" not in file_context
+    assert file_contents == {}
 
 
-def test_gather_file_context_stops_at_total_byte_budget(monkeypatch):
+def test_fetch_review_file_context_stops_context_at_total_byte_budget(monkeypatch):
+    # The total-byte cap only bounds the prompt blob (file_context) - the
+    # citation-check dict (file_contents) still gets every file that was
+    # actually fetched, since a citation check needs the real content of
+    # anything the model was shown, and truncating that too would make
+    # _line_citation_content_matches unable to verify files it has every
+    # right to check.
     from scan_worker import flash_review
 
     monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILES", 10)
@@ -740,12 +755,15 @@ def test_gather_file_context_stops_at_total_byte_budget(monkeypatch):
 
     monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
 
-    result = flash_review.gather_file_context(None, "tok", "o/r", ["a.py", "b.py", "c.py"], "sha")
+    file_context, file_contents = flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["a.py", "b.py", "c.py"], "sha"
+    )
 
-    assert result.count("0123456789") == 1
+    assert file_context.count("0123456789") == 1
+    assert file_contents == {"a.py": "0123456789", "b.py": "0123456789", "c.py": "0123456789"}
 
 
-def test_fetch_changed_file_contents_returns_path_to_content_mapping(monkeypatch):
+def test_fetch_review_file_context_returns_path_to_content_mapping(monkeypatch):
     from scan_worker import flash_review
 
     def fake_fetch(client, token, repo, path, ref):
@@ -753,12 +771,14 @@ def test_fetch_changed_file_contents_returns_path_to_content_mapping(monkeypatch
 
     monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
 
-    result = flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py", "b.py"], "sha")
+    _, file_contents = flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["a.py", "b.py"], "sha"
+    )
 
-    assert result == {"a.py": "content of a.py", "b.py": "content of b.py"}
+    assert file_contents == {"a.py": "content of a.py", "b.py": "content of b.py"}
 
 
-def test_fetch_changed_file_contents_skips_files_where_fetch_returns_none(monkeypatch):
+def test_fetch_review_file_context_skips_files_where_fetch_returns_none(monkeypatch):
     from scan_worker import flash_review
 
     def fake_fetch(client, token, repo, path, ref):
@@ -766,41 +786,36 @@ def test_fetch_changed_file_contents_skips_files_where_fetch_returns_none(monkey
 
     monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
 
-    result = flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py", "missing.py"], "sha")
+    _, file_contents = flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["a.py", "missing.py"], "sha"
+    )
 
-    assert result == {"a.py": "real content"}
+    assert file_contents == {"a.py": "real content"}
 
 
-def test_fetch_changed_file_contents_skips_oversized_files(monkeypatch):
+def test_fetch_review_file_context_preserves_diff_order_when_truncating(monkeypatch):
+    # The concurrent fetch can complete in any order, but the formatted
+    # context blob must still truncate based on the *original* changed-files
+    # order (matching diff order), not fetch-completion order - otherwise
+    # which file gets cut when the total budget is hit would be
+    # nondeterministic instead of "whichever file was last in the diff".
     from scan_worker import flash_review
 
-    monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILE_BYTES", 5)
+    monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILES", 10)
+    monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILE_BYTES", 1000)
+    monkeypatch.setattr(flash_review, "MAX_CONTEXT_TOTAL_BYTES", 12)
 
     def fake_fetch(client, token, repo, path, ref):
-        return "way too long for the cap"
+        return "0123456789"
 
     monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
 
-    result = flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py"], "sha")
+    file_context, _ = flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["a.py", "b.py"], "sha"
+    )
 
-    assert result == {}
-
-
-def test_fetch_changed_file_contents_stops_at_max_files(monkeypatch):
-    from scan_worker import flash_review
-
-    monkeypatch.setattr(flash_review, "MAX_CONTEXT_FILES", 2)
-    fetched = []
-
-    def fake_fetch(client, token, repo, path, ref):
-        fetched.append(path)
-        return "x" * 10
-
-    monkeypatch.setattr(flash_review, "fetch_file_content", fake_fetch)
-
-    flash_review.fetch_changed_file_contents(None, "tok", "o/r", ["a.py", "b.py", "c.py", "d.py"], "sha")
-
-    assert fetched == ["a.py", "b.py"]
+    assert "a.py" in file_context
+    assert "b.py" not in file_context
 
 
 def test_validate_findings_keeps_a_finding_just_past_a_deletion_only_hunk():

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1315,8 +1315,7 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
         lambda diff_text, file_context="", **kwargs: [
@@ -1365,8 +1364,7 @@ def test_flash_review_job_posts_grounding_note_when_some_findings_are_dropped(mo
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
 
     def fake_review_diff(diff_text, file_context="", **kwargs):
         kwargs["on_grounding_result"]({"proposed": 2, "kept": 1})
@@ -1402,8 +1400,7 @@ def test_flash_review_job_reports_zero_grounded_distinctly_from_no_issues_found(
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
 
     def fake_review_diff(diff_text, file_context="", **kwargs):
         kwargs["on_grounding_result"]({"proposed": 3, "kept": 0})
@@ -1432,9 +1429,8 @@ def test_flash_review_job_reports_zero_grounded_distinctly_from_no_issues_found(
 def test_flash_review_job_discloses_files_it_never_reviewed(monkeypatch):
     # "No issues found in this diff." over a PR where most files were never
     # read is the most damaging form of the silent-degradation problem:
-    # silence reads as an all-clear. gather_file_context and
-    # fetch_changed_file_contents stop at MAX_CONTEXT_FILES, so this is
-    # reachable on any sufficiently large PR.
+    # silence reads as an all-clear. fetch_review_file_context stops at
+    # MAX_CONTEXT_FILES, so this is reachable on any sufficiently large PR.
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr(
@@ -1452,10 +1448,11 @@ def test_flash_review_job_discloses_files_it_never_reviewed(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["a.py", "huge.py", "later.py"]
     )
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
     # Only a.py's content came back - huge.py was over the size cap and
     # later.py fell past the file-count cap.
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {"a.py": "x"})
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {"a.py": "x"})
+    )
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
@@ -1491,8 +1488,9 @@ def test_flash_review_job_adds_no_coverage_note_when_every_file_was_read(monkeyp
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- a.py ---\n+x")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["a.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {"a.py": "x"})
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {"a.py": "x"})
+    )
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
@@ -1570,8 +1568,7 @@ def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkey
         lambda *a, **k: "--- dashboard.py ---\n@@ -1,1 +75,1 @@\n+_github_http_client()\n",
     )
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["dashboard.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
     monkeypatch.setattr(
         "scan_worker.jobs._latest_evidence_or_none",
         lambda *a, **k: {
@@ -1639,11 +1636,10 @@ def test_flash_review_job_passes_changed_file_contents_to_review_diff(monkeypatc
         lambda *a, **k: "--- app.py ---\n@@ -1,1 +1,1 @@\n+broken",
     )
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
     monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
     monkeypatch.setattr(
-        "scan_worker.jobs.fetch_changed_file_contents",
-        lambda *a, **k: {"app.py": "real content of app.py"},
+        "scan_worker.jobs.fetch_review_file_context",
+        lambda *a, **k: ("", {"app.py": "real content of app.py"}),
     )
     captured = {}
     monkeypatch.setattr(
@@ -1679,8 +1675,7 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
         lambda diff_text, file_context="", **kwargs: [
@@ -1721,8 +1716,7 @@ def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch)
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+fine")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
-    monkeypatch.setattr("scan_worker.jobs.gather_file_context", lambda *a, **k: "")
-    monkeypatch.setattr("scan_worker.jobs.fetch_changed_file_contents", lambda *a, **k: {})
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", **kwargs: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- Direct follow-up to #137 (job_timeout 180s -> 900s, merged/deployed): that fix keeps the job alive long enough to finish; this cuts the actual latency that made 900s necessary.
- Found while investigating: `gather_file_context` and `fetch_changed_file_contents` were two separate functions that each looped over the *same* `changed_files` list and issued their own `GET /repos/{repo}/contents/{path}` per file - every file Flash review reads was fetched from GitHub **twice**, sequentially, for no reason.
- Consolidated into one `fetch_review_file_context` that fetches each file once, concurrently (`ThreadPoolExecutor` - `httpx.Client` is safe for concurrent use across threads), and derives both outputs (the formatted prompt blob and the citation-check dict) from that single pass. Behavior is preserved exactly: same `MAX_CONTEXT_FILES`/`MAX_CONTEXT_FILE_BYTES`/`MAX_CONTEXT_TOTAL_BYTES` caps, same original-diff-order truncation for the prompt blob, same "no total cap" for the citation dict.
- A single Flash review was measured at 5m50s in production before either fix landed.

## Test plan
- [x] `pytest tests/test_flash_review.py tests/test_jobs.py -q` - 169 passed (7 old tests for the two removed functions replaced with 6 new tests covering the same behaviors, plus concurrency-order-independence)
- [x] Full suite: 876 passed, 8 skipped (one earlier run showed 4 unrelated failures in `test_marketplace_webhook.py`/`test_postgres_graph_store.py` that don't reproduce in isolation or on a second full run - pre-existing flakiness, not touched by this change)
- [ ] CI checks
- [ ] Post-merge: deploy to prod (app-server, scan-worker), confirm a fresh PR's Flash review lands well under the old 5m50s

🤖 Generated with [Claude Code](https://claude.com/claude-code)