### PR TITLE
feat: alert on unhandled exceptions in Aletheore's own backend

### DIFF
--- a/github-app/app_server/error_alerts.py
+++ b/github-app/app_server/error_alerts.py
@@ -1,0 +1,70 @@
+"""Best-effort alerting for an unexpected, unhandled exception in
+Aletheore's OWN backend - app_server routes and scan_worker jobs -
+as opposed to runtime_events.py, which only ever ingests exceptions
+from a *customer's* app. Before this, the only way to learn about a
+crash here was reading logs after the fact (see: the event-loop
+freeze bug, found reactively).
+
+Reuses the existing Resend transactional-email infra rather than
+standing up a separate error-tracking service - sends to
+email_reply_to_address (support@aletheore.com), a real inbox someone
+already checks.
+"""
+
+import logging
+import time
+
+from app_server.config import get_settings
+from scan_worker.email import send_transactional_email
+
+logger = logging.getLogger("app_server.error_alerts")
+
+# Rate-limited per (source, exception type), not globally - a runaway loop
+# hitting the same bug shouldn't flood the inbox, but an unrelated second
+# bug during the same window should still get its own alert. Process-local
+# and reset on restart, which is fine: the goal is "don't flood," not a
+# durable dedupe ledger.
+_ALERT_COOLDOWN_SECONDS = 900
+_last_alert_at: dict[str, float] = {}
+
+
+def _should_alert(key: str) -> bool:
+    now = time.monotonic()
+    last = _last_alert_at.get(key)
+    if last is not None and now - last < _ALERT_COOLDOWN_SECONDS:
+        return False
+    _last_alert_at[key] = now
+    return True
+
+
+def send_error_alert(source: str, error: BaseException, context: str = "") -> None:
+    """source identifies where this came from (e.g. "app_server" or a job
+    name like "run_flash_review_job"), context is a short human-readable
+    line (e.g. the request path, or the installation/repo being processed).
+
+    Never raises - a failure to send the alert itself must not turn one
+    bug into two. Call this from an except block, not instead of logging;
+    it's a notification, not a substitute for the structured log entry.
+    """
+    key = f"{source}:{type(error).__name__}"
+    if not _should_alert(key):
+        return
+
+    settings = get_settings()
+    if not settings.resend_api_key:
+        return
+
+    subject = f"[Aletheore alert] {source}: {type(error).__name__}"
+    body_text = f"{context}\n\n{type(error).__name__}: {error}".strip()
+    try:
+        send_transactional_email(
+            settings.resend_api_key,
+            settings.email_from_address,
+            settings.email_reply_to_address,
+            settings.email_reply_to_address,
+            subject,
+            f"<pre>{body_text}</pre>",
+            body_text,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("failed to send error alert email for %s", key, exc_info=True)

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -255,7 +255,45 @@ table.findings tr:last-child td { border-bottom: none; }
 .wiki-banner { display: flex; align-items: center; justify-content: space-between; gap: 1rem; background: linear-gradient(90deg, var(--accent-soft), color-mix(in srgb, var(--accent-soft) 62%, var(--paper))); border: 1px solid rgba(224, 134, 58, 0.22); border-radius: 12px; padding: 13px 15px; margin: 10px 0 14px; flex-wrap: wrap; }
 .wiki-banner-text { font-size: 12.5px; color: var(--accent-strong); line-height: 1.5; max-width: 46ch; }
 .wiki-banner-text b { font-weight: 500; }
-.docs-module-body { white-space: pre-wrap; font-size: 12px; line-height: 1.55; padding: 10px 2px 2px; margin: 0; font-family: inherit; }
+.docs-overview { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 18px; align-items: center; border: 1px solid rgba(224, 134, 58, 0.22);
+  border-radius: 14px; padding: 16px; margin: 10px 0 16px; background:
+    radial-gradient(circle at 92% 12%, color-mix(in srgb, var(--accent) 16%, transparent), transparent 36%),
+    linear-gradient(135deg, color-mix(in srgb, var(--accent-soft) 46%, var(--paper)), color-mix(in srgb, var(--paper) 86%, var(--slate-50))); }
+.docs-overview-kicker { font-size: 11px; font-weight: 720; letter-spacing: 0.06em; text-transform: uppercase; color: var(--accent-strong); }
+.docs-overview h2 { margin: 5px 0 5px; font-size: 20px; line-height: 1.2; }
+.docs-overview p { margin: 0; color: var(--slate-600); font-size: 13px; line-height: 1.55; max-width: 72ch; }
+.docs-overview-stats { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
+.docs-stat-pill { min-width: 104px; border: 1px solid var(--border); border-radius: 12px; background: color-mix(in srgb, var(--paper) 78%, var(--slate-50));
+  padding: 10px 12px; box-shadow: var(--shadow-card); }
+.docs-stat-value { font-family: var(--font-mono); font-size: 18px; font-weight: 720; color: var(--ink-900); }
+.docs-stat-label { margin-top: 2px; font-size: 11px; color: var(--slate-600); }
+.docs-status-banner { border: 1px solid var(--border); border-radius: 12px; padding: 12px 14px; margin: 0 0 14px; font-size: 12.5px; line-height: 1.55; }
+.docs-status-banner.failed { border-color: color-mix(in srgb, var(--critical) 34%, transparent); background: var(--critical-soft); color: var(--critical); }
+.docs-status-banner.partial { border-color: color-mix(in srgb, var(--warning) 34%, transparent); background: var(--warning-soft); color: var(--warning); }
+.docs-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; align-items: start; }
+.docs-module-card { border: 1px solid var(--border); border-radius: 13px; background: linear-gradient(180deg, var(--paper), color-mix(in srgb, var(--paper) 88%, var(--slate-50)));
+  box-shadow: var(--shadow-card); overflow: hidden; transition: border-color 0.15s ease, box-shadow 0.15s ease; }
+.docs-module-card[open] { grid-column: 1 / -1; border-color: color-mix(in srgb, var(--accent) 32%, var(--border)); box-shadow: var(--shadow-card-hover); }
+.docs-module-summary { list-style: none; cursor: pointer; padding: 14px 15px; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 14px; align-items: center; }
+.docs-module-summary::-webkit-details-marker { display: none; }
+.docs-module-title { display: flex; align-items: center; gap: 9px; min-width: 0; }
+.docs-module-title i { color: var(--accent-strong); font-size: 17px; flex-shrink: 0; }
+.docs-module-path { font-family: var(--font-mono); font-size: 12.5px; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.docs-module-sub { margin-top: 4px; font-size: 11.5px; color: var(--slate-600); }
+.docs-module-meta { display: flex; align-items: center; gap: 7px; justify-content: flex-end; flex-wrap: wrap; }
+.docs-chip { display: inline-flex; align-items: center; gap: 5px; border-radius: 999px; padding: 4px 8px; background: var(--slate-100); color: var(--slate-600); font-size: 11px; white-space: nowrap; }
+.docs-chip.ai { background: var(--accent-soft); color: var(--accent-strong); }
+.docs-module-chevron { color: var(--slate-400); font-size: 16px; transition: transform 0.15s ease; }
+.docs-module-card[open] .docs-module-chevron { transform: rotate(180deg); }
+.docs-module-content { border-top: 1px solid var(--border); background: color-mix(in srgb, var(--slate-50) 78%, var(--paper)); padding: 14px; }
+.docs-module-body { white-space: pre-wrap; font-size: 12px; line-height: 1.7; padding: 14px; margin: 0; font-family: var(--font-mono); color: var(--ink-700);
+  overflow-x: auto; border: 1px solid var(--border); border-radius: 10px; background: color-mix(in srgb, var(--paper) 84%, var(--slate-50)); }
+.docs-commit-card { display: flex; align-items: center; justify-content: space-between; gap: 16px; border: 1px solid var(--border); border-radius: 12px; padding: 14px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--paper) 88%, var(--slate-50)), var(--paper)); }
+.docs-commit-copy { min-width: 0; }
+.docs-commit-title { font-size: 13.5px; font-weight: 650; margin-bottom: 4px; }
+.docs-commit-desc { font-size: 12.5px; color: var(--slate-600); line-height: 1.55; }
+.docs-commit-desc a { font-weight: 650; }
 .diagram-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; background:
   radial-gradient(circle at 50% 20%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 36%),
   var(--slate-50); padding: 14px; }
