### PR TITLE
feat: rate limit /auth/login and /auth/callback

### DIFF
--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -23,6 +23,8 @@ from app_server.db import (
 )
 from app_server.email_queue import enqueue_transactional_email
 from app_server.github_auth import generate_app_jwt, get_installation_details
+from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for
+from app_server.rate_limit import is_rate_limited
 
 SESSION_COOKIE_NAME = "session"
 SESSION_TTL = timedelta(days=30)
@@ -30,8 +32,48 @@ OAUTH_STATE_COOKIE_NAME = "oauth_state"
 OAUTH_STATE_TTL = timedelta(minutes=10)
 NEXT_COOKIE_NAME = "aletheore_oauth_next"
 
+# GitHub's own OAuth flow already gates against credential brute-forcing
+# (there's no password here to guess), but neither /auth/login nor
+# /auth/callback had any rate limiting at all - the latter makes two real
+# GitHub API calls per hit (_exchange_code_and_fetch_user). Shared budget
+# across both endpoints, not a separate one each, since they're the same
+# logical flow and a per-endpoint split would just double an attacker's
+# effective allowance.
+AUTH_RATE_LIMIT = 20
+AUTH_RATE_LIMIT_WINDOW_SECONDS = 300
+
 auth_router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def _enforce_auth_rate_limit(request: Request) -> None:
+    from redis import Redis
+
+    settings = get_settings()
+    client_ip = client_ip_from_forwarded_for(
+        request.headers.get("x-forwarded-for"),
+        request.client.host if request.client else "",
+    )
+    try:
+        rate_limited = is_rate_limited(
+            Redis.from_url(settings.redis_url),
+            f"ratelimit:auth:{client_ip}",
+            AUTH_RATE_LIMIT,
+            AUTH_RATE_LIMIT_WINDOW_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # A Redis outage should degrade this endpoint's abuse protection,
+        # not take down sign-in itself - fail open, same as the public
+        # health rate limit and the Paddle IP allowlist do.
+        logger.warning("auth rate limit check failed (%s); allowing request", exc)
+        rate_limited = False
+
+    if rate_limited:
+        raise HTTPException(
+            status_code=429,
+            detail="too many requests",
+            headers={"Retry-After": str(AUTH_RATE_LIMIT_WINDOW_SECONDS)},
+        )
 
 
 def _derive_key(session_secret: str, purpose: bytes, length: int = 32) -> bytes:
@@ -217,7 +259,8 @@ def _is_safe_next_path(next_path: str | None) -> str:
 
 
 @auth_router.get("/auth/login")
-async def login(next: str | None = None):
+async def login(request: Request, next: str | None = None):
+    _enforce_auth_rate_limit(request)
     settings = get_settings()
     state = secrets.token_urlsafe(32)
     safe_next = _is_safe_next_path(next)
@@ -249,6 +292,7 @@ async def login(next: str | None = None):
 
 @auth_router.get("/auth/callback")
 async def callback(code: str, request: Request, state: str | None = None, installation_id: int | None = None):
+    _enforce_auth_rate_limit(request)
     settings = get_settings()
 
     # GitHub redirects here from two different entry points: our own

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -97,6 +97,19 @@ def _no_real_paddle_ip_fetch(monkeypatch):
     monkeypatch.setattr(paddle_ip_allowlist, "_fetch_paddle_networks", _fake_fetch)
 
 
+@pytest.fixture(autouse=True)
+def _no_real_auth_rate_limiting(monkeypatch):
+    # /auth/login and /auth/callback share one real-Redis-backed rate limit
+    # keyed by client IP - every test hitting either route runs from the
+    # same "testclient" source IP, so without this the whole suite (well
+    # over AUTH_RATE_LIMIT calls across test_auth.py and
+    # test_frontend_subscribe.py alone) would trip real 429s partway
+    # through, unrelated to whatever each test actually verifies. Tests
+    # that specifically exercise the 429 path patch is_rate_limited back
+    # to something real (or fake it directly) within their own test body.
+    monkeypatch.setattr("app_server.auth.is_rate_limited", lambda *a, **k: False)
+
+
 def _make_git_repo(path: Path, files: dict[str, str]) -> str:
     path.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "-q"], cwd=path, check=True)

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -612,3 +612,97 @@ async def test_callback_degrades_gracefully_when_email_permission_not_granted(po
     assert response.status_code == 307
     row = await pool.fetchrow("SELECT 1 FROM github_user_emails WHERE github_login = 'octocat'")
     assert row is None
+
+
+@pytest.mark.asyncio
+async def test_login_rate_limits_after_threshold(pool, monkeypatch, redis_conn):
+    import app_server.auth as auth_module
+    from app_server.rate_limit import is_rate_limited as real_is_rate_limited
+
+    monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
+    monkeypatch.setattr(auth_module, "AUTH_RATE_LIMIT", 2)
+    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    headers = {"x-forwarded-for": "203.0.113.60"}
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get("/auth/login", headers=headers, follow_redirects=False)
+        second = await client.get("/auth/login", headers=headers, follow_redirects=False)
+        third = await client.get("/auth/login", headers=headers, follow_redirects=False)
+
+    assert first.status_code == 307
+    assert second.status_code == 307
+    assert third.status_code == 429
+    assert "retry-after" in third.headers
+
+
+@pytest.mark.asyncio
+async def test_auth_rate_limit_is_shared_between_login_and_callback(pool, monkeypatch, redis_conn):
+    # Same logical flow, one budget - a separate limit per endpoint would
+    # just double an attacker's effective allowance.
+    import app_server.auth as auth_module
+    from app_server.rate_limit import is_rate_limited as real_is_rate_limited
+
+    monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
+    monkeypatch.setattr(auth_module, "AUTH_RATE_LIMIT", 1)
+    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    headers = {"x-forwarded-for": "203.0.113.61"}
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        login_response = await client.get("/auth/login", headers=headers, follow_redirects=False)
+        callback_response = await client.get(
+            "/auth/callback?code=fake-code", headers=headers, follow_redirects=False
+        )
+
+    assert login_response.status_code == 307
+    assert callback_response.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_auth_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis_conn):
+    import app_server.auth as auth_module
+    from app_server.rate_limit import is_rate_limited as real_is_rate_limited
+
+    monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
+    monkeypatch.setattr(auth_module, "AUTH_RATE_LIMIT", 1)
+    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get(
+            "/auth/login", headers={"x-forwarded-for": "1.1.1.1"}, follow_redirects=False
+        )
+        second_same_ip = await client.get(
+            "/auth/login", headers={"x-forwarded-for": "1.1.1.1"}, follow_redirects=False
+        )
+        first_other_ip = await client.get(
+            "/auth/login", headers={"x-forwarded-for": "2.2.2.2"}, follow_redirects=False
+        )
+
+    assert first.status_code == 307
+    assert second_same_ip.status_code == 429
+    assert first_other_ip.status_code == 307
+
+
+@pytest.mark.asyncio
+async def test_login_fails_open_when_redis_is_unreachable(pool, monkeypatch):
+    import app_server.auth as auth_module
+    from app_server.rate_limit import is_rate_limited as real_is_rate_limited
+
+    monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
+
+    def _boom(url):
+        raise ConnectionError("redis unreachable")
+
+    monkeypatch.setattr("redis.Redis.from_url", _boom)
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/auth/login", follow_redirects=False)
+
+    assert response.status_code == 307


