### PR TITLE
feat: route AI writing surfaces onto GPT-5.6 Luna, cap AIRview full builds

### DIFF
--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 MODEL_RATES_PER_MILLION_USD = {
     "deepseek-v4-pro": {"input": 0.435, "output": 0.87, "verified_at": "2026-07-23"},
     "deepseek-v4-flash": {"input": 0.14, "output": 0.28, "verified_at": "2026-07-23"},
+    "gpt-5.6-luna": {"input": 0.20, "output": 1.20, "verified_at": "2026-08-09"},
     "gpt-4o": {"input": 2.50, "output": 10.00, "verified_at": "2026-07-23"},
     "claude-opus-4-8": {"input": 15.00, "output": 75.00, "verified_at": "2026-07-23"},
 }

--- a/github-app/migrations/034_wiki_catchup_sweep.sql
+++ b/github-app/migrations/034_wiki_catchup_sweep.sql
@@ -1,0 +1,11 @@
+-- Tracks the last time the recurring AIRview catch-up sweep ran for a repo -
+-- mirrors docs_catchup_sweeps exactly (029_docs_catchup_sweep.sql), kept as
+-- its own table rather than shared: AIRview's full build and Docs' full
+-- build are swept independently, on their own schedules, and a repo can be
+-- due for one without being due for the other.
+CREATE TABLE IF NOT EXISTS wiki_catchup_sweeps (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name   TEXT NOT NULL,
+    last_swept_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (installation_id, repo_full_name)
+);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -905,6 +905,56 @@ def record_docs_catchup_swept(dsn: str, installation_id: int, repo_full_name: st
         conn.commit()
 
 
+def list_paid_repos_due_for_wiki_catchup(dsn: str, interval_seconds: int) -> list[tuple[int, str]]:
+    """Paid-plan repos due for the recurring AIRview catch-up sweep - mirrors
+    list_paid_repos_due_for_docs_catchup exactly (never swept before, or
+    swept more than interval_seconds ago AND scanned at least once since
+    that last sweep), against wiki_catchup_sweeps instead of
+    docs_catchup_sweeps.
+    """
+    import psycopg
+    import psycopg.rows
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+            cur.execute(
+                """
+                SELECT DISTINCT rh.installation_id, rh.repo_full_name
+                FROM repo_history rh
+                JOIN installations i ON i.installation_id = rh.installation_id
+                LEFT JOIN wiki_catchup_sweeps s
+                    ON s.installation_id = rh.installation_id
+                   AND s.repo_full_name = rh.repo_full_name
+                WHERE i.plan != 'free'
+                  AND (
+                        s.last_swept_at IS NULL
+                        OR (
+                            rh.scanned_at > s.last_swept_at
+                            AND s.last_swept_at <= now() - make_interval(secs => %s)
+                        )
+                  )
+                """,
+                (interval_seconds,),
+            )
+            return [(row[0], row[1]) for row in cur.fetchall()]
+
+
+def record_wiki_catchup_swept(dsn: str, installation_id: int, repo_full_name: str) -> None:
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO wiki_catchup_sweeps (installation_id, repo_full_name, last_swept_at)
+                VALUES (%s, %s, now())
+                ON CONFLICT (installation_id, repo_full_name) DO UPDATE SET last_swept_at = now()
+                """,
+                (installation_id, repo_full_name),
+            )
+        conn.commit()
+
+
 def insert_evidence_packet_cache_row(
     dsn: str,
     installation_id: int,

--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -9,15 +9,17 @@ from aletheore.evidence_resolution import (
     attach_risk_evidence,
     normalize_resolution,
 )
-from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from scan_worker.github_api import (
     MAX_CONTEXT_FILE_BYTES,
     MAX_CONTEXT_FILES,
     MAX_CONTEXT_TOTAL_BYTES,
     fetch_file_content,
 )
+from scan_worker.model_tiers import resolve_model, writing_adapter_for
 
 logger = logging.getLogger(__name__)
+
+FLASH_REVIEW_FALLBACK_MODEL = "deepseek-v4-flash"
 
 FLASH_REVIEW_SYSTEM_PROMPT = """You are reviewing a code diff for potential issues. You may also be
 given the full current content of the changed files for context. You must respond with ONLY a
@@ -496,12 +498,20 @@ def review_diff(
     referenced_symbol_context: str = "",
     cache_lookup: Callable[[str], list[dict] | None] | None = None,
     cache_write: Callable[[str, list[dict], str], None] | None = None,
-    model_used: str = "deepseek-v4-flash",
+    model_used: str | None = None,
     file_contents: dict[str, str] | None = None,
     on_grounding_result: Callable[[dict], None] | None = None,
 ) -> list[dict]:
     if not diff_text.strip():
         return []
+
+    # Resolved once, up front, and reused both for the cache-write label
+    # below and for the adapter actually constructed - so a cached
+    # finding's recorded model can never drift from the model that really
+    # produced it (they used to be two independent hardcoded literals that
+    # only matched by coincidence).
+    if model_used is None:
+        model_used = resolve_model(FLASH_REVIEW_FALLBACK_MODEL)
 
     if cache_lookup is not None:
         try:
@@ -515,13 +525,7 @@ def review_diff(
                 on_grounding_result({"proposed": len(cached), "kept": len(kept)})
             return kept
 
-    adapter = OpenAICompatibleAdapter(
-        name="DeepSeek",
-        base_url="https://api.deepseek.com",
-        api_key_env_var="DEEPSEEK_API_KEY",
-        model="deepseek-v4-flash",
-        on_usage=on_usage,
-    )
+    adapter = writing_adapter_for(FLASH_REVIEW_FALLBACK_MODEL, on_usage=on_usage)
     prompt_parts = [diff_text]
     if file_context:
         prompt_parts.append(file_context)

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -72,6 +72,7 @@ from scan_worker.db import (
     list_installation_member_emails,
     list_paid_installations_due_for_digest,
     list_paid_repos_due_for_docs_catchup,
+    list_paid_repos_due_for_wiki_catchup,
     list_recent_endpoint_incidents,
     list_repos_for_installation,
     list_wiki_subsystems,
@@ -80,6 +81,7 @@ from scan_worker.db import (
     record_docs_repo_commit,
     record_llm_spend,
     record_sent_email,
+    record_wiki_catchup_swept,
     set_docs_build_status,
     set_last_reviewed_sha,
     set_wiki_build_status,
@@ -89,6 +91,7 @@ from scan_worker.db import (
 )
 from scan_worker.docs_repo_commit import sync_docs_to_repo
 from scan_worker.flash_review import (
+    FLASH_REVIEW_FALLBACK_MODEL,
     build_code_evidence_context,
     build_referenced_symbol_context,
     fetch_review_file_context,
@@ -119,7 +122,13 @@ from app_server.email_templates import (
 from app_server.email_queue import enqueue_transactional_email
 from app_server.email_client import send_transactional_email
 from scan_worker.managed_audit import run_managed_audit
-from scan_worker.model_tiers import PRO_MODEL, model_for_plan, writing_adapter_for_plan
+from scan_worker.model_tiers import (
+    PRO_MODEL,
+    model_for_plan,
+    resolve_model,
+    writing_adapter_for,
+    writing_adapter_for_plan,
+)
 from scan_worker.packet_cache import lookup_cached_result, store_result
 from scan_worker.code_graph_store import CodeGraphStore
 from scan_worker.postgres_graph_store import PostgresRepoGraphStore
@@ -175,12 +184,12 @@ GRAPH_COLD_SYNC_DEPTH_CAP = 50_000
 SECRETS_HISTORY_DEPTH_CAP = 20_000
 
 # The real, customer-facing promise for Pro ($34.99/mo): up to 300 PR
-# reviews/month. Worst-case cost at 300 reviews hitting the max context
-# caps each is well under $3 (deepseek-v4-flash, ~$0.14/M input +
-# $0.28/M output) - this is a usage ceiling for the promise itself, not a
+# reviews/month. This is a usage ceiling for the promise itself, not a
 # cost-protection measure; the existing dollar-based monthly_cap_for_installation
 # check stays in place as a separate defense against a pathological
-# per-review cost blowing past what 300 reviews should ever cost.
+# per-review cost blowing past what 300 reviews should ever cost - see
+# model_tiers.py/flash_review.py for which model that cost is actually
+# priced against (Luna, falling back to deepseek-v4-flash).
 MAX_FLASH_REVIEWS_PER_MONTH = 300
 
 
@@ -1261,10 +1270,11 @@ def _run_flash_review(
             evidence, changed_files, diff_text, _fetch_symbol_source
         )
         dsn = settings.database_url
+        flash_review_model = resolve_model(FLASH_REVIEW_FALLBACK_MODEL)
 
         def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
             spend_accumulator["total"] += cost_for_usage(
-                "deepseek-v4-flash", prompt_tokens, completion_tokens
+                flash_review_model, prompt_tokens, completion_tokens
             )
 
         def _cache_lookup(diff: str) -> list[dict] | None:
@@ -1285,7 +1295,7 @@ def _run_flash_review(
                 referenced_symbol_context=referenced_symbol_context,
                 cache_lookup=_cache_lookup,
                 cache_write=_cache_write,
-                model_used="deepseek-v4-flash",
+                model_used=flash_review_model,
                 file_contents=file_contents,
                 on_grounding_result=_on_grounding_result,
             )
@@ -1297,7 +1307,7 @@ def _run_flash_review(
                 referenced_symbol_context=referenced_symbol_context,
                 cache_lookup=_cache_lookup,
                 cache_write=_cache_write,
-                model_used="deepseek-v4-flash",
+                model_used=flash_review_model,
                 file_contents=file_contents,
                 on_grounding_result=_on_grounding_result,
             )
@@ -1508,16 +1518,11 @@ If you cannot identify a plausible concrete cause from what's given, respond wit
 
 
 def _health_fix_suggestion_adapter() -> OpenAICompatibleAdapter:
-    # Always Pro, never tier-routed through model_tiers.writing_adapter_for_plan -
-    # this feature is part of every Pro subscription at one fixed cost, not
-    # something that varies by a tier that no longer exists.
-    return OpenAICompatibleAdapter(
-        name="DeepSeek",
-        base_url="https://api.deepseek.com",
-        api_key_env_var="DEEPSEEK_API_KEY",
-        model=PRO_MODEL,
-        supports_tool_choice=False,
-    )
+    # Always Pro, at one fixed cost for every Pro subscription rather than
+    # varying by a tier that no longer exists - same Luna-with-DeepSeek-
+    # fallback resolution as every other Pro-tier writing surface, via
+    # model_tiers.writing_adapter_for.
+    return writing_adapter_for(PRO_MODEL)
 
 
 def _find_enclosing_symbol(evidence: dict | None, source_file: str, source_line: int | None) -> str | None:
@@ -2003,27 +2008,17 @@ def run_weekly_digest_sweep_job() -> None:
 
 
 def _live_wiki_naming_adapter() -> OpenAICompatibleAdapter:
-    return OpenAICompatibleAdapter(
-        name="DeepSeek",
-        base_url="https://api.deepseek.com",
-        api_key_env_var="DEEPSEEK_API_KEY",
-        model=live_wiki.FLASH_MODEL,
-    )
+    return writing_adapter_for(live_wiki.FLASH_MODEL)
 
 
 def _live_wiki_full_build_writing_adapter(plan: str) -> OpenAICompatibleAdapter | AnthropicAdapter:
     # The one-time full build uses the same model as managed audits (see
-    # model_tiers.py) - always DeepSeek Pro, for every plan.
+    # model_tiers.py) - Luna (falling back to DeepSeek Pro), for every plan.
     return writing_adapter_for_plan(plan)
 
 
 def _live_wiki_update_writing_adapter() -> OpenAICompatibleAdapter:
-    return OpenAICompatibleAdapter(
-        name="DeepSeek",
-        base_url="https://api.deepseek.com",
-        api_key_env_var="DEEPSEEK_API_KEY",
-        model=live_wiki.UPDATE_MODEL,
-    )
+    return writing_adapter_for(live_wiki.UPDATE_MODEL)
 
 
 def _real_line_count_fetcher(
@@ -2108,12 +2103,48 @@ def _store_wiki_generation(
     )
 
 
+# Every cluster gets an LLM call in a full build (naming + subsystem
+# generation), unlike an incremental update's affected-clusters-only cost.
+# Capped here rather than left unbounded for a repo's very first build,
+# mirroring MAX_DOCS_FULL_BUILD_FILES's exact role for Docs. A full build's
+# job is only ever to reach initial coverage - _maybe_update_live_wiki (the
+# push-triggered path) is what keeps an already-covered cluster fresh, and
+# run_live_wiki_catchup_sweep_job is what gives an oversized repo further
+# chances to cover the clusters this cap left out, over time.
+MAX_WIKI_FULL_BUILD_CLUSTERS = 50
+
+
+def _clusters_with_uncovered_wiki_work(
+    evidence: dict, covered_cluster_ids: set[str], limit: int
+) -> set[int]:
+    """Cluster ids from evidence that don't have a stored subsystem yet,
+    capped at `limit` - mirrors _modules_with_uncovered_docs_work's role for
+    Docs. Unlike a Docs module (which can be partially covered, symbol by
+    symbol), a wiki cluster is generated as a whole in one shot, so
+    "uncovered" is just "no subsystem row exists for this cluster id yet".
+    """
+    all_ids = [c["id"] for c in evidence.get("architecture", {}).get("clusters", [])]
+    uncovered = [cid for cid in all_ids if str(cid) not in covered_cluster_ids]
+    return set(uncovered[:limit])
+
+
 @log_job
 def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> None:
     dsn = get_settings().database_url
     evidence = get_latest_evidence(dsn, installation_id, repo_full_name)
     if evidence is None:
         return  # nothing scanned for this repo yet - nothing to build from
+
+    covered_cluster_ids = {
+        r["subsystem_id"] for r in list_wiki_subsystems(dsn, installation_id, repo_full_name)
+    }
+    cluster_ids = _clusters_with_uncovered_wiki_work(evidence, covered_cluster_ids, MAX_WIKI_FULL_BUILD_CLUSTERS)
+    if not cluster_ids:
+        # Nothing new to do - a prior run (or the catch-up sweep) already
+        # covers every cluster current evidence calls for. Still a real
+        # "ready" outcome, not a no-op to be silent about.
+        set_wiki_build_status(dsn, installation_id, repo_full_name, "ready")
+        return
 
     installation = get_installation_row(dsn, installation_id)
     plan = installation["plan"] if installation is not None else "air"
@@ -2127,6 +2158,7 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
             evidence,
             naming_adapter,
             writing_adapter,
+            cluster_ids=cluster_ids,
             cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
             cache_write=lambda packet, output, used: store_result(
                 dsn, installation_id, repo_full_name, packet, output, used
@@ -2175,6 +2207,45 @@ def run_live_wiki_full_build_for_installation_job(installation_id: int) -> None:
         )
 
 
+# How often the recurring catch-up sweep is willing to re-touch the same
+# repo - not how often it runs (it's enqueued on every scheduler tick like
+# the Docs catch-up sweep already is; the interval is enforced inside the
+# job itself via wiki_catchup_sweeps). Same value as Docs' own sweep
+# interval - no reason for AIRview coverage to lag further behind than
+# Docs coverage does.
+WIKI_CATCHUP_SWEEP_INTERVAL_SECONDS = 48 * 60 * 60
+
+
+def run_live_wiki_catchup_sweep_job() -> None:
+    """Recurring, per-repo-throttled pass that gives a repo whose first
+    full build never finished every cluster (MAX_WIKI_FULL_BUILD_CLUSTERS
+    caps a single build at 50) further chances to catch up over time -
+    mirrors run_live_docs_catchup_sweep_job exactly, against
+    wiki_catchup_sweeps instead of docs_catchup_sweeps.
+
+    Deliberately reuses run_live_wiki_full_build_job as-is rather than
+    duplicating its logic: that function already only spends on clusters
+    without a stored subsystem yet (see _clusters_with_uncovered_wiki_work),
+    so a repeat call here is naturally cheap and a no-op once nothing is
+    actually missing.
+    """
+    dsn = get_settings().database_url
+    due = list_paid_repos_due_for_wiki_catchup(dsn, WIKI_CATCHUP_SWEEP_INTERVAL_SECONDS)
+    for installation_id, repo_full_name in due:
+        try:
+            run_live_wiki_full_build_job(installation_id, repo_full_name)
+        except Exception as exc:  # noqa: BLE001
+            # A single repo's failure (or its own internal build-status
+            # bookkeeping) shouldn't stop the sweep from touching the rest
+            # of the due list, or from recording that this repo was tried.
+            logging.getLogger("scan_worker.jobs").warning(
+                "live wiki catch-up sweep failed for installation=%s repo=%s (%s)",
+                installation_id, repo_full_name, exc,
+            )
+        finally:
+            record_wiki_catchup_swept(dsn, installation_id, repo_full_name)
+
+
 def _maybe_update_live_wiki(
     installation_id: int, repo_full_name: str, evidence: dict, changed_files: list[str], head_sha: str
 ) -> None:
@@ -2201,7 +2272,7 @@ def _maybe_update_live_wiki(
             cache_write=lambda packet, output, used: store_result(
                 dsn, installation_id, repo_full_name, packet, output, used
             ),
-            model_used=live_wiki.UPDATE_MODEL,
+            model_used=resolve_model(live_wiki.UPDATE_MODEL),
             fetch_line_count=fetch_line_count,
         )
         _store_wiki_generation(
@@ -2239,12 +2310,7 @@ def _live_docs_full_build_writing_adapter(plan: str) -> OpenAICompatibleAdapter:
 
 
 def _live_docs_update_writing_adapter() -> OpenAICompatibleAdapter:
-    return OpenAICompatibleAdapter(
-        name="DeepSeek",
-        base_url="https://api.deepseek.com",
-        api_key_env_var="DEEPSEEK_API_KEY",
-        model=live_docs.FLASH_MODEL,
-    )
+    return writing_adapter_for(live_docs.FLASH_MODEL)
 
 
 def _github_client_and_token(installation_id: int) -> tuple[httpx.Client, str] | None:

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -1,41 +1,68 @@
-"""Which LLM the single Pro plan actually uses for one-time managed audit
-reports and one-time AIRview builds - the pricing page's model claims are
-read from this file, not written separately, so they can never drift from
-what actually runs.
+"""Which LLM Aletheore's paid AI work actually runs on - the pricing
+page's model claims are read from this file, not written separately, so
+they can never drift from what actually runs.
 
-PR reviews and AIRview's incremental updates don't go through this module
-at all - they're hardcoded to deepseek-v4-flash directly in flash_review.py
-and live_wiki.py, since they fire on every push/PR and need to stay cheap
-regardless of which model the one-time work above uses.
+GPT-5.6 Luna is the primary model for every writing surface (managed
+audits, one-time AIRview/Docs builds, PR reviews, and AIRview/Docs
+incremental updates) as of 2026-08-09: DeepSeek V4 Flash wasn't catching
+enough real issues on PR review specifically, and DeepSeek's announced
+"significant" price hike (2x-10x per their own founder, size and date
+still unconfirmed) made staying DeepSeek-only a real vendor-risk bet, not
+just a cost one. Luna's own coding/intelligence/agentic benchmarks
+(Artificial Analysis, via OpenRouter's compare page) beat DeepSeek V4
+Pro's while pricing under it.
 
-Always DeepSeek Pro - a single, uniform model for every Pro-plan LLM call,
-matching jobs.py's own health fix-suggestion adapter, which already made
-this same call ("never tier-routed... a tier that no longer exists").
+Falls back to the pre-existing DeepSeek model for that surface if
+OPENAI_API_KEY isn't configured yet, so a build never hard-fails on
+missing infra - logged, never silent, so this is never mistaken for the
+intended path. (The retired gpt-5.6-terra rollout crashed instead of
+falling back, but only because its price entry was missing from
+llm_cost.py, not because it lacked a fallback path - gpt-5.6-luna has a
+price entry from the start.)
 """
 
+import logging
 from typing import Callable
 
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
+from aletheore.credentials import has_api_key
 
+LUNA_MODEL = "gpt-5.6-luna"
 PRO_MODEL = "deepseek-v4-pro"
 
 
-def model_for_plan(plan: str) -> str:
-    """The model name writing_adapter_for_plan() will actually construct
-    for this plan right now - used for cost accounting, so a spend cap
-    never silently prices Pro's real tokens at the wrong rate.
+def _openai_available() -> bool:
+    return has_api_key("OPENAI_API_KEY", "OpenAI")
+
+
+def resolve_model(fallback_model: str) -> str:
+    """The model name writing_adapter_for(fallback_model, ...) will
+    actually construct right now - used for cost accounting and cache
+    labeling, so a spend cap or cached result is never silently mispriced
+    or mislabeled against a model that isn't the one that actually ran.
     """
-    return PRO_MODEL
+    return LUNA_MODEL if _openai_available() else fallback_model
 
 
-def writing_adapter_for_plan(
-    plan: str, on_usage: Callable[[int, int], None] | None = None
+def writing_adapter_for(
+    fallback_model: str, on_usage: Callable[[int, int], None] | None = None
 ) -> OpenAICompatibleAdapter:
+    if _openai_available():
+        return OpenAICompatibleAdapter(
+            name="OpenAI",
+            base_url="https://api.openai.com/v1",
+            api_key_env_var="OPENAI_API_KEY",
+            model=LUNA_MODEL,
+            on_usage=on_usage,
+        )
+    logging.getLogger(__name__).warning(
+        "OPENAI_API_KEY not configured - falling back to DeepSeek (%s)", fallback_model
+    )
     return OpenAICompatibleAdapter(
         name="DeepSeek",
         base_url="https://api.deepseek.com",
         api_key_env_var="DEEPSEEK_API_KEY",
-        model=model_for_plan(plan),
+        model=fallback_model,
         # deepseek-v4-pro runs in thinking mode by default, which rejects
         # tool_choice="required" (400 invalid_request_error) - fall back to
         # the same unforced tool-choice path used for Ollama. Harmless for
@@ -43,3 +70,13 @@ def writing_adapter_for_plan(
         supports_tool_choice=False,
         on_usage=on_usage,
     )
+
+
+def model_for_plan(plan: str) -> str:
+    return resolve_model(PRO_MODEL)
+
+
+def writing_adapter_for_plan(
+    plan: str, on_usage: Callable[[int, int], None] | None = None
+) -> OpenAICompatibleAdapter:
+    return writing_adapter_for(PRO_MODEL, on_usage=on_usage)

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -22,6 +22,10 @@ SESSION_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # above normal runtime for the rare tick where several repos are due at
 # once, same reasoning as HEALTH_SWEEP_JOB_TIMEOUT_SECONDS.
 DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS = 600
+# Same reasoning as DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS - run_live_wiki_
+# catchup_sweep_job only calls run_live_wiki_full_build_job for repos
+# list_paid_repos_due_for_wiki_catchup already filtered to genuinely due.
+WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS = 600
 # Reads the due list (a cheap join over installations/digest_sends), then
 # enqueues one send per recipient onto "email" rather than sending inline -
 # the actual Resend calls happen there, not in this job, so this stays
@@ -62,6 +66,10 @@ def run_forever(
         scans_queue.enqueue(
             "scan_worker.jobs.run_live_docs_catchup_sweep_job",
             job_timeout=DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
+        )
+        scans_queue.enqueue(
+            "scan_worker.jobs.run_live_wiki_catchup_sweep_job",
+            job_timeout=WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
         )
         scans_queue.enqueue(
             "scan_worker.jobs.run_weekly_digest_sweep_job",

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -3,6 +3,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 from scan_worker.flash_review import (
+    FLASH_REVIEW_FALLBACK_MODEL,
     FLASH_REVIEW_SYSTEM_PROMPT,
     files_missing_from_review_context,
     _diff_valid_lines,
@@ -256,7 +257,7 @@ def test_review_diff_returns_empty_list_for_empty_diff():
     assert review_diff("   \n  ") == []
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_parses_valid_findings(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = (
@@ -271,7 +272,7 @@ def test_review_diff_parses_valid_findings(mock_adapter_class):
     ]
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_treats_malformed_json_as_no_findings(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = "not valid json at all"
@@ -280,7 +281,7 @@ def test_review_diff_treats_malformed_json_as_no_findings(mock_adapter_class):
     assert review_diff("--- app.py ---\n@@ -1,1 +1,1 @@\n+print(1)") == []
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_drops_findings_missing_required_fields(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = (
@@ -294,7 +295,7 @@ def test_review_diff_drops_findings_missing_required_fields(mock_adapter_class):
     assert findings == [{"file": "b.py", "line": 3, "issue": "this one is valid"}]
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_drops_a_hallucinated_finding_outside_the_diff(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = (
@@ -312,7 +313,7 @@ def test_review_diff_serves_validated_cache_hit_without_calling_the_model():
     diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
     cached_findings = [{"file": "app.py", "line": 42, "issue": "cached finding"}]
 
-    with patch("scan_worker.flash_review.OpenAICompatibleAdapter") as mock_adapter_class:
+    with patch("scan_worker.flash_review.writing_adapter_for") as mock_adapter_class:
         findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
 
     mock_adapter_class.assert_not_called()
@@ -326,14 +327,14 @@ def test_review_diff_revalidates_cache_hit_against_current_diff():
         {"file": "app.py", "line": 9999, "issue": "stale - not in this diff anymore"},
     ]
 
-    with patch("scan_worker.flash_review.OpenAICompatibleAdapter") as mock_adapter_class:
+    with patch("scan_worker.flash_review.writing_adapter_for") as mock_adapter_class:
         findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
 
     mock_adapter_class.assert_not_called()
     assert findings == [{"file": "app.py", "line": 42, "issue": "still valid"}]
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_falls_through_to_model_call_on_cache_miss(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = (
@@ -347,7 +348,7 @@ def test_review_diff_falls_through_to_model_call_on_cache_miss(mock_adapter_clas
     assert findings == [{"file": "app.py", "line": 42, "issue": "fresh finding"}]
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_writes_to_cache_after_a_fresh_call(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = (
@@ -369,7 +370,28 @@ def test_review_diff_writes_to_cache_after_a_fresh_call(mock_adapter_class):
     ]
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
+def test_review_diff_resolves_model_used_dynamically_when_not_passed(mock_adapter_class, monkeypatch):
+    mock_adapter = MagicMock()
+    mock_adapter.simple_completion.return_value = (
+        '[{"file": "app.py", "line": 42, "issue": "fresh finding"}]'
+    )
+    mock_adapter_class.return_value = mock_adapter
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    written = []
+
+    monkeypatch.setattr("scan_worker.flash_review.resolve_model", lambda fallback: "gpt-5.6-luna")
+
+    review_diff(
+        diff_text,
+        cache_lookup=lambda diff: None,
+        cache_write=lambda diff, findings, model_used: written.append(model_used),
+    )
+
+    assert written == ["gpt-5.6-luna"]
+
+
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_does_not_call_the_model_at_all_for_an_empty_diff_even_with_cache_lookup(
     mock_adapter_class,
 ):
@@ -382,7 +404,7 @@ def test_review_diff_does_not_call_the_model_at_all_for_an_empty_diff_even_with_
     mock_adapter_class.assert_not_called()
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_threads_on_usage_to_the_adapter(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = "[]"
@@ -391,12 +413,12 @@ def test_review_diff_threads_on_usage_to_the_adapter(mock_adapter_class):
     on_usage = lambda p, c: None
     review_diff("--- a.py ---\n@@ -1,1 +1,1 @@\n+x = 1", on_usage=on_usage)
 
-    _, kwargs = mock_adapter_class.call_args
+    args, kwargs = mock_adapter_class.call_args
     assert kwargs["on_usage"] is on_usage
-    assert kwargs["model"] == "deepseek-v4-flash"
+    assert args[0] == FLASH_REVIEW_FALLBACK_MODEL
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_includes_file_context_in_prompt(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = "[]"
@@ -408,7 +430,7 @@ def test_review_diff_includes_file_context_in_prompt(mock_adapter_class):
     assert "print(1)" in call_args.args[1] or "print(1)" in call_args.kwargs.get("user_prompt", "")
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_includes_code_evidence_context_in_prompt(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = "[]"
@@ -451,7 +473,7 @@ def test_build_code_evidence_context_includes_file_symbol_dependency_and_risk():
     assert "risk=generic_secret at a.py:2" in context
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_parses_optional_suggestion_field(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = (
@@ -467,7 +489,7 @@ def test_review_diff_parses_optional_suggestion_field(mock_adapter_class):
     ]
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_suggestion_field_is_optional(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = (
@@ -583,7 +605,7 @@ def test_build_referenced_symbol_context_skips_when_fetch_returns_none():
     assert context == ""
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_includes_referenced_symbol_context_in_prompt(mock_adapter_class):
     mock_adapter = MagicMock()
     mock_adapter.simple_completion.return_value = "[]"
@@ -632,7 +654,7 @@ def test_system_prompt_instructs_model_to_treat_diff_content_as_data_not_instruc
     assert "ignore previous instructions" in normalized
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_drops_finding_whose_issue_smuggles_a_suggestion_fence(mock_adapter_class):
     # jobs.py renders "issue" with no fence at all. A finding whose issue
     # text contains a ```suggestion block would break out and get GitHub
@@ -650,7 +672,7 @@ def test_review_diff_drops_finding_whose_issue_smuggles_a_suggestion_fence(mock_
     assert review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing") == []
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_drops_only_the_suggestion_when_it_smuggles_a_fence(mock_adapter_class):
     malicious_suggestion = "```\n```suggestion\nrm -rf /\n```"
     mock_adapter = MagicMock()
@@ -671,7 +693,7 @@ def test_review_diff_drops_only_the_suggestion_when_it_smuggles_a_fence(mock_ada
     assert findings == [{"file": "a.py", "line": 3, "issue": "real, benign issue text"}]
 
 
-@patch("scan_worker.flash_review.OpenAICompatibleAdapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_ignores_unexpected_fields_on_a_finding(mock_adapter_class):
     # A manipulated response might try to smuggle extra authority-bearing
     # keys (e.g. claiming approval/bypass status). Only the known fields

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1824,6 +1824,7 @@ def test_run_live_wiki_full_build_job_skips_model_call_on_cache_hit(monkeypatch)
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     monkeypatch.setattr(
         "scan_worker.jobs.lookup_cached_result",
         lambda *a, **k: ({"description": "Cached, verified description.", "files": []}, "deepseek-v4-pro"),
@@ -2993,6 +2994,7 @@ def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     fake_record = {
         "subsystem_id": "0",
@@ -3031,6 +3033,7 @@ def test_run_live_wiki_full_build_job_records_failed_status_on_error(monkeypatch
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     def _raise(*a, **k):
         raise RuntimeError("model provider unavailable")
@@ -3081,6 +3084,7 @@ def test_run_live_wiki_full_build_job_passes_fetch_line_count_through(monkeypatc
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     sentinel = lambda path: 42  # noqa: E731
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
 
@@ -3100,6 +3104,163 @@ def test_run_live_wiki_full_build_job_passes_fetch_line_count_through(monkeypatc
 
     assert captured_subsystems["fetch_line_count"] is sentinel
     assert captured_store["fetch_line_count"] is sentinel
+
+
+def _multi_cluster_wiki_evidence(cluster_ids: list[int]) -> dict:
+    return {
+        "repository": {
+            "modules": [
+                {
+                    "path": f"pkg{cid}/mod.py",
+                    "language": "python",
+                    "imports": [],
+                    "symbols": {"functions": [], "classes": []},
+                }
+                for cid in cluster_ids
+            ],
+            "dependency_graph": {"nodes": [], "edges": []},
+        },
+        "architecture": {
+            "clusters": [
+                {"id": cid, "modules": [f"pkg{cid}/mod.py"], "internal_edges": 0}
+                for cid in cluster_ids
+            ]
+        },
+    }
+
+
+def test_clusters_with_uncovered_wiki_work_filters_covered_clusters():
+    from scan_worker.jobs import _clusters_with_uncovered_wiki_work
+
+    evidence = _multi_cluster_wiki_evidence([0, 1, 2])
+
+    result = _clusters_with_uncovered_wiki_work(evidence, covered_cluster_ids={"0"}, limit=10)
+
+    assert result == {1, 2}
+
+
+def test_clusters_with_uncovered_wiki_work_respects_limit():
+    from scan_worker.jobs import _clusters_with_uncovered_wiki_work
+
+    evidence = _multi_cluster_wiki_evidence([0, 1, 2, 3, 4])
+
+    result = _clusters_with_uncovered_wiki_work(evidence, covered_cluster_ids=set(), limit=2)
+
+    assert len(result) == 2
+
+
+def test_clusters_with_uncovered_wiki_work_empty_when_everything_covered():
+    from scan_worker.jobs import _clusters_with_uncovered_wiki_work
+
+    evidence = _multi_cluster_wiki_evidence([0, 1])
+
+    result = _clusters_with_uncovered_wiki_work(evidence, covered_cluster_ids={"0", "1"}, limit=10)
+
+    assert result == set()
+
+
+def test_run_live_wiki_full_build_job_only_requests_uncovered_clusters(monkeypatch):
+    from scan_worker.jobs import run_live_wiki_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    evidence = _multi_cluster_wiki_evidence([0, 1, 2])
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: evidence)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [{"subsystem_id": "0"}]
+    )
+
+    captured = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.generate_subsystems",
+        lambda *a, **k: captured.update(k) or [],
+    )
+    monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_wiki_build_status", lambda *a, **k: None)
+
+    run_live_wiki_full_build_job(1, "octocat/hello-world")
+
+    assert captured["cluster_ids"] == {1, 2}
+
+
+def test_run_live_wiki_full_build_job_is_noop_when_every_cluster_already_covered(monkeypatch):
+    from scan_worker.jobs import run_live_wiki_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    evidence = _multi_cluster_wiki_evidence([0, 1])
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: evidence)
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_wiki_subsystems",
+        lambda *a, **k: [{"subsystem_id": "0"}, {"subsystem_id": "1"}],
+    )
+    generate_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.generate_subsystems",
+        lambda *a, **k: generate_calls.append(1),
+    )
+    build_status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error=None: build_status_calls.append((status, error)),
+    )
+
+    run_live_wiki_full_build_job(1, "octocat/hello-world")
+
+    assert generate_calls == []
+    assert build_status_calls == [("ready", None)]
+
+
+def test_live_wiki_catchup_sweep_job_rebuilds_each_due_repo(monkeypatch):
+    from scan_worker.jobs import run_live_wiki_catchup_sweep_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_paid_repos_due_for_wiki_catchup",
+        lambda *a, **k: [(1, "octocat/hello-world"), (2, "octocat/other-repo")],
+    )
+    built = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.run_live_wiki_full_build_job",
+        lambda iid, repo: built.append((iid, repo)),
+    )
+    swept = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.record_wiki_catchup_swept",
+        lambda dsn, iid, repo: swept.append((iid, repo)),
+    )
+
+    run_live_wiki_catchup_sweep_job()
+
+    assert built == [(1, "octocat/hello-world"), (2, "octocat/other-repo")]
+    assert swept == built
+
+
+def test_live_wiki_catchup_sweep_job_survives_one_repo_failing(monkeypatch):
+    from scan_worker.jobs import run_live_wiki_catchup_sweep_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_paid_repos_due_for_wiki_catchup",
+        lambda *a, **k: [(1, "octocat/broken-repo"), (2, "octocat/fine-repo")],
+    )
+
+    def _maybe_raise(iid, repo):
+        if repo == "octocat/broken-repo":
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("scan_worker.jobs.run_live_wiki_full_build_job", _maybe_raise)
+    swept = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.record_wiki_catchup_swept",
+        lambda dsn, iid, repo: swept.append((iid, repo)),
+    )
+
+    run_live_wiki_catchup_sweep_job()
+
+    # Both repos recorded as swept - including the one that failed, so it
+    # isn't retried every tick for the same repeated failure - and the
+    # second repo's build still happened despite the first one raising.
+    assert swept == [(1, "octocat/broken-repo"), (2, "octocat/fine-repo")]
 
 
 def test_maybe_update_live_wiki_passes_fetch_line_count_through(monkeypatch):
@@ -3544,3 +3705,82 @@ def test_maybe_sync_docs_to_repo_swallows_github_api_errors(monkeypatch):
 
     # Should not raise - a repo-commit failure must not fail the Docs build job.
     _maybe_sync_docs_to_repo("dsn", 1, "octocat/hello-world")
+
+
+def test_health_fix_suggestion_adapter_uses_luna_when_openai_key_configured(monkeypatch):
+    from scan_worker.jobs import _health_fix_suggestion_adapter
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+
+    adapter = _health_fix_suggestion_adapter()
+
+    assert adapter.name == "OpenAI"
+    assert adapter._model == "gpt-5.6-luna"
+
+
+def test_health_fix_suggestion_adapter_falls_back_to_deepseek_pro(monkeypatch):
+    from scan_worker.jobs import _health_fix_suggestion_adapter
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+
+    adapter = _health_fix_suggestion_adapter()
+
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == "deepseek-v4-pro"
+
+
+def test_live_wiki_naming_adapter_uses_luna_when_openai_key_configured(monkeypatch):
+    from scan_worker.jobs import _live_wiki_naming_adapter
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+
+    assert _live_wiki_naming_adapter().name == "OpenAI"
+
+
+def test_live_wiki_naming_adapter_falls_back_to_deepseek_flash(monkeypatch):
+    from scan_worker.jobs import _live_wiki_naming_adapter
+    from scan_worker import live_wiki
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+
+    adapter = _live_wiki_naming_adapter()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == live_wiki.FLASH_MODEL
+
+
+def test_live_wiki_update_writing_adapter_uses_luna_when_openai_key_configured(monkeypatch):
+    from scan_worker.jobs import _live_wiki_update_writing_adapter
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+
+    assert _live_wiki_update_writing_adapter().name == "OpenAI"
+
+
+def test_live_wiki_update_writing_adapter_falls_back_to_deepseek_flash(monkeypatch):
+    from scan_worker.jobs import _live_wiki_update_writing_adapter
+    from scan_worker import live_wiki
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+
+    adapter = _live_wiki_update_writing_adapter()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == live_wiki.UPDATE_MODEL
+
+
+def test_live_docs_update_writing_adapter_uses_luna_when_openai_key_configured(monkeypatch):
+    from scan_worker.jobs import _live_docs_update_writing_adapter
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+
+    assert _live_docs_update_writing_adapter().name == "OpenAI"
+
+
+def test_live_docs_update_writing_adapter_falls_back_to_deepseek_flash(monkeypatch):
+    from scan_worker.jobs import _live_docs_update_writing_adapter
+    from scan_worker import live_docs
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+
+    adapter = _live_docs_update_writing_adapter()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == live_docs.FLASH_MODEL

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -18,6 +18,12 @@ def test_cost_for_usage_deepseek_v4_flash():
     )
 
 
+def test_cost_for_usage_gpt_5_6_luna():
+    assert cost_for_usage("gpt-5.6-luna", 1_000_000, 1_000_000) == pytest.approx(
+        0.20 + 1.20
+    )
+
+
 def test_cost_for_usage_small_real_call():
     expected = (2_000 * 0.14 + 300 * 0.28) / 1_000_000
     assert cost_for_usage("deepseek-v4-flash", 2_000, 300) == pytest.approx(expected)

--- a/github-app/tests/test_managed_audit.py
+++ b/github-app/tests/test_managed_audit.py
@@ -11,7 +11,8 @@ from scan_worker.managed_audit import (
 )
 
 
-def test_run_managed_audit_returns_report_text(tmp_path, monkeypatch):
+def test_run_managed_audit_falls_back_to_deepseek_pro_without_openai_key(tmp_path, monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
     repo_path = tmp_path / "repo"
     (repo_path / ".aletheore").mkdir(parents=True)
     (repo_path / ".aletheore" / "air.toon").write_text("fake toon evidence")
@@ -34,6 +35,31 @@ def test_run_managed_audit_returns_report_text(tmp_path, monkeypatch):
     assert adapter._api_key_env_var == "DEEPSEEK_API_KEY"
     assert adapter._model == "deepseek-v4-pro"
     assert adapter._supports_tool_choice is False
+
+
+def test_run_managed_audit_uses_luna_when_openai_key_configured(tmp_path, monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    repo_path = tmp_path / "repo"
+    (repo_path / ".aletheore").mkdir(parents=True)
+    (repo_path / ".aletheore" / "air.toon").write_text("fake toon evidence")
+
+    captured_adapters = []
+
+    def fake_run_reasoning_phase(adapter, repo_path_arg, manual_dir):
+        captured_adapters.append(adapter)
+        report_path = Path(repo_path_arg) / ".aletheore" / "audit-report.md"
+        report_path.write_text("# Real Report\n\nfindings here")
+        return str(report_path)
+
+    monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
+
+    assert "Real Report" in run_managed_audit(repo_path, plan="air")
+
+    adapter = captured_adapters[0]
+    assert adapter.name == "OpenAI"
+    assert adapter._base_url == "https://api.openai.com/v1"
+    assert adapter._api_key_env_var == "OPENAI_API_KEY"
+    assert adapter._model == "gpt-5.6-luna"
 
 
 def test_run_managed_audit_threads_on_usage_to_the_adapter(tmp_path, monkeypatch):

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -1,8 +1,64 @@
+import logging
+
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
-from scan_worker.model_tiers import PRO_MODEL, model_for_plan, writing_adapter_for_plan
+from scan_worker.model_tiers import (
+    LUNA_MODEL,
+    PRO_MODEL,
+    model_for_plan,
+    resolve_model,
+    writing_adapter_for,
+    writing_adapter_for_plan,
+)
 
 
-def test_pro_uses_deepseek_pro():
+def test_resolve_model_returns_luna_when_openai_key_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    assert resolve_model("some-fallback") == LUNA_MODEL
+
+
+def test_resolve_model_falls_back_when_openai_key_not_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+    assert resolve_model("some-fallback") == "some-fallback"
+
+
+def test_writing_adapter_for_builds_openai_adapter_when_key_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    adapter = writing_adapter_for("some-fallback")
+    assert isinstance(adapter, OpenAICompatibleAdapter)
+    assert adapter.name == "OpenAI"
+    assert adapter._model == LUNA_MODEL
+    assert adapter._base_url == "https://api.openai.com/v1"
+    assert adapter._api_key_env_var == "OPENAI_API_KEY"
+
+
+def test_writing_adapter_for_falls_back_to_deepseek_when_key_not_configured(monkeypatch, caplog):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+    with caplog.at_level(logging.WARNING, logger="scan_worker.model_tiers"):
+        adapter = writing_adapter_for("deepseek-v4-flash")
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == "deepseek-v4-flash"
+    assert adapter._supports_tool_choice is False
+    assert "OPENAI_API_KEY not configured" in caplog.text
+
+
+def test_writing_adapter_for_threads_on_usage_through_either_branch(monkeypatch):
+    for key_configured in (True, False):
+        monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: key_configured)
+        received = []
+        adapter = writing_adapter_for("deepseek-v4-flash", on_usage=lambda p, c: received.append((p, c)))
+        adapter._on_usage(10, 20)
+        assert received == [(10, 20)], key_configured
+
+
+def test_pro_uses_luna_when_openai_key_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    adapter = writing_adapter_for_plan("pro")
+    assert adapter.name == "OpenAI"
+    assert adapter._model == LUNA_MODEL
+
+
+def test_pro_falls_back_to_deepseek_pro_when_openai_key_not_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
     adapter = writing_adapter_for_plan("pro")
     assert isinstance(adapter, OpenAICompatibleAdapter)
     assert adapter.name == "DeepSeek"
@@ -10,26 +66,22 @@ def test_pro_uses_deepseek_pro():
     assert adapter._supports_tool_choice is False
 
 
-def test_non_pro_plan_also_uses_deepseek_pro():
-    # free (or any other non-"pro" value) still gets DeepSeek Pro - this
-    # path shouldn't be reachable in practice (managed audits already
-    # reject free plan earlier), but the behavior must be safe regardless.
-    adapter = writing_adapter_for_plan("free")
-    assert adapter.name == "DeepSeek"
-    assert adapter._model == PRO_MODEL
+def test_non_pro_plan_resolves_the_same_as_pro(monkeypatch):
+    # free (or any other non-"pro" value) resolves identically - there is
+    # only one plan's worth of routing left, this path shouldn't be
+    # reachable in practice (managed audits already reject free plan
+    # earlier), but the behavior must be safe regardless.
+    for key_configured in (True, False):
+        monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: key_configured)
+        assert writing_adapter_for_plan("free")._model == writing_adapter_for_plan("pro")._model
 
 
-def test_on_usage_is_threaded_through_to_the_adapter():
-    received = []
-    adapter = writing_adapter_for_plan("pro", on_usage=lambda p, c: received.append((p, c)))
-    adapter._on_usage(10, 20)
-    assert received == [(10, 20)]
-
-
-def test_model_for_plan_never_drifts_from_writing_adapter_for_plan():
+def test_model_for_plan_never_drifts_from_writing_adapter_for_plan(monkeypatch):
     # cost_for_usage() prices tokens by whatever model_for_plan() reports -
     # if it ever disagreed with the adapter writing_adapter_for_plan()
     # actually built, Pro's spend would be silently mispriced.
-    for plan in ["pro", "free"]:
-        adapter = writing_adapter_for_plan(plan)
-        assert model_for_plan(plan) == adapter._model, plan
+    for key_configured in (True, False):
+        monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: key_configured)
+        for plan in ["pro", "free"]:
+            adapter = writing_adapter_for_plan(plan)
+            assert model_for_plan(plan) == adapter._model, (key_configured, plan)

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -31,12 +31,14 @@ from scan_worker.db import (
     list_installation_member_emails,
     list_paid_installations_due_for_digest,
     list_paid_repos_due_for_docs_catchup,
+    list_paid_repos_due_for_wiki_catchup,
     list_repos_for_installation,
     list_wiki_subsystems,
     record_digest_sent,
     record_docs_catchup_swept,
     record_llm_spend,
     record_sent_email,
+    record_wiki_catchup_swept,
     set_last_reviewed_sha,
     upsert_docs_symbol,
     upsert_wiki_overview,
@@ -824,6 +826,106 @@ async def test_record_docs_catchup_swept_upserts_on_conflict(pool):
 
     count = await pool.fetchval(
         "SELECT count(*) FROM docs_catchup_sweeps WHERE installation_id = $1", 507
+    )
+    assert count == 1
+    assert second >= first
+
+
+@pytest.mark.asyncio
+async def test_wiki_catchup_due_list_excludes_free_plan_repos(pool):
+    await _insert_installation(pool, 518, "free-wiki-org", plan="free")
+    insert_repo_history(TEST_DATABASE_URL, 518, "free-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
+
+    due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert (518, "free-wiki-org/repo") not in due
+
+
+@pytest.mark.asyncio
+async def test_wiki_catchup_due_list_includes_paid_repo_never_swept(pool):
+    await _insert_installation(pool, 512, "paid-wiki-org", plan="indie")
+    insert_repo_history(TEST_DATABASE_URL, 512, "paid-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
+
+    due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert (512, "paid-wiki-org/repo") in due
+
+
+@pytest.mark.asyncio
+async def test_wiki_catchup_due_list_excludes_paid_repo_with_no_scan_history(pool):
+    await _insert_installation(pool, 513, "unscanned-wiki-org", plan="indie")
+
+    due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert all(installation_id != 513 for installation_id, _ in due)
+
+
+@pytest.mark.asyncio
+async def test_wiki_catchup_due_list_excludes_repo_swept_within_cooldown(pool):
+    await _insert_installation(pool, 514, "recent-wiki-org", plan="indie")
+    insert_repo_history(TEST_DATABASE_URL, 514, "recent-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
+    record_wiki_catchup_swept(TEST_DATABASE_URL, 514, "recent-wiki-org/repo")
+
+    due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert (514, "recent-wiki-org/repo") not in due
+
+
+@pytest.mark.asyncio
+async def test_wiki_catchup_due_list_excludes_repo_swept_long_ago_with_no_new_activity(pool):
+    await _insert_installation(pool, 515, "stale-wiki-org", plan="indie")
+    old_scan = datetime.now(timezone.utc) - timedelta(days=10)
+    insert_repo_history(TEST_DATABASE_URL, 515, "stale-wiki-org/repo", old_scan, {"v": 1})
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO wiki_catchup_sweeps (installation_id, repo_full_name, last_swept_at)
+            VALUES ($1, $2, now() - interval '5 days')
+            """,
+            515,
+            "stale-wiki-org/repo",
+        )
+
+    due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert (515, "stale-wiki-org/repo") not in due
+
+
+@pytest.mark.asyncio
+async def test_wiki_catchup_due_list_includes_repo_swept_long_ago_with_new_activity_since(pool):
+    await _insert_installation(pool, 516, "active-wiki-org", plan="indie")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO wiki_catchup_sweeps (installation_id, repo_full_name, last_swept_at)
+            VALUES ($1, $2, now() - interval '5 days')
+            """,
+            516,
+            "active-wiki-org/repo",
+        )
+    insert_repo_history(TEST_DATABASE_URL, 516, "active-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
+
+    due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert (516, "active-wiki-org/repo") in due
+
+
+@pytest.mark.asyncio
+async def test_record_wiki_catchup_swept_upserts_on_conflict(pool):
+    await _insert_installation(pool, 517, "upsert-wiki-org", plan="indie")
+    insert_repo_history(TEST_DATABASE_URL, 517, "upsert-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
+
+    record_wiki_catchup_swept(TEST_DATABASE_URL, 517, "upsert-wiki-org/repo")
+    first = await pool.fetchval(
+        "SELECT last_swept_at FROM wiki_catchup_sweeps WHERE installation_id = $1", 517
+    )
+    record_wiki_catchup_swept(TEST_DATABASE_URL, 517, "upsert-wiki-org/repo")
+    second = await pool.fetchval(
+        "SELECT last_swept_at FROM wiki_catchup_sweeps WHERE installation_id = $1", 517
+    )
+
+    count = await pool.fetchval(
+        "SELECT count(*) FROM wiki_catchup_sweeps WHERE installation_id = $1", 517
     )
     assert count == 1
     assert second >= first

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -7,6 +7,7 @@ from scan_worker.scheduler import (
     SCANS_QUEUE_NAME,
     SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
     WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
+    WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
     run_forever,
 )
 
@@ -41,7 +42,7 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
 
-    assert scans_queue.enqueue.call_count == 9
+    assert scans_queue.enqueue.call_count == 12
     session_cleanup_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
@@ -50,17 +51,24 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_live_docs_catchup_sweep_job",)
     ]
+    wiki_catchup_calls = [
+        c for c in scans_queue.enqueue.call_args_list
+        if c.args == ("scan_worker.jobs.run_live_wiki_catchup_sweep_job",)
+    ]
     weekly_digest_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_weekly_digest_sweep_job",)
     ]
     assert len(session_cleanup_calls) == 3
     assert len(docs_catchup_calls) == 3
+    assert len(wiki_catchup_calls) == 3
     assert len(weekly_digest_calls) == 3
     for call in session_cleanup_calls:
         assert call.kwargs == {"job_timeout": SESSION_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in docs_catchup_calls:
         assert call.kwargs == {"job_timeout": DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS}
+    for call in wiki_catchup_calls:
+        assert call.kwargs == {"job_timeout": WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS}
     for call in weekly_digest_calls:
         assert call.kwargs == {"job_timeout": WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS}
     # Sleeps between iterations, not after the last one.


### PR DESCRIPTION
## Summary
- Every LLM writing surface (managed audits, one-time AIRview/Docs builds, PR reviews, AIRview/Docs incremental updates, health fix-suggestions) now resolves through `model_tiers.writing_adapter_for`: GPT-5.6 Luna via OpenAI when `OPENAI_API_KEY` is configured, else the same DeepSeek model each surface used before (logged, never silent).
- DeepSeek V4 Flash wasn't reliable enough on PR review specifically, and DeepSeek announced an unconfirmed but real API price hike - Luna benchmarks above DeepSeek V4 Pro on Artificial Analysis (Coding Agent 71 vs 59, Intelligence 52 vs 45) at a lower price.
- Cost accounting and cache/result labeling are resolved from the same function that picks the adapter, so they can never drift from the model that actually ran.
- AIRview's full build is now capped at 50 clusters/run (`MAX_WIKI_FULL_BUILD_CLUSTERS`, matching Docs' `MAX_DOCS_FULL_BUILD_FILES`), with a new 48h-cooldown catch-up sweep (`wiki_catchup_sweeps` / `run_live_wiki_catchup_sweep_job`, mirroring the existing Docs sweep) so an oversized repo is covered over time instead of paying unbounded per-build cost.

## Test plan
- [x] Full `github-app` test suite passes (973 passed, 8 pre-existing/unrelated skips)
- [x] New tests cover both the `OPENAI_API_KEY`-present (Luna) and absent (DeepSeek fallback) branches for every adapter builder
- [ ] `OPENAI_API_KEY` needs to be set in production for Luna to actually take effect - until then every job keeps using DeepSeek exactly as before (fallback working as designed)
- [ ] Migration `034_wiki_catchup_sweep.sql` needs to run against production on deploy