@@ -314,7 +352,9 @@ table.findings tr:last-child td { border-bottom: none; }
   .dashboard-summary { grid-template-columns: 1fr; }
   .summary-chip-row { justify-content: flex-start; }
   .stat-strip { grid-template-columns: repeat(2, minmax(0,1fr)); }
-  .health-grid, .subsystem-grid, .settings-grid { grid-template-columns: 1fr; }
+  .health-grid, .subsystem-grid, .settings-grid, .docs-grid { grid-template-columns: 1fr; }
+  .docs-overview, .docs-module-summary, .docs-commit-card { grid-template-columns: 1fr; }
+  .docs-overview-stats, .docs-module-meta { justify-content: flex-start; }
   .picker-head { align-items: flex-start; gap: 1rem; flex-direction: column; }
   .diagram-zoom-toolbar { left: 14px; right: 14px; transform: none; justify-content: center; flex-wrap: wrap; border-radius: 14px; }
   .diagram-zoom-hint { order: 2; width: 100%; text-align: center; }
@@ -1348,9 +1388,14 @@ loadPlanBadge();
 # had no docstring, always marked distinct from a verbatim source comment.
 # ---------------------------------------------------------------------------
 DOCS_LOCKED_PREVIEW = (
-    '<div class="subsystem-grid">'
-    '<div class="subsystem-card"><div class="subsystem-name">checkout/session.py</div>'
-    '<div class="subsystem-desc">create_session(cart_id) - Validates a cart and opens a new payment session.</div></div>'
+    '<div class="docs-grid">'
+    '<details class="docs-module-card" open><summary class="docs-module-summary">'
+    '<div><div class="docs-module-title"><i class="ti ti-file-code"></i><span class="docs-module-path">checkout/session.py</span></div>'
+    '<div class="docs-module-sub">1 documented symbol</div></div>'
+    '<div class="docs-module-meta"><span class="docs-chip">1 symbol</span><i class="ti ti-chevron-down docs-module-chevron"></i></div>'
+    '</summary><div class="docs-module-content"><pre class="docs-module-body">'
+    '# checkout/session.py\n\n### `create_session(cart_id)`\n\nValidates a cart and opens a new payment session.\n\n`checkout/session.py:42`'
+    '</pre></div></details>'
     "</div>"
 )
 
