### PR TITLE
feat: dismiss/mute findings on the hosted dashboard

### DIFF
--- a/docs/superpowers/specs/2026-08-09-dismiss-mute-findings-design.md
+++ b/docs/superpowers/specs/2026-08-09-dismiss-mute-findings-design.md
@@ -1,0 +1,284 @@
+# Dismiss/mute findings (gap item #6)
+
+## Goal
+
+Let a customer dismiss a specific secret or dependency-vulnerability finding
+from the hosted dashboard so it stops being shown as open there and stops
+appearing in future PR comments — without ever deleting or mutating the
+underlying stored scan evidence.
+
+## Scope decisions (confirmed)
+
+- **Finding types**: secrets + dependency vulnerabilities only. Layer
+  violations and dead code have no identity concept today and are lower
+  security stakes; can extend the same pattern later.
+- **Surface**: the hosted dashboard's existing Security findings page
+  (`/dashboard/{org}/{repo}/security`) only. No new GitHub-native
+  interaction (no reactions/checkboxes — nothing like that exists anywhere
+  in the app today, so this would be new surface area for v1).
+- **Storage**: a new hosted-only DB table. No automated write-back to the
+  customer's `.aletheore.json` (no commit-authoring flow, no repo write
+  access needed). A dashboard dismissal has no effect on a local
+  `aletheore scan`/`aletheore diff` run — genuinely separate mechanisms,
+  same as the existing `accepted_secrets` (repo-committed baseline) staying
+  untouched and still working exactly as it does today, composed with this
+  new layer rather than replaced by it.
+
+## Why the PR-comment filtering can't reuse severity_threshold's pattern
+
+`severity_threshold` (shipped in PR #147) reads `.aletheore.json` directly
+inside `history.py::compute_diff()`, because that file is on disk and
+readable by both the CLI and the hosted worker (which runs `aletheore scan`/
+`aletheore diff` as a subprocess against a real checkout). `dismissed_findings`
+only exists in the hosted Postgres database — the plain `aletheore` package
+must never depend on it (same one-way dependency rule as `app_server` never
+importing `scan_worker`). So `compute_diff()` stays completely unaware of
+dismissals; filtering happens as a **post-processing step** in
+`scan_worker/jobs.py`, after `compute_diff()` returns and before the PR
+comment is built.
+
+## 1. Migration `033_dismissed_findings.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS dismissed_findings (
+    id              BIGSERIAL PRIMARY KEY,
+    installation_id BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name  TEXT NOT NULL,
+    finding_type    TEXT NOT NULL CHECK (finding_type IN ('secret', 'vulnerability')),
+    identity_key    TEXT NOT NULL,
+    reason          TEXT,
+    dismissed_by    TEXT NOT NULL,
+    dismissed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (installation_id, repo_full_name, finding_type, identity_key)
+);
+
+CREATE INDEX IF NOT EXISTS dismissed_findings_lookup
+    ON dismissed_findings (installation_id, repo_full_name);
+```
+
+## 2. Identity keys (new module `app_server/dismissed_findings.py`)
+
+Pure function, no DB dependency — shared by both `app_server` (async
+dashboard routes) and `scan_worker` (sync PR-comment job), same
+cross-package direction already established (`scan_worker` imports from
+`app_server`, never the reverse):
+
+```python
+def finding_identity_key(finding_type: str, finding: dict) -> str:
+    """Canonical identity string for a finding, used both to store a
+    dismissal and to check whether a fresh finding matches one. Uses the
+    same field tuples history.py already uses for new/resolved diffing:
+    (path, pattern, match_preview) for secrets, (ecosystem, package,
+    advisory_id) for vulnerabilities. \\x1f (unit separator) joins fields -
+    not a character any of these fields would plausibly contain."""
+    if finding_type == "secret":
+        return f"{finding['path']}\x1f{finding['pattern']}\x1f{finding['match_preview']}"
+    if finding_type == "vulnerability":
+        return f"{finding['ecosystem']}\x1f{finding['package']}\x1f{finding['advisory_id']}"
+    raise ValueError(f"unknown finding_type: {finding_type!r}")
+
+
+def filter_dismissed(findings: list[dict], finding_type: str, dismissed_keys: set[str]) -> list[dict]:
+    """Used by the PR-scan job to drop already-dismissed findings from a
+    diff's "new" list before building the PR comment. Never mutates the
+    evidence/diff findings a caller already has a reference to elsewhere -
+    returns a new filtered list."""
+    return [f for f in findings if finding_identity_key(finding_type, f) not in dismissed_keys]
+```
+
+Identity is **always computed server-side** from the finding's own fields —
+a dismiss request never accepts a client-supplied identity string directly,
+closing off any possibility of dismissing an arbitrary, unrelated key.
+
+## 3. Async DB helpers (`app_server/dismissed_findings.py`, used by dashboard routes)
+
+```python
+async def dismiss_finding(
+    pool, installation_id: int, repo_full_name: str, finding_type: str,
+    finding: dict, dismissed_by: str, reason: str | None = None,
+) -> None:
+    identity_key = finding_identity_key(finding_type, finding)
+    await pool.execute(
+        """INSERT INTO dismissed_findings
+               (installation_id, repo_full_name, finding_type, identity_key, dismissed_by, reason)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (installation_id, repo_full_name, finding_type, identity_key) DO NOTHING""",
+        installation_id, repo_full_name, finding_type, identity_key, dismissed_by, reason,
+    )
+
+
+async def undismiss_finding(
+    pool, installation_id: int, repo_full_name: str, finding_type: str, finding: dict,
+) -> None:
+    identity_key = finding_identity_key(finding_type, finding)
+    await pool.execute(
+        """DELETE FROM dismissed_findings
+           WHERE installation_id = $1 AND repo_full_name = $2
+             AND finding_type = $3 AND identity_key = $4""",
+        installation_id, repo_full_name, finding_type, identity_key,
+    )
+
+
+async def get_dismissed_identity_keys(
+    pool, installation_id: int, repo_full_name: str,
+) -> dict[str, set[str]]:
+    rows = await pool.fetch(
+        """SELECT finding_type, identity_key FROM dismissed_findings
+           WHERE installation_id = $1 AND repo_full_name = $2""",
+        installation_id, repo_full_name,
+    )
+    result: dict[str, set[str]] = {"secret": set(), "vulnerability": set()}
+    for row in rows:
+        result[row["finding_type"]].add(row["identity_key"])
+    return result
+```
+
+## 4. Sync DB helper (`scan_worker/db.py`, used by the PR-scan job)
+
+Matches the existing sync `psycopg` style already used there (e.g.
+`get_installation`):
+
+```python
+def get_dismissed_identity_keys(dsn: str, installation_id: int, repo_full_name: str) -> dict[str, set[str]]:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """SELECT finding_type, identity_key FROM dismissed_findings
+                   WHERE installation_id = %s AND repo_full_name = %s""",
+                (installation_id, repo_full_name),
+            )
+            result: dict[str, set[str]] = {"secret": set(), "vulnerability": set()}
+            for finding_type, identity_key in cur.fetchall():
+                result[finding_type].add(identity_key)
+            return result
+```
+
+## 5. Wiring into the PR-scan job (`scan_worker/jobs.py::run_pr_scan_job`)
+
+Right after `diff = compute_diff(old, new, full=False)`:
+
+```python
+dismissed = get_dismissed_identity_keys(settings.database_url, installation_id, repo_full_name)
+diff["secrets"]["new"] = filter_dismissed(diff["secrets"]["new"], "secret", dismissed["secret"])
+diff["vulnerabilities"]["new"] = filter_dismissed(
+    diff["vulnerabilities"]["new"], "vulnerability", dismissed["vulnerability"]
+)
+```
+
+`diff[...]["resolved"]` is left untouched — a dismissed-then-resolved
+finding disappearing from "resolved" isn't meaningfully confusing, and
+touching it adds no real value.
+
+## 6. Dashboard API (`app_server/dashboard.py`)
+
+`GET /app/{org}/{repo}` gains one field on its existing response:
+
+```python
+dismissed = await get_dismissed_identity_keys(pool, installation_id, repo_full_name)
+return {
+    "repo_full_name": repo_full_name,
+    "history": history,
+    "dismissed_finding_keys": {"secret": list(dismissed["secret"]), "vulnerability": list(dismissed["vulnerability"])},
+}
+```
+
+Two new routes, gated the same as the underlying data route the security
+page actually fetches from — `_require_dashboard_installation` (session +
+membership + **paid-plan check**, `dashboard.py:179`). Correction from an
+earlier assumption: the security page's HTML shell route only checks
+session, but the JS on that page fetches `GET /app/{org}/{repo}` via
+`_require_dashboard_installation`, which 402s on the free plan. Dismiss/
+undismiss follow the same gate for consistency — you already need a paid
+plan to see dashboard findings at all today.
+
+`_require_dashboard_installation` currently returns only `installation_id`,
+not the session, but `dismissed_by` needs `session["github_login"]`.
+Refactored to return `tuple[dict, int]` (`session, installation_id`); its 3
+existing call sites (`get_dashboard`, `get_dashboard_health`, one more at
+`dashboard.py:273`) are updated to unpack both values — a small, mechanical
+change, not a behavior change for any of them.
+
+```python
+@dashboard_router.post("/app/{org}/{repo}/findings/dismiss")
+async def dismiss_finding_route(org: str, repo: str, request: Request):
+    session, installation_id = await _require_dashboard_session(request, org, repo)
+    body = await request.json()
+    finding_type = body.get("finding_type")
+    finding = body.get("finding")
+    if finding_type not in ("secret", "vulnerability") or not isinstance(finding, dict):
+        raise HTTPException(status_code=400, detail="invalid finding_type or finding")
+    pool = request.app.state.db_pool
+    await dismiss_finding(
+        pool, installation_id, f"{org}/{repo}", finding_type, finding,
+        session["github_login"], body.get("reason"),
+    )
+    return {"ok": True}
+
+
+@dashboard_router.post("/app/{org}/{repo}/findings/undismiss")
+async def undismiss_finding_route(org: str, repo: str, request: Request):
+    session, installation_id = await _require_dashboard_session(request, org, repo)
+    body = await request.json()
+    finding_type = body.get("finding_type")
+    finding = body.get("finding")
+    if finding_type not in ("secret", "vulnerability") or not isinstance(finding, dict):
+        raise HTTPException(status_code=400, detail="invalid finding_type or finding")
+    pool = request.app.state.db_pool
+    await undismiss_finding(pool, installation_id, f"{org}/{repo}", finding_type, finding)
+    return {"ok": True}
+```
+
+(`_require_dashboard_session` here means whatever the existing session-gate
+helper is that also resolves `installation_id` for this org/repo — the
+existing `get_dashboard`/`get_dashboard_health` routes already do this via
+`_require_dashboard_installation`, which needs to additionally return the
+session dict so `dismissed_by` can be set to the real GitHub login rather
+than a placeholder.)
+
+## 7. Frontend (`app_server/frontend.py`)
+
+A small JS helper mirroring the Python identity-key format (trivial format,
+low duplication risk — unlike the CVSS calculator, not worth avoiding a JS
+mirror for):
+
+```js
+function findingIdentityKey(findingType, f) {
+  if (findingType === 'secret') return f.path + '\x1f' + f.pattern + '\x1f' + f.match_preview;
+  return f.ecosystem + '\x1f' + f.package + '\x1f' + f.advisory_id;
+}
+```
+
+**Security page** (`loadSecurity()`): filter `secretFindings`/`vulnFindings`
+by `!dismissedKeys[type].includes(findingIdentityKey(type, f))` before
+rendering the open-findings table. Each row gets a "Dismiss" button (POSTs
+to the dismiss route, then re-runs `loadSecurity()`). A new
+"Show dismissed (N)" toggle reveals the dismissed findings in a second,
+visually de-emphasized table with an "Undismiss" button per row — dismissal
+must stay visible and reversible, never a silent, permanent hide.
+
+**Overview page** (`loadOverview()`): same filtering applied to
+`secretFindings`/`vulnFindings` before computing `totalFindings` and the
+"recent findings" preview, so the two pages agree on what counts as open.
+
+## Testing
+
+- `finding_identity_key`: correct format per finding type, raises on an
+  unknown finding_type.
+- `filter_dismissed`: removes matched findings, leaves non-matched
+  findings untouched, no-ops on an empty dismissed set.
+- `dismiss_finding`/`undismiss_finding`/`get_dismissed_identity_keys`
+  (async, `app_server`): insert then read back; `ON CONFLICT DO NOTHING`
+  makes a duplicate dismiss a no-op rather than an error; undismiss then
+  re-read confirms removal.
+- `get_dismissed_identity_keys` (sync, `scan_worker`): same read-back
+  behavior via the sync connection.
+- `run_pr_scan_job`: a dismissed secret/vulnerability does not appear in
+  the posted PR comment body; a non-dismissed one still does.
+- Dashboard routes: dismiss/undismiss require a session (401 without one);
+  reject an unknown `finding_type` (400); a full end-to-end test seeds a
+  `repo_history` row with a secret finding, dismisses it via the route,
+  then confirms `GET /app/{org}/{repo}`'s `dismissed_finding_keys` includes
+  it and the security page's rendered output excludes it from the open
+  table.

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -15,6 +15,7 @@ from app_server.admin import (
 )
 from app_server.auth import get_current_session
 from app_server.config import get_settings
+from app_server.dismissed_findings import dismiss_finding, get_dismissed_identity_keys, undismiss_finding
 from app_server.db import (
     MAX_SCANNED_REPOS_PER_MONTH,
     count_monthly_scanned_repos,
@@ -176,7 +177,7 @@ async def list_my_repos(request: Request):
     return {"repos": result}
 
 
-async def _require_dashboard_installation(request: Request, org: str, repo: str) -> int:
+async def _require_dashboard_installation(request: Request, org: str, repo: str) -> tuple[dict, int]:
     # Session + ownership check first, before any repo lookup - an unauthenticated
     # caller should not learn whether a given org/repo has scan history at all.
     session = await get_current_session(request)
@@ -196,21 +197,68 @@ async def _require_dashboard_installation(request: Request, org: str, repo: str)
             raise HTTPException(status_code=402, detail="the managed dashboard requires a paid plan")
         await _require_seat_if_paid(pool, installation, session["github_login"])
 
-    return installation_id
+    return session, installation_id
 
 
 @dashboard_router.get("/app/{org}/{repo}")
 async def get_dashboard(org: str, repo: str, request: Request):
-    installation_id = await _require_dashboard_installation(request, org, repo)
+    _session, installation_id = await _require_dashboard_installation(request, org, repo)
     pool = request.app.state.db_pool
     repo_full_name = f"{org}/{repo}"
     history = await get_recent_history(pool, installation_id, repo_full_name)
-    return {"repo_full_name": repo_full_name, "history": history}
+    dismissed = await get_dismissed_identity_keys(pool, installation_id, repo_full_name)
+    return {
+        "repo_full_name": repo_full_name,
+        "history": history,
+        "dismissed_finding_keys": {
+            "secret": list(dismissed["secret"]),
+            "vulnerability": list(dismissed["vulnerability"]),
+        },
+    }
+
+
+@dashboard_router.post("/app/{org}/{repo}/findings/dismiss")
+async def dismiss_finding_route(org: str, repo: str, request: Request):
+    session, installation_id = await _require_dashboard_installation(request, org, repo)
+    body = await request.json()
+    finding_type = body.get("finding_type")
+    finding = body.get("finding")
+    if finding_type not in ("secret", "vulnerability") or not isinstance(finding, dict):
+        raise HTTPException(status_code=400, detail="invalid finding_type or finding")
+
+    pool = request.app.state.db_pool
+    repo_full_name = f"{org}/{repo}"
+    try:
+        await dismiss_finding(
+            pool, installation_id, repo_full_name, finding_type, finding,
+            session["github_login"], body.get("reason"),
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail=f"finding missing required field: {exc}") from exc
+    return {"ok": True}
+
+
+@dashboard_router.post("/app/{org}/{repo}/findings/undismiss")
+async def undismiss_finding_route(org: str, repo: str, request: Request):
+    _session, installation_id = await _require_dashboard_installation(request, org, repo)
+    body = await request.json()
+    finding_type = body.get("finding_type")
+    finding = body.get("finding")
+    if finding_type not in ("secret", "vulnerability") or not isinstance(finding, dict):
+        raise HTTPException(status_code=400, detail="invalid finding_type or finding")
+
+    pool = request.app.state.db_pool
+    repo_full_name = f"{org}/{repo}"
+    try:
+        await undismiss_finding(pool, installation_id, repo_full_name, finding_type, finding)
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail=f"finding missing required field: {exc}") from exc
+    return {"ok": True}
 
 
 @dashboard_router.get("/app/{org}/{repo}/health")
 async def get_dashboard_health(org: str, repo: str, request: Request):
-    installation_id = await _require_dashboard_installation(request, org, repo)
+    _session, installation_id = await _require_dashboard_installation(request, org, repo)
     pool = request.app.state.db_pool
     repo_full_name = f"{org}/{repo}"
 
@@ -270,7 +318,7 @@ async def get_dashboard_health_history(
     target_id: int | None = None,
     limit: int = 50,
 ):
-    installation_id = await _require_dashboard_installation(request, org, repo)
+    _session, installation_id = await _require_dashboard_installation(request, org, repo)
     pool = request.app.state.db_pool
     repo_full_name = f"{org}/{repo}"
 

--- a/github-app/app_server/dismissed_findings.py
+++ b/github-app/app_server/dismissed_findings.py
@@ -1,0 +1,89 @@
+import asyncpg
+
+
+def finding_identity_key(finding_type: str, finding: dict) -> str:
+    """Canonical identity string for a finding, used both to store a
+    dismissal and to check whether a fresh finding matches one already
+    dismissed. Uses the same field tuples history.py already uses for
+    new/resolved diffing: (path, pattern, match_preview) for secrets,
+    (ecosystem, package, advisory_id) for vulnerabilities. \x1f (unit
+    separator) joins fields - not a character any of these fields would
+    plausibly contain.
+    """
+    if finding_type == "secret":
+        return f"{finding['path']}\x1f{finding['pattern']}\x1f{finding['match_preview']}"
+    if finding_type == "vulnerability":
+        return f"{finding['ecosystem']}\x1f{finding['package']}\x1f{finding['advisory_id']}"
+    raise ValueError(f"unknown finding_type: {finding_type!r}")
+
+
+def filter_dismissed(findings: list[dict], finding_type: str, dismissed_keys: set[str]) -> list[dict]:
+    """Drops already-dismissed findings from a list - used by the PR-scan
+    job on a diff's "new" findings before building the PR comment. Returns
+    a new list; never mutates the one passed in.
+    """
+    return [f for f in findings if finding_identity_key(finding_type, f) not in dismissed_keys]
+
+
+async def dismiss_finding(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    repo_full_name: str,
+    finding_type: str,
+    finding: dict,
+    dismissed_by: str,
+    reason: str | None = None,
+) -> None:
+    identity_key = finding_identity_key(finding_type, finding)
+    await pool.execute(
+        """
+        INSERT INTO dismissed_findings
+            (installation_id, repo_full_name, finding_type, identity_key, dismissed_by, reason)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (installation_id, repo_full_name, finding_type, identity_key) DO NOTHING
+        """,
+        installation_id,
+        repo_full_name,
+        finding_type,
+        identity_key,
+        dismissed_by,
+        reason,
+    )
+
+
+async def undismiss_finding(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    repo_full_name: str,
+    finding_type: str,
+    finding: dict,
+) -> None:
+    identity_key = finding_identity_key(finding_type, finding)
+    await pool.execute(
+        """
+        DELETE FROM dismissed_findings
+        WHERE installation_id = $1 AND repo_full_name = $2
+          AND finding_type = $3 AND identity_key = $4
+        """,
+        installation_id,
+        repo_full_name,
+        finding_type,
+        identity_key,
+    )
+
+
+async def get_dismissed_identity_keys(
+    pool: asyncpg.Pool, installation_id: int, repo_full_name: str
+) -> dict[str, set[str]]:
+    rows = await pool.fetch(
+        """
+        SELECT finding_type, identity_key FROM dismissed_findings
+        WHERE installation_id = $1 AND repo_full_name = $2
+        """,
+        installation_id,
+        repo_full_name,
+    )
+    result: dict[str, set[str]] = {"secret": set(), "vulnerability": set()}
+    for row in rows:
+        result[row["finding_type"]].add(row["identity_key"])
+    return result

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -381,6 +381,31 @@ async function apiGet(url) {
   }
   return res;
 }
+async function apiPost(url, body) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 401) {
+    window.location.href = '/auth/logout';
+    return null;
+  }
+  if (!res.ok) {
+    console.error('apiPost failed: ' + url + ' -> ' + res.status);
+    return null;
+  }
+  return res;
+}
+function findingIdentityKey(findingType, f) {
+  // Mirrors app_server/dismissed_findings.py's finding_identity_key() -
+  // identity is always recomputed server-side on dismiss/undismiss (never
+  // trusted from the client); this is only used client-side to check
+  // membership against the dismissed_finding_keys set the read endpoint
+  // already returns.
+  if (findingType === 'secret') return f.path + '\x1f' + f.pattern + '\x1f' + f.match_preview;
+  return f.ecosystem + '\x1f' + f.package + '\x1f' + f.advisory_id;
+}
 function relativeTime(iso) {
   const diffMs = Date.now() - new Date(iso).getTime();
   const mins = Math.round(diffMs / 60000);
@@ -692,9 +717,14 @@ async function loadOverview() {{
   const evidence = latest.evidence || {{}};
   document.getElementById('last-scanned').textContent = 'Last scanned ' + relativeTime(latest.scanned_at);
 
+  const dismissedKeys = data.dismissed_finding_keys || {{ secret: [], vulnerability: [] }};
   const security = evidence.security || {{}};
-  const secretFindings = ((security.secrets || {{}}).findings || []).filter(function (f) {{ return !f.likely_placeholder && !f.accepted; }});
-  const vulnFindings = (security.dependency_vulnerabilities || {{}}).findings || [];
+  const secretFindings = ((security.secrets || {{}}).findings || []).filter(function (f) {{
+    return !f.likely_placeholder && !f.accepted && dismissedKeys.secret.indexOf(findingIdentityKey('secret', f)) === -1;
+  }});
+  const vulnFindings = ((security.dependency_vulnerabilities || {{}}).findings || []).filter(function (f) {{
+    return dismissedKeys.vulnerability.indexOf(findingIdentityKey('vulnerability', f)) === -1;
+  }});
   const totalFindings = secretFindings.length + vulnFindings.length;
   document.getElementById('summary-title').textContent =
     totalFindings === 0 ? repo + ' is clean in the latest scan' : repo + ' has ' + totalFindings + ' open finding' + (totalFindings === 1 ? '' : 's');
@@ -783,6 +813,61 @@ SECURITY_HTML = _page_head("Security findings — {repo} — Aletheore") + _shel
 {FETCH_HELPERS}
 {PAGE_HEAD_JS}
 
+function findingActionButtonHtml(findingType, f, label, handler) {{
+  if (findingType === 'secret') {{
+    return '<button class="btn" data-type="secret" data-path="' + escapeHtml(f.path) +
+      '" data-pattern="' + escapeHtml(f.pattern) + '" data-match-preview="' + escapeHtml(f.match_preview) +
+      '" onclick="' + handler + '(this)">' + label + '</button>';
+  }}
+  return '<button class="btn" data-type="vulnerability" data-ecosystem="' + escapeHtml(f.ecosystem) +
+    '" data-package="' + escapeHtml(f.package) + '" data-advisory-id="' + escapeHtml(f.advisory_id) +
+    '" onclick="' + handler + '(this)">' + label + '</button>';
+}}
+
+function findingPayloadFromButton(btn) {{
+  if (btn.dataset.type === 'secret') {{
+    return {{
+      finding_type: 'secret',
+      finding: {{ path: btn.dataset.path, pattern: btn.dataset.pattern, match_preview: btn.dataset.matchPreview }},
+    }};
+  }}
+  return {{
+    finding_type: 'vulnerability',
+    finding: {{ ecosystem: btn.dataset.ecosystem, package: btn.dataset.package, advisory_id: btn.dataset.advisoryId }},
+  }};
+}}
+
+async function dismissFinding(btn) {{
+  btn.disabled = true;
+  await apiPost(base + '/findings/dismiss', findingPayloadFromButton(btn));
+  loadSecurity();
+}}
+
+async function undismissFinding(btn) {{
+  btn.disabled = true;
+  await apiPost(base + '/findings/undismiss', findingPayloadFromButton(btn));
+  loadSecurity();
+}}
+
+function toggleDismissedFindings(event, dismissedSecretFindings, dismissedVulnFindings) {{
+  event.preventDefault();
+  const el = document.getElementById('dismissed-findings-body');
+  if (el.style.display !== 'none') {{ el.style.display = 'none'; return; }}
+  let rows = '';
+  dismissedSecretFindings.forEach(function (f) {{
+    rows += '<tr><td><span class="finding-title">Possible ' + escapeHtml(f.pattern) + ' secret</span></td>' +
+      '<td class="finding-cite">' + escapeHtml(f.path) + ':' + f.line + '</td>' +
+      '<td>' + findingActionButtonHtml('secret', f, 'Undismiss', 'undismissFinding') + '</td></tr>';
+  }});
+  dismissedVulnFindings.forEach(function (f) {{
+    rows += '<tr><td><span class="finding-title">' + escapeHtml(f.advisory_id) + ': ' + escapeHtml(f.summary || 'known vulnerability') + '</span></td>' +
+      '<td class="finding-cite">' + escapeHtml(f.package) + '@' + escapeHtml(f.installed_version) + '</td>' +
+      '<td>' + findingActionButtonHtml('vulnerability', f, 'Undismiss', 'undismissFinding') + '</td></tr>';
+  }});
+  el.innerHTML = '<table class="findings" style="opacity:0.7"><thead><tr><th>Finding</th><th>Evidence</th><th></th></tr></thead><tbody>' + rows + '</tbody></table>';
+  el.style.display = 'block';
+}}
+
 async function loadSecurity() {{
   const res = await apiGet(base);
   const body = document.getElementById('security-body');
@@ -791,27 +876,48 @@ async function loadSecurity() {{
   const data = await res.json();
   const history = data.history || [];
   if (history.length === 0) {{ body.innerHTML = '<div class="empty-state">No scans yet.</div>'; return; }}
+  const dismissedKeys = data.dismissed_finding_keys || {{ secret: [], vulnerability: [] }};
   const evidence = history[0].evidence || {{}};
   const security = evidence.security || {{}};
-  const secretFindings = ((security.secrets || {{}}).findings || []).filter(function (f) {{ return !f.likely_placeholder && !f.accepted; }});
-  const vulnFindings = (security.dependency_vulnerabilities || {{}}).findings || [];
+  const allSecretFindings = ((security.secrets || {{}}).findings || []).filter(function (f) {{ return !f.likely_placeholder && !f.accepted; }});
+  const allVulnFindings = (security.dependency_vulnerabilities || {{}}).findings || [];
+
+  const secretFindings = allSecretFindings.filter(function (f) {{ return dismissedKeys.secret.indexOf(findingIdentityKey('secret', f)) === -1; }});
+  const vulnFindings = allVulnFindings.filter(function (f) {{ return dismissedKeys.vulnerability.indexOf(findingIdentityKey('vulnerability', f)) === -1; }});
+  const dismissedSecretFindings = allSecretFindings.filter(function (f) {{ return dismissedKeys.secret.indexOf(findingIdentityKey('secret', f)) !== -1; }});
+  const dismissedVulnFindings = allVulnFindings.filter(function (f) {{ return dismissedKeys.vulnerability.indexOf(findingIdentityKey('vulnerability', f)) !== -1; }});
+  const dismissedCount = dismissedSecretFindings.length + dismissedVulnFindings.length;
 
   if (secretFindings.length === 0 && vulnFindings.length === 0) {{
     body.innerHTML = '<div class="empty-state">No open findings.</div>';
+    if (dismissedCount > 0) {{
+      body.innerHTML += '<p class="section-sub" style="margin-top:16px"><a href="#" onclick="toggleDismissedFindings(event, window._dismissedSecretFindings, window._dismissedVulnFindings)">Show dismissed (' + dismissedCount + ')</a></p>' +
+        '<div id="dismissed-findings-body" style="display:none"></div>';
+    }}
+    window._dismissedSecretFindings = dismissedSecretFindings;
+    window._dismissedVulnFindings = dismissedVulnFindings;
     return;
   }}
   let rows = '';
   secretFindings.forEach(function (f) {{
     rows += '<tr><td><span class="sev-stripe critical"></span><span class="finding-title">Possible ' + escapeHtml(f.pattern) + ' secret</span></td>' +
       '<td class="finding-cite">' + escapeHtml(f.path) + ':' + f.line + '</td>' +
-      '<td><span class="chip critical">Critical</span></td></tr>';
+      '<td><span class="chip critical">Critical</span></td>' +
+      '<td>' + findingActionButtonHtml('secret', f, 'Dismiss', 'dismissFinding') + '</td></tr>';
   }});
   vulnFindings.forEach(function (f) {{
     rows += '<tr><td><span class="sev-stripe warning"></span><span class="finding-title">' + escapeHtml(f.advisory_id) + ': ' + escapeHtml(f.summary || 'known vulnerability') + '</span></td>' +
       '<td class="finding-cite">' + escapeHtml(f.package) + '@' + escapeHtml(f.installed_version) + '</td>' +
-      '<td><span class="chip warning">Warning</span></td></tr>';
+      '<td><span class="chip warning">Warning</span></td>' +
+      '<td>' + findingActionButtonHtml('vulnerability', f, 'Dismiss', 'dismissFinding') + '</td></tr>';
   }});
-  body.innerHTML = '<table class="findings"><thead><tr><th>Finding</th><th>Evidence</th><th>Severity</th></tr></thead><tbody>' + rows + '</tbody></table>';
+  body.innerHTML = '<table class="findings"><thead><tr><th>Finding</th><th>Evidence</th><th>Severity</th><th></th></tr></thead><tbody>' + rows + '</tbody></table>';
+  if (dismissedCount > 0) {{
+    body.innerHTML += '<p class="section-sub" style="margin-top:16px"><a href="#" onclick="toggleDismissedFindings(event, window._dismissedSecretFindings, window._dismissedVulnFindings)">Show dismissed (' + dismissedCount + ')</a></p>' +
+      '<div id="dismissed-findings-body" style="display:none"></div>';
+  }}
+  window._dismissedSecretFindings = dismissedSecretFindings;
+  window._dismissedVulnFindings = dismissedVulnFindings;
 }}
 
 loadSecurity();

--- a/github-app/migrations/033_dismissed_findings.sql
+++ b/github-app/migrations/033_dismissed_findings.sql
@@ -1,0 +1,21 @@
+-- Per-installation, per-repo dismissal of a specific secret or dependency-
+-- vulnerability finding. Hosted-only - has no effect on a local `aletheore
+-- scan`/`aletheore diff` and no write-back to the customer's own
+-- .aletheore.json accepted_secrets baseline, which keeps working exactly as
+-- it does today. identity_key is a canonical string computed server-side
+-- from the finding's own fields (never trusted from a client request) - see
+-- app_server/dismissed_findings.py's finding_identity_key().
+CREATE TABLE IF NOT EXISTS dismissed_findings (
+    id              BIGSERIAL PRIMARY KEY,
+    installation_id BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name  TEXT NOT NULL,
+    finding_type    TEXT NOT NULL CHECK (finding_type IN ('secret', 'vulnerability')),
+    identity_key    TEXT NOT NULL,
+    reason          TEXT,
+    dismissed_by    TEXT NOT NULL,
+    dismissed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (installation_id, repo_full_name, finding_type, identity_key)
+);
+
+CREATE INDEX IF NOT EXISTS dismissed_findings_lookup
+    ON dismissed_findings (installation_id, repo_full_name);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -347,6 +347,29 @@ def get_installation(dsn: str, installation_id: int) -> dict | None:
             return dict(zip(columns, row))
 
 
+def get_dismissed_identity_keys(dsn: str, installation_id: int, repo_full_name: str) -> dict[str, set[str]]:
+    """Sync counterpart to app_server/dismissed_findings.py's async version
+    of the same read, for use in RQ job code (which runs synchronously, not
+    on the app_server's asyncpg pool). Used by the PR-scan job to filter
+    already-dismissed findings out of a diff before posting a PR comment -
+    see app_server/dismissed_findings.py's filter_dismissed()."""
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT finding_type, identity_key FROM dismissed_findings
+                WHERE installation_id = %s AND repo_full_name = %s
+                """,
+                (installation_id, repo_full_name),
+            )
+            result: dict[str, set[str]] = {"secret": set(), "vulnerability": set()}
+            for finding_type, identity_key in cur.fetchall():
+                result[finding_type].add(identity_key)
+            return result
+
+
 def list_health_check_targets_all(dsn: str) -> list[dict]:
     """Every configured health check target across every paid installation -
     the health sweep job's worklist. One row per target, not per

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -35,6 +35,7 @@ from aletheore.healthcheck import run_healthcheck
 from aletheore.signature_diff import find_regression_fence_violations
 from app_server.config import get_settings
 from app_server.db import MAX_SCANNED_REPOS_PER_MONTH
+from app_server.dismissed_findings import filter_dismissed
 from app_server.github_auth import generate_app_jwt, get_installation_token
 from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation
 from app_server.logging_config import log_job
@@ -51,6 +52,7 @@ from scan_worker.db import (
     delete_expired_sessions,
     delete_wiki_subsystems_not_in,
     email_already_sent,
+    get_dismissed_identity_keys,
     get_docs_repo_commit_settings,
     get_endpoint_health_summary,
     get_extra_seats,
@@ -716,6 +718,18 @@ def run_pr_scan_job(
         old = json.loads(base_evidence_path.read_text())
         new = json.loads(head_evidence_path.read_text())
         diff = compute_diff(old, new, full=False)
+        dismissed = get_dismissed_identity_keys(settings.database_url, installation_id, repo_full_name)
+        # history_secrets shares the same (path, pattern, match_preview) identity
+        # space as secrets - accepted_secrets (.aletheore.json) already treats them
+        # as one baseline (secrets.py's _baseline_keys is shared by find_secrets and
+        # find_secrets_in_history), so a "secret" dismissal filters both here too.
+        diff["secrets"]["new"] = filter_dismissed(diff["secrets"]["new"], "secret", dismissed["secret"])
+        diff["history_secrets"]["new"] = filter_dismissed(
+            diff["history_secrets"]["new"], "secret", dismissed["secret"]
+        )
+        diff["vulnerabilities"]["new"] = filter_dismissed(
+            diff["vulnerabilities"]["new"], "vulnerability", dismissed["vulnerability"]
+        )
 
         client = httpx.Client(base_url="https://api.github.com")
         upsert_pr_comment(client, token, repo_full_name, pr_number, format_diff_comment(diff))

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -564,6 +564,105 @@ async def test_dashboard_returns_data_for_known_repo(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_returns_empty_dismissed_finding_keys_by_default(pool, monkeypatch):
+    await upsert_installation(pool, 1, "octocat")
+    await set_installation_plan(pool, 1, "indie")
+    await insert_repo_history(
+        pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
+    async with client:
+        response = await client.get("/app/octocat/hello-world")
+    body = response.json()
+    assert body["dismissed_finding_keys"] == {"secret": [], "vulnerability": []}
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_route_requires_login(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/app/octocat/hello-world/findings/dismiss",
+            json={"finding_type": "secret", "finding": {"path": "a.py", "pattern": "x", "match_preview": "y"}},
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_route_rejects_unknown_finding_type(pool, monkeypatch):
+    await upsert_installation(pool, 1, "octocat")
+    await set_installation_plan(pool, 1, "indie")
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
+    async with client:
+        response = await client.post(
+            "/app/octocat/hello-world/findings/dismiss",
+            json={"finding_type": "layer_violation", "finding": {}},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_route_rejects_finding_missing_required_field(pool, monkeypatch):
+    await upsert_installation(pool, 1, "octocat")
+    await set_installation_plan(pool, 1, "indie")
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
+    async with client:
+        response = await client.post(
+            "/app/octocat/hello-world/findings/dismiss",
+            json={"finding_type": "secret", "finding": {"path": "a.py"}},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_route_then_get_dashboard_reflects_it(pool, monkeypatch):
+    await upsert_installation(pool, 1, "octocat")
+    await set_installation_plan(pool, 1, "indie")
+    await insert_repo_history(
+        pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+    )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
+    finding = {"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP"}
+    async with client:
+        dismiss_response = await client.post(
+            "/app/octocat/hello-world/findings/dismiss",
+            json={"finding_type": "secret", "finding": finding, "reason": "false positive"},
+        )
+        get_response = await client.get("/app/octocat/hello-world")
+
+    assert dismiss_response.status_code == 200
+    body = get_response.json()
+    assert len(body["dismissed_finding_keys"]["secret"]) == 1
+
+    row = await pool.fetchrow("SELECT reason, dismissed_by FROM dismissed_findings WHERE installation_id = 1")
+    assert row["reason"] == "false positive"
+    assert row["dismissed_by"] == "octocat"
+
+
+@pytest.mark.asyncio
+async def test_undismiss_finding_route_removes_it(pool, monkeypatch):
+    await upsert_installation(pool, 1, "octocat")
+    await set_installation_plan(pool, 1, "indie")
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
+    finding = {"ecosystem": "PyPI", "package": "requests", "advisory_id": "GHSA-1"}
+    async with client:
+        await client.post(
+            "/app/octocat/hello-world/findings/dismiss",
+            json={"finding_type": "vulnerability", "finding": finding},
+        )
+        undismiss_response = await client.post(
+            "/app/octocat/hello-world/findings/undismiss",
+            json={"finding_type": "vulnerability", "finding": finding},
+        )
+        get_response = await client.get("/app/octocat/hello-world")
+
+    assert undismiss_response.status_code == 200
+    body = get_response.json()
+    assert body["dismissed_finding_keys"]["vulnerability"] == []
+
+
+@pytest.mark.asyncio
 async def test_public_health_returns_latest_per_endpoint(pool):
     await upsert_installation(pool, 500, "octocat")
     async with pool.acquire() as conn:

--- a/github-app/tests/test_dismissed_findings.py
+++ b/github-app/tests/test_dismissed_findings.py
@@ -1,0 +1,108 @@
+import pytest
+
+from app_server.db import upsert_installation
+from app_server.dismissed_findings import (
+    dismiss_finding,
+    filter_dismissed,
+    finding_identity_key,
+    get_dismissed_identity_keys,
+    undismiss_finding,
+)
+
+SECRET_FINDING = {"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP"}
+VULN_FINDING = {"ecosystem": "PyPI", "package": "requests", "advisory_id": "GHSA-1"}
+
+
+def test_finding_identity_key_secret():
+    assert finding_identity_key("secret", SECRET_FINDING) == "config.py\x1faws_access_key_id\x1fAKIA****...MNOP"
+
+
+def test_finding_identity_key_vulnerability():
+    assert finding_identity_key("vulnerability", VULN_FINDING) == "PyPI\x1frequests\x1fGHSA-1"
+
+
+def test_finding_identity_key_raises_on_unknown_type():
+    with pytest.raises(ValueError):
+        finding_identity_key("layer_violation", {})
+
+
+def test_filter_dismissed_removes_matching_findings():
+    findings = [SECRET_FINDING, {"path": "other.py", "pattern": "aws_access_key_id", "match_preview": "x"}]
+    dismissed_keys = {finding_identity_key("secret", SECRET_FINDING)}
+    result = filter_dismissed(findings, "secret", dismissed_keys)
+    assert result == [findings[1]]
+
+
+def test_filter_dismissed_empty_set_returns_all_unchanged():
+    findings = [SECRET_FINDING]
+    result = filter_dismissed(findings, "secret", set())
+    assert result == findings
+
+
+def test_filter_dismissed_does_not_mutate_input_list():
+    findings = [SECRET_FINDING]
+    filter_dismissed(findings, "secret", {finding_identity_key("secret", SECRET_FINDING)})
+    assert findings == [SECRET_FINDING]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_then_get_dismissed_identity_keys(pool):
+    await upsert_installation(pool, 1, "octocat")
+
+    await dismiss_finding(pool, 1, "octocat/repo", "secret", SECRET_FINDING, "octocat")
+
+    dismissed = await get_dismissed_identity_keys(pool, 1, "octocat/repo")
+    assert finding_identity_key("secret", SECRET_FINDING) in dismissed["secret"]
+    assert dismissed["vulnerability"] == set()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_is_idempotent(pool):
+    await upsert_installation(pool, 1, "octocat")
+
+    await dismiss_finding(pool, 1, "octocat/repo", "secret", SECRET_FINDING, "octocat")
+    await dismiss_finding(pool, 1, "octocat/repo", "secret", SECRET_FINDING, "octocat")
+
+    dismissed = await get_dismissed_identity_keys(pool, 1, "octocat/repo")
+    assert len(dismissed["secret"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_dismiss_finding_stores_reason(pool):
+    await upsert_installation(pool, 1, "octocat")
+
+    await dismiss_finding(pool, 1, "octocat/repo", "secret", SECRET_FINDING, "octocat", reason="test fixture")
+
+    row = await pool.fetchrow("SELECT reason, dismissed_by FROM dismissed_findings WHERE installation_id = $1", 1)
+    assert row["reason"] == "test fixture"
+    assert row["dismissed_by"] == "octocat"
+
+
+@pytest.mark.asyncio
+async def test_undismiss_finding_removes_it(pool):
+    await upsert_installation(pool, 1, "octocat")
+    await dismiss_finding(pool, 1, "octocat/repo", "vulnerability", VULN_FINDING, "octocat")
+
+    await undismiss_finding(pool, 1, "octocat/repo", "vulnerability", VULN_FINDING)
+
+    dismissed = await get_dismissed_identity_keys(pool, 1, "octocat/repo")
+    assert dismissed["vulnerability"] == set()
+
+
+@pytest.mark.asyncio
+async def test_undismiss_finding_that_was_never_dismissed_is_a_no_op(pool):
+    await upsert_installation(pool, 1, "octocat")
+
+    await undismiss_finding(pool, 1, "octocat/repo", "secret", SECRET_FINDING)
+
+    dismissed = await get_dismissed_identity_keys(pool, 1, "octocat/repo")
+    assert dismissed["secret"] == set()
+
+
+@pytest.mark.asyncio
+async def test_dismissed_findings_are_scoped_per_repo(pool):
+    await upsert_installation(pool, 1, "octocat")
+    await dismiss_finding(pool, 1, "octocat/repo-a", "secret", SECRET_FINDING, "octocat")
+
+    dismissed = await get_dismissed_identity_keys(pool, 1, "octocat/repo-b")
+    assert dismissed["secret"] == set()

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -313,6 +313,10 @@ def test_happy_path_posts_comment_and_writes_history(bare_repo_with_two_commits,
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", fake_upsert)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
@@ -335,6 +339,55 @@ def test_happy_path_posts_comment_and_writes_history(bare_repo_with_two_commits,
     assert posted["pr_number"] == 7
 
 
+def test_run_pr_scan_job_excludes_a_dismissed_secret_from_the_pr_comment(
+    bare_repo_with_two_commits, monkeypatch
+):
+    # Same fixture and setup as test_happy_path_posts_comment_and_writes_history
+    # above (which confirms "Secrets" IS present when nothing is dismissed) -
+    # this test only changes get_dismissed_identity_keys to report the
+    # planted secret finding as already dismissed, and confirms it no
+    # longer reaches the posted PR comment. filter_dismissed/
+    # finding_identity_key's own correctness is covered directly in
+    # test_dismissed_findings.py - this test is only about the wiring: that
+    # run_pr_scan_job actually applies the filter before posting.
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+    posted = {}
+
+    def fake_upsert(client, token, repo_full_name, pr_number, body):
+        posted["body"] = body
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": {"dismiss-everything"}, "vulnerability": set()},
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.filter_dismissed",
+        lambda findings, finding_type, dismissed_keys: (
+            [] if finding_type == "secret" and dismissed_keys == {"dismiss-everything"} else findings
+        ),
+    )
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", fake_upsert)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_create_check_run", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: None)
+
+    run_pr_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        pr_number=7,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+    assert "Secrets" not in posted["body"]
+
+
 def test_check_run_failure_does_not_overwrite_diff_comment(bare_repo_with_two_commits, monkeypatch):
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     posted = {}
@@ -347,6 +400,10 @@ def test_check_run_failure_does_not_overwrite_diff_comment(bare_repo_with_two_co
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", fake_upsert)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
@@ -458,6 +515,10 @@ def test_slack_alert_fires_on_paid_install_with_webhook_url_and_new_secret(
         "scan_worker.jobs.get_installation_row",
         lambda *a, **k: {"plan": "air", "webhook_url": "https://hooks.slack.com/x"},
     )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     sent = {}
     monkeypatch.setattr(
@@ -484,6 +545,10 @@ def test_check_run_failure_on_new_secret(bare_repo_with_two_commits, monkeypatch
     monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     created = {}
     monkeypatch.setattr(
@@ -2622,6 +2687,10 @@ def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_wit
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
@@ -2663,6 +2732,10 @@ def test_run_pr_scan_job_logs_slack_alert_failure_instead_of_swallowing_it(
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
@@ -2833,6 +2906,10 @@ def test_run_pr_scan_job_free_plan_is_not_subject_to_monthly_scan_cap(bare_repo_
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"})
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr(
         "scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not be called for free plan")),

--- a/github-app/tests/test_pr_scan_e2e.py
+++ b/github-app/tests/test_pr_scan_e2e.py
@@ -26,6 +26,10 @@ def test_pull_request_webhook_to_pr_comment_end_to_end(
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", fake_upsert)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -15,6 +15,7 @@ from scan_worker.db import (
     delete_expired_sessions,
     delete_wiki_subsystems_not_in,
     email_already_sent,
+    get_dismissed_identity_keys,
     get_endpoint_health_summary,
     get_extra_seats,
     get_last_endpoint_health,
@@ -965,3 +966,26 @@ async def test_list_installation_member_emails_sync_matches_async_semantics(pool
     emails = list_installation_member_emails(TEST_DATABASE_URL, 808)
 
     assert emails == ["alice@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_get_dismissed_identity_keys_sync_matches_async_writer(pool):
+    from app_server.dismissed_findings import dismiss_finding, finding_identity_key
+
+    await _insert_installation(pool, 809, "co")
+    secret_finding = {"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP"}
+    await dismiss_finding(pool, 809, "co/repo", "secret", secret_finding, "octocat")
+
+    dismissed = get_dismissed_identity_keys(TEST_DATABASE_URL, 809, "co/repo")
+
+    assert finding_identity_key("secret", secret_finding) in dismissed["secret"]
+    assert dismissed["vulnerability"] == set()
+
+
+@pytest.mark.asyncio
+async def test_get_dismissed_identity_keys_sync_returns_empty_sets_when_none_dismissed(pool):
+    await _insert_installation(pool, 810, "co")
+
+    dismissed = get_dismissed_identity_keys(TEST_DATABASE_URL, 810, "co/repo")
+
+    assert dismissed == {"secret": set(), "vulnerability": set()}


### PR DESCRIPTION
## Summary
Implements gap-analysis item #6 per the approved design spec (`docs/superpowers/specs/2026-08-09-dismiss-mute-findings-design.md`).

- New `dismissed_findings` table (migration 033) - hosted-only, no effect on local CLI scans, no automated write-back to the repo's own `.aletheore.json`.
- Identity always computed server-side, never trusted from a client request.
- Dashboard: `GET /app/{org}/{repo}` returns `dismissed_finding_keys`; two new POST routes (`findings/dismiss`, `findings/undismiss`), gated the same as the security page's underlying data route.
- PR comments: `run_pr_scan_job` filters dismissed findings out of secrets, history secrets (shares the same identity space as the existing `accepted_secrets` baseline), and vulnerabilities before posting - `evidence.json`/`repo_history` are never mutated.
- Frontend: Dismiss button per open finding, "Show dismissed (N)" with Undismiss, on both the security and overview pages.

## Test plan
- [x] Full github-app suite passes locally: 943 passed, 8 skipped (up from 922 - 21 new tests)
- [x] Real Postgres-backed round-trip tests for dismiss/undismiss/read (not mocked)
- [x] Caught and fixed a real gap during testing: the fixture's planted secret also appears in `history_secrets` (git-history scan), which the initial wiring missed - now filtered too, matching the existing `accepted_secrets` precedent of treating working-tree and history secrets as one identity space
- [x] JS syntax validated via existing `test_frontend_js_syntax.py`
- [ ] Real browser click-through against the live dashboard - planned after this merges and deploys, alongside PR #147