### PR DESCRIPTION
## Summary
- Closes the login/auth half of gap #11 ("a dedicated pass across login/auth ... hasn't been done as its own audit"). Neither `/auth/login` nor `/auth/callback` had any rate limiting - the latter makes two real GitHub API calls per hit.
- Defense-in-depth rather than closing an exploitable hole (GitHub's own OAuth flow already resists credential brute-forcing) - brings these two endpoints in line with the caution already applied to managed-audit/demo-scan cooldowns and the public health status rate limit.
- Shared budget across both endpoints (`ratelimit:auth:{client_ip}`), same fail-open-on-Redis-outage behavior as the existing pattern.
- `is_rate_limited` promoted to a module-level import in `auth.py` so it's independently patchable from `app_server.rate_limit`'s copy (used by `dashboard.py`) - without that, the 23+ existing test calls to these routes across `test_auth.py`/`test_frontend_subscribe.py` (all sharing one real Redis instance under the test client's fixed source IP) would trip real 429s unrelated to what each test actually verifies. New autouse conftest fixture defaults it off for the rest of the suite; new rate-limit-specific tests re-enable the real function.

## Test plan
- [x] `pytest tests/test_auth.py -v` - 33 passed, including 4 new rate-limit tests (threshold, shared budget across login+callback, per-IP keying, fail-open on Redis outage)
- [x] Full suite: 922 passed, 8 skipped
- [ ] CI checks

**Not deploying yet** - batching more items before the next prod push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)