### PR TITLE
docs: update marketing/privacy copy for the OpenAI Luna model swap

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -42,7 +42,7 @@
         "name": "Aletheore AIR",
         "price": "29.99",
         "priceCurrency": "USD",
-        "description": "Up to 5 team members. Managed audits and AIRview builds run on DeepSeek Pro."
+        "description": "Up to 5 team members. Managed audits and AIRview builds run on an OpenAI frontier model."
       }
     ],
     "featureList": [
@@ -54,7 +54,7 @@
       "MCP server for coding agents",
       "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, DeepSeek, Ollama)",
       "GitHub App: automatic PR comments and branch-protection check runs",
-      "AI-powered managed audit reports on pull requests, written by DeepSeek Pro",
+      "AI-powered managed audit reports on pull requests, written by an OpenAI frontier model",
       "Automatic Flash reviews on every pull request push",
       "Slack/Teams alerts on new findings",
       "Live API endpoint health monitoring across multiple targets, with a public status API",

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -69,7 +69,7 @@
           </div>
           <ul>
             <li>Everything in Community.</li>
-            <li>Managed audits and AIRview, written by DeepSeek Pro.</li>
+            <li>Managed audits and AIRview, written by an OpenAI frontier model.</li>
             <li>AI-generated Docs for every public symbol - grounded in source, kept current automatically, nobody has to write one.</li>
             <li>Automatic Flash reviews on every push to an open pull request.</li>
             <li>Slack / Teams alerts on new findings.</li>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -32,7 +32,7 @@
       <p>Running <code>aletheore scan</code> locally sends nothing to Aletheore's servers. Evidence is written to your own machine. If you use an AI-assisted audit command, evidence, not source code, is sent to whichever LLM provider you configure, using your own API key.</p>
 
       <h2>The GitHub App (Aletheore AIR)</h2>
-      <p>Installing the GitHub App is a different trust boundary. Source code is transiently cloned to run a scan, then immediately discarded. Only derived evidence, such as secrets findings, dependency graphs, and endpoint health rows, is stored. Managed audit and AIRview runs send evidence, not source code, to our LLM provider (DeepSeek), using our shared key.</p>
+      <p>Installing the GitHub App is a different trust boundary. Source code is transiently cloned to run a scan, then immediately discarded. Only derived evidence, such as secrets findings, dependency graphs, and endpoint health rows, is stored. Managed audit and AIRview runs send evidence, not source code, to our LLM provider - OpenAI (GPT-5.6 Luna), using our shared key - with an automatic fallback to DeepSeek if OpenAI is unavailable.</p>
 
       <h2>What we store</h2>
       <p>For paid installations: your GitHub account or organization identity, evidence snapshots from scans, and, if configured, a Slack/Teams webhook URL and health-check monitoring settings. We do not sell this data or share it beyond the service providers necessary to run Aletheore, including our LLM provider for managed audits and our payment provider for billing.</p>


### PR DESCRIPTION
## Summary
- `pricing.html` and `index.html` (JSON-LD offer description + feature list) now say "an OpenAI frontier model" instead of naming DeepSeek Pro - evergreen marketing phrasing, doesn't need updating on the next model swap.
- `privacy.html`, being the actual data-processor disclosure, names the specific model (GPT-5.6 Luna) and now also discloses the automatic DeepSeek fallback - matches what's actually running in production (deployed in #149).
- Left the CLI's "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, DeepSeek, Ollama)" feature-list line untouched - that's describing the open-source CLI's own provider support, unrelated to what the hosted service runs on.

## Test plan
- [x] `cspell` clean on all three changed files