### PR TITLE
feat: surface LLM spend and Flash review usage in the dashboard

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -23,7 +23,9 @@ from app_server.db import (
     delete_session,
     get_docs_repo_commit_settings,
     get_extra_seats,
+    get_flash_review_count_this_month,
     get_installation,
+    get_llm_spend_this_month,
     get_max_tokens,
     is_installation_member,
     list_api_tokens,
@@ -36,6 +38,7 @@ from app_server.db import (
     set_webhook_url,
     update_session_tokens,
 )
+from app_server.llm_cost import base_cap_for_plan, monthly_cap_for_installation
 from app_server.paddle_client import PaddleAPIError
 from app_server.paddle_client import create_portal_session
 from app_server.paddle_client import get_subscription as get_paddle_subscription
@@ -323,6 +326,9 @@ async def admin_page(org: str, repo: str, request: Request):
     seat_limit = included_seats + extra_seats
     health_targets = await list_health_check_targets(pool, installation_id, repo_full_name)
     health_target_limit = INCLUDED_HEALTH_CHECK_TARGETS.get(installation["plan"], DEFAULT_HEALTH_CHECK_TARGET_LIMIT)
+    llm_spend_month_to_date = await get_llm_spend_this_month(pool, installation_id)
+    flash_reviews_month_to_date = await get_flash_review_count_this_month(pool, installation_id)
+    llm_spend_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
     return {
         "installation": installation,
         "tokens": tokens,
@@ -333,6 +339,13 @@ async def admin_page(org: str, repo: str, request: Request):
         "health_target_limit": health_target_limit,
         "public_status_url": f"/v1/health/{org}/{repo}",
         "branch_protection_disclosure": BRANCH_PROTECTION_DISCLOSURE,
+        # llm_spend and flash_review_monthly_count are already tracked
+        # internally for the hard spend cap (scan_worker/jobs.py) - this is
+        # the first place a customer actually sees what their AI review
+        # usage is costing/producing, previously invisible to them.
+        "llm_spend_month_to_date": llm_spend_month_to_date,
+        "llm_spend_cap": llm_spend_cap,
+        "flash_reviews_month_to_date": flash_reviews_month_to_date,
     }
 
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -271,6 +271,17 @@ async def record_llm_spend(pool: asyncpg.Pool, installation_id: int, cost_usd: f
     )
 
 
+async def get_flash_review_count_this_month(pool: asyncpg.Pool, installation_id: int) -> int:
+    row = await pool.fetchrow(
+        """
+        SELECT review_count FROM flash_review_monthly_count
+        WHERE installation_id = $1 AND month = date_trunc('month', now())::date
+        """,
+        installation_id,
+    )
+    return row["review_count"] if row else 0
+
+
 async def get_extra_seats(pool: asyncpg.Pool, installation_id: int) -> int:
     row = await pool.fetchrow(
         "SELECT extra_seats FROM installations WHERE installation_id = $1",

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1697,6 +1697,21 @@ async function loadSettings() {{
   window._hasActiveSubscription = !!installation.paddle_subscription_id;
   window._extraSeats = data.extra_seats || 0;
 
+  // llm_spend and flash_review_monthly_count were already tracked
+  // internally for the hard spend cap (see app_server/llm_cost.py) - this
+  // is the first place a customer actually sees what their AI review
+  // usage is costing/producing, previously invisible to them.
+  const llmSpend = data.llm_spend_month_to_date || 0;
+  const llmCap = data.llm_spend_cap || 0;
+  const flashReviews = data.flash_reviews_month_to_date || 0;
+  const spendPct = llmCap > 0 ? Math.min(100, Math.round((llmSpend / llmCap) * 100)) : 0;
+  const usageHtml =
+    '<div class="settings-block">' +
+      '<div class="settings-block-label">AI usage this month</div>' +
+      '<div class="settings-block-hint">' + flashReviews + ' automated PR review' + (flashReviews === 1 ? '' : 's') + '</div>' +
+      '<div class="settings-block-hint">$' + llmSpend.toFixed(2) + ' of $' + llmCap.toFixed(2) + ' spend cap used (' + spendPct + '%)</div>' +
+    '</div>';
+
   const seatBillingHtml = window._hasActiveSubscription
     ? '<div class="form-row">' +
       '<button class="btn" onclick="buySeat()">Buy extra seat ($3.99/mo)</button>' +
@@ -1716,6 +1731,7 @@ async function loadSettings() {{
           '<div id="member-status" class="settings-block-hint"></div>' +
           seatBillingHtml +
         '</div>' +
+        usageHtml +
         '<div class="settings-block">' +
           '<div class="settings-block-label">API tokens</div>' +
           '<div id="token-list">' + renderTokenRows(data.tokens) + '</div>' +

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -18,6 +18,7 @@ from app_server.db import (
     get_max_tokens,
     get_session,
     insert_repo_history,
+    record_llm_spend,
     set_installation_plan,
     upsert_installation,
 )
@@ -268,6 +269,45 @@ async def test_admin_page_rejects_free_plan(pool, monkeypatch):
     async with client:
         response = await client.get("/admin/octocat/hello-world")
     assert response.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_admin_page_surfaces_llm_spend_and_flash_review_usage(pool, monkeypatch):
+    # llm_spend and flash_review_monthly_count were already tracked
+    # internally for the hard spend cap - this is the first place a
+    # customer actually sees what their AI review usage is costing them.
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    await record_llm_spend(pool, 100, 4.20)
+    await pool.execute(
+        """
+        INSERT INTO flash_review_monthly_count (installation_id, month, review_count)
+        VALUES ($1, date_trunc('month', now())::date, $2)
+        """,
+        100,
+        7,
+    )
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["llm_spend_month_to_date"] == 4.20
+    assert body["flash_reviews_month_to_date"] == 7
+    assert body["llm_spend_cap"] > 0
+
+
+@pytest.mark.asyncio
+async def test_admin_page_reports_zero_usage_before_any_spend(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["llm_spend_month_to_date"] == 0.0
+    assert body["flash_reviews_month_to_date"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Closes gap #3: "LLM spend is tracked but never shown to the customer." `llm_spend` and `flash_review_monthly_count` were already tracked internally for the hard spend cap - this is the first place a customer sees it, outside the weekly digest email.
- New async `get_flash_review_count_this_month` in `app_server/db.py` (mirrors the existing sync version in `scan_worker/db.py`).
- Folded `llm_spend_month_to_date`, `llm_spend_cap`, `flash_reviews_month_to_date` into the existing `GET /admin/{org}/{repo}` payload rather than a new route - reuses its existing plan/seat gate.
- Dashboard: "AI usage this month" block in Settings, review count + spend against the plan's cap.

## Test plan
- [x] `pytest tests/test_admin.py -k "llm_spend or usage" -q` - 2 passed (new tests)
- [x] Full suite: 910 passed, 8 skipped
- [ ] CI checks

**Not deploying yet** - batching more items before the next prod push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)