### PR TITLE
Bump extra seat to $4.99/mo, fix zero-margin LLM cap gap

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -38,7 +38,7 @@ from app_server.db import (
     set_webhook_url,
     update_session_tokens,
 )
-from app_server.llm_cost import base_cap_for_plan, monthly_cap_for_installation
+from app_server.llm_cost import EXTRA_SEAT_PRICE_USD, base_cap_for_plan, monthly_cap_for_installation
 from app_server.paddle_client import PaddleAPIError
 from app_server.paddle_client import create_portal_session
 from app_server.paddle_client import get_subscription as get_paddle_subscription
@@ -364,7 +364,7 @@ async def add_member(org: str, repo: str, request: Request, body: AddMemberReque
                 status_code=409,
                 detail=(
                     f"seat limit reached ({seat_limit}) - buy an extra seat in Settings "
-                    "($3.99/mo) or remove someone first."
+                    f"(${EXTRA_SEAT_PRICE_USD}/mo) or remove someone first."
                 ),
             )
         await add_installation_member(pool, installation_id, body.github_login, session["github_login"])

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -25,6 +25,7 @@ from app_server.auth import SESSION_COOKIE_NAME, get_current_session
 from app_server.config import get_settings
 from app_server.db import list_installations_for_ids
 from app_server.github_install import github_app_install_url
+from app_server.llm_cost import EXTRA_SEAT_PRICE_USD
 from app_server.paddle_pricing import resolve_price_id_for_plan
 
 frontend_router = APIRouter()
@@ -1913,7 +1914,7 @@ async function loadSettings() {{
 
   const seatBillingHtml = window._hasActiveSubscription
     ? '<div class="form-row">' +
-      '<button class="btn" onclick="buySeat()">Buy extra seat ($3.99/mo)</button>' +
+      '<button class="btn" onclick="buySeat()">Buy extra seat (${EXTRA_SEAT_PRICE_USD}/mo)</button>' +
       (window._extraSeats > 0 ? '<button class="btn" onclick="removeSeat()" style="margin-left:6px;">Remove a seat</button>' : '') +
       '<button class="btn" onclick="openBillingPortal()" style="margin-left:6px;">Manage billing</button>' +
       '</div><div id="seat-billing-status" class="settings-block-hint"></div>'

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -19,7 +19,15 @@ MODEL_RATES_PER_MILLION_USD = {
 
 STALE_PRICE_MAX_AGE_DAYS = 90
 
-EXTRA_SEAT_MONTHLY_COST_USD = 3.99
+# What a seat actually bills at (paddle_pricing.EXTRA_SEAT_PRICE_ID,
+# pricing.html's "+$4.99/mo per additional team member").
+EXTRA_SEAT_PRICE_USD = 4.99
+
+# How much of that a seat is allowed to add to the LLM spend cap. Kept
+# deliberately below EXTRA_SEAT_PRICE_USD (not equal to it, as this used to
+# be) so a seat has guaranteed positive worst-case margin instead of being
+# a wash - at cap, a seat used to cost exactly what it earned.
+EXTRA_SEAT_LLM_CAP_USD = 3.00
 
 # Base monthly price per plan (github-app/../website/pricing.html) - the hard
 # LLM spend cap is set as a fraction of this, not a flat dollar figure, so it
@@ -75,4 +83,4 @@ def base_cap_for_plan(plan: str) -> float:
 
 
 def monthly_cap_for_installation(base_cap_usd: float, extra_seats: int) -> float:
-    return base_cap_usd + EXTRA_SEAT_MONTHLY_COST_USD * extra_seats
+    return base_cap_usd + EXTRA_SEAT_LLM_CAP_USD * extra_seats

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -1,10 +1,13 @@
 """Paddle price ID to Aletheore plan mapping."""
 
-# The AIR add-on for a seat beyond the plan's included count ($3.99/mo,
-# pricing.html's "+$3.99/mo per additional team member"). Added as a second
+# The AIR add-on for a seat beyond the plan's included count ($4.99/mo,
+# pricing.html's "+$4.99/mo per additional team member"). Added as a second
 # line item (by quantity) on a customer's existing AIR subscription, not a
-# separate subscription of its own.
-EXTRA_SEAT_PRICE_ID = "pri_01kym2q99kevmdg7h71nwpm4ej"
+# separate subscription of its own. Replaces the original $3.99 price
+# (pri_01kym2q99kevmdg7h71nwpm4ej, now archived in Paddle) - archived rather
+# than mutated in place so any pre-existing $3.99 subscribers (there were
+# none at the time of the swap) would never have been silently repriced.
+EXTRA_SEAT_PRICE_ID = "pri_01kzks8ccwf6h5bxxtmjfdy1fg"
 
 PADDLE_PRICE_TO_PLAN: dict[str, str] = {
     "pri_01kyhevc8bkcghfpwjymz16y2h": "air",

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -43,7 +43,7 @@ def test_monthly_cap_for_installation_base_only():
 
 
 def test_monthly_cap_for_installation_with_extra_seats():
-    assert monthly_cap_for_installation(7.00, 3) == pytest.approx(18.97)
+    assert monthly_cap_for_installation(7.00, 3) == pytest.approx(16.00)
 
 
 def test_stale_models_returns_empty_when_all_recently_verified():

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -17,6 +17,7 @@ from app_server.db import (
     upsert_installation,
 )
 from app_server.main import app
+from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
 from app_server.webhooks.paddle import handle_paddle_webhook_event
 
 WEBHOOK_SECRET = "pdl_ntfset_test_secret"
@@ -342,7 +343,7 @@ async def test_subscription_updated_reconciles_extra_seats_from_items(pool):
             "custom_data": {"installation_id": "305"},
             "items": [
                 {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
-                {"price": {"id": "pri_01kym2q99kevmdg7h71nwpm4ej"}, "quantity": 3},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 3},
             ],
         },
     }

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -75,7 +75,7 @@
             <li>Slack / Teams alerts on new findings.</li>
             <li>Branch-protection Check Runs for new secrets.</li>
             <li>Endpoint health monitoring across multiple targets, with a public status API.</li>
-            <li>+$3.99/mo per additional team member.</li>
+            <li>+$4.99/mo per additional team member.</li>
           </ul>
           <button type="button" class="btn btn-primary" data-subscribe="air">Subscribe</button>
         </article>


### PR DESCRIPTION
## Summary
- Extra AIR seat price: $3.99/mo → $4.99/mo (new Paddle price created, old one archived — zero active subscribers on it at time of swap)
- Decoupled the seat's LLM spend cap allowance from its price: was accidentally the same constant (both $3.99), meaning a seat at max AI usage earned exactly $0 margin before fees. Now `EXTRA_SEAT_PRICE_USD = 4.99` and `EXTRA_SEAT_LLM_CAP_USD = 3.00`, giving every seat guaranteed positive worst-case margin.
- Updated seat price copy in admin.py, frontend.py, pricing.html

## Test plan
- [x] Full test suite passes locally (984 passed, 8 skipped)
- [x] Verified live Paddle price object created at $4.99 and old $3.99 price archived
- [x] Confirmed zero active subscriptions on the old price before archiving

🤖 Generated with [Claude Code](https://claude.com/claude-code)