### PR TITLE
feat: self-serve Paddle billing portal link in the dashboard

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -37,6 +37,7 @@ from app_server.db import (
     update_session_tokens,
 )
 from app_server.paddle_client import PaddleAPIError
+from app_server.paddle_client import create_portal_session
 from app_server.paddle_client import get_subscription as get_paddle_subscription
 from app_server.paddle_client import update_subscription_items as update_paddle_subscription_items
 from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
@@ -274,7 +275,16 @@ async def _require_seat_if_paid(pool, installation: dict, github_login: str) -> 
         )
 
 
-async def _require_admin_installation(request: Request, org: str, repo: str) -> dict:
+async def _require_authorized_installation(request: Request, org: str, repo: str) -> tuple[dict, dict]:
+    """Session + "do you administer this installation" only - no plan or
+    seat gate. Returns (session, installation).
+
+    Split out of _require_admin_installation for the billing portal: a
+    customer whose card just failed is exactly the person who needs to
+    reach it, and by then Paddle's own webhook has already downgraded the
+    installation to free - gating the portal on "not free" would lock out
+    the one person who needs to fix it.
+    """
     session = await get_current_session(request)
     if session is None:
         raise HTTPException(status_code=401, detail="login required")
@@ -288,8 +298,14 @@ async def _require_admin_installation(request: Request, org: str, repo: str) -> 
     installation = await get_installation(pool, installation_id)
     if installation is None:
         raise HTTPException(status_code=404, detail="installation not found")
+    return session, installation
+
+
+async def _require_admin_installation(request: Request, org: str, repo: str) -> dict:
+    session, installation = await _require_authorized_installation(request, org, repo)
     if installation["plan"] == "free":
         raise HTTPException(status_code=402, detail="this feature requires a paid plan")
+    pool = request.app.state.db_pool
     await _require_seat_if_paid(pool, installation, session["github_login"])
     return installation
 
@@ -444,6 +460,54 @@ async def remove_extra_seat(org: str, repo: str, request: Request):
         ) from exc
 
     return {"ok": True}
+
+
+@admin_router.get("/admin/{org}/{repo}/billing-portal")
+async def get_billing_portal_url(org: str, repo: str, request: Request):
+    """Deliberately not behind _require_admin_installation's plan gate (see
+    _require_authorized_installation) - a payment failure has already
+    downgraded this installation to free by the time anyone would use this,
+    and that's exactly who needs to reach it."""
+    _, installation = await _require_authorized_installation(request, org, repo)
+    customer_id = installation.get("paddle_customer_id")
+    if not customer_id:
+        raise HTTPException(
+            status_code=400, detail="no billing account on file yet - subscribe first to set one up"
+        )
+    subscription_id = installation.get("paddle_subscription_id")
+    subscription_ids = [subscription_id] if subscription_id else None
+
+    settings = get_settings()
+    try:
+        session_data = await asyncio.to_thread(
+            create_portal_session, settings.paddle_api_key, customer_id, subscription_ids
+        )
+    except PaddleAPIError as exc:
+        logger.error(
+            "billing portal session failed for installation %s (customer %s): %s",
+            installation["installation_id"],
+            customer_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Could not open the billing portal right now - please try again, or contact support if this keeps happening.",
+        ) from exc
+
+    urls = session_data.get("urls", {})
+    # Prefer a subscription-scoped deep link (lets the customer update their
+    # payment method for this subscription directly) over the general
+    # account overview, when Paddle returned one - it only will if
+    # subscription_ids was non-empty above. Confirmed against a real portal
+    # session response: each entry has update_subscription_payment_method
+    # directly on it, not nested under a further "urls" key.
+    subscription_urls = urls.get("subscriptions") or []
+    url = subscription_urls[0]["update_subscription_payment_method"] if subscription_urls else None
+    if url is None:
+        url = urls.get("general", {}).get("overview")
+    if url is None:
+        raise HTTPException(status_code=502, detail="Paddle did not return a portal URL")
+    return {"url": url}
 
 
 @admin_router.delete("/admin/{org}/{repo}/members/{github_login}")

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1654,6 +1654,21 @@ async function removeSeat() {{
   }}
 }}
 