@@ -1381,16 +1426,64 @@ DOCS_HTML = _page_head("Docs — {repo} — Aletheore") + _shell(
 {PAGE_HEAD_JS}
 {CONFIRM_UPGRADE_JS}
 
+function docsSymbolCount(markdown) {{
+  const matches = markdown.match(/^###\\s+/gm);
+  return matches ? matches.length : 0;
+}}
+
+function docsLineCount(markdown) {{
+  return markdown.split('\\n').filter(function (line) {{ return line.trim().length > 0; }}).length;
+}}
+
+function docsHasAiText(markdown) {{
+  return markdown.indexOf('AI-generated') !== -1 || markdown.indexOf('AI-polished') !== -1;
+}}
+
+function renderDocsOverview(modulePaths, modules) {{
+  const symbolCount = modulePaths.reduce(function (total, path) {{
+    return total + docsSymbolCount(modules[path] || '');
+  }}, 0);
+  const aiCount = modulePaths.filter(function (path) {{ return docsHasAiText(modules[path] || ''); }}).length;
+  return '<div class="docs-overview">' +
+    '<div>' +
+      '<div class="docs-overview-kicker">Aletheore Docs</div>' +
+      '<h2>Evidence-grounded API reference</h2>' +
+      '<p>Public functions and classes are grouped by source file with signatures, docstrings, generated descriptions, and file:line citations kept visibly grounded in repository evidence.</p>' +
+    '</div>' +
+    '<div class="docs-overview-stats">' +
+      '<div class="docs-stat-pill"><div class="docs-stat-value">' + modulePaths.length + '</div><div class="docs-stat-label">modules</div></div>' +
+      '<div class="docs-stat-pill"><div class="docs-stat-value">' + symbolCount + '</div><div class="docs-stat-label">symbols</div></div>' +
+      '<div class="docs-stat-pill"><div class="docs-stat-value">' + aiCount + '</div><div class="docs-stat-label">AI-assisted files</div></div>' +
+    '</div>' +
+  '</div>';
+}}
+
 function renderDocsModule(modulePath, markdown) {{
   const details = document.createElement('details');
-  details.className = 'subsystem-card';
+  details.className = 'docs-module-card';
   const summary = document.createElement('summary');
-  summary.textContent = modulePath;
+  summary.className = 'docs-module-summary';
+  const symbols = docsSymbolCount(markdown);
+  const lines = docsLineCount(markdown);
+  const hasAi = docsHasAiText(markdown);
+  summary.innerHTML =
+    '<div>' +
+      '<div class="docs-module-title"><i class="ti ti-file-code" aria-hidden="true"></i><span class="docs-module-path">' + escapeHtml(modulePath) + '</span></div>' +
+      '<div class="docs-module-sub">' + symbols + ' public symbol' + (symbols === 1 ? '' : 's') + ' documented from source evidence</div>' +
+    '</div>' +
+    '<div class="docs-module-meta">' +
+      '<span class="docs-chip">' + lines + ' lines</span>' +
+      (hasAi ? '<span class="docs-chip ai"><i class="ti ti-sparkles" aria-hidden="true"></i>AI marked</span>' : '') +
+      '<i class="ti ti-chevron-down docs-module-chevron" aria-hidden="true"></i>' +
+    '</div>';
+  const content = document.createElement('div');
+  content.className = 'docs-module-content';
   const pre = document.createElement('pre');
   pre.className = 'docs-module-body';
   pre.textContent = markdown;
   details.appendChild(summary);
-  details.appendChild(pre);
+  content.appendChild(pre);
+  details.appendChild(content);
   return details;
 }}
 
@@ -1436,20 +1529,20 @@ async function loadDocs() {{
   }}
   let staleBanner = '';
   if (data.build_status === 'failed') {{
-    staleBanner = '<div class="empty-state" style="color:var(--critical);margin-bottom:12px;">' +
+    staleBanner = '<div class="docs-status-banner failed">' +
       'The latest Docs update failed' + (data.build_error ? ': ' + escapeHtml(data.build_error) : '.') +
       ' Showing the last successful build below - it may be stale.</div>';
   }} else if (data.build_error) {{
     // A "ready" status with a build_error means a partial run: some files
     // got documented, others didn't (a transient API error, mid-run). The
     // ones below are real and current - this just says the rest is coming.
-    staleBanner = '<div class="empty-state" style="color:var(--warning);margin-bottom:12px;">' +
+    staleBanner = '<div class="docs-status-banner partial">' +
       'The latest Docs update didn\\'t finish everything: ' + escapeHtml(data.build_error) +
       ' It will pick up automatically on the next run.</div>';
   }}
-  body.innerHTML = staleBanner;
+  body.innerHTML = renderDocsOverview(modulePaths, data.modules || {{}}) + staleBanner;
   const list = document.createElement('div');
-  list.className = 'subsystem-grid';
+  list.className = 'docs-grid';
   modulePaths.sort().forEach(function (path) {{
     list.appendChild(renderDocsModule(path, data.modules[path]));
   }});
@@ -1468,12 +1561,12 @@ async function loadDocsRepoCommitSettings() {{
 
 function renderDocsRepoCommit(body, enabled, prNumber) {{
   let statusHtml = enabled
-    ? '<p>Enabled - .aletheore/docs/API.md is kept current on a single rolling pull request.'
+    ? '<div class="docs-commit-title">Repo commit is enabled</div><div class="docs-commit-desc">.aletheore/docs/API.md is kept current on a single rolling pull request.'
       + (prNumber ? ' <a href="https://github.com/' + org + '/' + repo + '/pull/' + prNumber + '" target="_blank" rel="noopener">View PR #' + prNumber + '</a>' : ' The first pull request opens the next time Docs regenerates.')
-      + '</p>'
-    : '<p>Disabled - this reference only lives in the Aletheore dashboard.</p>';
-  body.innerHTML = statusHtml +
-    '<button class="btn" id="docs-repo-commit-toggle">' + (enabled ? 'Disable' : 'Enable') + '</button>';
+      + '</div>'
+    : '<div class="docs-commit-title">Dashboard-only reference</div><div class="docs-commit-desc">Docs is available here, but Aletheore is not opening a docs update pull request in your repository.</div>';
+  body.innerHTML = '<div class="docs-commit-card"><div class="docs-commit-copy">' + statusHtml + '</div>' +
+    '<button class="btn" id="docs-repo-commit-toggle"><i class="ti ti-git-pull-request" aria-hidden="true"></i>' + (enabled ? 'Disable' : 'Enable') + '</button></div>';
   document.getElementById('docs-repo-commit-toggle').onclick = async function () {{
     const res = await fetch(adminBase + '/docs-repo-commit', {{
       method: 'PUT', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify({{ enabled: !enabled }}),

--- a/github-app/app_server/logging_config.py
+++ b/github-app/app_server/logging_config.py
@@ -61,12 +61,21 @@ def log_job(func):
         start = time.monotonic()
         try:
             result = func(*args, **kwargs)
-        except Exception:
+        except Exception as exc:
             duration_ms = round((time.monotonic() - start) * 1000, 2)
             _job_logger.exception(
                 "job failed",
                 extra={"job_id": job_id, "job_name": func.__name__, "duration_ms": duration_ms},
             )
+            # An exception reaching here means whatever the job function
+            # itself does to handle expected failures (a dead GitHub token,
+            # a flaky external API) didn't catch it - by the time it's here,
+            # it's much more likely a real bug than routine external-API
+            # noise, worth a live alert rather than only a log line to find
+            # later.
+            from app_server.error_alerts import send_error_alert
+
+            send_error_alert(func.__name__, exc, f"job_id={job_id}")
             raise
         duration_ms = round((time.monotonic() - start) * 1000, 2)
         _job_logger.info(

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -14,6 +15,7 @@ from app_server.config import get_settings
 from app_server.dashboard import dashboard_router
 from app_server.db import create_pool
 from app_server.demo_scan_api import demo_scan_router
+from app_server.error_alerts import send_error_alert
 from app_server.frontend import frontend_router
 from app_server.logging_config import configure_json_logging
 from app_server.managed_audit_api import managed_audit_router
@@ -93,6 +95,23 @@ async def log_requests(request: Request, call_next):
     )
     response.headers["X-Request-ID"] = request_id
     return response
+
+
+@app.exception_handler(Exception)
+async def handle_unexpected_exception(request: Request, exc: Exception) -> JSONResponse:
+    # FastAPI's default HTTPException handler stays in effect for
+    # HTTPException specifically (a more specific handler is already
+    # registered for it) - this only ever catches something nobody
+    # deliberately raised, i.e. a real bug. Previously the only way to
+    # learn about one of these was reading logs after the fact.
+    logging.getLogger("app_server.errors").exception(
+        "unhandled exception in request",
+        extra={"method": request.method, "path": request.url.path},
+    )
+    await asyncio.to_thread(
+        send_error_alert, "app_server", exc, f"{request.method} {request.url.path}"
+    )
+    return JSONResponse(status_code=500, content={"detail": "internal server error"})
 
 
 @app.get("/healthz")

--- a/github-app/tests/test_error_alerts.py
+++ b/github-app/tests/test_error_alerts.py
@@ -1,0 +1,83 @@
+from app_server import error_alerts
+from app_server.error_alerts import send_error_alert
+
+
+def test_skips_when_resend_api_key_not_configured(monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setattr(error_alerts, "_last_alert_at", {})
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError("should not attempt to send without a configured API key")
+
+    monkeypatch.setattr(error_alerts, "send_transactional_email", _fail_if_called)
+
+    send_error_alert("app_server", ValueError("boom"))
+
+
+def test_sends_alert_with_source_and_exception_details(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr(error_alerts, "_last_alert_at", {})
+
+    sent = []
+    monkeypatch.setattr(
+        error_alerts,
+        "send_transactional_email",
+        lambda api_key, from_addr, reply_to, to, subject, html, text: sent.append(
+            {"api_key": api_key, "to": to, "subject": subject, "text": text}
+        ),
+    )
+
+    send_error_alert("run_flash_review_job", ValueError("boom"), "job_id=abc123")
+
+    assert len(sent) == 1
+    assert sent[0]["api_key"] == "re_test_key"
+    assert "run_flash_review_job" in sent[0]["subject"]
+    assert "ValueError" in sent[0]["subject"]
+    assert "boom" in sent[0]["text"]
+    assert "job_id=abc123" in sent[0]["text"]
+
+
+def test_rate_limits_repeated_alerts_for_the_same_source_and_error_type(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr(error_alerts, "_last_alert_at", {})
+
+    sent = []
+    monkeypatch.setattr(
+        error_alerts,
+        "send_transactional_email",
+        lambda *a, **k: sent.append(1),
+    )
+
+    send_error_alert("app_server", ValueError("first"))
+    send_error_alert("app_server", ValueError("second"))
+
+    assert len(sent) == 1
+
+
+def test_does_not_rate_limit_a_different_exception_type_from_the_same_source(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr(error_alerts, "_last_alert_at", {})
+
+    sent = []
+    monkeypatch.setattr(
+        error_alerts,
+        "send_transactional_email",
+        lambda *a, **k: sent.append(1),
+    )
+
+    send_error_alert("app_server", ValueError("a"))
+    send_error_alert("app_server", KeyError("b"))
+
+    assert len(sent) == 2
+
+
+def test_never_raises_when_sending_the_alert_itself_fails(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr(error_alerts, "_last_alert_at", {})
+
+    def _boom(*a, **k):
+        raise RuntimeError("Resend is down")
+
+    monkeypatch.setattr(error_alerts, "send_transactional_email", _boom)
+
+    send_error_alert("app_server", ValueError("boom"))  # must not raise

--- a/github-app/tests/test_logging_config.py
+++ b/github-app/tests/test_logging_config.py
@@ -105,3 +105,41 @@ def test_log_job_logs_failure_and_reraises(caplog):
 
     record = next(r for r in caplog.records if r.message == "job failed")
     assert record.job_name == "failing_job"
+
+
+def test_log_job_alerts_on_failure(monkeypatch):
+    # A job function reaching log_job's except block means whatever it does
+    # to handle expected failures (a dead token, a flaky external API)
+    # didn't catch it - much more likely a real bug than routine noise, so
+    # this is the one place worth a live alert rather than only a log line.
+    from app_server import error_alerts
+
+    calls = []
+    monkeypatch.setattr(error_alerts, "send_error_alert", lambda *a, **k: calls.append((a, k)))
+
+    @log_job
+    def failing_job() -> None:
+        raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError):
+        failing_job()
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args[0] == "failing_job"
+    assert isinstance(args[1], RuntimeError)
+
+
+def test_log_job_does_not_alert_on_success(monkeypatch):
+    from app_server import error_alerts
+
+    calls = []
+    monkeypatch.setattr(error_alerts, "send_error_alert", lambda *a, **k: calls.append(1))
+
+    @log_job
+    def do_work() -> int:
+        return 1
+
+    do_work()
+
+    assert calls == []

--- a/github-app/tests/test_main.py
+++ b/github-app/tests/test_main.py
@@ -155,6 +155,39 @@ async def test_healthz_returns_503_when_redis_is_unreachable(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_unhandled_exception_returns_generic_500_and_alerts(monkeypatch):
+    # An unhandled exception here means something nobody deliberately
+    # raised via HTTPException - a real bug, not a routine 4xx. Previously
+    # the only way to learn about one was reading logs after the fact.
+    app.state.db_pool = object()
+    body = b"not valid json"
+
+    calls = []
+    monkeypatch.setattr("app_server.main.send_error_alert", lambda *a, **k: calls.append((a, k)))
+
+    # raise_app_exceptions=False: httpx's ASGITransport otherwise re-raises
+    # any exception the app handled internally, defeating the point of
+    # this test (verifying a caught exception still produces a real HTTP
+    # response, not that it propagates - that's what the other tests are
+    # for).
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-Hub-Signature-256": _signature(body, settings.github_webhook_secret),
+                "X-GitHub-Event": "installation",
+            },
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "internal server error"}
+    assert len(calls) == 1
+    assert calls[0][0][0] == "app_server"
+
+
+@pytest.mark.asyncio
 async def test_request_logging_middleware_adds_request_id_header():
     app.state.db_pool = object()
     transport = ASGITransport(app=app)


### PR DESCRIPTION
## Summary
- Closes gap #10: "no error/exception monitoring for your own backend." `runtime_events.py` is Sentry-compatible ingestion but only for a *customer's* app - nothing watched `app_server`/`scan_worker`'s own crashes in real time before this.
- New `app_server/error_alerts.py` - reuses the existing Resend transactional-email infra (no new service/dependency), sends to `email_reply_to_address` (a real inbox already checked). Rate-limited per (source, exception type), 15-minute process-local cooldown.
- Wired into a global `@app.exception_handler(Exception)` in `main.py` (leaves the existing `HTTPException` handling untouched - only catches something nobody raised on purpose) and into `log_job`'s except branch in `logging_config.py` (an exception reaching there means whatever the job does to handle expected failures didn't catch it - much more likely a real bug than routine external-API noise).

## Test plan
- [x] `pytest tests/test_error_alerts.py tests/test_logging_config.py tests/test_main.py -q` - all passing, including a new end-to-end test proving an unhandled exception in a route returns a generic 500 and fires the alert
- [x] Full suite: 918 passed, 8 skipped
- [ ] CI checks

**Not deploying yet** - batching more items before the next prod push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)