### PR TITLE
Data deletion, AIR schema validation, webhook dedupe, MCP consent boundary

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,87 @@ Reports involving hosted data are security-sensitive when they involve:
 
 Please give maintainers a reasonable opportunity to investigate and patch before public disclosure. Coordinated disclosure timing will depend on impact, exploitability, and whether active abuse is suspected.
 
+## Inbound Webhook Handling
+
+Both inbound webhook paths authenticate before doing anything else, and both
+deduplicate deliveries afterwards in a shared `webhook_deliveries` ledger
+retained 30 days. The claim is a single atomic `INSERT … ON CONFLICT DO
+NOTHING`, so two deliveries of one event arriving together cannot both win it.
+The ledger is keyed by `(source, delivery_id)`, keeping GitHub and Paddle
+identifiers in separate namespaces.
+
+### GitHub
+
+Authenticated by HMAC-SHA256 over the raw body, compared with
+`hmac.compare_digest`; a failing request is rejected with 401. GitHub
+signatures carry no timestamp, so the ledger is this path's only replay
+protection. Deliveries are deduplicated on the `X-GitHub-Delivery` GUID:
+
+- **Automatic retries** reuse the GUID and are suppressed, so a delivery that
+  already succeeded cannot enqueue a second scan or review.
+- **Replays of a captured payload** carry a GUID already on file and are
+  likewise suppressed. The header is mandatory — a request without it is
+  rejected with 400 rather than processed, so it cannot be stripped to bypass
+  this.
+- **Manual redelivery** from the GitHub UI mints a fresh GUID and is processed,
+  which is the intended operator behavior.
+- **Failed processing** releases the claim before returning the error, so
+  GitHub's retry is not mistaken for a duplicate and the event is not lost.
+
+### Paddle
+
+Authenticated by HMAC-SHA256 over `timestamp:body`, with the timestamp checked
+to a 5-second tolerance and an allowlist check against Paddle's published
+source addresses. Because the timestamp is inside the signed payload, replay of
+a captured payload is bounded to that 5-second window.
+
+Deduplication on `event_id` therefore exists here for concurrency rather than
+replay: the subscription handler reads an installation's current plan, then
+writes it, and gates a pair of expensive full AIRview and Docs builds on that
+read having been `free`. Two deliveries of one event arriving together would
+both observe `free` and both enqueue those builds. The atomic claim is what
+makes that gate hold. A payload without an `event_id` is rejected with 400
+rather than processed undeduplicated.
+
+### Both paths
+
+The claim is taken only after signature verification, so an unauthenticated
+caller cannot poison the ledger with invented identifiers to suppress the
+genuine deliveries that follow. A handler that raises releases its claim before
+the error propagates, so the provider's retry is not mistaken for a duplicate —
+losing an event outright is a worse failure than processing one twice.
+
+## What an Audit Signature Attests
+
+Managed audit reports are signed with Ed25519 and can be checked at
+`/v1/audit/{token}/verify`, which returns the signature, the public key, and a
+`verified` boolean. That signature attests **provenance and integrity**: this
+exact text was produced by Aletheore and has not been altered since. It does
+not attest that every claim in the report is backed by a citation.
+
+Those are different guarantees, and the difference is load-bearing. Every
+finding in an audit resolves to evidence in your code. One optional section
+does not: the model's own overall rating and improvement suggestions, appended
+after the findings under a heading that names it as not evidence-backed. It is
+excluded from the Citation Verification section's counts, because measuring
+citation coverage across text that is allowed to speak without citations would
+report the wrong number.
+
+So that a reader cannot mistake one guarantee for the other, the verification
+response states it directly:
+
+| Field | Meaning |
+| --- | --- |
+| `verified` | The signature is valid for this content hash — provenance and integrity. |
+| `fully_evidence_backed` | `true` when the report contains only cited findings. |
+| `non_evidence_backed_sections` | Names any section that is not, empty when there are none. |
+
+Installations that need reports containing only cited findings can turn the
+section off in Settings → Managed audit content. With it off, the model call is
+skipped entirely rather than made and discarded, so it costs nothing against
+the monthly LLM spend cap, and the report's certificate reports
+`fully_evidence_backed: true`.
+
 ## Current Limitations
 
 - This project is not yet SOC 2 certified.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,7 +103,7 @@ writes it, and gates a pair of expensive full AIRview and Docs builds on that
 read having been `free`. Two deliveries of one event arriving together would
 both observe `free` and both enqueue those builds. The atomic claim is what
 makes that gate hold. A payload without an `event_id` is rejected with 400
-rather than processed undeduplicated.
+rather than processed without a dedupe check.
 
 ### Both paths
 

--- a/cspell.json
+++ b/cspell.json
@@ -82,6 +82,7 @@
     "nomic",
     "opencode",
     "openvswitch",
+    "pathlib",
     "petclinic",
     "psycopg",
     "pipx",

--- a/docs/AIR-SCHEMA.md
+++ b/docs/AIR-SCHEMA.md
@@ -1,0 +1,98 @@
+# The AIR Contract
+
+**Purpose:** Define AIR (`air.json`) as a versioned public contract and the rules for changing it.
+**Status:** Active baseline
+**Owner:** Arihant Kaul
+**Related Documents:** [README.md](README.md), [../schemas/air.schema.json](../schemas/air.schema.json), [../SECURITY.md](../SECURITY.md)
+**Last Updated:** 2026-08-09
+
+## Purpose
+
+AIR is the deterministic evidence document produced by `aletheore scan`. It is
+read by the CLI, the MCP server, the hosted dashboard, the GitHub App worker,
+and by customers writing their own tooling. That last group is why AIR is a
+contract and not an implementation detail: a key rename that is trivial inside
+this repository is a breaking change outside it.
+
+## Where the contract lives
+
+| Artifact | Role |
+| --- | --- |
+| `src/aletheore/air_schema.py` | The contract itself, as JSON Schema (draft 2020-12). Single source of truth. |
+| `schemas/air.schema.json` | The same schema, checked in for external consumers to fetch. Generated, never hand-edited. |
+| `EVIDENCE_VERSION` in `src/aletheore/evidence.py` | The version stamped into every scan. |
+| `src/tests/test_air_schema.py` | Enforcement. Nothing below is advisory. |
+
+## Versioning
+
+`EVIDENCE_VERSION` is semver, currently pre-1.0. While major is `0`, a **MINOR**
+bump signals the breaking change — `0.2.0` and `0.2.7` are the same schema,
+`0.2.0` and `0.3.0` are not. `is_evidence_version_compatible` compares
+`(major, minor)`, so a reader refuses evidence from a different minor rather
+than misreading it. Once AIR reaches `1.0.0`, that comparison moves to major
+alone.
+
+## Migration rules
+
+1. **Any change to `AIR_JSON_SCHEMA` requires an `EVIDENCE_VERSION` MINOR bump.**
+   This includes adding a key. Additive changes feel safe, but a consumer that
+   version-checks and then reads the new key would silently get `KeyError` on
+   older evidence that passed the check.
+2. **Update all four artifacts together** in one change: the schema module, the
+   regenerated `schemas/air.schema.json`, `EVIDENCE_VERSION`, and the
+   `EXPECTED_SCHEMA_FINGERPRINT` / `EXPECTED_EVIDENCE_VERSION` constants in
+   `test_air_schema.py`.
+3. **Never update the fingerprint alone.** The fingerprint exists to make step 1
+   impossible to skip. Changing it to make a red test green defeats the only
+   mechanism preventing silent drift.
+4. **Record the change** in the changelog below.
+5. **Do not narrow an array's item schema to match a detector's current output.**
+   Item schemas deliberately require only the fields consumers read; detectors
+   stay free to add their own keys without a version bump.
+
+Regenerate the published schema with:
+
+```bash
+cd src && python3 -c "import json, pathlib; from aletheore.air_schema import AIR_JSON_SCHEMA; \
+pathlib.Path('../schemas/air.schema.json').write_text(json.dumps(AIR_JSON_SCHEMA, indent=2, sort_keys=True) + '\n')"
+```
+
+## What is enforced, and where
+
+- **Producer conformance.** `test_scan_output_conforms_to_the_schema` runs a real
+  scan of a real git repo and validates the result with `deep=True`. The schema
+  is a claim about what `scan_repository` emits, so it is checked against actual
+  output rather than a fixture.
+- **Consumer coverage.** `test_schema_covers_every_path_consumers_index` asserts
+  the reverse: every two-level path the CLI, MCP server, and dashboard index
+  into is declared. A schema that omitted a key consumers depend on would pass
+  conformance while protecting nothing.
+- **Drift.** `test_schema_changes_require_an_evidence_version_bump` pins the
+  fingerprint.
+- **Read boundary.** `load_evidence_file` validates shape after the version
+  check and raises `MalformedEvidenceError` naming the offending path. A
+  truncated, hand-edited, or foreign file now fails at the boundary instead of
+  as a `KeyError` several modules downstream.
+
+Validation at the read boundary is shallow (`deep=False`): it checks the
+section skeleton and container types, which is what a consumer about to index
+into evidence actually depends on, and stays O(sections) regardless of repo
+size. Deep validation walks every element of every typed array — tens of
+thousands of objects on a large repo — and is reserved for the test suite.
+
+## Conditional sections
+
+`git` is the one section whose contents are conditional. A repository with no
+commits yields `{"available": false}` and nothing else, so `available` is its
+only required key. **Consumers must branch on `git.available` before reading
+anything else in that section.** `git.hotspots` is likewise present only when
+git is available and modules were found.
+
+`architecture.config_applied` is `null` whenever the repository ships no
+architecture config, which is the common case.
+
+## Changelog
+
+| Version | Change |
+| --- | --- |
+| `0.2.0` | Contract formalized: JSON Schema extracted, published, and enforced in CI. No shape change from the `0.2.0` documents already in the wild — this version documents the existing shape rather than altering it. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Docs
 
+- `AIR-SCHEMA.md` — the AIR evidence contract, its versioning, and the rules for changing it.
+  Read this before touching anything `scan_repository` emits.
 - `superpowers/specs/` and `superpowers/plans/` — design specs and implementation plans, written
   during development. Historical record of what was decided and why, not living documentation -
   read the code and `src/README.md` / `github-app/README.md` for current behavior.

--- a/docs/operations/DATA-HANDLING.md
+++ b/docs/operations/DATA-HANDLING.md
@@ -4,7 +4,7 @@
 **Status:** Active baseline
 **Owner:** Arihant Kaul
 **Related Documents:** [README.md](README.md), [INCIDENT-RESPONSE.md](INCIDENT-RESPONSE.md), [../../SECURITY.md](../../SECURITY.md)
-**Last Updated:** 2026-07-23
+**Last Updated:** 2026-08-09
 
 ## Purpose
 
@@ -20,6 +20,7 @@ This document describes what the hosted GitHub App may process and what must rem
 | Sessions | GitHub login session and encrypted access token. | Encrypted at rest and expired by session TTL plus cleanup job. |
 | Alert targets | Slack/Teams webhook URL, health-check base URL. | Validate before storage; treat as sensitive operational configuration. |
 | LLM usage | Prompt/completion token counts and derived cost. | Store aggregate cost for spend-cap enforcement. |
+| Deletion audit | Installation ID, account login, requesting actor, counts, timestamp. | Retained after a purge as proof of erasure; never itself deleted. |
 
 ## Data Transfer Rules
 
@@ -30,12 +31,36 @@ This document describes what the hosted GitHub App may process and what must rem
 
 ## Deletion Baseline
 
-Deletion capability is not yet fully productized. Until then, deletion requests must be handled manually by installation/repository scope and recorded as an operational event.
+Deletion is self-serve and available on every plan, including Community and
+lapsed subscriptions. Two paths trigger the same purge:
+
+- **Dashboard.** Settings → Delete all data, confirmed by typing the account
+  login. Requires a session holding GitHub admin rights on the installation;
+  it is deliberately not gated on plan or seat, so a customer whose payment
+  failed can still erase their data.
+- **Uninstalling the GitHub App.** The `installation.deleted` webhook runs the
+  identical purge.
+
+Scope of a purge, in one transaction:
+
+| Data | Outcome |
+| --- | --- |
+| Installation-scoped rows (evidence, findings, docs, wiki, tokens, seats, health targets, billing links) | Deleted. Every such table declares `ON DELETE CASCADE` against `installations`. |
+| `github_user_emails`, `sessions` for anyone who has accessed the installation | Deleted **only** for people left with no other Aletheore installation. A user who administers two orgs is not logged out of the second when the first deletes itself. "Anyone who has accessed" is tracked in `installation_access_log`, on every plan - not `installation_members`, which exists only for paid-seat billing and would silently miss every Community-plan user. |
+| `cli_telemetry_events` | Retained. Keyed by a rotating anonymous ID with no link to an installation or a person. |
+| `demo_scan_rate_limits` | Retained. IP-keyed abuse control for the unauthenticated demo scanner, not customer data. |
+| `data_deletion_log` | Written, never deleted. See below. |
+
+Every purge writes one `data_deletion_log` row: installation ID, account login,
+the actor who requested it, repo and user counts, and a timestamp. That table
+deliberately carries no foreign key to `installations` — a cascading one would
+destroy the record of the deletion as part of the deletion itself. It is the
+one place an account login outlives the account, and it is the audit trail.
 
 ## Open Controls
 
 - Customer-facing retention settings.
-- Self-serve data deletion.
-- Audit logs for admin actions.
+- Self-serve data export.
+- Audit logs for admin actions other than deletion.
 - Enterprise data-processing addendum.
 - Region and subprocessor disclosures.

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -31,10 +31,14 @@ from app_server.db import (
     list_api_tokens,
     list_health_check_targets,
     list_installation_members,
+    list_repos_for_installations,
+    purge_installation_data,
+    record_installation_access,
     remove_health_check_target,
     remove_installation_member,
     revoke_api_token,
     set_docs_repo_commit_enabled,
+    set_llm_suggestions_enabled,
     set_webhook_url,
     update_session_tokens,
 )
@@ -85,6 +89,14 @@ class CreateCliTokenRequest(BaseModel):
 # look-around, so this is segment-based rather than a lookahead pattern -
 # still rejects leading/trailing/doubled hyphens.)
 _GITHUB_LOGIN_PATTERN = r"^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
+
+
+class SetLLMSuggestionsRequest(BaseModel):
+    enabled: bool
+
+
+class DeleteInstallationDataRequest(BaseModel):
+    confirm: str = Field(min_length=1, max_length=200)
 
 
 class AddMemberRequest(BaseModel):
@@ -301,6 +313,10 @@ async def _require_authorized_installation(request: Request, org: str, repo: str
     installation = await get_installation(pool, installation_id)
     if installation is None:
         raise HTTPException(status_code=404, detail="installation not found")
+    # Every plan, not just paid seats - this is the record
+    # purge_installation_data actually relies on to find PII to purge, since
+    # installation_members only ever exists for paid seat holders.
+    await record_installation_access(pool, installation_id, session["github_login"])
     return session, installation
 
 
@@ -649,6 +665,85 @@ async def remove_health_check_target_route(org: str, repo: str, target_id: int, 
         request.app.state.db_pool, installation["installation_id"], f"{org}/{repo}", target_id
     )
     return {"ok": True}
+
+
+@admin_router.put("/admin/{org}/{repo}/llm-suggestions")
+async def set_llm_suggestions_route(
+    org: str, repo: str, request: Request, body: SetLLMSuggestionsRequest
+):
+    """Opt the installation in or out of the non-evidence-backed suggestion
+    section on managed audits.
+
+    Uses the admin gate (paid plan + seat) rather than the looser authorized
+    gate, because managed audits are a paid feature - an installation with no
+    audits to configure has nothing to set here.
+    """
+    installation = await _require_admin_installation(request, org, repo)
+    await set_llm_suggestions_enabled(
+        request.app.state.db_pool, installation["installation_id"], body.enabled
+    )
+    return {"ok": True, "llm_suggestions_enabled": body.enabled}
+
+
+@admin_router.get("/admin/{org}/{repo}/deletion-preview")
+async def deletion_preview(org: str, repo: str, request: Request):
+    """What a purge would actually destroy, so the confirmation dialog can
+    say it out loud. Deletion is installation-wide but every admin route is
+    repo-scoped, so a customer standing on acme/api's settings page is one
+    click from wiping acme/web too - naming the other repos is the only
+    honest way to present that.
+    """
+    _session, installation = await _require_authorized_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    installation_id = installation["installation_id"]
+    repos = await list_repos_for_installations(pool, [installation_id])
+    return {
+        "account_login": installation["account_login"],
+        "repos": [row["repo_full_name"] for row in repos],
+        "member_count": await count_installation_members(pool, installation_id),
+    }
+
+
+@admin_router.post("/admin/{org}/{repo}/delete-all-data")
+async def delete_all_data(
+    org: str, repo: str, request: Request, body: DeleteInstallationDataRequest
+):
+    """Self-serve erasure for everything the hosted service holds.
+
+    Gated on _require_authorized_installation, not _require_admin_installation:
+    no plan gate and no seat gate. Same reasoning as the billing portal above -
+    a customer on the free plan, or one whose card just failed and got
+    downgraded, is precisely the person who must still be able to delete
+    their data. A 402 on this route would be indefensible.
+    """
+    session, installation = await _require_authorized_installation(request, org, repo)
+
+    # The typed confirmation is the account login, not the repo name: the
+    # blast radius is the whole installation, and making someone type the
+    # repo they happen to be looking at would misrepresent that.
+    if body.confirm.strip() != installation["account_login"]:
+        raise HTTPException(
+            status_code=400,
+            detail=f"type {installation['account_login']} exactly to confirm deletion",
+        )
+
+    result = await purge_installation_data(
+        request.app.state.db_pool,
+        installation["installation_id"],
+        session["github_login"],
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="installation not found")
+
+    logger.info(
+        "purged installation %s (%s) on request of %s: %s repos, %s users",
+        result["installation_id"],
+        result["account_login"],
+        session["github_login"],
+        result["repos_deleted"],
+        result["users_purged"],
+    )
+    return {"ok": True, **result}
 
 
 @admin_router.get("/v1/my-installations")

--- a/github-app/app_server/audit_signing.py
+++ b/github-app/app_server/audit_signing.py
@@ -7,6 +7,22 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
 )
 
 
+# The heading that opens the one section of an audit that is deliberately not
+# evidence-backed (see scan_worker/managed_audit.py). It lives here rather
+# than beside the writer because the *verifier* needs it too: a signature says
+# "Aletheore produced this exact text", which is not the same as "every claim
+# in it is backed by a citation". A certificate that doesn't distinguish the
+# two lends the signature's authority to a model opinion.
+#
+# Treated as a contract: changing it changes what a verified report discloses,
+# so both sides import this constant rather than spelling it out.
+LLM_SUGGESTION_HEADING = "## LLM Based Suggestion (Not Evidence Backed)"
+
+
+def contains_non_evidence_backed_section(report_text: str) -> bool:
+    return LLM_SUGGESTION_HEADING in report_text
+
+
 def content_hash(report_text: str) -> str:
     return hashlib.sha256(report_text.encode()).hexdigest()
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -28,7 +28,7 @@ async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | N
         """
         SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
                health_check_base_url, health_check_latency_threshold_ms,
-               paddle_subscription_id, paddle_customer_id
+               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
         FROM installations
         WHERE installation_id = $1
         """,
