### PR TITLE
feat: hang detection + auto-restart, staleness alert for the health sweep

### DIFF
--- a/github-app/app_server/heartbeat.py
+++ b/github-app/app_server/heartbeat.py
@@ -1,0 +1,38 @@
+import threading
+import time
+from pathlib import Path
+
+DEFAULT_HEARTBEAT_PATH = Path("/tmp/heartbeat")
+
+
+def touch_heartbeat(path: Path = DEFAULT_HEARTBEAT_PATH) -> None:
+    """Writes the current time to path, creating it if absent. Called once
+    per iteration of a long-running loop (scheduler.py's own work loop) or
+    periodically by a background thread (RQ workers - see
+    start_heartbeat_thread) as the liveness signal a Docker HEALTHCHECK
+    reads via the file's mtime. A background thread only proves the process
+    itself hasn't fully deadlocked (Python schedules threads independently
+    of what the main thread is blocked on for typical I/O waits) - it does
+    not prove the specific work loop (e.g. RQ actually dequeuing jobs) is
+    making progress. That stronger guarantee needs a separate check, not
+    this file.
+    """
+    path.write_text(str(time.time()))
+
+
+def start_heartbeat_thread(
+    path: Path = DEFAULT_HEARTBEAT_PATH, interval_seconds: float = 30.0
+) -> threading.Thread:
+    """Starts a daemon thread that touches the heartbeat file every
+    interval_seconds, for processes (RQ workers) whose main loop has no
+    natural per-iteration hook to touch it from directly. Daemon so it
+    never blocks process exit."""
+
+    def _loop() -> None:
+        while True:
+            touch_heartbeat(path)
+            time.sleep(interval_seconds)
+
+    thread = threading.Thread(target=_loop, daemon=True)
+    thread.start()
+    return thread

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -4,6 +4,28 @@ services:
       context: ..
       dockerfile: github-app/Dockerfile.app-server
     restart: unless-stopped
+    labels:
+      - autoheal=true
+    # `restart: unless-stopped` only reacts to the process actually
+    # exiting - it did nothing to help an import-time crash-loop earlier
+    # (correctly kept restarting it, since the process really did exit
+    # each time) but would do nothing at all for a process that's still
+    # running but hung. This HEALTHCHECK plus the autoheal service below
+    # closes that gap: any container Docker reports unhealthy for
+    # AUTOHEAL_START_PERIOD gets `docker restart`ed automatically. Uses
+    # Python's stdlib rather than adding curl to the image.
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz', timeout=3)",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     env_file:
       - path: .env
         required: false
@@ -26,6 +48,19 @@ services:
       context: ..
       dockerfile: github-app/Dockerfile.scan-worker
     restart: unless-stopped