+async function openBillingPortal() {{
+  const status = document.getElementById('seat-billing-status');
+  if (status) {{ status.textContent = 'Opening billing portal...'; status.style.color = 'var(--slate-600)'; }}
+  const res = await fetch(adminBase + '/billing-portal');
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  if (res.ok && data.url) {{
+    window.location.href = data.url;
+    return;
+  }}
+  if (status) {{
+    status.textContent = data.detail || 'Could not open the billing portal.';
+    status.style.color = 'var(--critical)';
+  }}
+}}
+
 async function loadSettings() {{
   const body = document.getElementById('settings-body');
   const res = await apiGet(adminBase);
@@ -1663,7 +1678,14 @@ async function loadSettings() {{
       'API tokens, webhooks, and team seats are paid features',
       'Upgrade to configure them for this repository.',
       {SETTINGS_LOCKED_PREVIEW!r}
-    );
+    ) +
+      // A lapsed/failed-payment subscription lands here too (that's what
+      // "plan == free" means to this route) - the one person who needs to
+      // fix their card must not be locked out of doing so by the same gate
+      // that's blocking everything else on this page.
+      '<div class="settings-block-hint" style="text-align:center;margin-top:12px;">' +
+      'Already subscribed? <a href="#" onclick="openBillingPortal(); return false;">Manage billing</a>' +
+      '</div>';
     return;
   }}
   if (!res.ok) {{
@@ -1679,6 +1701,7 @@ async function loadSettings() {{
     ? '<div class="form-row">' +
       '<button class="btn" onclick="buySeat()">Buy extra seat ($3.99/mo)</button>' +
       (window._extraSeats > 0 ? '<button class="btn" onclick="removeSeat()" style="margin-left:6px;">Remove a seat</button>' : '') +
+      '<button class="btn" onclick="openBillingPortal()" style="margin-left:6px;">Manage billing</button>' +
       '</div><div id="seat-billing-status" class="settings-block-hint"></div>'
     : '<div class="settings-block-hint">Extra seats need an active subscription - subscribe first to buy one.</div>';
 

--- a/github-app/app_server/paddle_client.py
+++ b/github-app/app_server/paddle_client.py
@@ -26,6 +26,32 @@ def get_subscription(api_key: str | None, subscription_id: str) -> dict:
     return response.json()["data"]
 
 
+def create_portal_session(
+    api_key: str | None,
+    customer_id: str,
+    subscription_ids: list[str] | None = None,
+) -> dict:
+    """Paddle-hosted, temporary, authenticated link where a customer can
+    update their payment method, view invoices, and manage or cancel a
+    subscription - the self-serve fix for exactly what a failed-payment
+    customer needs, without Aletheore building its own billing screens.
+    Session URLs shouldn't be cached (Paddle's own guidance) - callers must
+    request a fresh one per visit, not store the URL."""
+    if not api_key:
+        raise PaddleAPINotConfigured("PADDLE_API_KEY is not configured")
+    payload = {"subscription_ids": subscription_ids} if subscription_ids else {}
+    try:
+        response = httpx.post(
+            f"{_PADDLE_API_BASE}/customers/{customer_id}/portal-sessions",
+            headers=_headers(api_key),
+            json=payload,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise PaddleAPIError(f"could not create portal session for customer {customer_id}: {exc}") from exc
+    return response.json()["data"]
+
+
 def update_subscription_items(
     api_key: str | None,
     subscription_id: str,

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -923,6 +923,113 @@ async def test_remove_extra_seat_updates_paddle_subscription(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_billing_portal_requires_billing_account_on_file(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/billing-portal")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_accessible_on_free_plan(pool, monkeypatch):
+    # A payment failure has already downgraded the installation to free by
+    # the time anyone would use this - it must NOT be behind the same
+    # plan=='free' -> 402 gate every other paid-plan feature uses, or the
+    # one person who needs to fix their card gets locked out of doing so.
+    await upsert_installation(pool, 100, "octocat")
+    await set_installation_plan(pool, 100, "free")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test", "ctm_test")
+    client = await _logged_in_client(pool, monkeypatch, plan="free")
+
+    monkeypatch.setattr(
+        "app_server.admin.create_portal_session",
+        lambda api_key, customer_id, subscription_ids: {
+            "urls": {"general": {"overview": "https://customer-portal.paddle.com/overview"}}
+        },
+    )
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/billing-portal")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_returns_subscription_scoped_url(pool, monkeypatch):
+    # Response shape confirmed against a real Paddle portal session:
+    # each subscriptions[] entry has update_subscription_payment_method
+    # directly on it, not nested under a further "urls" key.
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test", "ctm_test")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    captured = {}
+
+    def fake_create_portal_session(api_key, customer_id, subscription_ids):
+        captured["customer_id"] = customer_id
+        captured["subscription_ids"] = subscription_ids
+        return {
+            "urls": {
+                "general": {"overview": "https://customer-portal.paddle.com/overview"},
+                "subscriptions": [
+                    {
+                        "id": "sub_test",
+                        "cancel_subscription": "https://customer-portal.paddle.com/cancel",
+                        "update_subscription_payment_method": "https://customer-portal.paddle.com/update-payment",
+                    }
+                ],
+            }
+        }
+
+    monkeypatch.setattr("app_server.admin.create_portal_session", fake_create_portal_session)
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/billing-portal")
+
+    assert response.status_code == 200
+    assert response.json() == {"url": "https://customer-portal.paddle.com/update-payment"}
+    assert captured["customer_id"] == "ctm_test"
+    assert captured["subscription_ids"] == ["sub_test"]
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_falls_back_to_general_url_without_subscription(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, None, "ctm_test")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    monkeypatch.setattr(
+        "app_server.admin.create_portal_session",
+        lambda api_key, customer_id, subscription_ids: {
+            "urls": {"general": {"overview": "https://customer-portal.paddle.com/overview"}}
+        },
+    )
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/billing-portal")
+
+    assert response.status_code == 200
+    assert response.json() == {"url": "https://customer-portal.paddle.com/overview"}
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_reports_paddle_api_failure(pool, monkeypatch):
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test", "ctm_test")
+    client = await _logged_in_client(pool, monkeypatch)
+
+    def _boom(api_key, customer_id, subscription_ids):
+        raise PaddleAPIError("could not create portal session")
+
+    monkeypatch.setattr("app_server.admin.create_portal_session", _boom)
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/billing-portal")
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
 async def test_add_member_rejects_invalid_github_login(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
     async with client:

--- a/github-app/tests/test_paddle_client.py
+++ b/github-app/tests/test_paddle_client.py
@@ -4,6 +4,7 @@ import pytest
 from app_server.paddle_client import (
     PaddleAPIError,
     PaddleAPINotConfigured,
+    create_portal_session,
     get_subscription,
     update_subscription_items,
 )
@@ -12,6 +13,79 @@ from app_server.paddle_client import (
 def test_get_subscription_requires_api_key():
     with pytest.raises(PaddleAPINotConfigured):
         get_subscription(None, "sub_123")
+
+
+def test_create_portal_session_requires_api_key():
+    with pytest.raises(PaddleAPINotConfigured):
+        create_portal_session(None, "ctm_123")
+
+
+def test_create_portal_session_sends_post_with_subscription_ids(monkeypatch):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        import json
+
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            201,
+            json={"data": {"id": "cpls_123", "customer_id": "ctm_123", "urls": {"general": {}}}},
+        )
+
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, headers, json: httpx.Client(transport=httpx.MockTransport(handler)).post(
+            url, headers=headers, json=json
+        ),
+    )
+
+    result = create_portal_session("test_key", "ctm_123", ["sub_123"])
+
+    assert result == {"id": "cpls_123", "customer_id": "ctm_123", "urls": {"general": {}}}
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/customers/ctm_123/portal-sessions"
+    assert captured["body"] == {"subscription_ids": ["sub_123"]}
+
+
+def test_create_portal_session_omits_subscription_ids_when_none_given(monkeypatch):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"data": {"id": "cpls_123", "urls": {"general": {}}}})
+
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, headers, json: httpx.Client(transport=httpx.MockTransport(handler)).post(
+            url, headers=headers, json=json
+        ),
+    )
+
+    create_portal_session("test_key", "ctm_123")
+
+    assert captured["body"] == {}
+
+
+def test_create_portal_session_wraps_http_errors(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "not found"})
+
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, headers, json: httpx.Client(transport=httpx.MockTransport(handler)).post(
+            url, headers=headers, json=json
+        ),
+    )
+
+    with pytest.raises(PaddleAPIError):
+        create_portal_session("test_key", "ctm_123")
 
 
 def test_update_subscription_items_requires_api_key():


### PR DESCRIPTION
## Summary
- Closes gap #2 from the earlier review pass: "no self-serve Paddle customer portal link in the dashboard."
- New `GET /admin/{org}/{repo}/billing-portal`, backed by Paddle's `customer.portal-sessions` API - a customer can update payment method, view invoices, manage/cancel subscription without any custom billing UI.
- Deliberately not behind the plan=='free' gate: split `_require_admin_installation` into a new `_require_authorized_installation` (auth only) + the plan/seat checks layered on top, so this route stays reachable exactly when a payment failure has already downgraded the installation - the person who most needs to fix their card.
- Verified the real Paddle response shape against Aletheore's own live subscription rather than trusting docs/assumption - caught a wrong field-nesting guess (`update_subscription_payment_method` is flat on the entry, not under a nested `urls` key) before it shipped.
- "Manage billing" button in Settings for paid installations, and the same link on the locked-feature message a free/lapsed installation sees.

## Test plan
- [x] `pytest tests/test_admin.py tests/test_paddle_client.py tests/test_dashboard.py -q` - 129 passed
- [x] Full suite: 908 passed, 8 skipped
- [x] `test_frontend_js_syntax.py` (validates embedded `<script>` blocks with `node --check`) - caught and fixed a real JS escaping bug before this PR
- [ ] CI checks

**Not deploying yet** - batching a few more items before the next prod push, per instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)