@@ -79,7 +79,193 @@ async def list_installations_for_ids(pool: asyncpg.Pool, installation_ids: list[
 
 
 async def delete_installation(pool: asyncpg.Pool, installation_id: int) -> None:
+    """Drop the installations row and everything cascading off it.
+
+    Prefer purge_installation_data() for anything customer-facing: this
+    leaves behind the member email addresses and sessions that are keyed by
+    github_login rather than installation_id, and writes no audit row. It
+    remains as the raw primitive for cascade tests.
+    """
     await pool.execute("DELETE FROM installations WHERE installation_id = $1", installation_id)
+
+
+async def set_llm_suggestions_enabled(
+    pool: asyncpg.Pool, installation_id: int, enabled: bool
+) -> None:
+    """Turn the non-evidence-backed suggestion section of managed audits on or off.
+
+    Off means a managed audit contains only cited, evidence-backed findings -
+    which is what the product promises, and what some customers need in order
+    to hand a signed report to an auditor without caveats.
+    """
+    await pool.execute(
+        "UPDATE installations SET llm_suggestions_enabled = $2, updated_at = now() "
+        "WHERE installation_id = $1",
+        installation_id,
+        enabled,
+    )
+
+
+async def claim_webhook_delivery(
+    pool: asyncpg.Pool, source: str, delivery_id: str, event: str
+) -> bool:
+    """Try to claim one inbound webhook delivery. True means this caller won
+    it and should process the event; False means it has already been handled
+    and this is a retry, a replay, or a concurrent duplicate.
+
+    `source` namespaces the id ("github" for X-GitHub-Delivery GUIDs,
+    "paddle" for event ids) so the two providers can't collide.
+
+    A single INSERT ... ON CONFLICT DO NOTHING does the whole thing
+    atomically. A read-then-write would leave a window where two concurrent
+    deliveries of the same id both see "not seen yet" and both proceed -
+    which is the exact duplicate-work outcome this exists to prevent.
+    """
+    row = await pool.fetchrow(
+        """
+        INSERT INTO webhook_deliveries (source, delivery_id, event)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (source, delivery_id) DO NOTHING
+        RETURNING delivery_id
+        """,
+        source,
+        delivery_id,
+        event,
+    )
+    return row is not None
+
+
+async def release_webhook_delivery(pool: asyncpg.Pool, source: str, delivery_id: str) -> None:
+    """Give up a claim so the provider's own retry of the same id can be
+    processed later.
+
+    Without this, a handler that raised would leave the delivery marked as
+    handled forever and the retry - the thing that would have rescued it -
+    would be silently discarded. Losing events outright is a worse failure
+    than processing one twice.
+    """
+    await pool.execute(
+        "DELETE FROM webhook_deliveries WHERE source = $1 AND delivery_id = $2",
+        source,
+        delivery_id,
+    )
+
+
+async def record_installation_access(
+    pool: asyncpg.Pool, installation_id: int, github_login: str
+) -> None:
+    """Note that this login has passed _require_authorized_installation for
+    this installation - on every plan, not just paid seats.
+
+    This is purge_installation_data's actual source of truth for "who might
+    have PII tied to this installation": installation_members is populated
+    only for paid-plan seat holders (_require_seat_if_paid skips free plans
+    entirely), so a free-plan installation always has zero rows there even
+    though its real users have real sessions and captured emails. This
+    table is separate from and doesn't affect installation_members, which
+    remains exactly what it was - seat/billing bookkeeping.
+    """
+    await pool.execute(
+        """
+        INSERT INTO installation_access_log (installation_id, github_login)
+        VALUES ($1, $2)
+        ON CONFLICT (installation_id, github_login) DO UPDATE SET last_seen_at = now()
+        """,
+        installation_id,
+        github_login,
+    )
+
+
+async def purge_installation_data(
+    pool: asyncpg.Pool, installation_id: int, actor_login: str
+) -> dict | None:
+    """Erase everything the hosted service holds for one installation, and
+    write an audit row proving it happened. Returns None if the
+    installation was already gone (the caller asked for a no-op), otherwise
+    a summary dict.
+
+    Deleting the installations row cascades to every installation-scoped
+    table. Two kinds of row don't cascade, because they're keyed by
+    github_login rather than installation_id:
+
+      - github_user_emails - a real email address, no TTL
+      - sessions           - an encrypted GitHub access token
+
+    Those are account-level, not installation-level, so they're only purged
+    for people left with no *other* installation after this one goes. A
+    user who administers two orgs shouldn't be logged out of the second one
+    because the first deleted itself. "Left with no other installation" is
+    decided from installation_access_log, not installation_members - the
+    latter only covers paid seats and would silently skip every free-plan
+    user's PII (see record_installation_access).
+
+    The whole thing runs in one transaction: a partial purge that dropped
+    the evidence but kept the email - or wrote the audit row for a delete
+    that then rolled back - is worse than either outcome cleanly.
+    """
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            installation = await conn.fetchrow(
+                "SELECT account_login FROM installations WHERE installation_id = $1",
+                installation_id,
+            )
+            if installation is None:
+                return None
+
+            # Read the access log and repo count before the cascade takes
+            # both away - after the DELETE there is nothing left to count.
+            member_logins = [
+                row["github_login"]
+                for row in await conn.fetch(
+                    "SELECT github_login FROM installation_access_log WHERE installation_id = $1",
+                    installation_id,
+                )
+            ]
+            repos_deleted = await conn.fetchval(
+                "SELECT count(DISTINCT repo_full_name) FROM repo_history WHERE installation_id = $1",
+                installation_id,
+            )
+
+            await conn.execute(
+                "DELETE FROM installations WHERE installation_id = $1", installation_id
+            )
+
+            users_purged = 0
+            for login in member_logins:
+                # installation_access_log rows for this installation are
+                # gone with the cascade, so anything still here is another
+                # installation this person has accessed.
+                still_a_member = await conn.fetchval(
+                    "SELECT count(*) FROM installation_access_log WHERE github_login = $1",
+                    login,
+                )
+                if still_a_member:
+                    continue
+                await conn.execute(
+                    "DELETE FROM github_user_emails WHERE github_login = $1", login
+                )
+                await conn.execute("DELETE FROM sessions WHERE github_login = $1", login)
+                users_purged += 1
+
+            await conn.execute(
+                """
+                INSERT INTO data_deletion_log
+                    (installation_id, account_login, actor_login, repos_deleted, users_purged)
+                VALUES ($1, $2, $3, $4, $5)
+                """,
+                installation_id,
+                installation["account_login"],
+                actor_login,
+                repos_deleted,
+                users_purged,
+            )
+
+    return {
+        "installation_id": installation_id,
+        "account_login": installation["account_login"],
+        "repos_deleted": repos_deleted,
+        "users_purged": users_purged,
+    }
 
 
 async def insert_repo_history(

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -329,6 +329,11 @@ table.findings tr:last-child td { border-bottom: none; }
 .settings-block { margin-bottom: 18px; }
 .settings-block-label { font-size: 12px; font-weight: 500; margin-bottom: 7px; }
 .settings-block-hint { font-size: 11px; color: var(--slate-600); margin-top: 6px; }
+.danger-zone { margin-top: 24px; border: 1px solid var(--critical); border-radius: 6px; padding: 14px 16px; }
+.danger-zone .settings-block-label { color: var(--critical); }
+.danger-zone .btn-danger { background: var(--critical); border-color: var(--critical); color: #fff; }
+.danger-zone .btn-danger[disabled] { opacity: 0.5; cursor: not-allowed; }
+.danger-repo-list { font-size: 11px; color: var(--slate-600); margin-top: 6px; word-break: break-all; }
 .token-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 7px 0; border-bottom: 1px solid var(--border); font-size: 12.5px; }
 .token-row:last-child { border-bottom: none; }
 .token-label { font-weight: 500; }
@@ -1801,6 +1806,27 @@ async function generateToken() {{
   refreshTokenList();
 }}
 
+async function saveLlmSuggestions(checkbox) {{
+  const status = document.getElementById('llm-suggestions-status');
+  checkbox.disabled = true;
+  const res = await fetch(adminBase + '/llm-suggestions', {{
+    method: 'PUT', headers: {{ 'Content-Type': 'application/json' }},
+    body: JSON.stringify({{ enabled: checkbox.checked }}),
+  }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  checkbox.disabled = false;
+  if (!res.ok) {{
+    checkbox.checked = !checkbox.checked;
+    status.textContent = data.detail || 'Could not save.';
+    status.style.color = 'var(--critical)';
+    return;
+  }}
+  status.textContent = checkbox.checked
+    ? 'Audits will include the model\\'s second opinion.'
+    : 'Audits will contain only evidence-backed findings.';
+  status.style.color = 'var(--success)';
+}}
+
 async function saveWebhook() {{
   const input = document.getElementById('webhook-url-input');
   const status = document.getElementById('webhook-status');
@@ -1869,6 +1895,76 @@ async function openBillingPortal() {{
   }}
 }}
 
+// The danger zone renders on every plan, including free and lapsed - the
+// settings page 402s those customers out of everything else, but locking
+// someone out of erasing their own data because their card failed is not
+// defensible. It hangs off its own endpoint for the same reason: the main
+// /admin GET is plan-gated, this one isn't.
+async function loadDangerZone() {{
+  const host = document.getElementById('danger-zone');
+  if (!host) return;
+  const res = await fetch(adminBase + '/deletion-preview');
+  if (!res.ok) return;
+  const data = await res.json();
+  window._deleteConfirmPhrase = data.account_login;
+  const repos = data.repos || [];
+  // Deletion is installation-wide but this page is repo-scoped. Naming the
+  // other repos is the only honest way to show the real blast radius.
+  const repoLine = repos.length
+    ? 'This deletes scan history, evidence, findings, and documentation for all ' +
+      repos.length + ' repositor' + (repos.length === 1 ? 'y' : 'ies') + ' in this installation: ' +
+      repos.map(escapeHtml).join(', ') + '.'
+    : 'This deletes everything stored for this installation.';
+  host.innerHTML =
+    '<div class="danger-zone">' +
+      '<div class="settings-block-label">Delete all data</div>' +
+      '<div class="settings-block-hint">' + repoLine + '</div>' +
+      '<div class="danger-repo-list">API tokens, team seats, and alert settings go too. ' +
+      'Members who belong to no other Aletheore installation have their stored email address and ' +
+      'sessions erased as well. This cannot be undone.</div>' +
+      '<div class="form-row" style="margin-top:10px;">' +
+        '<input class="field" id="delete-confirm-input" autocomplete="off" ' +
+        'placeholder="Type ' + escapeHtml(data.account_login) + ' to confirm" ' +
+        'oninput="syncDeleteButton()">' +
+        '<button class="btn btn-danger" id="delete-all-btn" disabled onclick="deleteAllData()">Delete</button>' +
+      '</div>' +
+      '<div id="delete-status" class="settings-block-hint"></div>' +
+    '</div>';
+}}
+
+function syncDeleteButton() {{
+  const input = document.getElementById('delete-confirm-input');
+  const btn = document.getElementById('delete-all-btn');
+  if (!input || !btn) return;
+  btn.disabled = input.value.trim() !== window._deleteConfirmPhrase;
+}}
+
+async function deleteAllData() {{
+  const input = document.getElementById('delete-confirm-input');
+  const btn = document.getElementById('delete-all-btn');
+  const status = document.getElementById('delete-status');
+  btn.disabled = true;
+  status.textContent = 'Deleting...';
+  status.style.color = 'var(--slate-600)';
+  const res = await fetch(adminBase + '/delete-all-data', {{
+    method: 'POST',
+    headers: {{ 'Content-Type': 'application/json' }},
+    body: JSON.stringify({{ confirm: input.value.trim() }}),
+  }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  if (!res.ok) {{
+    status.textContent = data.detail || 'Could not delete your data.';
+    status.style.color = 'var(--critical)';
+    syncDeleteButton();
+    return;
+  }}
+  // Everything this page reads is gone, including possibly this session -
+  // there is nothing left here to re-render, so leave for the marketing site.
+  status.textContent = 'Deleted. Signing you out...';
+  status.style.color = 'var(--success)';
+  window.location.href = '/auth/logout';
+}}
+
 async function loadSettings() {{
   const body = document.getElementById('settings-body');
   const res = await apiGet(adminBase);
@@ -1885,7 +1981,9 @@ async function loadSettings() {{
       // that's blocking everything else on this page.
       '<div class="settings-block-hint" style="text-align:center;margin-top:12px;">' +
       'Already subscribed? <a href="#" onclick="openBillingPortal(); return false;">Manage billing</a>' +
-      '</div>';
+      '</div>' +
+      '<div id="danger-zone"></div>';
+    loadDangerZone();
     return;
   }}
   if (!res.ok) {{
@@ -1949,11 +2047,28 @@ async function loadSettings() {{
           '<div class="settings-block-hint">New critical findings are posted here shortly after a scan finishes. Paste a Slack incoming-webhook URL or a Teams workflow webhook URL - both are auto-detected.</div>' +
         '</div>' +
         '<div class="settings-block">' +
+          '<div class="settings-block-label">Managed audit content</div>' +
+          '<label style="display:flex;align-items:center;gap:7px;font-size:12.5px;">' +
+          '<input type="checkbox" id="llm-suggestions-toggle"' +
+          (installation.llm_suggestions_enabled === false ? '' : ' checked') +
+          ' onchange="saveLlmSuggestions(this)">' +
+          'Include the model\\'s second opinion' +
+          '</label>' +
+          '<div id="llm-suggestions-status" class="settings-block-hint"></div>' +
+          '<div class="settings-block-hint">Every finding in an audit is tied to a citation in your code. ' +
+          'This one optional section is not: it is the model\\'s own overall rating and improvement ideas, ' +
+          'appended after the evidence-backed findings and labelled as such. Turn it off to have audits ' +
+          'contain only cited findings - the signed report and its verification page will then confirm ' +
+          'the report is fully evidence-backed.</div>' +
+        '</div>' +
+        '<div class="settings-block">' +
           '<div class="settings-block-label">Endpoint health targets</div>' +
           '<div class="settings-block-hint">Configure staging/production URLs and see live results on the <a data-href="/health">Endpoint health</a> page.</div>' +
         '</div>' +
       '</div>' +
-    '</div>';
+    '</div>' +
+    '<div id="danger-zone"></div>';
+  loadDangerZone();
   document.querySelectorAll('[data-href]').forEach(function (el) {{ el.href = pageBase + el.dataset.href; }});
 }}
 

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -13,7 +13,7 @@ from app_server.admin import admin_router
 from app_server.auth import auth_router
 from app_server.config import get_settings
 from app_server.dashboard import dashboard_router
-from app_server.db import create_pool
+from app_server.db import claim_webhook_delivery, create_pool, release_webhook_delivery
 from app_server.demo_scan_api import demo_scan_router
 from app_server.error_alerts import send_error_alert
 from app_server.frontend import frontend_router
@@ -144,27 +144,53 @@ async def webhook(request: Request):
     if not verify_signature(body, signature, settings.github_webhook_secret):
         raise HTTPException(status_code=401, detail="invalid signature")
 
+    # Required, not optional. GitHub sends X-GitHub-Delivery on every
+    # delivery including pings, and treating a missing header as "just
+    # process it" would hand anyone holding a captured payload a one-header
+    # bypass of the replay protection below.
+    delivery_id = request.headers.get("X-GitHub-Delivery", "")
+    if not delivery_id:
+        raise HTTPException(status_code=400, detail="missing X-GitHub-Delivery")
+
     event = request.headers.get("X-GitHub-Event", "")
     payload = json.loads(body)
     pool = request.app.state.db_pool
 
-    if event in ("installation", "installation_repositories"):
-        await handle_installation_event(event, payload, pool, settings.redis_url)
-    elif event == "marketplace_purchase":
-        from app_server.webhooks.marketplace import handle_marketplace_event
+    # Claimed after the signature check, so an unauthenticated caller can't
+    # poison the ledger with invented GUIDs and suppress the real deliveries
+    # that follow. Also after JSON parsing, so a body that could never be
+    # handled doesn't burn a GUID on its way to failing.
+    if not await claim_webhook_delivery(pool, "github", delivery_id, event):
+        access_logger.info(
+            "duplicate webhook delivery ignored",
+            extra={"delivery_id": delivery_id, "github_event": event},
+        )
+        return {"ok": True, "duplicate": True}
 
-        await handle_marketplace_event(payload, pool, settings.redis_url)
-    elif event == "pull_request":
-        from app_server.webhooks.pull_request import handle_pull_request_event
+    try:
+        if event in ("installation", "installation_repositories"):
+            await handle_installation_event(event, payload, pool, settings.redis_url)
+        elif event == "marketplace_purchase":
+            from app_server.webhooks.marketplace import handle_marketplace_event
 
-        await handle_pull_request_event(payload, settings.redis_url)
-    elif event == "push":
-        from app_server.webhooks.push import handle_push_event
+            await handle_marketplace_event(payload, pool, settings.redis_url)
+        elif event == "pull_request":
+            from app_server.webhooks.pull_request import handle_pull_request_event
 
-        await handle_push_event(payload, settings.redis_url)
-    elif event == "issue_comment":
-        from app_server.webhooks.issue_comment import handle_issue_comment_event
+            await handle_pull_request_event(payload, settings.redis_url)
+        elif event == "push":
+            from app_server.webhooks.push import handle_push_event
 
-        await handle_issue_comment_event(payload, settings.redis_url)
+            await handle_push_event(payload, settings.redis_url)
+        elif event == "issue_comment":
+            from app_server.webhooks.issue_comment import handle_issue_comment_event
+
+            await handle_issue_comment_event(payload, settings.redis_url)
+    except Exception:
+        # Hand the GUID back before failing, or GitHub's retry of this same
+        # delivery would be treated as a duplicate and dropped - turning a
+        # transient error into permanent event loss.
+        await release_webhook_delivery(pool, "github", delivery_id)
+        raise
 
     return {"ok": True}

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -5,7 +5,12 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from app_server.audit_signing import public_key_hex_from_private, verify_report
+from app_server.audit_signing import (
+    LLM_SUGGESTION_HEADING,
+    contains_non_evidence_backed_section,
+    public_key_hex_from_private,
+    verify_report,
+)
 from app_server.config import get_settings
 from app_server.db import (
     MAX_SCANNED_REPOS_PER_MONTH,
@@ -122,11 +127,23 @@ async def verify_audit_report(verification_token: str, request: Request):
     public_key_hex = public_key_hex_from_private(settings.audit_signing_private_key)
     verified = verify_report(report["report_text"], report["signature"], public_key_hex)
 
+    # A signature attests "Aletheore produced this exact text" - not "every
+    # claim in it is backed by a citation". Those are different guarantees,
+    # and a certificate that reports only `verified: true` invites a reader to
+    # conflate them, extending the signature's authority to the one section
+    # that is deliberately a model opinion. Stating it here means a consumer
+    # of this endpoint can tell the two apart without parsing the markdown.
+    has_opinion_section = contains_non_evidence_backed_section(report["report_text"])
+
     return {
         "repo_full_name": report["repo_full_name"],
         "content_hash": report["content_hash"],
         "signed_at": report["created_at"].isoformat(),
         "verified": verified,
+        "fully_evidence_backed": not has_opinion_section,
+        "non_evidence_backed_sections": [LLM_SUGGESTION_HEADING.lstrip("# ")]
+        if has_opinion_section
+        else [],
         # Included so this is an actual verifiable certificate, not just an
         # "our database says so" boolean - anyone can independently confirm
         # signature over content_hash using this public key, without

--- a/github-app/app_server/webhooks/installation.py
+++ b/github-app/app_server/webhooks/installation.py
@@ -4,7 +4,7 @@ import logging
 import httpx
 
 from app_server.config import get_settings
-from app_server.db import delete_installation, upsert_installation
+from app_server.db import purge_installation_data, upsert_installation
 from app_server.github_auth import generate_app_jwt, get_installation_token
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,13 @@ async def handle_installation_event(
     account_login = installation["account"]["login"]
 
     if event_name == "installation" and action == "deleted":
-        await delete_installation(pool, installation_id)
+        # Uninstalling is a deletion request like any other - it goes
+        # through the same purge as the dashboard button so it clears the
+        # user-scoped email/session rows too, and lands in the same audit
+        # log. A bare DELETE here would leave those behind.
+        sender = payload.get("sender") or {}
+        actor = sender.get("login") or "github:installation.deleted"
+        await purge_installation_data(pool, installation_id, actor)
         return
 
     await upsert_installation(pool, installation_id, account_login)

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -5,8 +5,10 @@ from fastapi import APIRouter, Request, Response
 from app_server.config import get_settings
 from app_server.db import (
     add_paddle_ids_to_installation,
+    claim_webhook_delivery,
     get_installation,
     list_installation_member_emails,
+    release_webhook_delivery,
     set_extra_seats,
     set_installation_plan,
 )
@@ -184,6 +186,32 @@ async def handle_paddle_webhook(request: Request) -> Response:
     if not isinstance(payload, dict):
         return Response(status_code=401)
 
-    await handle_paddle_webhook_event(payload, request.app.state.db_pool, settings.redis_url)
+    # Claimed after signature and IP verification, so an unauthenticated
+    # caller can't burn an event id and suppress the genuine delivery.
+    #
+    # The signature's own 5s timestamp tolerance already makes captured
+    # payload replay a narrow window. This is here for concurrency:
+    # handle_paddle_webhook_event reads installations.plan, then writes it,
+    # and gates a pair of expensive full AIRview/Docs builds on that read
+    # having been "free". Two deliveries of the same event arriving together
+    # both read "free" and both enqueue those builds - real duplicated LLM
+    # spend. The claim is what makes that gate hold under concurrency.
+    event_id = payload.get("event_id")
+    if not isinstance(event_id, str) or not event_id:
+        logger.warning("paddle webhook missing event_id, refusing to process undedupable event")
+        return Response(status_code=400)
+
+    pool = request.app.state.db_pool
+    if not await claim_webhook_delivery(pool, "paddle", event_id, payload.get("event_type") or ""):
+        logger.info("duplicate paddle webhook %s ignored", event_id)
+        return Response(status_code=200)
+
+    try:
+        await handle_paddle_webhook_event(payload, pool, settings.redis_url)
+    except Exception:
+        # Hand the id back before failing, or Paddle's retry of this same
+        # event would be discarded as a duplicate and the plan change lost.
+        await release_webhook_delivery(pool, "paddle", event_id)
+        raise
 
     return Response(status_code=200)

--- a/github-app/migrations/035_data_deletion_log.sql
+++ b/github-app/migrations/035_data_deletion_log.sql
@@ -1,0 +1,22 @@
+-- Audit trail for customer data deletion.
+--
+-- installation_id is deliberately a bare BIGINT with no REFERENCES
+-- installations(installation_id): every other installation-scoped table
+-- cascades on delete, and a cascading FK here would destroy the record of
+-- the deletion as part of the very deletion it exists to document.
+--
+-- This table is therefore never truncated by an installation purge, and is
+-- the one place where an account_login outlives the account. That is the
+-- point - "we deleted everything and kept no proof" is not an audit trail.
+CREATE TABLE IF NOT EXISTS data_deletion_log (
+    id               BIGSERIAL PRIMARY KEY,
+    installation_id  BIGINT NOT NULL,
+    account_login    TEXT NOT NULL,
+    actor_login      TEXT NOT NULL,
+    repos_deleted    INT NOT NULL DEFAULT 0,
+    users_purged     INT NOT NULL DEFAULT 0,
+    deleted_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS data_deletion_log_installation_idx
+    ON data_deletion_log (installation_id, deleted_at DESC);

--- a/github-app/migrations/036_webhook_deliveries.sql
+++ b/github-app/migrations/036_webhook_deliveries.sql
@@ -1,0 +1,33 @@
+-- Replay/duplicate protection for inbound webhooks, GitHub and Paddle both.
+--
+-- GitHub: every delivery carries an X-GitHub-Delivery GUID. Automatic
+-- retries reuse it; a manual "Redeliver" from the GitHub UI mints a new
+-- one. Keying on it gives exactly the semantics wanted - retries and
+-- captured-payload replays are suppressed, while a deliberate operator
+-- redelivery still runs. GitHub signatures carry no timestamp, so this
+-- ledger is the only replay protection that path has.
+--
+-- Paddle: signatures already embed a timestamp checked to a 5s tolerance,
+-- so replay is largely closed there. The claim exists for concurrency
+-- instead: handle_paddle_webhook_event reads installations.plan and then
+-- writes it, and gates a pair of expensive full AIRview/Docs builds on that
+-- read. Two concurrent deliveries of one event both see plan == 'free' and
+-- both enqueue those builds. An atomic claim is what makes that gate hold.
+--
+-- (source, delivery_id) is the primary key so the claim can be a single
+-- atomic INSERT ... ON CONFLICT DO NOTHING - two concurrent deliveries of
+-- the same event cannot both win it. source keeps GitHub GUIDs and Paddle
+-- event ids in separate namespaces rather than trusting them never to
+-- collide.
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    source       TEXT NOT NULL,
+    delivery_id  TEXT NOT NULL,
+    event        TEXT NOT NULL,
+    received_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (source, delivery_id)
+);
+
+-- Supports the retention sweep's range delete only; the dedupe lookup
+-- itself rides the primary key.
+CREATE INDEX IF NOT EXISTS webhook_deliveries_received_at_idx
+    ON webhook_deliveries (received_at);

--- a/github-app/migrations/037_llm_suggestions_setting.sql
+++ b/github-app/migrations/037_llm_suggestions_setting.sql
@@ -1,0 +1,14 @@
+-- Customer control over the one part of a managed audit that is not
+-- evidence-backed.
+--
+-- Aletheore's core promise is "no claim without evidence". The LLM suggestion
+-- section (scan_worker/managed_audit.py) is the single deliberate exception:
+-- a model's own rating and improvement ideas, clearly labeled, appended after
+-- the cited findings. It has always been well separated visually, but there
+-- was no way to decline it - a customer who bought the evidence-first promise
+-- had that section in every signed report whether they wanted it or not.
+--
+-- Defaults to true, preserving existing behavior: this adds a switch, it does
+-- not silently withdraw a feature paying installations already receive.
+ALTER TABLE installations
+    ADD COLUMN IF NOT EXISTS llm_suggestions_enabled BOOLEAN NOT NULL DEFAULT true;

--- a/github-app/migrations/038_installation_access_log.sql
+++ b/github-app/migrations/038_installation_access_log.sql
@@ -1,0 +1,28 @@
+-- Durable, plan-independent record of every github_login that has ever
+-- passed _require_authorized_installation for a given installation.
+--
+-- installation_members alone is not enough for this: it's only ever
+-- populated for paid-plan seat holders (_require_seat_if_paid skips free
+-- plans entirely, by design - there's no seat revenue to protect there).
+-- github_user_emails and sessions are captured on login independent of
+-- plan or seat status, so a free-plan installation's real users have real
+-- PII with nothing in installation_members to find them by. This table is
+-- purge_installation_data's actual source of truth for "who might have PII
+-- tied to this installation" - installation_members remains exactly what
+-- it was, seat/billing bookkeeping, untouched by this table's existence.
+--
+-- ON DELETE CASCADE mirrors installation_members: rows for an installation
+-- are read here (for the purge's membership list) before the cascade
+-- removes them, same ordering purge_installation_data already relies on.
+CREATE TABLE IF NOT EXISTS installation_access_log (
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    github_login     TEXT NOT NULL,
+    first_seen_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (installation_id, github_login)
+);
+
+-- Supports "does this login still have access to any *other* installation"
+-- during a purge - a lookup by github_login alone, across all installations.
+CREATE INDEX IF NOT EXISTS installation_access_log_login_idx
+    ON installation_access_log (github_login);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -334,7 +334,8 @@ def get_installation(dsn: str, installation_id: int) -> dict | None:
             cur.execute(
                 """
                 SELECT installation_id, account_login, plan, webhook_url,
-                       health_check_base_url, health_check_latency_threshold_ms
+                       health_check_base_url, health_check_latency_threshold_ms,
+                       llm_suggestions_enabled
                 FROM installations
                 WHERE installation_id = %s
                 """,
@@ -539,6 +540,28 @@ def insert_endpoint_health(
                 (installation_id, repo_full_name, method, path, target_id, keep),
             )
         conn.commit()
+
+
+def delete_expired_webhook_deliveries(dsn: str, retention_days: int) -> int:
+    """Drop delivery GUIDs older than the retention window.
+
+    The window has to outlive GitHub's own redelivery horizon, or an
+    operator redelivering an old event - or an attacker replaying a captured
+    payload - would find the ledger already swept and the delivery treated
+    as new. GitHub keeps delivery logs for roughly 30 days, so the default
+    matches that rather than the ~3-day automatic retry window.
+    """
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM webhook_deliveries WHERE received_at < now() - make_interval(days => %s)",
+                (retention_days,),
+            )
+            deleted = cur.rowcount
+        conn.commit()
+    return deleted
 
 
 def delete_expired_sessions(dsn: str) -> int:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -51,6 +51,7 @@ from scan_worker.db import (
     count_repo_scans_since,
     delete_docs_symbols_not_in,
     delete_expired_sessions,
+    delete_expired_webhook_deliveries,
     delete_wiki_subsystems_not_in,
     email_already_sent,
     get_dismissed_identity_keys,
@@ -1037,6 +1038,12 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
     plan = installation["plan"] if installation is not None else "air"
+    # Read off the row already fetched rather than a second query. Defaults to
+    # on for a missing row or an older row, matching the column default - a
+    # lookup miss must not silently change what a customer's report contains.
+    include_suggestions = (
+        installation.get("llm_suggestions_enabled", True) if installation is not None else True
+    )
 
     if plan != "free" and not check_and_reserve_monthly_repo_scan_slot(
         settings.database_url, installation_id, repo_full_name, MAX_SCANNED_REPOS_PER_MONTH
@@ -1081,7 +1088,12 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                             spend_accumulator["model"], prompt_tokens, completion_tokens
                         )
 
-                    report_text = run_managed_audit(repo_dir, on_usage=_on_usage, plan=plan)
+                    report_text = run_managed_audit(
+                        repo_dir,
+                        on_usage=_on_usage,
+                        plan=plan,
+                        include_llm_suggestions=include_suggestions,
+                    )
                     record_llm_spend(
                         settings.database_url, installation_id, spend_accumulator["total"]
                     )
@@ -1132,6 +1144,12 @@ def run_managed_audit_api_job(
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
     plan = installation["plan"] if installation is not None else "air"
+    # Read off the row already fetched rather than a second query. Defaults to
+    # on for a missing row or an older row, matching the column default - a
+    # lookup miss must not silently change what a customer's report contains.
+    include_suggestions = (
+        installation.get("llm_suggestions_enabled", True) if installation is not None else True
+    )
     with installation_spend_lock(settings.database_url, installation_id):
         extra_seats = get_extra_seats(settings.database_url, installation_id)
         monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
@@ -1157,7 +1175,12 @@ def run_managed_audit_api_job(
                     spend_accumulator["model"], prompt_tokens, completion_tokens
                 )
 
-            result = run_managed_audit(job_dir, on_usage=_on_usage, plan=plan)
+            result = run_managed_audit(
+                job_dir,
+                on_usage=_on_usage,
+                plan=plan,
+                include_llm_suggestions=include_suggestions,
+            )
             record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
             verification_token = _sign_and_persist_audit_report(
                 settings,
@@ -1882,6 +1905,21 @@ def run_session_cleanup_job() -> None:
     deleted = delete_expired_sessions(dsn)
     logging.getLogger("scan_worker.jobs").info(
         "session cleanup completed", extra={"deleted_count": deleted}
+    )
+
+
+# Matches GitHub's own ~30-day delivery-log horizon, so a redelivered or
+# replayed event can never outlive its ledger entry. See
+# delete_expired_webhook_deliveries.
+WEBHOOK_DELIVERY_RETENTION_DAYS = 30
+
+
+@log_job
+def run_webhook_delivery_cleanup_job() -> None:
+    dsn = get_settings().database_url
+    deleted = delete_expired_webhook_deliveries(dsn, WEBHOOK_DELIVERY_RETENTION_DAYS)
+    logging.getLogger("scan_worker.jobs").info(
+        "webhook delivery cleanup completed", extra={"deleted_count": deleted}
     )
 
 

--- a/github-app/scan_worker/managed_audit.py
+++ b/github-app/scan_worker/managed_audit.py
@@ -6,6 +6,7 @@ from typing import Callable
 import aletheore.cli as _aletheore_cli
 from aletheore.citation_verifier import citation_verification_section as _citation_verification_section
 from aletheore.report import run_reasoning_phase
+from app_server.audit_signing import LLM_SUGGESTION_HEADING
 from scan_worker.model_tiers import writing_adapter_for_plan
 
 logger = logging.getLogger("scan_worker.managed_audit")
@@ -44,7 +45,7 @@ def _llm_based_suggestion_section(
         return None
 
     lines = [
-        "\n\n---\n\n## LLM Based Suggestion (Not Evidence Backed)\n",
+        f"\n\n---\n\n{LLM_SUGGESTION_HEADING}\n",
         "_Everything above is Aletheore's deterministic, evidence-grounded audit. "
         "The section below is the model's own broader judgment, not tied to a specific "
         "citation - treat it as a second opinion, not a finding._\n",
@@ -60,6 +61,7 @@ def run_managed_audit(
     plan: str,
     manual_dir: str | None = None,
     on_usage: Callable[[int, int], None] | None = None,
+    include_llm_suggestions: bool = True,
 ) -> str:
     adapter = writing_adapter_for_plan(plan, on_usage=on_usage)
     report_path = run_reasoning_phase(
@@ -75,7 +77,12 @@ def run_managed_audit(
     # here would be measuring the wrong thing.
     report_text += _citation_verification_section(report_text, repo_path)
 
-    suggestion_section = _llm_based_suggestion_section(report_text, plan, on_usage=on_usage)
-    if suggestion_section:
-        report_text += suggestion_section
+    # Skipped entirely rather than generated-and-discarded when the
+    # installation has opted out: this is a billed model call, and a customer
+    # who turned the section off should not be paying for it against their
+    # monthly LLM spend cap.
+    if include_llm_suggestions:
+        suggestion_section = _llm_based_suggestion_section(report_text, plan, on_usage=on_usage)
+        if suggestion_section:
+            report_text += suggestion_section
     return report_text

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -16,6 +16,12 @@ HEALTH_SWEEP_INTERVAL_SECONDS = 180
 HEALTH_SWEEP_JOB_TIMEOUT_SECONDS = 600
 # A single indexed DELETE against a small table - generous but bounded.
 SESSION_CLEANUP_JOB_TIMEOUT_SECONDS = 60
+# Same shape as the session cleanup: one range DELETE over an index on
+# webhook_deliveries.received_at. Runs on every tick, which is far more
+# often than a 30-day retention window needs, but it costs a no-op query
+# and means the table can never quietly grow unbounded if the scheduler
+# spends a long stretch restarting.
+WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # The sweep itself only calls run_live_docs_full_build_job for repos that
 # list_paid_repos_due_for_docs_catchup already filtered to "genuinely due"
 # (48h+ since last sweep, real activity since then) - most ticks this
@@ -66,6 +72,10 @@ def run_forever(
         scans_queue.enqueue(
             "scan_worker.jobs.run_session_cleanup_job",
             job_timeout=SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
+        )
+        scans_queue.enqueue(
+            "scan_worker.jobs.run_webhook_delivery_cleanup_job",
+            job_timeout=WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS,
         )
         scans_queue.enqueue(
             "scan_worker.jobs.run_live_docs_catchup_sweep_job",

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -40,9 +40,14 @@ async def pool():
         migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
         for migration in sorted(migrations_dir.glob("*.sql")):
             await conn.execute(migration.read_text())
+        # data_deletion_log and webhook_deliveries are listed explicitly
+        # because neither has an FK to installations (see
+        # 035_data_deletion_log.sql and 036_webhook_deliveries.sql) - the
+        # CASCADE from installations doesn't reach them, so without this
+        # their rows would leak from one test into the next.
         await conn.execute(
             "TRUNCATE installations, sessions, demo_scan_rate_limits, cli_telemetry_events, "
-            "github_user_emails, sent_emails CASCADE"
+            "github_user_emails, sent_emails, data_deletion_log, webhook_deliveries CASCADE"
         )
     yield p
     await p.close()

--- a/github-app/tests/test_data_deletion.py
+++ b/github-app/tests/test_data_deletion.py
@@ -1,0 +1,333 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app_server.auth import encrypt_access_token
+from app_server.db import (
+    add_installation_member,
+    create_session,
+    get_installation,
+    get_session,
+    insert_repo_history,
+    purge_installation_data,
+    record_installation_access,
+    set_installation_plan,
+    upsert_installation,
+)
+from app_server.webhooks.installation import handle_installation_event
+from test_admin import _logged_in_client
+
+
+async def _seed_installation(pool, installation_id, account_login, repo_full_name):
+    await upsert_installation(pool, installation_id, account_login)
+    await insert_repo_history(
+        pool,
+        installation_id,
+        repo_full_name,
+        datetime.now(timezone.utc),
+        {"scanned_at": "x"},
+    )
+
+
+async def _seed_user(pool, session_id, login, email, user_id=1):
+    await create_session(
+        pool,
+        session_id,
+        user_id,
+        login,
+        encrypt_access_token("gho_faketoken", "test-session-secret"),
+        datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ($1, $2) "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email",
+        login,
+        email,
+    )
+
+
+@pytest.mark.asyncio
+async def test_purge_removes_installation_and_cascading_evidence(pool):
+    await _seed_installation(pool, 900, "acme", "acme/api")
+
+    result = await purge_installation_data(pool, 900, "octocat")
+
+    assert result["repos_deleted"] == 1
+    assert await get_installation(pool, 900) is None
+    remaining = await pool.fetchval(
+        "SELECT count(*) FROM repo_history WHERE installation_id = 900"
+    )
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_purge_writes_audit_row_that_survives_its_own_deletion(pool):
+    await _seed_installation(pool, 901, "acme", "acme/api")
+
+    await purge_installation_data(pool, 901, "octocat")
+
+    row = await pool.fetchrow(
+        "SELECT * FROM data_deletion_log WHERE installation_id = 901"
+    )
+    assert row is not None, "audit row cascaded away with the installation it documents"
+    assert row["account_login"] == "acme"
+    assert row["actor_login"] == "octocat"
+    assert row["repos_deleted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_purge_clears_email_and_session_of_orphaned_member(pool):
+    await _seed_installation(pool, 902, "acme", "acme/api")
+    await record_installation_access(pool, 902, "solo-dev")
+    await _seed_user(pool, "sess-solo", "solo-dev", "solo@example.com")
+
+    result = await purge_installation_data(pool, 902, "solo-dev")
+
+    assert result["users_purged"] == 1
+    assert await get_session(pool, "sess-solo") is None
+    email = await pool.fetchval(
+        "SELECT email FROM github_user_emails WHERE github_login = 'solo-dev'"
+    )
+    assert email is None, "PII survived a full deletion"
+
+
+@pytest.mark.asyncio
+async def test_purge_clears_pii_of_free_plan_member_with_no_seat(pool):
+    # The bug this regression-guards: installation_members is only ever
+    # populated for paid-plan seat holders (_require_seat_if_paid skips
+    # free plans entirely), so a purge that read membership from that table
+    # alone would silently leave a free-plan user's email and session
+    # behind forever. installation_access_log is plan-independent and
+    # deliberately has zero installation_members involvement here.
+    await _seed_installation(pool, 907, "acme", "acme/api")
+    await set_installation_plan(pool, 907, "free")
+    await record_installation_access(pool, 907, "free-plan-dev")
+    await _seed_user(pool, "sess-free", "free-plan-dev", "free-dev@example.com")
+
+    members = await pool.fetchval(
+        "SELECT count(*) FROM installation_members WHERE installation_id = 907"
+    )
+    assert members == 0, "test setup should not touch installation_members"
+
+    result = await purge_installation_data(pool, 907, "free-plan-dev")
+
+    assert result["users_purged"] == 1
+    assert await get_session(pool, "sess-free") is None
+    email = await pool.fetchval(
+        "SELECT email FROM github_user_emails WHERE github_login = 'free-plan-dev'"
+    )
+    assert email is None, "free-plan PII survived a full deletion"
+
+
+@pytest.mark.asyncio
+async def test_purge_keeps_member_who_belongs_to_another_installation(pool):
+    await _seed_installation(pool, 903, "acme", "acme/api")
+    await _seed_installation(pool, 904, "globex", "globex/web")
+    await record_installation_access(pool, 903, "two-orgs")
+    await record_installation_access(pool, 904, "two-orgs")
+    await _seed_user(pool, "sess-two", "two-orgs", "two@example.com")
+
+    result = await purge_installation_data(pool, 903, "two-orgs")
+
+    assert result["users_purged"] == 0
+    assert await get_session(pool, "sess-two") is not None, "logged out of an unrelated org"
+    email = await pool.fetchval(
+        "SELECT email FROM github_user_emails WHERE github_login = 'two-orgs'"
+    )
+    assert email == "two@example.com"
+
+
+@pytest.mark.asyncio
+async def test_record_installation_access_upsert_is_idempotent(pool):
+    await _seed_installation(pool, 908, "acme", "acme/api")
+
+    await record_installation_access(pool, 908, "solo-dev")
+    first = await pool.fetchrow(
+        "SELECT first_seen_at, last_seen_at FROM installation_access_log "
+        "WHERE installation_id = 908 AND github_login = 'solo-dev'"
+    )
+    await record_installation_access(pool, 908, "solo-dev")
+    second = await pool.fetchrow(
+        "SELECT first_seen_at, last_seen_at FROM installation_access_log "
+        "WHERE installation_id = 908 AND github_login = 'solo-dev'"
+    )
+
+    count = await pool.fetchval(
+        "SELECT count(*) FROM installation_access_log WHERE installation_id = 908"
+    )
+    assert count == 1, "a second visit should update the row, not duplicate it"
+    assert second["first_seen_at"] == first["first_seen_at"]
+    assert second["last_seen_at"] >= first["last_seen_at"]
+
+
+@pytest.mark.asyncio
+async def test_purge_of_unknown_installation_is_a_no_op(pool):
+    assert await purge_installation_data(pool, 999_999, "octocat") is None
+    logged = await pool.fetchval(
+        "SELECT count(*) FROM data_deletion_log WHERE installation_id = 999999"
+    )
+    assert logged == 0
+
+
+@pytest.mark.asyncio
+async def test_uninstall_webhook_purges_user_rows_too(pool):
+    await _seed_installation(pool, 905, "acme", "acme/api")
+    await record_installation_access(pool, 905, "solo-dev")
+    await _seed_user(pool, "sess-uninstall", "solo-dev", "solo@example.com")
+
+    payload = {
+        "action": "deleted",
+        "installation": {"id": 905, "account": {"login": "acme"}},
+        "sender": {"login": "solo-dev"},
+    }
+    await handle_installation_event("installation", payload, pool, "redis://unused")
+
+    assert await get_installation(pool, 905) is None
+    assert await get_session(pool, "sess-uninstall") is None
+    row = await pool.fetchrow(
+        "SELECT actor_login FROM data_deletion_log WHERE installation_id = 905"
+    )
+    assert row["actor_login"] == "solo-dev"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data_route_purges_on_correct_confirmation(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post(
+            "/admin/octocat/hello-world/delete-all-data",
+            json={"confirm": "octocat"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+    assert await get_installation(pool, 100) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data_route_rejects_wrong_confirmation(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post(
+            "/admin/octocat/hello-world/delete-all-data",
+            json={"confirm": "hello-world"},
+        )
+
+    assert response.status_code == 400
+    assert await get_installation(pool, 100) is not None, "deleted without confirmation"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data_route_works_on_the_free_plan(pool, monkeypatch):
+    # A free-plan customer must still be able to erase their data - gating
+    # this route behind a paid plan would be indefensible. This also
+    # regression-guards the original bug: a free-plan requester is never a
+    # row in installation_members (_require_seat_if_paid skips free plans),
+    # so if the route's purge fell back to reading membership from that
+    # table, this would report success while leaving the caller's own
+    # email and session behind.
+    client = await _logged_in_client(pool, monkeypatch, plan="free")
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
+    async with client:
+        response = await client.post(
+            "/admin/octocat/hello-world/delete-all-data",
+            json={"confirm": "octocat"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert await get_installation(pool, 100) is None
+    assert await get_session(pool, "sess-1") is None, "free-plan requester's own session survived"
+    email = await pool.fetchval(
+        "SELECT email FROM github_user_emails WHERE github_login = 'octocat'"
+    )
+    assert email is None, "free-plan requester's own email survived"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data_route_rejects_non_administrator(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, installation_id=100)
+    # A second installation this session does not administer - the mocked
+    # GitHub /user/installations response only ever returns id 100.
+    await _seed_installation(pool, 101, "globex", "globex/web")
+    async with client:
+        response = await client.post(
+            "/admin/globex/web/delete-all-data",
+            json={"confirm": "globex"},
+        )
+
+    assert response.status_code == 403
+    assert await get_installation(pool, 101) is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data_route_requires_login(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        client.cookies.clear()
+        response = await client.post(
+            "/admin/octocat/hello-world/delete-all-data",
+            json={"confirm": "octocat"},
+        )
+
+    assert response.status_code == 401
+    assert await get_installation(pool, 100) is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data_route_404s_if_installation_vanishes_mid_request(pool, monkeypatch):
+    # Concurrent uninstall: authorization passed, but the row is gone by the
+    # time the purge runs. Must not report success for a delete that no-oped.
+    client = await _logged_in_client(pool, monkeypatch)
+
+    async def _already_gone(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app_server.admin.purge_installation_data", _already_gone)
+    async with client:
+        response = await client.post(
+            "/admin/octocat/hello-world/delete-all-data",
+            json={"confirm": "octocat"},
+        )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_deletion_preview_names_every_repo_in_the_installation(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    await insert_repo_history(
+        pool, 100, "octocat/second-repo", datetime.now(timezone.utc), {"scanned_at": "x"}
+    )
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/deletion-preview")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["account_login"] == "octocat"
+    # The blast radius is installation-wide, so a repo the user isn't
+    # looking at must still be named in the confirmation.
+    assert "octocat/second-repo" in body["repos"]
+
+
+@pytest.mark.asyncio
+async def test_purge_leaves_no_installation_scoped_rows_behind(pool, monkeypatch):
+    await _seed_installation(pool, 906, "acme", "acme/api")
+    await set_installation_plan(pool, 906, "air")
+    await add_installation_member(pool, 906, "solo-dev", "solo-dev")
+    await record_installation_access(pool, 906, "solo-dev")
+
+    await purge_installation_data(pool, 906, "solo-dev")
+
+    for table in (
+        "repo_history",
+        "installation_members",
+        "installation_access_log",
+        "monthly_scanned_repos",
+    ):
+        remaining = await pool.fetchval(
+            f"SELECT count(*) FROM {table} WHERE installation_id = 906"  # noqa: S608
+        )
+        assert remaining == 0, f"{table} survived the cascade"

--- a/github-app/tests/test_llm_suggestion_opt_out.py
+++ b/github-app/tests/test_llm_suggestion_opt_out.py
@@ -1,0 +1,219 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from app_server.audit_signing import (
+    LLM_SUGGESTION_HEADING,
+    contains_non_evidence_backed_section,
+)
+from app_server.db import get_installation, set_llm_suggestions_enabled, upsert_installation
+from scan_worker.db import get_installation as get_installation_row
+from test_admin import _logged_in_client
+
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://postgres:test@localhost:55433/aletheore_test",
+)
+
+EVIDENCE_BACKED_REPORT = "# Audit\n\n- finding, see `app.py:12`\n"
+
+
+# --- The setting -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_suggestions_are_on_by_default(pool):
+    # This adds a switch; it must not silently withdraw a section paying
+    # installations already receive.
+    await upsert_installation(pool, 900, "acme")
+
+    assert (await get_installation(pool, 900))["llm_suggestions_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_the_setting_round_trips(pool):
+    await upsert_installation(pool, 901, "acme")
+
+    await set_llm_suggestions_enabled(pool, 901, False)
+    assert (await get_installation(pool, 901))["llm_suggestions_enabled"] is False
+
+    await set_llm_suggestions_enabled(pool, 901, True)
+    assert (await get_installation(pool, 901))["llm_suggestions_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_the_worker_reads_the_same_setting(pool):
+    # app_server writes it with asyncpg, the worker reads it with psycopg -
+    # two different drivers against one column, so this pins that they agree.
+    # The worker reads it off the installation row it already fetches rather
+    # than issuing a second query.
+    await upsert_installation(pool, 902, "acme")
+    await set_llm_suggestions_enabled(pool, 902, False)
+
+    row = get_installation_row(TEST_DATABASE_URL, 902)
+    assert row["llm_suggestions_enabled"] is False
+
+
+def test_the_worker_sees_nothing_for_an_unknown_installation():
+    # jobs.py treats a missing row as "enabled", matching the column default -
+    # a lookup miss must not quietly change what a report contains.
+    assert get_installation_row(TEST_DATABASE_URL, 999_999) is None
+
+
+# --- The audit honours it ----------------------------------------------------
+
+
+def _run_audit(monkeypatch, tmp_path, *, include: bool):
+    import scan_worker.managed_audit as managed_audit
+
+    report_path = tmp_path / "report.md"
+    report_path.write_text(EVIDENCE_BACKED_REPORT)
+
+    monkeypatch.setattr(managed_audit, "run_reasoning_phase", lambda *a, **k: str(report_path))
+    monkeypatch.setattr(managed_audit, "_citation_verification_section", lambda *a, **k: "")
+    monkeypatch.setattr(
+        managed_audit, "writing_adapter_for_plan", lambda *a, **k: MagicMock()
+    )
+    calls = []
+
+    def fake_section(report_text, plan, on_usage=None):
+        calls.append(report_text)
+        return f"\n\n---\n\n{LLM_SUGGESTION_HEADING}\n\n**Overall rating: 7/10**\n"
+
+    monkeypatch.setattr(managed_audit, "_llm_based_suggestion_section", fake_section)
+
+    text = managed_audit.run_managed_audit(
+        tmp_path, plan="air", include_llm_suggestions=include
+    )
+    return text, calls
+
+
+def test_opting_out_produces_a_fully_evidence_backed_report(monkeypatch, tmp_path):
+    text, _ = _run_audit(monkeypatch, tmp_path, include=False)
+
+    assert LLM_SUGGESTION_HEADING not in text
+    assert contains_non_evidence_backed_section(text) is False
+    assert "finding, see" in text  # the real audit survives
+
+
+def test_opting_out_does_not_spend_on_the_model_call(monkeypatch, tmp_path):
+    # Generating-then-discarding would bill the customer's monthly LLM cap for
+    # a section they turned off.
+    _text, calls = _run_audit(monkeypatch, tmp_path, include=False)
+
+    assert calls == []
+
+
+def test_leaving_it_on_still_appends_the_section(monkeypatch, tmp_path):
+    text, calls = _run_audit(monkeypatch, tmp_path, include=True)
+
+    assert LLM_SUGGESTION_HEADING in text
+    assert len(calls) == 1
+
+
+def test_the_heading_constant_matches_what_the_writer_emits(monkeypatch, tmp_path):
+    """The verifier detects the section by this exact string. If the writer's
+    heading and the shared constant ever drift, the certificate would silently
+    start reporting opinion-bearing reports as fully evidence-backed.
+    """
+    import scan_worker.managed_audit as managed_audit
+
+    monkeypatch.setattr(
+        managed_audit, "writing_adapter_for_plan", lambda *a, **k: MagicMock()
+    )
+    monkeypatch.setattr(
+        managed_audit.json,
+        "loads",
+        lambda _raw: {"rating": 7, "rating_justification": "ok", "suggestions": ["do a thing"]},
+    )
+
+    section = managed_audit._llm_based_suggestion_section("report", "air")
+
+    assert contains_non_evidence_backed_section(section)
+
+
+# --- The certificate discloses it -------------------------------------------
+
+
+def test_detector_is_false_for_a_purely_evidence_backed_report():
+    assert contains_non_evidence_backed_section(EVIDENCE_BACKED_REPORT) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_reports_a_clean_audit_as_fully_evidence_backed(pool, monkeypatch):
+    body = await _verify_body(pool, monkeypatch, EVIDENCE_BACKED_REPORT, token="tok-clean")
+
+    assert body["fully_evidence_backed"] is True
+    assert body["non_evidence_backed_sections"] == []
+
+
+@pytest.mark.asyncio
+async def test_verify_discloses_the_opinion_section_when_present(pool, monkeypatch):
+    # The point of the whole change: a signature proves Aletheore wrote this
+    # text, not that every claim in it is cited. The certificate must not let
+    # a reader conflate the two.
+    report = EVIDENCE_BACKED_REPORT + f"\n\n---\n\n{LLM_SUGGESTION_HEADING}\n\n**Overall rating: 7/10**\n"
+    body = await _verify_body(pool, monkeypatch, report, token="tok-opinion")
+
+    assert body["verified"] is True
+    assert body["fully_evidence_backed"] is False
+    assert body["non_evidence_backed_sections"] == ["LLM Based Suggestion (Not Evidence Backed)"]
+
+
+async def _verify_body(pool, monkeypatch, report_text: str, token: str) -> dict:
+    from httpx import ASGITransport, AsyncClient
+
+    from app_server.audit_signing import content_hash, sign_report
+    from app_server.main import app
+
+    private_key = "11" * 32
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", private_key)
+    app.state.db_pool = pool
+    await upsert_installation(pool, 910, "acme")
+    await pool.execute(
+        """
+        INSERT INTO audit_reports
+            (installation_id, repo_full_name, report_text, content_hash, signature, verification_token)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        """,
+        910,
+        "acme/api",
+        report_text,
+        content_hash(report_text),
+        sign_report(report_text, private_key),
+        token,
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/v1/audit/{token}/verify")
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+# --- The admin route ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_route_toggles_the_setting(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/llm-suggestions", json={"enabled": False}
+        )
+
+    assert response.status_code == 200, response.text
+    assert (await get_installation(pool, 100))["llm_suggestions_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_admin_route_rejects_a_non_administrator(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, installation_id=100)
+    await upsert_installation(pool, 101, "globex")
+    async with client:
+        response = await client.put(
+            "/admin/globex/web/llm-suggestions", json={"enabled": False}
+        )
+
+    assert response.status_code in (403, 404)
+    assert (await get_installation(pool, 101))["llm_suggestions_enabled"] is True

--- a/github-app/tests/test_main.py
+++ b/github-app/tests/test_main.py
@@ -32,8 +32,8 @@ async def test_webhook_rejects_invalid_signature():
 
 
 @pytest.mark.asyncio
-async def test_webhook_dispatches_pull_request_enqueue(monkeypatch):
-    app.state.db_pool = object()
+async def test_webhook_dispatches_pull_request_enqueue(monkeypatch, pool):
+    app.state.db_pool = pool
     payload = {
         "action": "opened",
         "number": 9,
@@ -58,6 +58,7 @@ async def test_webhook_dispatches_pull_request_enqueue(monkeypatch):
             headers={
                 "X-Hub-Signature-256": _signature(body, settings.github_webhook_secret),
                 "X-GitHub-Event": "pull_request",
+                "X-GitHub-Delivery": "delivery-pr-1",
             },
         )
 
@@ -67,8 +68,8 @@ async def test_webhook_dispatches_pull_request_enqueue(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_webhook_dispatches_push_enqueue(monkeypatch):
-    app.state.db_pool = object()
+async def test_webhook_dispatches_push_enqueue(monkeypatch, pool):
+    app.state.db_pool = pool
     payload = {
         "ref": "refs/heads/main",
         "after": "def456",
@@ -93,6 +94,7 @@ async def test_webhook_dispatches_push_enqueue(monkeypatch):
             headers={
                 "X-Hub-Signature-256": _signature(body, settings.github_webhook_secret),
                 "X-GitHub-Event": "push",
+                "X-GitHub-Delivery": "delivery-push-1",
             },
         )
 
@@ -178,6 +180,11 @@ async def test_unhandled_exception_returns_generic_500_and_alerts(monkeypatch):
             headers={
                 "X-Hub-Signature-256": _signature(body, settings.github_webhook_secret),
                 "X-GitHub-Event": "installation",
+                # Present so the request gets past the delivery-header check
+                # and fails where this test intends: parsing the body. The
+                # pool stub is never touched, since parsing precedes the
+                # delivery claim.
+                "X-GitHub-Delivery": "delivery-malformed-1",
             },
         )
 

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -13,6 +13,7 @@ from scan_worker.db import (
     count_repo_scans_since,
     delete_docs_symbols_not_in,
     delete_expired_sessions,
+    delete_expired_webhook_deliveries,
     delete_wiki_subsystems_not_in,
     email_already_sent,
     get_dismissed_identity_keys,
@@ -279,6 +280,31 @@ async def test_delete_expired_sessions_removes_only_expired_rows(pool):
     assert deleted == 1
     remaining = await pool.fetch("SELECT id FROM sessions")
     assert {row["id"] for row in remaining} == {"active-session"}
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_webhook_deliveries_keeps_rows_inside_the_window(pool):
+    now = datetime.now(timezone.utc)
+    await pool.execute(
+        "INSERT INTO webhook_deliveries (source, delivery_id, event, received_at) "
+        "VALUES ('github', $1, $2, $3)",
+        "old-delivery",
+        "push",
+        now - timedelta(days=31),
+    )
+    await pool.execute(
+        "INSERT INTO webhook_deliveries (source, delivery_id, event, received_at) "
+        "VALUES ('github', $1, $2, $3)",
+        "recent-delivery",
+        "push",
+        now - timedelta(days=29),
+    )
+
+    deleted = delete_expired_webhook_deliveries(TEST_DATABASE_URL, 30)
+
+    assert deleted == 1
+    remaining = await pool.fetch("SELECT delivery_id FROM webhook_deliveries")
+    assert {row["delivery_id"] for row in remaining} == {"recent-delivery"}
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import MagicMock
 
 from scan_worker.scheduler import (
@@ -7,6 +8,7 @@ from scan_worker.scheduler import (
     HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS,
     SCANS_QUEUE_NAME,
     SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
+    WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS,
     WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
     WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
     run_forever,
@@ -26,7 +28,17 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
     monkeypatch.setattr("scan_worker.scheduler.Queue", _fake_queue)
     monkeypatch.setattr("scan_worker.scheduler.Redis.from_url", lambda url: MagicMock())
     sleeps = []
-    monkeypatch.setattr("scan_worker.scheduler.time.sleep", lambda seconds: sleeps.append(seconds))
+
+    def _record_main_thread_sleep(seconds):
+        # scan_worker.scheduler.time IS the global time module, so this patch
+        # is global too - and test_heartbeat.py leaves a daemon thread
+        # sleeping on a 0.05s loop for the rest of the session. Recording
+        # only the main thread keeps this assertion about run_forever's own
+        # sleeps instead of whatever else happens to be ticking.
+        if threading.current_thread() is threading.main_thread():
+            sleeps.append(seconds)
+
+    monkeypatch.setattr("scan_worker.scheduler.time.sleep", _record_main_thread_sleep)
 
     run_forever(interval_seconds=42, max_iterations=3)
 
@@ -43,7 +55,7 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
 
-    assert scans_queue.enqueue.call_count == 15
+    assert scans_queue.enqueue.call_count == 18
     session_cleanup_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
@@ -64,11 +76,16 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_health_sweep_staleness_check_job",)
     ]
+    webhook_cleanup_calls = [
+        c for c in scans_queue.enqueue.call_args_list
+        if c.args == ("scan_worker.jobs.run_webhook_delivery_cleanup_job",)
+    ]
     assert len(session_cleanup_calls) == 3
     assert len(docs_catchup_calls) == 3
     assert len(wiki_catchup_calls) == 3
     assert len(weekly_digest_calls) == 3
     assert len(staleness_check_calls) == 3
+    assert len(webhook_cleanup_calls) == 3
     for call in session_cleanup_calls:
         assert call.kwargs == {"job_timeout": SESSION_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in docs_catchup_calls:
@@ -79,6 +96,8 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.kwargs == {"job_timeout": WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS}
     for call in staleness_check_calls:
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS}
+    for call in webhook_cleanup_calls:
+        assert call.kwargs == {"job_timeout": WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS}
     # Sleeps between iterations, not after the last one.
     assert sleeps == [42, 42]
 

--- a/github-app/tests/test_webhook_dedupe.py
+++ b/github-app/tests/test_webhook_dedupe.py
@@ -1,0 +1,192 @@
+import hashlib
+import hmac
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.db import claim_webhook_delivery, release_webhook_delivery
+from app_server.main import app, settings
+
+
+def _signature(payload: bytes, secret: str) -> str:
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _push_payload() -> bytes:
+    return json.dumps(
+        {
+            "ref": "refs/heads/main",
+            "after": "abc123",
+            "installation": {"id": 123},
+            "repository": {"full_name": "octocat/hello-world"},
+        }
+    ).encode()
+
+
+async def _post(client, body, delivery_id, event="push"):
+    headers = {
+        "X-Hub-Signature-256": _signature(body, settings.github_webhook_secret),
+        "X-GitHub-Event": event,
+    }
+    if delivery_id is not None:
+        headers["X-GitHub-Delivery"] = delivery_id
+    return await client.post("/webhook", content=body, headers=headers)
+
+
+@pytest.mark.asyncio
+async def test_claim_is_granted_once_and_refused_after(pool):
+    assert await claim_webhook_delivery(pool, "github", "d-1", "push") is True
+    assert await claim_webhook_delivery(pool, "github", "d-1", "push") is False
+
+
+@pytest.mark.asyncio
+async def test_release_lets_a_delivery_be_claimed_again(pool):
+    await claim_webhook_delivery(pool, "github", "d-2", "push")
+    await release_webhook_delivery(pool, "github", "d-2")
+
+    assert await claim_webhook_delivery(pool, "github", "d-2", "push") is True
+
+
+@pytest.mark.asyncio
+async def test_distinct_delivery_ids_are_independent(pool):
+    assert await claim_webhook_delivery(pool, "github", "d-3", "push") is True
+    assert await claim_webhook_delivery(pool, "github", "d-4", "push") is True
+
+
+@pytest.mark.asyncio
+async def test_replayed_delivery_is_not_handled_twice(pool, monkeypatch):
+    app.state.db_pool = pool
+    handled = []
+
+    async def fake_handle(payload_arg, redis_url):
+        handled.append(payload_arg)
+
+    monkeypatch.setattr("app_server.webhooks.push.handle_push_event", fake_handle)
+    body = _push_payload()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await _post(client, body, "delivery-replay-1")
+        second = await _post(client, body, "delivery-replay-1")
+
+    assert first.status_code == 200
+    assert first.json() == {"ok": True}
+    assert second.status_code == 200
+    assert second.json() == {"ok": True, "duplicate": True}
+    assert len(handled) == 1, "a replayed delivery enqueued a second scan"
+
+
+@pytest.mark.asyncio
+async def test_a_genuinely_new_delivery_still_runs(pool, monkeypatch):
+    # Redelivering from the GitHub UI mints a fresh GUID, and that is an
+    # operator deliberately asking for another run - it must not be
+    # swallowed as a duplicate.
+    app.state.db_pool = pool
+    handled = []
+
+    async def fake_handle(payload_arg, redis_url):
+        handled.append(payload_arg)
+
+    monkeypatch.setattr("app_server.webhooks.push.handle_push_event", fake_handle)
+    body = _push_payload()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await _post(client, body, "delivery-new-1")
+        await _post(client, body, "delivery-new-2")
+
+    assert len(handled) == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_delivery_header_is_rejected(pool):
+    # Otherwise stripping one header would bypass replay protection wholesale.
+    app.state.db_pool = pool
+    body = _push_payload()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await _post(client, body, None)
+
+    assert response.status_code == 400
+    assert "X-GitHub-Delivery" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_unsigned_request_never_reaches_the_ledger(pool):
+    # A forged request must not be able to burn a GUID and thereby suppress
+    # the real delivery that follows.
+    app.state.db_pool = pool
+    body = _push_payload()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-Hub-Signature-256": "sha256=forged",
+                "X-GitHub-Event": "push",
+                "X-GitHub-Delivery": "delivery-forged-1",
+            },
+        )
+
+    assert response.status_code == 401
+    assert await claim_webhook_delivery(pool, "github", "delivery-forged-1", "push") is True
+
+
+@pytest.mark.asyncio
+async def test_failed_handler_releases_the_claim_so_github_can_retry(pool, monkeypatch):
+    app.state.db_pool = pool
+    attempts = []
+
+    async def failing_handle(payload_arg, redis_url):
+        attempts.append(payload_arg)
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setattr("app_server.webhooks.push.handle_push_event", failing_handle)
+    body = _push_payload()
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await _post(client, body, "delivery-retry-1")
+        assert first.status_code == 500
+
+        # GitHub's automatic retry reuses the same GUID. If the claim had
+        # stuck, this would be discarded as a duplicate and the event lost.
+        async def working_handle(payload_arg, redis_url):
+            attempts.append(payload_arg)
+
+        monkeypatch.setattr("app_server.webhooks.push.handle_push_event", working_handle)
+        second = await _post(client, body, "delivery-retry-1")
+
+    assert second.status_code == 200
+    assert second.json() == {"ok": True}
+    assert len(attempts) == 2, "retry of a failed delivery was wrongly suppressed"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_claims_of_one_id_produce_exactly_one_winner(pool):
+    """The property the whole design rests on.
+
+    Sequential dedupe is easy; the case that actually motivated an atomic
+    INSERT is two deliveries of one event landing at once. A read-then-write
+    implementation passes every other test in this file and fails here.
+    """
+    import asyncio
+
+    results = await asyncio.gather(
+        *(claim_webhook_delivery(pool, "github", "d-concurrent", "push") for _ in range(8))
+    )
+
+    assert sum(results) == 1, f"expected exactly one winner, got {sum(results)}"
+
+
+@pytest.mark.asyncio
+async def test_the_same_id_from_two_sources_does_not_collide(pool):
+    # GitHub GUIDs and Paddle event ids share one table; the source column is
+    # what keeps them from suppressing each other.
+    assert await claim_webhook_delivery(pool, "github", "shared-id", "push") is True
+    assert await claim_webhook_delivery(pool, "paddle", "shared-id", "subscription.created") is True

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from app_server import paddle_ip_allowlist
 from app_server.db import (
     add_installation_member,
+    claim_webhook_delivery,
     get_extra_seats,
     get_installation,
     upsert_github_user_email,
@@ -30,8 +31,11 @@ def _sign(raw_body: bytes, secret: str = WEBHOOK_SECRET) -> str:
     return f"ts={ts};h1={digest}"
 
 
-def _subscription_created_payload(price_id: str, installation_id: int) -> dict:
+def _subscription_created_payload(
+    price_id: str, installation_id: int, event_id: str = "evt_created_default"
+) -> dict:
     return {
+        "event_id": event_id,
         "event_type": "subscription.created",
         "data": {
             "id": "sub_test_123",
@@ -43,8 +47,15 @@ def _subscription_created_payload(price_id: str, installation_id: int) -> dict:
     }
 
 
-def _subscription_event_payload(event_type: str, status: str, installation_id: int, price_id: str | None = None) -> dict:
+def _subscription_event_payload(
+    event_type: str,
+    status: str,
+    installation_id: int,
+    price_id: str | None = None,
+    event_id: str = "evt_event_default",
+) -> dict:
     return {
+        "event_id": event_id,
         "event_type": event_type,
         "data": {
             "id": "sub_test_123",
@@ -535,8 +546,158 @@ async def test_no_email_enqueued_without_event_id(pool, monkeypatch):
         lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
     )
 
-    payload = _subscription_event_payload("subscription.updated", "past_due", 704)
+    # Explicitly event_id-less. The /webhooks/paddle route now rejects such
+    # a payload outright, but the handler keeps its own guard - it is called
+    # directly here and from tests, and an email dedupe key built from a
+    # missing id would collide across unrelated events.
+    payload = _subscription_event_payload("subscription.updated", "past_due", 704, event_id=None)
 
     await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
 
     assert enqueue_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Delivery dedupe. Paddle signatures already embed a timestamp checked to a 5s
+# tolerance, so replay of a captured payload is a narrow window. These cover
+# the concurrency case instead: handle_paddle_webhook_event reads
+# installations.plan, then writes it, and gates a pair of expensive full
+# AIRview/Docs builds on that read having been "free". Two deliveries of one
+# event arriving together would both read "free" and both enqueue.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_paddle_event_is_only_handled_once(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    await upsert_installation(pool, 800, "acme")
+
+    handled = []
+
+    async def counting_handler(payload, pool_arg, redis_url, queue=None):
+        handled.append(payload)
+
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.handle_paddle_webhook_event", counting_handler
+    )
+
+    body = json.dumps(
+        _subscription_created_payload(
+            "pri_01kyhevc8bkcghfpwjymz16y2h", 800, event_id="evt_dupe_1"
+        )
+    ).encode()
+    headers = {"paddle-signature": _sign(body)}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        first = await client.post("/webhooks/paddle", content=body, headers=headers)
+        second = await client.post("/webhooks/paddle", content=body, headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert len(handled) == 1, "a duplicate Paddle event was processed twice"
+
+
+@pytest.mark.asyncio
+async def test_distinct_paddle_events_are_both_handled(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    await upsert_installation(pool, 801, "acme")
+
+    handled = []
+
+    async def counting_handler(payload, pool_arg, redis_url, queue=None):
+        handled.append(payload)
+
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.handle_paddle_webhook_event", counting_handler
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for event_id in ("evt_distinct_1", "evt_distinct_2"):
+            body = json.dumps(
+                _subscription_created_payload(
+                    "pri_01kyhevc8bkcghfpwjymz16y2h", 801, event_id=event_id
+                )
+            ).encode()
+            await client.post(
+                "/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)}
+            )
+
+    assert len(handled) == 2
+
+
+@pytest.mark.asyncio
+async def test_paddle_event_without_event_id_is_rejected(pool, monkeypatch):
+    # Undedupable. Accepting it would leave the concurrency gap open for any
+    # caller willing to omit the field.
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 802)
+    del payload["event_id"]
+    body = json.dumps(payload).encode()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)}
+        )
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_forged_paddle_signature_never_claims_an_event_id(pool, monkeypatch):
+    # Otherwise anyone could burn an event id and suppress the real delivery.
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    body = json.dumps(
+        _subscription_created_payload(
+            "pri_01kyhevc8bkcghfpwjymz16y2h", 803, event_id="evt_forged_1"
+        )
+    ).encode()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/paddle", content=body, headers={"paddle-signature": "ts=1;h1=deadbeef"}
+        )
+
+    assert response.status_code == 401
+    assert await claim_webhook_delivery(pool, "paddle", "evt_forged_1", "") is True
+
+
+@pytest.mark.asyncio
+async def test_failed_paddle_handler_releases_the_claim_for_retry(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    await upsert_installation(pool, 804, "acme")
+    attempts = []
+
+    async def failing_handler(payload, pool_arg, redis_url, queue=None):
+        attempts.append(payload)
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setattr("app_server.webhooks.paddle.handle_paddle_webhook_event", failing_handler)
+
+    body = json.dumps(
+        _subscription_created_payload(
+            "pri_01kyhevc8bkcghfpwjymz16y2h", 804, event_id="evt_retry_1"
+        )
+    ).encode()
+    headers = {"paddle-signature": _sign(body)}
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.post("/webhooks/paddle", content=body, headers=headers)
+        assert first.status_code == 500
+
+        # Paddle's retry carries the same event_id. A stuck claim would drop
+        # it and the plan change would be lost for good.
+        async def working_handler(payload, pool_arg, redis_url, queue=None):
+            attempts.append(payload)
+
+        monkeypatch.setattr(
+            "app_server.webhooks.paddle.handle_paddle_webhook_event", working_handler
+        )
+        second = await client.post("/webhooks/paddle", content=body, headers=headers)
+
+    assert second.status_code == 200
+    assert len(attempts) == 2, "retry of a failed Paddle event was wrongly suppressed"

--- a/schemas/air.schema.json
+++ b/schemas/air.schema.json
@@ -1,0 +1,496 @@
+{
+  "$id": "https://aletheore.com/schemas/air.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Deterministic repository evidence produced by `aletheore scan`.",
+  "properties": {
+    "aletheore_version": {
+      "type": "string"
+    },
+    "architecture": {
+      "properties": {
+        "clusters": {
+          "items": {
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "modules": {
+                "type": "array"
+              }
+            },
+            "required": [
+              "id",
+              "modules"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "config_applied": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "cross_cluster_edges": {
+          "type": "array"
+        },
+        "layer_violations": {
+          "properties": {
+            "convention_detected": {
+              "type": "boolean"
+            },
+            "layers": {
+              "type": "array"
+            },
+            "violations": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "convention_detected",
+            "layers",
+            "violations"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "clusters",
+        "config_applied",
+        "cross_cluster_edges",
+        "layer_violations"
+      ],
+      "type": "object"
+    },
+    "git": {
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "branches": {
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "commit_cadence": {
+          "properties": {
+            "most_recent_week_partial": {
+              "type": "boolean"
+            },
+            "trend": {
+              "type": "string"
+            },
+            "weekly_counts": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "most_recent_week_partial",
+            "trend",
+            "weekly_counts"
+          ],
+          "type": "object"
+        },
+        "history_depth_limited": {
+          "type": "boolean"
+        },
+        "hotspots": {
+          "type": "array"
+        },
+        "ownership": {
+          "items": {
+            "properties": {
+              "commit_count": {
+                "type": "integer"
+              },
+              "email": {
+                "type": "string"
+              },
+              "percent": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "commit_count",
+              "email",
+              "percent"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "repo_age_days": {
+          "type": "integer"
+        },
+        "total_commits": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "available"
+      ],
+      "type": "object"
+    },
+    "repo_path": {
+      "type": "string"
+    },
+    "repository": {
+      "properties": {
+        "ai_usage": {
+          "properties": {
+            "local_inference": {
+              "type": "array"
+            },
+            "mcp": {
+              "type": "array"
+            },
+            "orchestration": {
+              "type": "array"
+            },
+            "providers": {
+              "type": "array"
+            },
+            "vector_stores": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "local_inference",
+            "mcp",
+            "orchestration",
+            "providers",
+            "vector_stores"
+          ],
+          "type": "object"
+        },
+        "api_endpoints": {
+          "properties": {
+            "checked": {
+              "type": "boolean"
+            },
+            "endpoints": {
+              "items": {
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "line": {
+                    "type": "integer"
+                  },
+                  "method": {
+                    "type": "string"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "file",
+                  "line",
+                  "method",
+                  "path"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "checked",
+            "endpoints"
+          ],
+          "type": "object"
+        },
+        "build_tools": {
+          "type": "array"
+        },
+        "database": {
+          "properties": {
+            "migration_directories": {
+              "type": "array"
+            },
+            "orm_frameworks": {
+              "type": "array"
+            },
+            "schema_files": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "migration_directories",
+            "orm_frameworks",
+            "schema_files"
+          ],
+          "type": "object"
+        },
+        "dead_code": {
+          "properties": {
+            "entry_points_detected": {
+              "type": "array"
+            },
+            "unreachable_modules": {
+              "type": "array"
+            },
+            "unused_dependencies": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "entry_points_detected",
+            "unreachable_modules",
+            "unused_dependencies"
+          ],
+          "type": "object"
+        },
+        "dependency_graph": {
+          "properties": {
+            "edges": {
+              "type": "array"
+            },
+            "nodes": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "edges",
+            "nodes"
+          ],
+          "type": "object"
+        },
+        "environment_variables": {
+          "properties": {
+            "declared": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "declared"
+          ],
+          "type": "object"
+        },
+        "frameworks": {
+          "type": "array"
+        },
+        "infrastructure": {
+          "properties": {
+            "docker_compose_services": {
+              "type": "array"
+            },
+            "helm_charts": {
+              "type": "array"
+            },
+            "kubernetes_manifests": {
+              "type": "array"
+            },
+            "terraform_files": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "docker_compose_services",
+            "helm_charts",
+            "kubernetes_manifests",
+            "terraform_files"
+          ],
+          "type": "object"
+        },
+        "languages": {
+          "items": {
+            "properties": {
+              "file_count": {
+                "type": "integer"
+              },
+              "loc": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_count",
+              "loc",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "modules": {
+          "items": {
+            "properties": {
+              "imported_by": {
+                "type": "array"
+              },
+              "imports": {
+                "type": "array"
+              },
+              "language": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "imported_by",
+              "imports",
+              "language",
+              "path"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "monorepo": {
+          "properties": {
+            "detected": {
+              "type": "boolean"
+            },
+            "workspaces": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "detected",
+            "workspaces"
+          ],
+          "type": "object"
+        },
+        "policy_docs": {
+          "type": "array"
+        },
+        "unparseable_files": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "ai_usage",
+        "api_endpoints",
+        "build_tools",
+        "database",
+        "dead_code",
+        "dependency_graph",
+        "environment_variables",
+        "frameworks",
+        "infrastructure",
+        "languages",
+        "modules",
+        "monorepo",
+        "policy_docs",
+        "unparseable_files"
+      ],
+      "type": "object"
+    },
+    "scanned_at": {
+      "type": "string"
+    },
+    "security": {
+      "properties": {
+        "dependency_licenses": {
+          "properties": {
+            "checked": {
+              "type": "boolean"
+            },
+            "findings": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "checked",
+            "findings"
+          ],
+          "type": "object"
+        },
+        "dependency_vulnerabilities": {
+          "properties": {
+            "checked": {
+              "type": "boolean"
+            },
+            "findings": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "checked",
+            "findings"
+          ],
+          "type": "object"
+        },
+        "secrets": {
+          "properties": {
+            "findings": {
+              "items": {
+                "properties": {
+                  "line": {
+                    "type": "integer"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "pattern": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "line",
+                  "path",
+                  "pattern"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "history_findings": {
+              "type": "array"
+            },
+            "history_scanned_commits": {
+              "type": "integer"
+            },
+            "scanned_files": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "findings",
+            "history_findings",
+            "history_scanned_commits",
+            "scanned_files"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "dependency_licenses",
+        "dependency_vulnerabilities",
+        "secrets"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "aletheore_version",
+    "architecture",
+    "git",
+    "repo_path",
+    "repository",
+    "scanned_at",
+    "security"
+  ],
+  "title": "Aletheore Intermediate Representation (AIR)",
+  "type": "object"
+}

--- a/src/README.md
+++ b/src/README.md
@@ -441,8 +441,9 @@ Starts a stdio MCP server scoped to one repository, so a coding agent can query 
 directly instead of shelling out via Bash or re-reading files on every lookup. Every tool
 result is [TOON](https://toonformat.dev)-encoded rather than plain JSON — the calling agent's
 own token budget is what actually pays for reading these results, and evidence's shape (almost
-entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 28 tools
-by default, plus one optional answer tool when started with `--agent`:
+entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 27 tools
+by default — see [Tool permissions](#tool-permissions) for the 28th — plus one optional answer
+tool when started with `--agent`:
 
 - The 16 query kinds above as tools, each named `aletheore_<kind>` with underscores in place of
   hyphens (`aletheore_imports`, `aletheore_imported_by`, `aletheore_symbols`, `aletheore_branch`,
@@ -468,15 +469,66 @@ by default, plus one optional answer tool when started with `--agent`:
   persists the result under `.aletheore/healthchecks/`.
 - `aletheore_index()` — builds the local semantic search index, same as `aletheore index`.
 - `aletheore_search_codebase(query, k=10)` — semantic search over the local code index.
-- `aletheore_managed_audit(token=None)` — runs a full managed audit report via Aletheore's
-  hosted service, resolving the token the same way `aletheore login` does: an explicit `token`
-  argument, then `ALETHEORE_API_TOKEN`, then the credential saved by `aletheore login`.
+- `aletheore_managed_audit(token=None)` — **not registered by default** (see below). Runs a full
+  managed audit report via Aletheore's hosted service, resolving the token the same way
+  `aletheore login` does: an explicit `token` argument, then `ALETHEORE_API_TOKEN`, then the
+  credential saved by `aletheore login`.
 - Optional: `aletheore_answer(question, k=5)` — available only when the MCP server is started
   with `--agent`, answers from the semantic index using the selected provider.
 
 ```bash
 aletheore mcp .
 ```
+
+#### Tool permissions
+
+Most of these tools only read `.aletheore/air.json`. A few do more, so each one carries standard
+MCP [tool annotations](https://modelcontextprotocol.io/specification/server/tools) —
+`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` — that any MCP client can
+read and display.
+
+Annotations are **hints**, though; the MCP spec is explicit that clients should not make tool-use
+decisions based on them. So the actual boundary is `ALETHEORE_MCP_ALLOW`, which controls which
+effect classes are permitted. A tool whose effects aren't permitted is **never registered** — it
+does not appear in the tool list and cannot be called.
+
+| Effect | Meaning | Default |
+| --- | --- | --- |
+| *(read)* | Reads evidence. Always permitted; not gateable. | on |
+| `write` | Writes files under `.aletheore/`. | on |
+| `network` | Outbound requests — OSV.dev, package registries, health probes, embeddings. | on |
+| `external` | Transmits this repository's evidence to a third-party service. | **off** |
+
+`external` is the one class off by default. Scanning and indexing are what the tool is *for*, and
+their effects stay on this machine; the genuinely surprising action is your repository's evidence
+leaving it. That could previously happen with no consent step at all, because
+`aletheore_managed_audit` silently resolves a token from the OS keychain — anyone who had once run
+`aletheore login` had an agent that could upload without being asked.
+
+```bash
+# Default: everything except evidence upload.
+aletheore mcp .
+
+# Allow the managed-audit tool to upload evidence.
+ALETHEORE_MCP_ALLOW=write,network,external aletheore mcp .
+
+# Read-only server: evidence queries only, no scans, writes, or network.
+ALETHEORE_MCP_ALLOW=read aletheore mcp .
+```
+
+An explicit value **replaces** the default rather than adding to it, so `read` really does mean
+read-only. An unrecognized effect name is a startup error rather than a silent no-op. When tools
+are withheld, the server prints one line to stderr naming them and the variable to set.
+
+`aletheore_answer` reaches an LLM provider but is not gated, because it is registered only when
+you pass `aletheore mcp --agent` — that flag is already the consent step.
+
+`aletheore_index` and `aletheore_search_codebase` embed through a local Ollama instance and can
+fall back to OpenAI, which is why they might look like they belong under `external`. They don't:
+that fallback requires an interactive confirmation and is refused outright when stdin isn't a
+TTY, and an MCP server is always spawned with piped stdio. From MCP these tools reach Ollama on
+localhost or fail — they cannot send code to OpenAI. If Ollama isn't running, expect an
+"embedding provider unavailable" error rather than a silent upload.
 
 ### `aletheore mcp-install [path]`
 

--- a/src/aletheore/air_schema.py
+++ b/src/aletheore/air_schema.py
@@ -1,0 +1,256 @@
+"""The AIR evidence contract.
+
+AIR (air.json) is consumed by the CLI, the MCP server, the hosted dashboard,
+the GitHub App worker, and anything a customer writes against it. Until this
+module, "the schema" existed only as the literal dict built at the end of
+scan_repository, and the only guard was EVIDENCE_VERSION - which said whether
+two builds *claimed* the same schema, never whether the evidence in hand
+actually had the shape a consumer was about to index into. A producer-side
+change that renamed or dropped a key shipped silently and surfaced as a
+KeyError deep inside an unrelated module.
+
+This module makes the contract explicit and machine-checkable:
+
+  - AIR_JSON_SCHEMA is the contract, written as JSON Schema (draft 2020-12)
+    so it can be published for external consumers verbatim.
+  - validate_evidence() checks evidence against it, returning readable paths
+    rather than raising from wherever the first bad index happened to be.
+  - schema_fingerprint() lets a test fail when the contract changes without
+    a matching EVIDENCE_VERSION bump. That test is the actual mechanism -
+    the schema alone documents drift, the fingerprint prevents it.
+
+The validator implements only the JSON Schema subset used below (type,
+properties, required, items). That is a deliberate trade: a real jsonschema
+dependency would pull a transitive tree into a CLI whose install size users
+notice, to check four keywords. If the schema ever needs more expressive
+power than this, take the dependency rather than growing the validator.
+"""
+
+import hashlib
+import json
+
+_STR: dict = {"type": "string"}
+_INT: dict = {"type": "integer"}
+_NUM: dict = {"type": "number"}
+_BOOL: dict = {"type": "boolean"}
+_ANY_LIST: dict = {"type": "array"}
+
+
+def _obj(properties: dict, required: list[str] | None = None) -> dict:
+    """An object schema. Everything listed is required unless `required` is
+    given explicitly - AIR sections are built unconditionally by
+    scan_repository, so "present" is the norm and optionality is the
+    exception worth spelling out.
+    """
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": sorted(properties) if required is None else sorted(required),
+    }
+
+
+def _arr(items: dict | None = None) -> dict:
+    return {"type": "array"} if items is None else {"type": "array", "items": items}
+
+
+# Findings arrays deliberately require only the fields every consumer reads.
+# Detectors add their own extra keys and must stay free to; over-specifying
+# here would turn a harmless additive change into a CI failure.
+_SECRET_FINDING = _obj({"path": _STR, "line": _INT, "pattern": _STR})
+_ENDPOINT = _obj({"file": _STR, "line": _INT, "method": _STR, "path": _STR})
+_MODULE = _obj({"path": _STR, "language": _STR, "imports": _ANY_LIST, "imported_by": _ANY_LIST})
+_LANGUAGE = _obj({"name": _STR, "file_count": _INT, "loc": _INT})
+_OWNERSHIP = _obj({"email": _STR, "commit_count": _INT, "percent": _NUM})
+_BRANCH = _obj({"name": _STR, "type": _STR})
+_CLUSTER = _obj({"id": _INT, "modules": _ANY_LIST})
+
+AIR_JSON_SCHEMA: dict = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://aletheore.com/schemas/air.schema.json",
+    "title": "Aletheore Intermediate Representation (AIR)",
+    "description": "Deterministic repository evidence produced by `aletheore scan`.",
+    "type": "object",
+    "required": [
+        "aletheore_version",
+        "architecture",
+        "git",
+        "repo_path",
+        "repository",
+        "scanned_at",
+        "security",
+    ],
+    "properties": {
+        "aletheore_version": _STR,
+        "scanned_at": _STR,
+        "repo_path": _STR,
+        "repository": _obj(
+            {
+                "languages": _arr(_LANGUAGE),
+                "frameworks": _ANY_LIST,
+                "ai_usage": _obj(
+                    {
+                        "providers": _ANY_LIST,
+                        "orchestration": _ANY_LIST,
+                        "vector_stores": _ANY_LIST,
+                        "local_inference": _ANY_LIST,
+                        "mcp": _ANY_LIST,
+                    }
+                ),
+                "policy_docs": _ANY_LIST,
+                "build_tools": _ANY_LIST,
+                "monorepo": _obj({"detected": _BOOL, "workspaces": _ANY_LIST}),
+                "database": _obj(
+                    {
+                        "orm_frameworks": _ANY_LIST,
+                        "migration_directories": _ANY_LIST,
+                        "schema_files": _ANY_LIST,
+                    }
+                ),
+                "infrastructure": _obj(
+                    {
+                        "docker_compose_services": _ANY_LIST,
+                        "kubernetes_manifests": _ANY_LIST,
+                        "terraform_files": _ANY_LIST,
+                        "helm_charts": _ANY_LIST,
+                    }
+                ),
+                "environment_variables": _obj({"declared": _ANY_LIST}),
+                "modules": _arr(_MODULE),
+                "dependency_graph": _obj({"nodes": _ANY_LIST, "edges": _ANY_LIST}),
+                "unparseable_files": _ANY_LIST,
+                "api_endpoints": _obj({"checked": _BOOL, "endpoints": _arr(_ENDPOINT)}),
+                "dead_code": _obj(
+                    {
+                        "unreachable_modules": _ANY_LIST,
+                        "unused_dependencies": _ANY_LIST,
+                        "entry_points_detected": _ANY_LIST,
+                    }
+                ),
+            }
+        ),
+        # A repo with no commits yields {"available": False} and nothing
+        # else, so `available` is the only unconditionally required key here.
+        # Consumers must branch on it before reading anything below.
+        "git": _obj(
+            {
+                "available": _BOOL,
+                "branches": _arr(_BRANCH),
+                "commit_cadence": _obj(
+                    {
+                        "weekly_counts": _ANY_LIST,
+                        "trend": _STR,
+                        "most_recent_week_partial": _BOOL,
+                    }
+                ),
+                "ownership": _arr(_OWNERSHIP),
+                "repo_age_days": _INT,
+                "total_commits": _INT,
+                "history_depth_limited": _BOOL,
+                "hotspots": _ANY_LIST,
+            },
+            required=["available"],
+        ),
+        "security": _obj(
+            {
+                "secrets": _obj(
+                    {
+                        "scanned_files": _INT,
+                        "findings": _arr(_SECRET_FINDING),
+                        "history_scanned_commits": _INT,
+                        "history_findings": _ANY_LIST,
+                    }
+                ),
+                "dependency_vulnerabilities": _obj({"checked": _BOOL, "findings": _ANY_LIST}),
+                "dependency_licenses": _obj({"checked": _BOOL, "findings": _ANY_LIST}),
+            }
+        ),
+        "architecture": _obj(
+            {
+                "clusters": _arr(_CLUSTER),
+                "cross_cluster_edges": _ANY_LIST,
+                "layer_violations": _obj(
+                    {
+                        "convention_detected": _BOOL,
+                        "layers": _ANY_LIST,
+                        "violations": _ANY_LIST,
+                    }
+                ),
+                # null whenever the repo ships no architecture config, which
+                # is the common case.
+                "config_applied": {"type": ["object", "null"]},
+            }
+        ),
+    },
+}
+
+_JSON_TYPES: dict[str, type | tuple[type, ...]] = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+    "null": type(None),
+}
+
+
+def _type_matches(value: object, expected: str) -> bool:
+    python_type = _JSON_TYPES[expected]
+    # bool is a subclass of int in Python; AIR distinguishes them and a
+    # counter that started returning True would be a real defect.
+    if expected in ("integer", "number") and isinstance(value, bool):
+        return False
+    return isinstance(value, python_type)
+
+
+def _validate(value: object, schema: dict, path: str, errors: list[str], deep: bool) -> None:
+    expected = schema.get("type")
+    if expected is not None:
+        allowed = [expected] if isinstance(expected, str) else list(expected)
+        if not any(_type_matches(value, option) for option in allowed):
+            errors.append(
+                f"{path}: expected {' or '.join(allowed)}, got {type(value).__name__}"
+            )
+            return
+
+    if isinstance(value, dict):
+        for key in schema.get("required", []):
+            if key not in value:
+                errors.append(f"{path}.{key}: required key missing")
+        for key, subschema in schema.get("properties", {}).items():
+            if key in value:
+                _validate(value[key], subschema, f"{path}.{key}", errors, deep)
+
+    elif isinstance(value, list) and deep:
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, item in enumerate(value):
+                _validate(item, item_schema, f"{path}[{index}]", errors, deep)
+
+
+def validate_evidence(evidence: object, *, deep: bool = False) -> list[str]:
+    """Problems found in `evidence`, as readable paths. Empty means valid.
+
+    `deep=False` (the default, and what the read path uses) checks the
+    section skeleton: every required key present, every container the right
+    type. That is what a consumer about to index into evidence actually
+    depends on, and it stays O(sections) regardless of repo size.
+
+    `deep=True` additionally validates every element of every typed array.
+    On a large repo that is tens of thousands of objects, so it is meant for
+    the conformance test rather than the hot path.
+    """
+    errors: list[str] = []
+    _validate(evidence, AIR_JSON_SCHEMA, "evidence", errors, deep)
+    return errors
+
+
+def schema_fingerprint() -> str:
+    """Stable hash of the contract.
+
+    Pinned by a test against EVIDENCE_VERSION so the schema cannot change
+    without the version changing too - which is the whole point of having a
+    version. See tests/test_air_schema.py.
+    """
+    canonical = json.dumps(AIR_JSON_SCHEMA, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
+from aletheore.air_schema import validate_evidence
 from aletheore.architecture import build_clusters, detect_layer_violations, load_architecture_config
 from aletheore.dead_code import find_dead_code
 from aletheore.endpoints import map_api_endpoints
@@ -76,13 +77,24 @@ class IncompatibleEvidenceVersionError(Exception):
     pass
 
 
+class MalformedEvidenceError(Exception):
+    pass
+
+
 def load_evidence_file(evidence_path: Path) -> dict:
     """Reads and validates a raw air.json or snapshot file, refusing evidence
-    written by an incompatible schema version.
+    written by an incompatible schema version or with the wrong shape.
 
     Every direct reader of an evidence file (CLI query/index/diff/healthcheck,
     the MCP server) should route through this or load_evidence rather than a
     bare json.loads - see is_evidence_version_compatible for why.
+
+    Two distinct failures are possible and they need different messages. A
+    version mismatch means "this file is fine, your build is different" and
+    re-scanning fixes it. A schema violation on a *compatible* version means
+    the file is truncated, hand-edited, or not AIR at all - re-scanning may
+    not help, and the caller needs to know which key is wrong rather than
+    discovering it as a KeyError three modules away.
     """
     evidence = json.loads(evidence_path.read_text())
     written_version = evidence.get("aletheore_version") if isinstance(evidence, dict) else None
@@ -91,6 +103,15 @@ def load_evidence_file(evidence_path: Path) -> dict:
             f"{evidence_path} was written by aletheore_version={written_version!r}, which "
             f"isn't compatible with this build's evidence schema ({EVIDENCE_VERSION}) - "
             "re-run 'aletheore scan' to refresh it"
+        )
+    problems = validate_evidence(evidence)
+    if problems:
+        detail = "; ".join(problems[:5])
+        if len(problems) > 5:
+            detail += f" (and {len(problems) - 5} more)"
+        raise MalformedEvidenceError(
+            f"{evidence_path} claims a compatible aletheore_version but does not match the "
+            f"AIR schema: {detail} - re-run 'aletheore scan' to regenerate it"
         )
     return evidence
 

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -1,8 +1,11 @@
 import json
+import os
 import re
+import sys
 from pathlib import Path, PurePath
 
 from mcp.server.mcpserver import MCPServer
+from mcp.types import ToolAnnotations
 
 from aletheore.adapters.base import AgentAdapter
 from aletheore.answer import answer_question
@@ -125,6 +128,88 @@ _QUERY_TOOL_DESCRIPTIONS = {
 _SEARCH_MATCH_CAP = 200
 
 
+# ---------------------------------------------------------------------------
+# Effect classes and the consent boundary.
+#
+# Most tools here just read .aletheore/air.json. A few do more: write files,
+# reach the network, or transmit this repository's evidence to a third party.
+# Until this, nothing distinguished them - an agent driving the server saw one
+# undifferentiated list and could trigger a scan, a live HTTP probe, or an
+# upload to the hosted audit service without anyone having agreed to it.
+#
+# Two mechanisms, because one alone isn't enough:
+#
+#   1. ToolAnnotations on every tool. This is MCP's own vocabulary, so clients
+#      already know how to read and display it. But the spec is explicit that
+#      annotations are *hints* - "clients should never make tool use decisions
+#      based on ToolAnnotations received from untrusted servers" - so they
+#      describe behavior, they don't constrain it.
+#
+#   2. ALETHEORE_MCP_ALLOW, below. This is the part that actually binds: a
+#      tool whose effects aren't permitted is never registered, so it isn't in
+#      the tool list and cannot be called at all.
+# ---------------------------------------------------------------------------
+
+EFFECT_WRITE = "write"  # writes files under the repo
+EFFECT_NETWORK = "network"  # outbound requests (OSV, registries, health probes, embeddings)
+EFFECT_EXTERNAL = "external"  # transmits repository evidence to a third-party service
+
+_ALL_EFFECTS = frozenset({EFFECT_WRITE, EFFECT_NETWORK, EFFECT_EXTERNAL})
+
+# Reading evidence is the server's reason to exist and is always permitted, so
+# it isn't an effect class - the empty set means "read-only".
+#
+# `external` is the one class off by default. Scanning and indexing are what a
+# tool called "aletheore" is for, and their effects stay on this machine; the
+# genuinely surprising action is this repository's evidence leaving it. That
+# happens with no launch-time consent step today, because the managed-audit
+# tool silently resolves a token from the OS keychain - a user who once ran
+# `aletheore login` has an agent that can upload without ever being asked.
+#
+# (aletheore_answer also reaches an LLM, but it is registered only when the
+# operator passes `aletheore mcp --agent`, which is itself the consent step.)
+_DEFAULT_ALLOWED_EFFECTS = frozenset({EFFECT_WRITE, EFFECT_NETWORK})
+
+_ALLOW_ENV_VAR = "ALETHEORE_MCP_ALLOW"
+
+
+class UnknownEffectError(ValueError):
+    pass
+
+
+def allowed_effects(raw: str | None) -> frozenset[str]:
+    """Parse ALETHEORE_MCP_ALLOW into the permitted effect classes.
+
+    Unset uses the default. An explicit value replaces it wholesale rather
+    than adding to it, so `ALETHEORE_MCP_ALLOW=read` is a genuinely read-only
+    server rather than the default plus a redundant token. An unrecognized
+    name is an error rather than a silent no-op: a typo like "extenral" that
+    quietly left evidence upload disabled would be merely confusing, but one
+    that quietly left it *enabled* would be a security hole with a plausible
+    explanation attached.
+    """
+    if raw is None:
+        return _DEFAULT_ALLOWED_EFFECTS
+    names = {part.strip().lower() for part in raw.split(",") if part.strip()}
+    # "read" is always implied; accept it as a spelling of "nothing else".
+    names.discard("read")
+    unknown = names - _ALL_EFFECTS
+    if unknown:
+        raise UnknownEffectError(
+            f"{_ALLOW_ENV_VAR} contains unknown effect(s): {', '.join(sorted(unknown))} - "
+            f"valid values are read, {', '.join(sorted(_ALL_EFFECTS))}"
+        )
+    return frozenset(names)
+
+
+READ_ONLY_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=False,
+)
+
+
 def _register_query_wrapper_tools(mcp_instance: MCPServer, repo_path: Path) -> None:
     for tool_name, kind in _TOOL_NAME_TO_QUERY_KIND.items():
         func, requires_target = QUERY_FUNCTIONS[kind]
@@ -147,11 +232,11 @@ def _register_query_wrapper_tools(mcp_instance: MCPServer, repo_path: Path) -> N
         tool_func = make_tool()
         tool_func.__name__ = tool_name
         tool_func.__doc__ = _QUERY_TOOL_DESCRIPTIONS[kind]
-        mcp_instance.tool(name=tool_name)(tool_func)
+        mcp_instance.tool(name=tool_name, annotations=READ_ONLY_ANNOTATIONS)(tool_func)
 
 
 def _register_changes_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_changes")
+    @mcp_instance.tool(name="aletheore_changes", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_changes(full: bool = False) -> str:
         """What changed between the two most recent scans of this repo."""
         snapshots = list_snapshots(repo_path)
@@ -166,7 +251,7 @@ def _register_changes_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
 
 
 def _register_neighborhood_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_neighborhood")
+    @mcp_instance.tool(name="aletheore_neighborhood", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_neighborhood(target: str) -> str:
         """A module's imports, dependents, and cluster in one call."""
         evidence = read_evidence(repo_path)
@@ -187,7 +272,7 @@ def _register_neighborhood_tool(mcp_instance: MCPServer, repo_path: Path) -> Non
 
 
 def _register_search_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_search")
+    @mcp_instance.tool(name="aletheore_search", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_search(pattern: str, regex: bool = False, path_glob: str | None = None) -> str:
         """Deterministic literal or regex search over the repository's source files."""
         compiled = re.compile(pattern) if regex else None
@@ -217,7 +302,7 @@ def _register_search_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
 
 
 def _register_symbol_source_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_symbol_source")
+    @mcp_instance.tool(name="aletheore_symbol_source", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_symbol_source(module: str, symbol: str) -> str:
         """Exact source text for one named function/class, with resolved line bounds."""
         evidence = read_evidence(repo_path)
@@ -225,19 +310,19 @@ def _register_symbol_source_tool(mcp_instance: MCPServer, repo_path: Path) -> No
 
 
 def _register_code_evidence_tools(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_find_evidence_for_endpoint")
+    @mcp_instance.tool(name="aletheore_find_evidence_for_endpoint", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_find_evidence_for_endpoint(method: str, path: str) -> str:
         """Resolve an API endpoint to source evidence: file, line, symbol, owner, commit, dependency, and risk."""
         evidence = read_evidence(repo_path)
         return _toon_result(find_code_evidence_for_endpoint(evidence, f"{method} {path}", repo_path))
 
-    @mcp_instance.tool(name="aletheore_find_evidence_for_symbol")
+    @mcp_instance.tool(name="aletheore_find_evidence_for_symbol", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_find_evidence_for_symbol(symbol: str) -> str:
         """Resolve a function or class symbol to source evidence."""
         evidence = read_evidence(repo_path)
         return _toon_result(find_code_evidence_for_symbol(evidence, symbol, repo_path))
 
-    @mcp_instance.tool(name="aletheore_find_evidence_for_dependency")
+    @mcp_instance.tool(name="aletheore_find_evidence_for_dependency", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_find_evidence_for_dependency(dependency: str) -> str:
         """Resolve a dependency or import to source evidence."""
         evidence = read_evidence(repo_path)
@@ -276,7 +361,16 @@ def _scan_summary(evidence: dict) -> dict:
 
 
 def _register_scan_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_scan")
+    @mcp_instance.tool(
+        name="aletheore_scan",
+        # Rewrites .aletheore/ and appends a snapshot, and reaches OSV.dev and
+        # package registries unless those checks are disabled. Not destructive
+        # (everything it overwrites it derived) and not idempotent (each run
+        # adds a snapshot and a fresh timestamp).
+        annotations=ToolAnnotations(
+            readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True
+        ),
+    )
     def aletheore_scan(
         check_vulnerabilities: bool = True,
         scan_git_history: bool = True,
@@ -297,7 +391,15 @@ def _register_scan_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
 
 
 def _register_healthcheck_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_healthcheck")
+    @mcp_instance.tool(
+        name="aletheore_healthcheck",
+        # Issues live GETs against a caller-supplied base_url and writes the
+        # result. The most openly world-affecting tool here: the target is an
+        # argument, so it can be pointed anywhere the host can reach.
+        annotations=ToolAnnotations(
+            readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True
+        ),
+    )
     def aletheore_healthcheck(base_url: str) -> str:
         """GET-only live health check of mapped API endpoints against a running instance."""
         evidence = read_evidence(repo_path)
@@ -308,7 +410,14 @@ def _register_healthcheck_tool(mcp_instance: MCPServer, repo_path: Path) -> None
 
 
 def _register_index_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_index")
+    @mcp_instance.tool(
+        name="aletheore_index",
+        # Writes the vector index and sends code chunks to the embedding
+        # provider - local Ollama when it is up, OpenAI on fallback.
+        annotations=ToolAnnotations(
+            readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
+        ),
+    )
     def aletheore_index() -> str:
         """Build the semantic search index this repo's evidence, required
         before aletheore_search_codebase or aletheore_answer can be used.
@@ -330,7 +439,14 @@ _NO_INDEX_ERROR = {
 
 
 def _register_search_codebase_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_search_codebase")
+    @mcp_instance.tool(
+        name="aletheore_search_codebase",
+        # Writes nothing, but embeds the query text through the configured
+        # provider, so it can reach the network.
+        annotations=ToolAnnotations(
+            readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True
+        ),
+    )
     def aletheore_search_codebase(query: str, k: int = 10) -> str:
         """Semantic search over the repository's indexed code."""
         try:
@@ -342,7 +458,13 @@ def _register_search_codebase_tool(mcp_instance: MCPServer, repo_path: Path) -> 
 def _register_answer_tool(
     mcp_instance: MCPServer, repo_path: Path, answer_adapter: AgentAdapter
 ) -> None:
-    @mcp_instance.tool(name="aletheore_answer")
+    @mcp_instance.tool(
+        name="aletheore_answer",
+        # Sends retrieved code chunks to the configured LLM adapter.
+        annotations=ToolAnnotations(
+            readOnlyHint=True, destructiveHint=False, idempotentHint=False, openWorldHint=True
+        ),
+    )
     def aletheore_answer(question: str, k: int = 5) -> str:
         """Answer a natural-language question about this repository from the semantic index."""
         try:
@@ -352,7 +474,13 @@ def _register_answer_tool(
 
 
 def _register_managed_audit_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
-    @mcp_instance.tool(name="aletheore_managed_audit")
+    @mcp_instance.tool(
+        name="aletheore_managed_audit",
+        # Uploads this repository's full evidence to the hosted service.
+        annotations=ToolAnnotations(
+            readOnlyHint=True, destructiveHint=False, idempotentHint=False, openWorldHint=True
+        ),
+    )
     def aletheore_managed_audit(token: str | None = None) -> str:
         """Run a full audit report using Aletheore's managed audit service."""
         # Same resolution the CLI's own `aletheore audit --managed` uses -
@@ -373,7 +501,36 @@ def _register_managed_audit_tool(mcp_instance: MCPServer, repo_path: Path) -> No
         return _toon_result({"report": run_managed_audit_request(evidence, resolved_token)})
 
 
-def build_server(repo_path: Path, answer_adapter: AgentAdapter | None = None) -> MCPServer:
+"""What each effectful tool needs permission to do.
+
+Read-only tools are absent from this map: reading evidence is the server's
+purpose and is never gated.
+"""
+TOOL_REQUIRED_EFFECTS: dict[str, frozenset[str]] = {
+    "aletheore_search_codebase": frozenset({EFFECT_NETWORK}),
+    "aletheore_scan": frozenset({EFFECT_WRITE, EFFECT_NETWORK}),
+    "aletheore_healthcheck": frozenset({EFFECT_WRITE, EFFECT_NETWORK}),
+    "aletheore_index": frozenset({EFFECT_WRITE, EFFECT_NETWORK}),
+    "aletheore_answer": frozenset({EFFECT_NETWORK}),
+    "aletheore_managed_audit": frozenset({EFFECT_EXTERNAL, EFFECT_NETWORK}),
+}
+
+
+def build_server(
+    repo_path: Path,
+    answer_adapter: AgentAdapter | None = None,
+    allow: frozenset[str] | None = None,
+) -> MCPServer:
+    """Assemble the MCP server, registering only tools whose effects are permitted.
+
+    Withheld tools are not registered rather than registered-and-refusing.
+    A tool absent from the list cannot be invoked at all, which is the actual
+    boundary; a registered tool that returns "not permitted" is only a
+    convention, and it still spends the agent's context advertising something
+    it may not do.
+    """
+    effects = allowed_effects(os.environ.get(_ALLOW_ENV_VAR)) if allow is None else allow
+
     mcp_instance = MCPServer("aletheore")
     _register_query_wrapper_tools(mcp_instance, repo_path)
     _register_changes_tool(mcp_instance, repo_path)
@@ -381,11 +538,37 @@ def build_server(repo_path: Path, answer_adapter: AgentAdapter | None = None) ->
     _register_search_tool(mcp_instance, repo_path)
     _register_symbol_source_tool(mcp_instance, repo_path)
     _register_code_evidence_tools(mcp_instance, repo_path)
-    _register_scan_tool(mcp_instance, repo_path)
-    _register_healthcheck_tool(mcp_instance, repo_path)
-    _register_index_tool(mcp_instance, repo_path)
-    _register_search_codebase_tool(mcp_instance, repo_path)
-    _register_managed_audit_tool(mcp_instance, repo_path)
-    if answer_adapter is not None:
+
+    withheld: list[str] = []
+
+    def permitted(tool_name: str) -> bool:
+        if TOOL_REQUIRED_EFFECTS[tool_name] <= effects:
+            return True
+        withheld.append(tool_name)
+        return False
+
+    if permitted("aletheore_scan"):
+        _register_scan_tool(mcp_instance, repo_path)
+    if permitted("aletheore_healthcheck"):
+        _register_healthcheck_tool(mcp_instance, repo_path)
+    if permitted("aletheore_index"):
+        _register_index_tool(mcp_instance, repo_path)
+    if permitted("aletheore_search_codebase"):
+        _register_search_codebase_tool(mcp_instance, repo_path)
+    if permitted("aletheore_managed_audit"):
+        _register_managed_audit_tool(mcp_instance, repo_path)
+    if answer_adapter is not None and permitted("aletheore_answer"):
         _register_answer_tool(mcp_instance, repo_path, answer_adapter)
+
+    if withheld:
+        # stderr, not stdout: stdout is the MCP transport. The operator is the
+        # one who grants consent, so they need to see what was withheld and
+        # how to allow it - otherwise a missing tool looks like a bug.
+        missing = sorted(set().union(*(TOOL_REQUIRED_EFFECTS[name] for name in withheld)) - effects)
+        print(
+            f"aletheore: withholding {len(withheld)} tool(s) needing "
+            f"{', '.join(missing)}: {', '.join(sorted(withheld))}. "
+            f"Set {_ALLOW_ENV_VAR}={','.join(sorted(effects | set(missing)))} to enable.",
+            file=sys.stderr,
+        )
     return mcp_instance

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -36,7 +36,13 @@ dependencies = [
     "httpx>=0.28.1,<1.0",
     "lancedb>=0.15,<1.0",
     "networkx>=3.0,<4.0",
-    "mcp>=1.23,<3.0",
+    # 2.0 renamed the server module: mcp.server.fastmcp.FastMCP became
+    # mcp.server.mcpserver.MCPServer, which is what aletheore/mcp_server.py
+    # imports. The old >=1.23 floor claimed to support the 1.x layout and
+    # never could - CI only passed because it always resolved to the latest
+    # release, while any environment holding an mcp 1.x pin got an
+    # ImportError at import time.
+    "mcp>=2.0,<3.0",
     "openai>=2.0,<3.0",
     "python-toon>=0.1.3,<0.2",
     "pyyaml>=6.0,<7.0",

--- a/src/tests/air_fixtures.py
+++ b/src/tests/air_fixtures.py
@@ -1,0 +1,34 @@
+"""Schema-valid AIR documents for tests.
+
+Fixtures used to hand-build partial evidence dicts like
+`{"aletheore_version": "0.2.0", "repository": {"modules": []}}`. Nothing
+ever produced such a file - save_snapshot and write_evidence both write
+whatever scan_repository returned, which is always the full document - so
+those fixtures were asserting behavior against inputs that cannot occur.
+Once load_evidence_file started enforcing the schema they broke, correctly.
+
+Building the skeleton from AIR_JSON_SCHEMA rather than restating it keeps
+these fixtures from rotting the next time the contract grows a section.
+"""
+
+from aletheore.air_schema import AIR_JSON_SCHEMA
+from aletheore.evidence import EVIDENCE_VERSION
+
+
+def minimal_instance(schema: dict):
+    """The smallest instance satisfying `schema`."""
+    types = schema.get("type")
+    kind = types[0] if isinstance(types, list) else types
+    if kind == "object":
+        properties = schema.get("properties", {})
+        return {key: minimal_instance(properties[key]) for key in schema.get("required", [])}
+    return {"array": [], "string": "", "integer": 0, "number": 0, "boolean": False}.get(kind)
+
+
+def minimal_air_evidence() -> dict:
+    """A schema-valid AIR document with every collection empty, stamped with
+    this build's EVIDENCE_VERSION so load_evidence_file accepts it.
+    """
+    evidence = minimal_instance(AIR_JSON_SCHEMA)
+    evidence["aletheore_version"] = EVIDENCE_VERSION
+    return evidence

--- a/src/tests/test_air_schema.py
+++ b/src/tests/test_air_schema.py
@@ -1,0 +1,191 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aletheore.air_schema import (
+    AIR_JSON_SCHEMA,
+    schema_fingerprint,
+    validate_evidence,
+)
+from aletheore.evidence import (
+    EVIDENCE_VERSION,
+    MalformedEvidenceError,
+    load_evidence_file,
+    scan_repository,
+)
+from tests.air_fixtures import minimal_air_evidence
+
+# Bump both of these together, never one alone. If a schema change lands
+# without a matching EVIDENCE_VERSION bump, every already-written air.json
+# stays "compatible" by version check while actually having a different
+# shape - which is exactly the silent drift the version field exists to
+# prevent. See docs/AIR-SCHEMA.md for the migration rules.
+EXPECTED_SCHEMA_FINGERPRINT = "e762994bf0e6f961"
+EXPECTED_EVIDENCE_VERSION = "0.2.0"
+
+
+def test_schema_changes_require_an_evidence_version_bump():
+    assert schema_fingerprint() == EXPECTED_SCHEMA_FINGERPRINT, (
+        "The AIR schema changed. If this was deliberate: bump EVIDENCE_VERSION's "
+        "MINOR in aletheore/evidence.py, update EXPECTED_EVIDENCE_VERSION and "
+        "EXPECTED_SCHEMA_FINGERPRINT here, and record the change in "
+        "docs/AIR-SCHEMA.md. Do not update the fingerprint alone."
+    )
+    assert EVIDENCE_VERSION == EXPECTED_EVIDENCE_VERSION
+
+
+def test_schema_is_serializable_as_published_json_schema():
+    # It is handed to external consumers verbatim, so it has to survive a
+    # round trip through plain JSON.
+    assert json.loads(json.dumps(AIR_JSON_SCHEMA)) == AIR_JSON_SCHEMA
+    assert AIR_JSON_SCHEMA["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+
+def _valid_evidence(**overrides) -> dict:
+    """A valid document with `overrides` replacing whole sections, so each
+    test can state the one malformed thing it is about.
+    """
+    return {**minimal_air_evidence(), **overrides}
+
+
+def test_the_minimal_instance_helper_is_itself_valid():
+    # Every test below rests on this, so it gets asserted rather than assumed.
+    assert validate_evidence(_valid_evidence(), deep=True) == []
+
+
+@pytest.fixture(scope="module")
+def scanned_repo(tmp_path_factory):
+    """A real scan of a real git repo - the schema is a claim about what
+    scan_repository actually emits, so checking it against a hand-built dict
+    would only prove the fixture matches the schema.
+    """
+    repo = tmp_path_factory.mktemp("air_schema_repo")
+    (repo / "pkg").mkdir()
+    (repo / "pkg" / "__init__.py").write_text("")
+    (repo / "pkg" / "core.py").write_text("import os\n\n\ndef run():\n    return os.getcwd()\n")
+    (repo / "pkg" / "app.py").write_text("from pkg.core import run\n\n\ndef main():\n    return run()\n")
+    (repo / "README.md").write_text("# fixture\n")
+
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+
+    return repo, scan_repository(
+        repo,
+        check_vulnerabilities=False,
+        scan_git_history=False,
+        check_licenses=False,
+    )
+
+
+def test_scan_output_conforms_to_the_schema(scanned_repo):
+    _repo, evidence = scanned_repo
+    assert validate_evidence(evidence, deep=True) == []
+
+
+def test_schema_covers_every_path_consumers_index(scanned_repo):
+    """Guards the other direction: a schema that omitted a key consumers
+    depend on would pass every conformance check while protecting nothing.
+
+    These are the two-level paths found across the CLI, MCP server, and
+    dashboard modules.
+    """
+    _repo, evidence = scanned_repo
+    consumer_paths = [
+        ("repository", "languages"),
+        ("repository", "modules"),
+        ("repository", "dependency_graph"),
+        ("repository", "api_endpoints"),
+        ("repository", "dead_code"),
+        ("repository", "database"),
+        ("repository", "monorepo"),
+        ("repository", "infrastructure"),
+        ("repository", "environment_variables"),
+        ("git", "branches"),
+        ("git", "commit_cadence"),
+        ("git", "ownership"),
+        ("git", "total_commits"),
+        ("security", "secrets"),
+        ("security", "dependency_vulnerabilities"),
+        ("security", "dependency_licenses"),
+        ("architecture", "clusters"),
+        ("architecture", "layer_violations"),
+    ]
+    for section, key in consumer_paths:
+        section_schema = AIR_JSON_SCHEMA["properties"][section]
+        assert key in section_schema["properties"], (
+            f"consumers read evidence['{section}']['{key}'] but the schema does not declare it"
+        )
+        assert key in evidence[section], f"scan output is missing {section}.{key}"
+
+
+def test_validate_reports_a_missing_section_by_path():
+    evidence = _valid_evidence()
+    del evidence["repository"]
+    del evidence["security"]
+
+    problems = validate_evidence(evidence)
+
+    assert any("evidence.repository: required key missing" in p for p in problems)
+    assert any("evidence.security: required key missing" in p for p in problems)
+
+
+def test_validate_reports_a_wrong_container_type():
+    problems = validate_evidence(_valid_evidence(repository=[]))
+
+    assert any(p.startswith("evidence.repository: expected object, got list") for p in problems)
+
+
+def test_validate_rejects_a_boolean_where_a_count_belongs():
+    # bool subclasses int in Python, so a naive isinstance check would let a
+    # counter that started returning True through.
+    problems = validate_evidence(_valid_evidence(git={"available": True, "total_commits": True}))
+
+    assert any("evidence.git.total_commits" in p for p in problems)
+
+
+def test_shallow_validation_ignores_array_items_but_deep_does_not():
+    evidence = _valid_evidence()
+    evidence["repository"]["languages"] = [{"name": "python"}]
+
+    assert validate_evidence(evidence, deep=False) == []
+    deep_problems = validate_evidence(evidence, deep=True)
+    assert any("evidence.repository.languages[0].loc" in p for p in deep_problems)
+
+
+def test_git_unavailable_repo_is_valid_with_only_the_available_flag():
+    # A repo with no commits yields {"available": False} and nothing else.
+    assert validate_evidence(_valid_evidence(git={"available": False})) == []
+
+
+def test_load_evidence_file_rejects_malformed_evidence(tmp_path):
+    path = tmp_path / "air.json"
+    evidence = _valid_evidence(aletheore_version=EVIDENCE_VERSION, repository="not-an-object")
+    path.write_text(json.dumps(evidence))
+
+    with pytest.raises(MalformedEvidenceError) as excinfo:
+        load_evidence_file(path)
+
+    assert "does not match the AIR schema" in str(excinfo.value)
+    assert "evidence.repository" in str(excinfo.value)
+
+
+def test_load_evidence_file_accepts_a_real_scan(scanned_repo, tmp_path):
+    _repo, evidence = scanned_repo
+    path = tmp_path / "air.json"
+    path.write_text(json.dumps(evidence))
+
+    assert load_evidence_file(path)["aletheore_version"] == EVIDENCE_VERSION
+
+
+def test_published_schema_file_matches_the_module(scanned_repo):
+    """The checked-in schema file is what external consumers fetch. If it
+    drifts from AIR_JSON_SCHEMA it is worse than not shipping one.
+    """
+    published = Path(__file__).resolve().parents[2] / "schemas" / "air.schema.json"
+    assert published.exists(), f"{published} is missing - regenerate it from AIR_JSON_SCHEMA"
+    assert json.loads(published.read_text()) == AIR_JSON_SCHEMA

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -24,6 +24,7 @@ from aletheore.cli import (
 from aletheore.device_auth import DeviceFlowError
 from aletheore.evidence import EVIDENCE_VERSION
 from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE, GitAnalysisError
+from tests.air_fixtures import minimal_air_evidence
 from aletheore.report import (
     AmbiguousAdapterError,
     NoAdapterAvailableError,
@@ -1438,24 +1439,15 @@ def make_evidence_file(
     vulnerabilities: list[dict] | None = None,
     layer_violations: list[dict] | None = None,
 ) -> Path:
-    evidence = {
-        "aletheore_version": EVIDENCE_VERSION,
-        "repository": {"modules": [], "dependency_graph": {"nodes": [], "edges": []}},
-        "git": {"total_commits": 0},
-        "security": {
-            "secrets": {
-                "findings": findings or [],
-                "history_scanned_commits": 0,
-                "history_findings": [],
-            },
-            "dependency_vulnerabilities": {
-                "checked": True,
-                "reason": None,
-                "findings": vulnerabilities or [],
-            },
-        },
-        "architecture": {"layer_violations": {"violations": layer_violations or []}},
-    }
+    # Built on the full schema skeleton rather than a hand-picked subset:
+    # `aletheore diff` reads these through load_evidence_file, which rejects
+    # anything that isn't a complete AIR document - and no real snapshot has
+    # ever been anything less.
+    evidence = minimal_air_evidence()
+    evidence["security"]["secrets"]["findings"] = findings or []
+    evidence["security"]["dependency_vulnerabilities"]["checked"] = True
+    evidence["security"]["dependency_vulnerabilities"]["findings"] = vulnerabilities or []
+    evidence["architecture"]["layer_violations"]["violations"] = layer_violations or []
     path.write_text(json.dumps(evidence))
     return path
 

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -217,7 +217,10 @@ def test_api_graph_returns_shape(tmp_path):
     assert set(body.keys()) == {"nodes", "edges", "clusters"}
 
 
-def test_api_mcp_tools_returns_28_tools(tmp_path):
+def test_api_mcp_tools_reflects_the_configured_consent_posture(tmp_path):
+    # The dashboard lists what an agent would actually be offered, so it
+    # shows the default posture: everything except the evidence-upload tool,
+    # which is withheld until ALETHEORE_MCP_ALLOW opts into `external`.
     repo = make_repo_with_evidence(tmp_path)
     app = build_app(repo)
     client = TestClient(app)
@@ -226,8 +229,9 @@ def test_api_mcp_tools_returns_28_tools(tmp_path):
 
     assert response.status_code == 200
     tools = response.json()
-    assert len(tools) == 28
+    assert len(tools) == 27
     names = {t["name"] for t in tools}
+    assert "aletheore_managed_audit" not in names
     assert "aletheore_scan" in names
     assert "aletheore_search" in names
     assert "aletheore_index" in names
@@ -240,7 +244,6 @@ def test_api_mcp_tools_returns_28_tools(tmp_path):
     assert "aletheore_database" in names
     assert "aletheore_infrastructure" in names
     assert "aletheore_environment_variables" in names
-    assert "aletheore_managed_audit" in names
 
 
 def test_logo_route_serves_the_bundled_png(tmp_path):

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -12,6 +12,7 @@ from aletheore.evidence import (
     scan_repository,
     write_evidence,
 )
+from tests.air_fixtures import minimal_air_evidence
 
 
 def run(repo: Path, *args: str):
@@ -58,9 +59,13 @@ def test_is_evidence_version_compatible_rejects_missing_or_malformed_versions():
 
 def test_load_evidence_file_returns_a_compatible_evidence_dict(tmp_path):
     evidence_path = tmp_path / "air.json"
-    evidence_path.write_text(json.dumps({"aletheore_version": EVIDENCE_VERSION, "repository": {}}))
+    evidence = minimal_air_evidence()
+    evidence["repository"]["modules"] = [
+        {"path": "a.py", "language": "python", "imports": [], "imported_by": []}
+    ]
+    evidence_path.write_text(json.dumps(evidence))
 
-    assert load_evidence_file(evidence_path)["repository"] == {}
+    assert load_evidence_file(evidence_path)["repository"]["modules"][0]["path"] == "a.py"
 
 
 def test_load_evidence_file_rejects_an_incompatible_version(tmp_path):
@@ -96,9 +101,7 @@ def test_load_evidence_raises_file_not_found_when_repo_never_scanned(tmp_path):
 
 def test_load_evidence_reads_the_repos_own_air_json(tmp_path):
     (tmp_path / ".aletheore").mkdir()
-    (tmp_path / ".aletheore" / "air.json").write_text(
-        json.dumps({"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}})
-    )
+    (tmp_path / ".aletheore" / "air.json").write_text(json.dumps(minimal_air_evidence()))
 
     assert load_evidence(tmp_path)["repository"]["modules"] == []
 

--- a/src/tests/test_mcp_consent.py
+++ b/src/tests/test_mcp_consent.py
@@ -1,0 +1,250 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from aletheore.evidence import EVIDENCE_VERSION
+from aletheore.mcp_server import (
+    EFFECT_EXTERNAL,
+    EFFECT_NETWORK,
+    EFFECT_WRITE,
+    TOOL_REQUIRED_EFFECTS,
+    UnknownEffectError,
+    allowed_effects,
+    build_server,
+)
+from tests.air_fixtures import minimal_air_evidence
+
+ALL_EFFECTS = frozenset({EFFECT_WRITE, EFFECT_NETWORK, EFFECT_EXTERNAL})
+
+
+def make_repo(tmp_path: Path) -> Path:
+    (tmp_path / ".aletheore").mkdir()
+    evidence = minimal_air_evidence()
+    evidence["aletheore_version"] = EVIDENCE_VERSION
+    (tmp_path / ".aletheore" / "air.json").write_text(json.dumps(evidence))
+    return tmp_path
+
+
+async def tool_names(repo: Path, **kwargs) -> set[str]:
+    server = build_server(repo, **kwargs)
+    return {tool.name for tool in await server.list_tools()}
+
+
+# --- ALETHEORE_MCP_ALLOW parsing -------------------------------------------
+
+
+def test_unset_allows_local_effects_but_not_evidence_upload():
+    effects = allowed_effects(None)
+
+    assert effects == frozenset({EFFECT_WRITE, EFFECT_NETWORK})
+    assert EFFECT_EXTERNAL not in effects
+
+
+def test_read_means_read_only_not_default_plus_read():
+    # An explicit value replaces the default rather than adding to it -
+    # otherwise "read" would be a no-op that looks like a lockdown.
+    assert allowed_effects("read") == frozenset()
+
+
+def test_values_are_parsed_case_and_whitespace_insensitively():
+    assert allowed_effects(" Write , NETWORK ") == frozenset({EFFECT_WRITE, EFFECT_NETWORK})
+
+
+def test_an_unknown_effect_name_is_rejected_rather_than_ignored():
+    # A typo that silently left evidence upload *enabled* would be a security
+    # hole with a plausible-looking explanation attached.
+    with pytest.raises(UnknownEffectError) as excinfo:
+        allowed_effects("write,extenral")
+
+    assert "extenral" in str(excinfo.value)
+
+
+def test_the_error_names_the_valid_effects():
+    with pytest.raises(UnknownEffectError) as excinfo:
+        allowed_effects("nonsense")
+
+    message = str(excinfo.value)
+    for effect in ("read", EFFECT_WRITE, EFFECT_NETWORK, EFFECT_EXTERNAL):
+        assert effect in message
+
+
+# --- Registration is the boundary -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evidence_upload_is_withheld_by_default(tmp_path):
+    names = await tool_names(make_repo(tmp_path))
+
+    assert "aletheore_managed_audit" not in names
+
+
+@pytest.mark.asyncio
+async def test_local_tools_still_work_by_default(tmp_path):
+    # The default posture must not break the product's own core loop: a scan
+    # writing .aletheore/ is what a tool called "aletheore" is for.
+    names = await tool_names(make_repo(tmp_path))
+
+    for expected in ("aletheore_scan", "aletheore_index", "aletheore_healthcheck"):
+        assert expected in names
+
+
+@pytest.mark.asyncio
+async def test_opting_in_to_external_registers_the_upload_tool(tmp_path):
+    names = await tool_names(make_repo(tmp_path), allow=ALL_EFFECTS)
+
+    assert "aletheore_managed_audit" in names
+
+
+@pytest.mark.asyncio
+async def test_read_only_posture_withholds_every_effectful_tool(tmp_path):
+    names = await tool_names(make_repo(tmp_path), allow=frozenset())
+
+    assert names.isdisjoint(TOOL_REQUIRED_EFFECTS)
+    # ...and still serves the evidence queries, which is the point of it.
+    assert "aletheore_imports" in names
+
+
+@pytest.mark.asyncio
+async def test_withheld_tools_are_absent_not_merely_refusing(tmp_path):
+    """The distinction the whole design rests on.
+
+    A registered tool that returns "not permitted" is a convention an agent
+    can keep retrying, and it still spends context advertising something it
+    may not do. Absent from list_tools means it cannot be invoked at all.
+    """
+    repo = make_repo(tmp_path)
+    server = build_server(repo, allow=frozenset())
+
+    assert "aletheore_scan" not in {tool.name for tool in await server.list_tools()}
+    with pytest.raises(Exception) as excinfo:
+        await server.call_tool("aletheore_scan", {})
+    assert "aletheore_scan" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_network_only_posture_withholds_writers_but_keeps_query_embedding(tmp_path):
+    names = await tool_names(make_repo(tmp_path), allow=frozenset({EFFECT_NETWORK}))
+
+    assert "aletheore_search_codebase" in names  # needs network only
+    assert "aletheore_scan" not in names  # also needs write
+    assert "aletheore_index" not in names
+
+
+@pytest.mark.asyncio
+async def test_the_env_var_drives_registration_when_allow_is_not_passed(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALETHEORE_MCP_ALLOW", "write,network,external")
+
+    names = await tool_names(make_repo(tmp_path))
+
+    assert "aletheore_managed_audit" in names
+
+
+@pytest.mark.asyncio
+async def test_withholding_prints_an_actionable_notice_to_stderr(tmp_path, capsys):
+    # stdout is the MCP transport, so the operator - who is the one granting
+    # consent - can only be told on stderr. A missing tool with no
+    # explanation reads as a bug.
+    build_server(make_repo(tmp_path), allow=frozenset())
+    notice = capsys.readouterr().err
+
+    assert "aletheore_scan" in notice
+    assert "ALETHEORE_MCP_ALLOW" in notice
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_printed_when_every_tool_is_permitted(tmp_path, capsys):
+    build_server(make_repo(tmp_path), allow=ALL_EFFECTS)
+
+    assert capsys.readouterr().err == ""
+
+
+# --- The embedding fallback is unreachable from MCP -------------------------
+
+
+def test_embedding_fallback_cannot_send_code_to_openai_without_a_terminal(monkeypatch):
+    """Why aletheore_index and aletheore_search_codebase are `network`, not `external`.
+
+    Both embed through Ollama and fall back to OpenAI, which on its face means
+    they could ship source off-machine under the default posture. They can't:
+    embed_texts refuses the fallback whenever stdin isn't a TTY, and an MCP
+    server is always spawned with piped stdio. This test pins that guard,
+    which lives in another module and is otherwise only incidentally
+    load-bearing for this property.
+    """
+    from unittest.mock import patch
+
+    from aletheore.search_index import EmbeddingProviderUnavailableError, embed_texts
+
+    with patch("aletheore.search_index.OpenAI") as mock_openai, patch(
+        "aletheore.search_index.has_api_key", return_value=True
+    ):
+        mock_openai.return_value.embeddings.create.side_effect = RuntimeError("ollama down")
+
+        with pytest.raises(EmbeddingProviderUnavailableError):
+            embed_texts(["def secret(): ..."])
+
+        # The decisive assertion: no client was ever pointed at OpenAI, so
+        # nothing left the machine. Asserting only on the raised error would
+        # still pass if the code sent the request and then failed.
+        base_urls = [call.kwargs.get("base_url") for call in mock_openai.call_args_list]
+        assert base_urls == ["http://localhost:11434/v1"]
+
+
+# --- Annotations ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_tool_declares_annotations(tmp_path):
+    server = build_server(make_repo(tmp_path), allow=ALL_EFFECTS)
+
+    unannotated = [t.name for t in await server.list_tools() if t.annotations is None]
+
+    assert unannotated == []
+
+
+@pytest.mark.asyncio
+async def test_effectful_tools_are_distinguishable_from_read_only_ones(tmp_path):
+    """Guards the reverse of the gate: annotations that labelled everything
+    read-only would pass every registration test above while telling a client
+    nothing.
+    """
+    server = build_server(make_repo(tmp_path), allow=ALL_EFFECTS)
+    tools = {t.name: t.annotations for t in await server.list_tools()}
+
+    # Writers must not claim to be read-only.
+    for name in ("aletheore_scan", "aletheore_index", "aletheore_healthcheck"):
+        assert tools[name].read_only_hint is False, f"{name} claims to be read-only"
+
+    # Anything reaching off-process must say so. aletheore_answer is in the
+    # effects map but registers only with an adapter, so intersect.
+    for name in set(TOOL_REQUIRED_EFFECTS) & set(tools):
+        assert tools[name].open_world_hint is True, f"{name} does not declare open-world"
+
+    # Pure evidence queries must claim neither.
+    for name in ("aletheore_imports", "aletheore_hotspots", "aletheore_symbol_source"):
+        assert tools[name].read_only_hint is True
+        assert tools[name].open_world_hint is False
+
+
+@pytest.mark.asyncio
+async def test_every_tool_is_either_gated_or_provably_inert(tmp_path):
+    """Catches the next tool added without classifying it.
+
+    A new tool that touches the filesystem or network but is neither listed
+    in TOOL_REQUIRED_EFFECTS nor annotated as such would reopen the finding
+    silently. Anything ungated must therefore prove it is inert: read-only
+    and closed-world.
+    """
+    server = build_server(make_repo(tmp_path), allow=ALL_EFFECTS)
+
+    for tool in await server.list_tools():
+        if tool.name in TOOL_REQUIRED_EFFECTS:
+            continue
+        assert tool.annotations.read_only_hint is True, (
+            f"{tool.name} is not gated but does not declare itself read-only - "
+            "add it to TOOL_REQUIRED_EFFECTS or correct its annotations"
+        )
+        assert tool.annotations.open_world_hint is False, (
+            f"{tool.name} is not gated but declares open-world access"
+        )

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -185,7 +185,10 @@ def test_read_evidence_rejects_evidence_with_no_version_field(tmp_path, monkeypa
 @pytest.mark.asyncio
 async def test_build_server_registers_expected_tools(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
-    server = build_server(repo)
+    # Every effect permitted, so this stays an inventory of the full tool
+    # surface. What the *default* posture registers is covered in
+    # tests/test_mcp_consent.py.
+    server = build_server(repo, allow=frozenset({"write", "network", "external"}))
 
     tools = await server.list_tools()
     names = {t.name for t in tools}
@@ -473,7 +476,9 @@ async def test_aletheore_hotspots_tool_returns_toon_results(tmp_path):
 @pytest.mark.asyncio
 async def test_aletheore_managed_audit_tool_calls_client(tmp_path, monkeypatch):
     repo = make_repo_with_evidence(tmp_path)
-    server = build_server(repo)
+    # This tool uploads evidence off-machine, so it is withheld by default -
+    # opt in explicitly to exercise it.
+    server = build_server(repo, allow=frozenset({"write", "network", "external"}))
     monkeypatch.setattr(
         "aletheore.mcp_server.run_managed_audit_request",
         lambda evidence, token: "# Report\n\nmanaged audit text",
@@ -492,7 +497,7 @@ async def test_aletheore_managed_audit_tool_falls_back_to_saved_credential(tmp_p
     # available" error through MCP even though the CLI's own `audit --managed`
     # worked fine for the exact same saved credential.
     repo = make_repo_with_evidence(tmp_path)
-    server = build_server(repo)
+    server = build_server(repo, allow=frozenset({"write", "network", "external"}))
     monkeypatch.delenv("ALETHEORE_API_TOKEN", raising=False)
     monkeypatch.setattr(
         "aletheore.mcp_server.get_api_key",


### PR DESCRIPTION
## Summary

Six-part hardening pass, reviewed line-by-line and one real gap fixed before merge.

1. **Self-serve data deletion** — `purge_installation_data()`, Settings → Delete all data, and uninstall now purge identically, with an append-only audit log. Not gated on plan or seat.
2. **AIR as a typed contract** — `schemas/air.schema.json`, a dependency-free validator, and `MalformedEvidenceError` naming the offending path instead of a downstream `KeyError`.
3. **Webhook replay/duplicate protection** — atomic `INSERT ... ON CONFLICT DO NOTHING` claim on inbound GitHub/Paddle deliveries, `X-GitHub-Delivery` now mandatory, release-on-failure.
4. **MCP consent boundary** — `ToolAnnotations` on all 28 tools plus `ALETHEORE_MCP_ALLOW`, which is the part that actually binds (withheld tools are never registered). `aletheore_managed_audit` off by default.
5. **MCP import floor fix** — `mcp>=2.0,<3.0`, matching what `mcp_server.py` actually imports.
6. **Managed-audit opinion section** — optional (`llm_suggestions_enabled`), and disclosed via `/verify`'s `fully_evidence_backed`/`non_evidence_backed_sections` rather than implying more than the Ed25519 signature actually attests.

## Fixed before merge

Verified this pass against a fresh test DB rather than trusting the summary. Found and fixed a real gap in #1: `purge_installation_data()` decided who to purge `github_user_emails`/`sessions` for by reading `installation_members` — a table only ever populated for **paid-plan seat holders** (`_require_seat_if_paid` skips free plans by design). Every free-plan installation therefore had zero rows there, so deleting or uninstalling a free-plan install silently left the account owner's email and session behind — the exact bug this feature exists to close, unfixed for the plan tier most installations are actually on.

Fix: added `installation_access_log` (migration 038), a durable record written on every `_require_authorized_installation` call regardless of plan, and repointed the purge at it. `installation_members` is untouched — still exactly what it was, seat/billing bookkeeping.

Confirmed with a red/green check, not just a passing test: temporarily disabled the one wiring line, reran the free-plan deletion test, watched it fail with `0 users purged` reproducing the original bug exactly; re-enabled it, watched it pass.

## Test plan

- [x] Full suite: `src/` 1024 passed; `github-app/` 1029 passed, 8 skipped (up from 1027 — 2 new regression tests, zero failures)
- [x] `ruff check` clean on every file touched
- [x] Red/green check on the free-plan deletion regression test (see above)
- [x] Manual empirical reproduction against a live test DB, before and after the fix

## Not in this PR

Migrations 035–038 are new and **unapplied in production** — this is not deployed with this merge. Two more things land first before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)