+    labels:
+      - autoheal=true
+    # No HTTP server here (RQ worker) - see app_server/heartbeat.py. A
+    # background thread touches /tmp/heartbeat every ~30s; this fails once
+    # that file goes stale, e.g. the process is hung. See app-server's
+    # healthcheck comment above for why this matters beyond `restart:
+    # unless-stopped` alone.
+    healthcheck:
+      test: ["CMD-SHELL", "find /tmp/heartbeat -mmin -2 | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     env_file:
       - path: .env
         required: false
@@ -68,6 +103,16 @@ services:
       context: ..
       dockerfile: github-app/Dockerfile.scan-worker
     restart: unless-stopped
+    labels:
+      - autoheal=true
+    # See scan-worker's healthcheck comment above - same mechanism, this
+    # container's own /tmp/heartbeat, checked independently.
+    healthcheck:
+      test: ["CMD-SHELL", "find /tmp/heartbeat -mmin -2 | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     command: ["python", "-m", "scan_worker.health_worker"]
     env_file:
       - path: .env
@@ -161,6 +206,20 @@ services:
       context: ..
       dockerfile: github-app/Dockerfile.scan-worker
     restart: unless-stopped
+    labels:
+      - autoheal=true
+    # touch_heartbeat() runs at the end of every completed loop iteration
+    # (scan_worker/scheduler.py) - a stronger signal than the RQ workers'
+    # background-thread heartbeat, since it only updates once the whole
+    # enqueue batch (including the Redis calls that stopped working for 11
+    # days without anyone noticing) actually succeeds. 180s iteration
+    # interval, so a wider window than the RQ workers' 30s thread tick.
+    healthcheck:
+      test: ["CMD-SHELL", "find /tmp/heartbeat -mmin -6 | grep -q ."]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     command: ["python", "-m", "scan_worker.scheduler"]
     env_file:
       - path: .env
@@ -212,6 +271,24 @@ services:
       - aletheore_caddy_config:/config
     depends_on:
       - app-server
+
+  # `docker restart`s any container labeled autoheal=true that Docker
+  # reports unhealthy for AUTOHEAL_START_PERIOD. `restart: unless-stopped`
+  # alone only reacts to a container actually exiting - nothing in this
+  # stack detected a process that's still running but stuck, which is the
+  # likely shape of the failure that let the health-check sweep go silent
+  # for 11 days without anyone noticing. willfarrell/autoheal: a small,
+  # widely-used, single-purpose image - just watches the Docker socket, no
+  # code of ours to maintain here.
+  autoheal:
+    image: willfarrell/autoheal:latest
+    restart: unless-stopped
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=autoheal
+      - AUTOHEAL_START_PERIOD=60
+      - AUTOHEAL_INTERVAL=30
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
   aletheore_postgres_data:

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -1,6 +1,6 @@
 import json
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app_server.evidence_limits import check_evidence_size
 
@@ -1207,6 +1207,26 @@ def get_endpoint_health_summary(dsn: str, installation_id: int, stale_after_seco
             )
             rows = cur.fetchall()
             return {"total": len(rows), "reachable": sum(1 for (reachable,) in rows if reachable)}
+
+
+def get_seconds_since_last_health_check(dsn: str) -> float | None:
+    """Seconds since the most recent row landed in endpoint_health, across
+    every installation and target - a global liveness signal for the
+    health-check sweep mechanism itself (scan_worker.jobs.
+    run_health_check_sweep_job), not any one customer's specific endpoint.
+    Returns None if the table has no rows at all (a fresh install, not a
+    failure - the caller should not alert on that).
+    """
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(checked_at) FROM endpoint_health")
+            row = cur.fetchone()
+            last_checked_at = row[0] if row else None
+            if last_checked_at is None:
+                return None
+            return (datetime.now(timezone.utc) - last_checked_at).total_seconds()
 
 
 def list_installation_member_emails(dsn: str, installation_id: int) -> list[str]:

--- a/github-app/scan_worker/health_worker.py
+++ b/github-app/scan_worker/health_worker.py
@@ -4,6 +4,7 @@ from redis import Redis
 from rq import Worker
 
 from app_server.config import get_settings
+from app_server.heartbeat import start_heartbeat_thread
 from app_server.logging_config import configure_json_logging
 
 
@@ -11,6 +12,15 @@ if __name__ == "__main__":
     configure_json_logging()
     settings = get_settings()
     redis_conn = Redis.from_url(os.environ.get("REDIS_URL", settings.redis_url))
+    # Background thread, not a per-job hook - RQ's own polling wait (Worker.
+    # work()'s internal BLPOP-with-timeout) has no natural "still alive"
+    # callback to touch a heartbeat from between jobs, and the gap between
+    # jobs here is normally minutes, not seconds. This only proves the
+    # process hasn't fully deadlocked (see heartbeat.py's docstring) - a
+    # weaker guarantee than "RQ is actually dequeuing," but a real
+    # improvement over no detection at all, which is what let the health
+    # sweep go silent for 11 days undetected.
+    start_heartbeat_thread()
     # "health" is checked first (RQ's priority order), but this worker is
     # otherwise mostly idle between the ~3-minute sweep ticks, so it also
     # takes "email" - transactional sends are single fast HTTP calls, not

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -36,6 +36,7 @@ from aletheore.signature_diff import find_regression_fence_violations
 from app_server.config import get_settings
 from app_server.db import MAX_SCANNED_REPOS_PER_MONTH
 from app_server.dismissed_findings import filter_dismissed
+from app_server.error_alerts import send_error_alert
 from app_server.github_auth import generate_app_jwt, get_installation_token
 from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation
 from app_server.logging_config import log_job
@@ -62,6 +63,7 @@ from scan_worker.db import (
     get_last_reviewed_sha,
     get_latest_evidence,
     get_llm_spend_this_month,
+    get_seconds_since_last_health_check,
     increment_flash_review_count,
     insert_audit_report,
     insert_endpoint_health,
@@ -1880,6 +1882,46 @@ def run_session_cleanup_job() -> None:
     deleted = delete_expired_sessions(dsn)
     logging.getLogger("scan_worker.jobs").info(
         "session cleanup completed", extra={"deleted_count": deleted}
+    )
+
+
+# The health sweep runs every HEALTH_SWEEP_INTERVAL_SECONDS (180s, see
+# scheduler.py). A gap this wide - 10 minutes, ~3x that interval - is
+# already well outside normal jitter, so it's a meaningful signal rather
+# than noise on an occasional slow tick.
+HEALTH_SWEEP_STALENESS_THRESHOLD_SECONDS = 600
+
+
+class HealthSweepStaleError(RuntimeError):
+    pass
+
+
+@log_job
+def run_health_sweep_staleness_check_job() -> None:
+    """Runs on the "scans" queue (scan-worker), deliberately not "health"
+    (health-worker) - the entire point is to keep working, and alert, even
+    if the health queue/worker specifically is what's broken. This is what
+    would have caught the 11-day gap in ~10 minutes instead of it going
+    unnoticed - Docker's HEALTHCHECK on health-worker (see
+    app_server/heartbeat.py) only proves that container's process hasn't
+    fully deadlocked, not that its actual sweep is landing data.
+    """
+    dsn = get_settings().database_url
+    seconds_since_last_check = get_seconds_since_last_health_check(dsn)
+    if seconds_since_last_check is None:
+        # No endpoint_health rows exist at all yet - a fresh install with
+        # no monitored targets configured, not a failure to alert on.
+        return
+    if seconds_since_last_check < HEALTH_SWEEP_STALENESS_THRESHOLD_SECONDS:
+        return
+    send_error_alert(
+        "health_sweep",
+        HealthSweepStaleError(
+            f"no endpoint_health row in {seconds_since_last_check:.0f}s "
+            f"(threshold {HEALTH_SWEEP_STALENESS_THRESHOLD_SECONDS}s) - "
+            "the health-check sweep may have stopped running"
+        ),
+        "run_health_sweep_staleness_check_job",
     )
 
 

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -4,6 +4,7 @@ from redis import Redis
 from rq import Queue
 
 from app_server.config import get_settings
+from app_server.heartbeat import touch_heartbeat
 from app_server.logging_config import configure_json_logging
 
 HEALTH_SWEEP_INTERVAL_SECONDS = 180
@@ -31,6 +32,9 @@ WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS = 600
 # the actual Resend calls happen there, not in this job, so this stays
 # bounded even if many installations are due the same tick.
 WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS = 300
+# A single max(checked_at) query plus, on the rare stale tick, one email -
+# nothing here can run long.
+HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS = 60
 
 SCANS_QUEUE_NAME = "scans"
 # The health sweep gets its own queue, consumed by a dedicated worker (see
@@ -75,6 +79,18 @@ def run_forever(
             "scan_worker.jobs.run_weekly_digest_sweep_job",
             job_timeout=WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
         )
+        # Deliberately on "scans" (scan-worker), not "health" (health-worker)
+        # - the whole point is that this keeps running, and alerting, even
+        # if the health queue/worker specifically is what's silently broken.
+        scans_queue.enqueue(
+            "scan_worker.jobs.run_health_sweep_staleness_check_job",
+            job_timeout=HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS,
+        )
+        # Touched only after every enqueue call above succeeds - a hang on
+        # any one of them (e.g. Redis unreachable) means this loop is stuck
+        # and the heartbeat correctly goes stale, which is what the Docker
+        # HEALTHCHECK on this container is watching for.
+        touch_heartbeat()
         iterations += 1
         if max_iterations is not None and iterations >= max_iterations:
             break

--- a/github-app/scan_worker/worker.py
+++ b/github-app/scan_worker/worker.py
@@ -4,6 +4,7 @@ from redis import Redis
 from rq import Worker
 
 from app_server.config import get_settings
+from app_server.heartbeat import start_heartbeat_thread
 from app_server.logging_config import configure_json_logging
 
 
@@ -11,4 +12,7 @@ if __name__ == "__main__":
     configure_json_logging()
     settings = get_settings()
     redis_conn = Redis.from_url(os.environ.get("REDIS_URL", settings.redis_url))
+    # See health_worker.py's comment - background thread, proves the
+    # process hasn't fully deadlocked, not that RQ is actively dequeuing.
+    start_heartbeat_thread()
     Worker(["scans"], connection=redis_conn).work()

--- a/github-app/tests/test_heartbeat.py
+++ b/github-app/tests/test_heartbeat.py
@@ -1,0 +1,46 @@
+import time
+
+from app_server.heartbeat import start_heartbeat_thread, touch_heartbeat
+
+
+def test_touch_heartbeat_creates_file(tmp_path):
+    path = tmp_path / "heartbeat"
+    assert not path.exists()
+
+    touch_heartbeat(path)
+
+    assert path.exists()
+
+
+def test_touch_heartbeat_updates_mtime_on_repeat_calls(tmp_path):
+    path = tmp_path / "heartbeat"
+    touch_heartbeat(path)
+    first_mtime = path.stat().st_mtime
+    time.sleep(0.01)
+
+    touch_heartbeat(path)
+
+    assert path.stat().st_mtime >= first_mtime
+
+
+def test_start_heartbeat_thread_touches_file_periodically(tmp_path):
+    path = tmp_path / "heartbeat"
+
+    start_heartbeat_thread(path, interval_seconds=0.05)
+    time.sleep(0.2)
+
+    assert path.exists()
+    # Written at least a couple of times in 0.2s at a 0.05s interval -
+    # confirms the loop is actually repeating, not a one-shot touch.
+    first_mtime = path.stat().st_mtime
+    time.sleep(0.15)
+    assert path.stat().st_mtime > first_mtime
+
+
+def test_start_heartbeat_thread_is_a_daemon_thread(tmp_path):
+    path = tmp_path / "heartbeat"
+
+    thread = start_heartbeat_thread(path, interval_seconds=10)
+
+    assert thread.daemon is True
+    assert thread.is_alive()

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3784,3 +3784,43 @@ def test_live_docs_update_writing_adapter_falls_back_to_deepseek_flash(monkeypat
     adapter = _live_docs_update_writing_adapter()
     assert adapter.name == "DeepSeek"
     assert adapter._model == live_docs.FLASH_MODEL
+
+
+def test_run_health_sweep_staleness_check_job_alerts_when_stale(monkeypatch):
+    from scan_worker.jobs import HEALTH_SWEEP_STALENESS_THRESHOLD_SECONDS, run_health_sweep_staleness_check_job
+
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_seconds_since_last_health_check",
+        lambda dsn: HEALTH_SWEEP_STALENESS_THRESHOLD_SECONDS + 1,
+    )
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
+
+    run_health_sweep_staleness_check_job()
+
+    assert len(alerts) == 1
+    assert alerts[0][0][0] == "health_sweep"
+
+
+def test_run_health_sweep_staleness_check_job_does_not_alert_when_fresh(monkeypatch):
+    from scan_worker.jobs import run_health_sweep_staleness_check_job
+
+    monkeypatch.setattr("scan_worker.jobs.get_seconds_since_last_health_check", lambda dsn: 30.0)
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
+
+    run_health_sweep_staleness_check_job()
+
+    assert alerts == []
+
+
+def test_run_health_sweep_staleness_check_job_does_not_alert_when_no_data_yet(monkeypatch):
+    from scan_worker.jobs import run_health_sweep_staleness_check_job
+
+    monkeypatch.setattr("scan_worker.jobs.get_seconds_since_last_health_check", lambda dsn: None)
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
+
+    run_health_sweep_staleness_check_job()
+
+    assert alerts == []

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -22,6 +22,7 @@ from scan_worker.db import (
     get_last_reviewed_sha,
     get_latest_evidence,
     get_llm_spend_this_month,
+    get_seconds_since_last_health_check,
     get_wiki_overview,
     insert_endpoint_health,
     insert_repo_history,
@@ -1091,3 +1092,50 @@ async def test_get_dismissed_identity_keys_sync_returns_empty_sets_when_none_dis
     dismissed = get_dismissed_identity_keys(TEST_DATABASE_URL, 810, "co/repo")
 
     assert dismissed == {"secret": set(), "vulnerability": set()}
+
+
+@pytest.mark.asyncio
+async def test_get_seconds_since_last_health_check_returns_none_when_no_rows(pool):
+    result = get_seconds_since_last_health_check(TEST_DATABASE_URL)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_seconds_since_last_health_check_reports_elapsed_time(pool):
+    await _insert_installation(pool, 811, "co")
+    checked_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO endpoint_health "
+            "(installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, checked_at) "
+            "VALUES (811, 'co/repo', 'GET', '/healthz', true, $1)",
+            checked_at,
+        )
+
+    result = get_seconds_since_last_health_check(TEST_DATABASE_URL)
+
+    assert result is not None
+    # ~300s elapsed - generous bounds so this isn't flaky on a slow CI runner.
+    assert 290 <= result <= 320
+
+
+@pytest.mark.asyncio
+async def test_get_seconds_since_last_health_check_uses_the_most_recent_row(pool):
+    await _insert_installation(pool, 812, "co")
+    old_check = datetime.now(timezone.utc) - timedelta(hours=1)
+    recent_check = datetime.now(timezone.utc) - timedelta(seconds=5)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO endpoint_health "
+            "(installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, checked_at) "
+            "VALUES (812, 'co/repo-a', 'GET', '/a', true, $1), "
+            "(812, 'co/repo-b', 'GET', '/b', true, $2)",
+            old_check,
+            recent_check,
+        )
+
+    result = get_seconds_since_last_health_check(TEST_DATABASE_URL)
+
+    assert result is not None
+    assert result < 60

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -4,6 +4,7 @@ from scan_worker.scheduler import (
     DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
     HEALTH_QUEUE_NAME,
     HEALTH_SWEEP_JOB_TIMEOUT_SECONDS,
+    HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS,
     SCANS_QUEUE_NAME,
     SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
     WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
@@ -42,7 +43,7 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
 
-    assert scans_queue.enqueue.call_count == 12
+    assert scans_queue.enqueue.call_count == 15
     session_cleanup_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
@@ -59,10 +60,15 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_weekly_digest_sweep_job",)
     ]
+    staleness_check_calls = [
+        c for c in scans_queue.enqueue.call_args_list
+        if c.args == ("scan_worker.jobs.run_health_sweep_staleness_check_job",)
+    ]
     assert len(session_cleanup_calls) == 3
     assert len(docs_catchup_calls) == 3
     assert len(wiki_catchup_calls) == 3
     assert len(weekly_digest_calls) == 3
+    assert len(staleness_check_calls) == 3
     for call in session_cleanup_calls:
         assert call.kwargs == {"job_timeout": SESSION_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in docs_catchup_calls:
@@ -71,5 +77,19 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.kwargs == {"job_timeout": WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS}
     for call in weekly_digest_calls:
         assert call.kwargs == {"job_timeout": WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS}
+    for call in staleness_check_calls:
+        assert call.kwargs == {"job_timeout": HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS}
     # Sleeps between iterations, not after the last one.
     assert sleeps == [42, 42]
+
+
+def test_run_forever_touches_heartbeat_once_per_completed_iteration(monkeypatch):
+    monkeypatch.setattr("scan_worker.scheduler.Queue", lambda name, **kwargs: MagicMock())
+    monkeypatch.setattr("scan_worker.scheduler.Redis.from_url", lambda url: MagicMock())
+    monkeypatch.setattr("scan_worker.scheduler.time.sleep", lambda seconds: None)
+    touches = []
+    monkeypatch.setattr("scan_worker.scheduler.touch_heartbeat", lambda: touches.append(True))
+
+    run_forever(interval_seconds=1, max_iterations=3)
+
+    assert len(touches) == 3


### PR DESCRIPTION
## Summary
Follow-up to a real production finding: the endpoint health-check sweep silently stopped recording data for **11 days** (2026-07-28 to 2026-08-09), with no crash-loop, no restart, and no alert. Root cause is unconfirmed (Docker log rotation on subsequent container rebuilds destroyed the historical logs), but the failure shape - no crash recorded, just silence - points at a hang rather than a crash, which nothing in the stack was watching for.

Two independent, complementary fixes:

**1. Hang detection + auto-restart**
- `app_server/heartbeat.py` - `touch_heartbeat()` (called after every completed loop iteration in `scheduler.py`) and `start_heartbeat_thread()` (background thread for RQ workers with no natural per-iteration hook - `health_worker.py`, `worker.py`)
- Docker `HEALTHCHECK` on `app-server` (existing `/healthz`), `scheduler`/`health-worker`/`scan-worker` (heartbeat file mtime)
- New `autoheal` service (`willfarrell/autoheal`, a small well-established single-purpose image) that restarts any container Docker reports unhealthy

**2. Staleness alert for the sweep itself** - the one failure mode a heartbeat wouldn't catch (a process that's alive and heartbeating but not actually doing its job). New `run_health_sweep_staleness_check_job`, enqueued on `scans` (not `health`) so it keeps working even if the health queue/worker specifically breaks. Alerts via the existing `error_alerts.py` infra if no `endpoint_health` row lands within 10 minutes. Would have caught the real gap in ~10 minutes instead of 11 days.

## Test plan
- [x] Full suite passes: 984 passed, 8 skipped (up from 943)
- [x] New tests for heartbeat file/thread mechanics, scheduler wiring (queue isolation preserved), the staleness job's alert/no-alert/no-data-yet branches, and the DB helper against a real Postgres instance
- [x] `docker compose config --quiet` validates the compose file syntax