### PR TITLE
Abuse controls on telemetry and runtime-events ingestion

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,6 +113,42 @@ genuine deliveries that follow. A handler that raises releases its claim before
 the error propagates, so the provider's retry is not mistaken for a duplicate —
 losing an event outright is a worse failure than processing one twice.
 
+## Inbound Ingestion Limits
+
+Two endpoints accept caller-supplied bodies outside the webhook paths above, and
+each is bounded on three axes: request size, request rate, and accepted schema.
+
+| | `/v1/telemetry` | `/v1/runtime-events` |
+| --- | --- | --- |
+| Auth | None — the CLI has no account to authenticate with | Bearer API token, paid plans only |
+| Body cap | 2 KiB | 256 KiB |
+| Rate limit | 120/hour per client IP | 300/hour per installation |
+| Schema | Unknown fields rejected; both fields length-bounded | Unknown top-level fields rejected; `event` deliberately open |
+| Retention | 365 days, swept on the scheduler tick | n/a — events are not stored, only correlated |
+
+**Body caps are enforced in middleware, before routing.** A check inside the
+handler would reject a payload the server had already read and parsed, which is
+the cost the cap exists to avoid. Requests declaring no `Content-Length` are
+rejected with 411 rather than waved through — without a declared size the cap is
+unenforceable before reading, and both legitimate clients always send one. The
+caps are per-path on purpose: a global limit would break the managed audit API,
+which accepts large evidence payloads by design.
+
+**The two rate limits are keyed differently, deliberately.** Telemetry is keyed
+by client IP, taken from the *last* `X-Forwarded-For` entry — the one the
+reverse proxy appends. Earlier entries arrive with the request and are
+attacker-controlled, so keying on them would let one caller mint unlimited
+buckets by varying a header. Runtime events are keyed by installation instead:
+that is the unit that owns the cost, and the only identity an authenticated
+caller cannot change. Each accepted runtime event enqueues a job onto the same
+`scans` queue that runs Flash reviews, AIRview builds, and managed audits, so an
+uncapped caller there delays billed work for every installation sharing the
+worker.
+
+Both limits fail open if Redis is unavailable, matching the sign-in rate limit
+and the Paddle IP allowlist: an outage should cost abuse protection, not
+availability.
+
 ## What an Audit Signature Attests
 
 Managed audit reports are signed with Ed25519 and can be checked at

--- a/github-app/app_server/ingest_limits.py
+++ b/github-app/app_server/ingest_limits.py
@@ -1,0 +1,64 @@
+"""Body-size caps for the two inbound ingestion endpoints.
+
+/v1/telemetry is public and unauthenticated; /v1/runtime-events is
+authenticated but accepts a caller-supplied dict. Neither had any bound on
+request size, so either could be handed an arbitrarily large body that the
+server parses into memory before any of its own validation runs.
+
+The cap is enforced in middleware rather than inside the handler because by
+the time a handler runs, FastAPI has already read and parsed the body - a
+check there rejects a payload the process has fully materialized, which is
+the cost the cap exists to avoid.
+
+Caps are per-path and deliberately generous relative to real traffic: the
+point is to make a hostile body impossible, not to police a legitimate one.
+"""
+
+# {"event": "scan", "anonymous_id": "<=64 chars"} is ~100 bytes. 2 KiB leaves
+# room for a future field without leaving room for an attack.
+TELEMETRY_MAX_BODY_BYTES = 2 * 1024
+
+# A Sentry-compatible error event carries a stack trace, so it is legitimately
+# much larger than a telemetry ping - but parse_sentry_event only reads
+# exception.values[].stacktrace.frames[] and request.url/method, so a payload
+# past this size is carrying data this endpoint has no use for.
+RUNTIME_EVENT_MAX_BODY_BYTES = 256 * 1024
+
+MAX_BODY_BYTES_BY_PATH = {
+    "/v1/telemetry": TELEMETRY_MAX_BODY_BYTES,
+    "/v1/runtime-events": RUNTIME_EVENT_MAX_BODY_BYTES,
+}
+
+
+class BodyTooLargeError(Exception):
+    def __init__(self, limit: int) -> None:
+        super().__init__(f"request body exceeds the {limit} byte limit for this endpoint")
+        self.limit = limit
+
+
+class MissingContentLengthError(Exception):
+    pass
+
+
+def check_declared_body_size(path: str, method: str, content_length: str | None) -> None:
+    """Raise if this request declares a body too large for `path`.
+
+    A missing Content-Length is rejected rather than waved through: without it
+    the cap is unenforceable before reading, and both clients that legitimately
+    call these endpoints (the Aletheore CLI via httpx, and Sentry-style
+    webhook senders) always send one for a JSON body. Accepting a chunked
+    request here would leave exactly the hole this module exists to close.
+    """
+    if method != "POST":
+        return
+    limit = MAX_BODY_BYTES_BY_PATH.get(path)
+    if limit is None:
+        return
+    if content_length is None:
+        raise MissingContentLengthError
+    try:
+        declared = int(content_length)
+    except ValueError as exc:
+        raise MissingContentLengthError from exc
+    if declared > limit:
+        raise BodyTooLargeError(limit)

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -17,6 +17,11 @@ from app_server.db import claim_webhook_delivery, create_pool, release_webhook_d
 from app_server.demo_scan_api import demo_scan_router
 from app_server.error_alerts import send_error_alert
 from app_server.frontend import frontend_router
+from app_server.ingest_limits import (
+    BodyTooLargeError,
+    MissingContentLengthError,
+    check_declared_body_size,
+)
 from app_server.logging_config import configure_json_logging
 from app_server.managed_audit_api import managed_audit_router
 from app_server.metrics import metrics_router
@@ -61,6 +66,23 @@ app.include_router(paddle_webhook_router)
 app.include_router(demo_scan_router)
 app.include_router(telemetry_router)
 app.include_router(runtime_events_router)
+
+
+@app.middleware("http")
+async def limit_ingest_body_size(request: Request, call_next):
+    # Runs before routing, so an oversized body is refused on its declared
+    # size rather than after the server has read and parsed it.
+    try:
+        check_declared_body_size(
+            request.url.path, request.method, request.headers.get("content-length")
+        )
+    except BodyTooLargeError as exc:
+        return JSONResponse(status_code=413, content={"detail": str(exc)})
+    except MissingContentLengthError:
+        return JSONResponse(
+            status_code=411, content={"detail": "content-length required for this endpoint"}
+        )
+    return await call_next(request)
 
 
 @app.middleware("http")

--- a/github-app/app_server/runtime_events.py
+++ b/github-app/app_server/runtime_events.py
@@ -11,20 +11,74 @@ this ingests the one well-known event shape (exception.values[].
 stacktrace.frames[], request.url/method - see aletheore.runtime_events)
 and does one thing with it well.
 """
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from aletheore.runtime_events import parse_sentry_event
 from app_server.config import get_settings
 from app_server.db import touch_api_token
 from app_server.managed_audit_api import _authenticate_token, _get_queue
+from app_server.rate_limit import is_rate_limited
 
 runtime_events_router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Every accepted event enqueues a job onto "scans" - the same queue that runs
+# Flash reviews, AIRview builds, and managed audits. So an uncapped caller
+# here doesn't just cost storage, it delays billed LLM work for that
+# installation and every other one sharing the worker. The limit is keyed by
+# installation rather than IP because that is the unit that owns the queue
+# pressure, and it is the only identity an authenticated caller can't change.
+#
+# A production incident is bursty by nature, so this is set well above a
+# realistic error spike: it exists to stop a runaway or a leaked token, not to
+# shape normal traffic.
+RUNTIME_EVENT_RATE_LIMIT = 300
+RUNTIME_EVENT_RATE_LIMIT_WINDOW_SECONDS = 3600
+
+# owner + "/" + repo, both capped by GitHub well below this.
+_MAX_REPO_FULL_NAME = 255
 
 
 class RuntimeEventRequest(BaseModel):
-    repo_full_name: str = Field(min_length=1)
+    model_config = ConfigDict(extra="forbid")
+
+    repo_full_name: str = Field(min_length=1, max_length=_MAX_REPO_FULL_NAME)
+    # Deliberately still an open dict: this ingests whatever a
+    # Sentry-compatible sender emits and parse_sentry_event picks out the few
+    # fields it needs. The bound on it is the body-size cap in
+    # app_server/ingest_limits.py, not a field schema that would reject real
+    # senders for carrying their own extra keys.
     event: dict
+
+
+def _enforce_runtime_event_rate_limit(installation_id: int) -> None:
+    from redis import Redis
+
+    settings = get_settings()
+    try:
+        rate_limited = is_rate_limited(
+            Redis.from_url(settings.redis_url),
+            f"ratelimit:runtime-events:{installation_id}",
+            RUNTIME_EVENT_RATE_LIMIT,
+            RUNTIME_EVENT_RATE_LIMIT_WINDOW_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Fail open, matching every other rate limit in this service. Note the
+        # blast radius differs here: a Redis outage that lets this through
+        # also means the queue this protects is itself unavailable, so the
+        # enqueue below would fail regardless.
+        logger.warning("runtime event rate limit check failed (%s); allowing request", exc)
+        rate_limited = False
+
+    if rate_limited:
+        raise HTTPException(
+            status_code=429,
+            detail="too many runtime events for this installation",
+            headers={"Retry-After": str(RUNTIME_EVENT_RATE_LIMIT_WINDOW_SECONDS)},
+        )
 
 
 @runtime_events_router.post("/v1/runtime-events")
@@ -32,6 +86,8 @@ async def report_runtime_event(request: Request, body: RuntimeEventRequest):
     installation, token_hash = await _authenticate_token(request)
     if installation["plan"] == "free":
         raise HTTPException(status_code=402, detail="runtime event correlation requires a paid plan")
+
+    _enforce_runtime_event_rate_limit(installation["installation_id"])
 
     parsed = parse_sentry_event(body.event)
     if parsed is None:

--- a/github-app/app_server/telemetry.py
+++ b/github-app/app_server/telemetry.py
@@ -1,27 +1,88 @@
 """Anonymous CLI usage telemetry - see migrations/023_cli_telemetry.sql
 for the privacy/scope rationale. Public, unauthenticated ingestion (the
 CLI has no account/token to authenticate with); internal stats read
-requires the same bearer-token gate as metrics.py's queue-stats."""
+requires the same bearer-token gate as metrics.py's queue-stats.
+
+Being unauthenticated makes this the most exposed write path in the
+service: every accepted request is an INSERT into a table nothing else
+gates. The abuse controls here are therefore the only thing standing
+between a stranger and unbounded row growth - a per-IP rate limit, a
+body-size cap enforced in middleware (app_server/ingest_limits.py), and
+a schema narrow enough that nothing but the two expected fields is
+accepted at all.
+"""
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app_server.config import get_settings
 from app_server.db import count_telemetry_events, record_telemetry_event
+from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for
+from app_server.rate_limit import is_rate_limited
 
 telemetry_router = APIRouter()
+logger = logging.getLogger(__name__)
 
 _VALID_EVENT_TYPES = {"scan"}
 
+# The CLI reports one event per scan. A developer scanning constantly, or a
+# CI fleet behind one NAT address, stays far under this; a script trying to
+# inflate the table does not. Being rate-limited only drops a usage stat -
+# the CLI treats reporting as fire-and-forget - so this is a cheap ceiling
+# with no user-visible cost when it trips.
+TELEMETRY_RATE_LIMIT = 120
+TELEMETRY_RATE_LIMIT_WINDOW_SECONDS = 3600
+
 
 class TelemetryEvent(BaseModel):
-    event: str
+    # Rejecting unknown keys keeps the accepted shape exactly the two fields
+    # below, so this endpoint can never become an accidental store for
+    # whatever a caller decides to attach.
+    model_config = ConfigDict(extra="forbid")
+
+    # Bounded even though the value is checked against _VALID_EVENT_TYPES
+    # below: without a max_length the check happens only after Pydantic has
+    # already materialized whatever string arrived.
+    event: str = Field(min_length=1, max_length=32)
     anonymous_id: str = Field(min_length=8, max_length=64)
+
+
+def _enforce_telemetry_rate_limit(request: Request) -> None:
+    from redis import Redis
+
+    settings = get_settings()
+    client_ip = client_ip_from_forwarded_for(
+        request.headers.get("x-forwarded-for"),
+        request.client.host if request.client else "",
+    )
+    try:
+        rate_limited = is_rate_limited(
+            Redis.from_url(settings.redis_url),
+            f"ratelimit:telemetry:{client_ip}",
+            TELEMETRY_RATE_LIMIT,
+            TELEMETRY_RATE_LIMIT_WINDOW_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Fail open, matching _enforce_auth_rate_limit and the Paddle IP
+        # allowlist: a Redis outage should cost abuse protection on a
+        # best-effort stats endpoint, not turn into a hard failure.
+        logger.warning("telemetry rate limit check failed (%s); allowing request", exc)
+        rate_limited = False
+
+    if rate_limited:
+        raise HTTPException(
+            status_code=429,
+            detail="too many requests",
+            headers={"Retry-After": str(TELEMETRY_RATE_LIMIT_WINDOW_SECONDS)},
+        )
 
 
 @telemetry_router.post("/v1/telemetry")
 async def report_telemetry_event(payload: TelemetryEvent, request: Request):
     if payload.event not in _VALID_EVENT_TYPES:
         raise HTTPException(status_code=400, detail="unknown event type")
+    _enforce_telemetry_rate_limit(request)
     await record_telemetry_event(request.app.state.db_pool, payload.event, payload.anonymous_id)
     return {"ok": True}
 

--- a/github-app/migrations/039_telemetry_retention_index.sql
+++ b/github-app/migrations/039_telemetry_retention_index.sql
@@ -1,0 +1,10 @@
+-- Supports the telemetry retention sweep's range delete.
+--
+-- 023_cli_telemetry.sql indexes (event_type, occurred_at DESC), which serves
+-- count_telemetry_events but cannot serve the sweep: that filters on
+-- occurred_at alone, and Postgres can't range-scan the second column of a
+-- composite index without a predicate on the first. Without this the sweep
+-- degrades to a sequential scan over the one table an unauthenticated caller
+-- can grow.
+CREATE INDEX IF NOT EXISTS cli_telemetry_events_occurred_at_idx
+    ON cli_telemetry_events (occurred_at);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -542,6 +542,28 @@ def insert_endpoint_health(
         conn.commit()
 
 
+def delete_expired_telemetry_events(dsn: str, retention_days: int) -> int:
+    """Drop anonymous CLI telemetry older than the retention window.
+
+    /v1/telemetry is unauthenticated, so without this the one table a stranger
+    can write to grows without bound. The rows are aggregate usage counters
+    with no per-user value once they age out - count_telemetry_events reports
+    totals and unique machines, neither of which needs multi-year history.
+    """
+    import psycopg
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM cli_telemetry_events "
+                "WHERE occurred_at < now() - make_interval(days => %s)",
+                (retention_days,),
+            )
+            deleted = cur.rowcount
+        conn.commit()
+    return deleted
+
+
 def delete_expired_webhook_deliveries(dsn: str, retention_days: int) -> int:
     """Drop delivery GUIDs older than the retention window.
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -51,6 +51,7 @@ from scan_worker.db import (
     count_repo_scans_since,
     delete_docs_symbols_not_in,
     delete_expired_sessions,
+    delete_expired_telemetry_events,
     delete_expired_webhook_deliveries,
     delete_wiki_subsystems_not_in,
     email_already_sent,
@@ -1912,6 +1913,21 @@ def run_session_cleanup_job() -> None:
 # replayed event can never outlive its ledger entry. See
 # delete_expired_webhook_deliveries.
 WEBHOOK_DELIVERY_RETENTION_DAYS = 30
+
+
+# Aggregate usage counters, not per-user data - a year is far more history
+# than count_telemetry_events needs, and bounds the one table an
+# unauthenticated caller can write to.
+TELEMETRY_RETENTION_DAYS = 365
+
+
+@log_job
+def run_telemetry_cleanup_job() -> None:
+    dsn = get_settings().database_url
+    deleted = delete_expired_telemetry_events(dsn, TELEMETRY_RETENTION_DAYS)
+    logging.getLogger("scan_worker.jobs").info(
+        "telemetry cleanup completed", extra={"deleted_count": deleted}
+    )
 
 
 @log_job

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -22,6 +22,8 @@ SESSION_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # and means the table can never quietly grow unbounded if the scheduler
 # spends a long stretch restarting.
 WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS = 60
+# Same shape again: one range DELETE over an indexed timestamp column.
+TELEMETRY_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # The sweep itself only calls run_live_docs_full_build_job for repos that
 # list_paid_repos_due_for_docs_catchup already filtered to "genuinely due"
 # (48h+ since last sweep, real activity since then) - most ticks this
@@ -76,6 +78,10 @@ def run_forever(
         scans_queue.enqueue(
             "scan_worker.jobs.run_webhook_delivery_cleanup_job",
             job_timeout=WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS,
+        )
+        scans_queue.enqueue(
+            "scan_worker.jobs.run_telemetry_cleanup_job",
+            job_timeout=TELEMETRY_CLEANUP_JOB_TIMEOUT_SECONDS,
         )
         scans_queue.enqueue(
             "scan_worker.jobs.run_live_docs_catchup_sweep_job",

--- a/github-app/tests/test_ingest_abuse_controls.py
+++ b/github-app/tests/test_ingest_abuse_controls.py
@@ -1,0 +1,489 @@
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.ingest_limits import (
+    RUNTIME_EVENT_MAX_BODY_BYTES,
+    TELEMETRY_MAX_BODY_BYTES,
+    BodyTooLargeError,
+    MissingContentLengthError,
+    check_declared_body_size,
+)
+from app_server.main import app
+from scan_worker.db import delete_expired_telemetry_events
+
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://postgres:test@localhost:55433/aletheore_test",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limit(monkeypatch):
+    """Default to rate limiting out of the way.
+
+    Every test that isn't about the limiter needs it disabled, and the tests
+    that *are* about it override this explicitly - that way a limiter bug can
+    never silently make an unrelated test pass by rejecting the request
+    before it reaches the thing under test.
+    """
+    monkeypatch.setattr("app_server.telemetry.is_rate_limited", lambda *a, **k: False)
+    monkeypatch.setattr("app_server.runtime_events.is_rate_limited", lambda *a, **k: False)
+
+
+# --- Body-size caps ----------------------------------------------------------
+
+
+def test_oversized_declared_body_is_rejected():
+    with pytest.raises(BodyTooLargeError):
+        check_declared_body_size("/v1/telemetry", "POST", str(TELEMETRY_MAX_BODY_BYTES + 1))
+
+
+def test_a_body_at_the_limit_is_allowed():
+    check_declared_body_size("/v1/telemetry", "POST", str(TELEMETRY_MAX_BODY_BYTES))
+
+
+def test_missing_content_length_is_refused_not_waved_through():
+    # Without a declared size the cap is unenforceable before reading, which
+    # is the whole hole. Both real clients always send one.
+    with pytest.raises(MissingContentLengthError):
+        check_declared_body_size("/v1/telemetry", "POST", None)
+
+
+def test_a_non_numeric_content_length_is_refused():
+    with pytest.raises(MissingContentLengthError):
+        check_declared_body_size("/v1/telemetry", "POST", "not-a-number")
+
+
+def test_uncapped_paths_are_untouched():
+    # The cap is per-path on purpose: a global limit would break the managed
+    # audit API, which legitimately accepts large evidence payloads.
+    check_declared_body_size("/v1/managed-audit", "POST", str(50 * 1024 * 1024))
+
+
+def test_get_requests_are_untouched():
+    check_declared_body_size("/v1/telemetry", "GET", None)
+
+
+def test_runtime_events_allows_a_real_stack_trace():
+    # A Sentry event with frames is legitimately far bigger than a telemetry
+    # ping; the caps are not interchangeable.
+    assert RUNTIME_EVENT_MAX_BODY_BYTES > TELEMETRY_MAX_BODY_BYTES * 50
+    check_declared_body_size("/v1/runtime-events", "POST", str(100 * 1024))
+
+
+@pytest.mark.asyncio
+async def test_oversized_telemetry_post_gets_413_end_to_end(pool):
+    app.state.db_pool = pool
+    body = json.dumps({"event": "scan", "anonymous_id": "x" * 60, "pad": "p" * 4000}).encode()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", content=body, headers={"Content-Type": "application/json"}
+        )
+
+    assert response.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_oversized_body_never_reaches_the_database(pool, monkeypatch):
+    """The point of enforcing in middleware rather than the handler.
+
+    A handler-level check rejects a payload the process has already read and
+    parsed - which is the cost the cap exists to avoid.
+    """
+    app.state.db_pool = pool
+    recorded = []
+    monkeypatch.setattr(
+        "app_server.telemetry.record_telemetry_event",
+        lambda *a, **k: recorded.append(a),
+    )
+    body = json.dumps({"event": "scan", "anonymous_id": "y" * 60, "pad": "p" * 8000}).encode()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post(
+            "/v1/telemetry", content=body, headers={"Content-Type": "application/json"}
+        )
+
+    assert recorded == []
+
+
+# --- Schema narrowing --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_telemetry_rejects_unknown_fields(pool):
+    # Otherwise an unauthenticated endpoint becomes a store for whatever a
+    # caller attaches.
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry",
+            json={"event": "scan", "anonymous_id": "a" * 20, "extra": "smuggled"},
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_telemetry_rejects_an_overlong_event_name(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", json={"event": "s" * 64, "anonymous_id": "a" * 20}
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_a_valid_telemetry_event_still_works(pool):
+    # The controls must not break the thing they protect.
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", json={"event": "scan", "anonymous_id": "machine-abc-123"}
+        )
+
+    assert response.status_code == 200, response.text
+    stored = await pool.fetchval(
+        "SELECT count(*) FROM cli_telemetry_events WHERE anonymous_id = 'machine-abc-123'"
+    )
+    assert stored == 1
+
+
+# --- Rate limiting -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_telemetry_returns_429_when_rate_limited(pool, monkeypatch):
+    app.state.db_pool = pool
+    monkeypatch.setattr("app_server.telemetry.is_rate_limited", lambda *a, **k: True)
+    recorded = []
+    monkeypatch.setattr(
+        "app_server.telemetry.record_telemetry_event", lambda *a, **k: recorded.append(a)
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", json={"event": "scan", "anonymous_id": "b" * 20}
+        )
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"]
+    assert recorded == [], "a rate-limited request still wrote to the database"
+
+
+@pytest.mark.asyncio
+async def test_telemetry_fails_open_when_redis_is_down(pool, monkeypatch):
+    # A Redis outage should cost abuse protection on a best-effort stats
+    # endpoint, not turn into a hard failure for every CLI user.
+    app.state.db_pool = pool
+
+    def _boom(*_args, **_kwargs):
+        raise ConnectionError("redis unavailable")
+
+    monkeypatch.setattr("app_server.telemetry.is_rate_limited", _boom)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", json={"event": "scan", "anonymous_id": "c" * 20}
+        )
+
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
+async def test_telemetry_rate_limit_key_cannot_be_spoofed_via_forwarded_for(pool, monkeypatch):
+    """The limit is only worth having if a caller can't rotate its own key.
+
+    Caddy appends the real connecting peer as the LAST X-Forwarded-For entry;
+    anything earlier arrived with the request and is attacker-controlled. So
+    the key must derive from the last entry - keying on the first would let
+    one client mint unlimited buckets just by varying a header.
+    """
+    app.state.db_pool = pool
+    keys = []
+    monkeypatch.setattr(
+        "app_server.telemetry.is_rate_limited",
+        lambda _conn, key, _limit, _window: keys.append(key) or False,
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post(
+            "/v1/telemetry",
+            json={"event": "scan", "anonymous_id": "d" * 20},
+            headers={"x-forwarded-for": "203.0.113.9, 10.0.0.1"},
+        )
+
+    assert keys == ["ratelimit:telemetry:10.0.0.1"]
+    assert "203.0.113.9" not in keys[0], "attacker-supplied hop was used as the key"
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_is_rejected_before_the_rate_limiter(pool, monkeypatch):
+    # A junk event must not consume a caller's budget - otherwise malformed
+    # traffic could exhaust the allowance for a legitimate client on the
+    # same NAT address.
+    app.state.db_pool = pool
+    calls = []
+    monkeypatch.setattr(
+        "app_server.telemetry.is_rate_limited", lambda *a, **k: calls.append(a) or False
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", json={"event": "not-a-real-event", "anonymous_id": "e" * 20}
+        )
+
+    assert response.status_code == 400
+    assert calls == []
+
+
+# --- Retention ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retention_sweep_drops_old_events_and_keeps_recent_ones(pool):
+    now = datetime.now(timezone.utc)
+    await pool.execute(
+        "INSERT INTO cli_telemetry_events (event_type, anonymous_id, occurred_at) "
+        "VALUES ($1, $2, $3)",
+        "scan",
+        "old-machine",
+        now - timedelta(days=366),
+    )
+    await pool.execute(
+        "INSERT INTO cli_telemetry_events (event_type, anonymous_id, occurred_at) "
+        "VALUES ($1, $2, $3)",
+        "scan",
+        "recent-machine",
+        now - timedelta(days=364),
+    )
+
+    deleted = delete_expired_telemetry_events(TEST_DATABASE_URL, 365)
+
+    assert deleted == 1
+    remaining = await pool.fetch("SELECT anonymous_id FROM cli_telemetry_events")
+    assert {row["anonymous_id"] for row in remaining} == {"recent-machine"}
+
+
+# --- Runtime events: the queue is the resource being protected ---------------
+
+
+def _sentry_event() -> dict:
+    return {
+        "exception": {
+            "values": [
+                {
+                    "type": "ZeroDivisionError",
+                    "value": "division by zero",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "filename": "app/handler.py",
+                                "function": "handle_request",
+                                "lineno": 42,
+                                "in_app": True,
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        "request": {"url": "https://api.example.com/v1/users", "method": "GET"},
+    }
+
+
+async def _paid_installation_with_token(pool, installation_id: int = 700) -> str:
+    import hashlib
+
+    from app_server.db import create_api_token, set_installation_plan, upsert_installation
+
+    await upsert_installation(pool, installation_id, "octocat")
+    await set_installation_plan(pool, installation_id, "air")
+    token = f"runtime-token-{installation_id}"
+    await create_api_token(
+        pool, installation_id, hashlib.sha256(token.encode()).hexdigest(), "laptop", "octocat"
+    )
+    return token
+
+
+@pytest.mark.asyncio
+async def test_runtime_events_returns_429_and_enqueues_nothing_when_limited(pool, monkeypatch):
+    # Each accepted event enqueues onto "scans" - the same queue as Flash
+    # reviews, AIRview builds, and managed audits. A rate-limited request
+    # that still enqueued would defeat the entire point.
+    app.state.db_pool = pool
+    token = await _paid_installation_with_token(pool, 700)
+    monkeypatch.setattr("app_server.runtime_events.is_rate_limited", lambda *a, **k: True)
+    enqueued = []
+    monkeypatch.setattr(
+        "app_server.runtime_events._get_queue",
+        lambda _url: type("Q", (), {"enqueue": lambda _s, *a, **k: enqueued.append(a)})(),
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={"repo_full_name": "octocat/widgets", "event": _sentry_event()},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 429
+    assert enqueued == [], "a rate-limited request still enqueued a job"
+
+
+@pytest.mark.asyncio
+async def test_runtime_events_rate_limit_is_keyed_by_installation(pool, monkeypatch):
+    # Installation, not IP: it is the unit that owns the queue pressure, and
+    # the only identity an authenticated caller cannot change at will.
+    app.state.db_pool = pool
+    token = await _paid_installation_with_token(pool, 701)
+    keys = []
+    monkeypatch.setattr(
+        "app_server.runtime_events.is_rate_limited",
+        lambda _conn, key, _limit, _window: keys.append(key) or False,
+    )
+    monkeypatch.setattr(
+        "app_server.runtime_events._get_queue",
+        lambda _url: type("Q", (), {"enqueue": lambda _s, *a, **k: type("J", (), {"id": "j1"})()})(),
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={"repo_full_name": "octocat/widgets", "event": _sentry_event()},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert keys == ["ratelimit:runtime-events:701"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_events_rejects_unknown_top_level_fields(pool):
+    app.state.db_pool = pool
+    token = await _paid_installation_with_token(pool, 702)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={
+                "repo_full_name": "octocat/widgets",
+                "event": _sentry_event(),
+                "smuggled": "x",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_runtime_events_rejects_an_overlong_repo_name(pool):
+    app.state.db_pool = pool
+    token = await _paid_installation_with_token(pool, 703)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={"repo_full_name": "o" * 300, "event": _sentry_event()},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_runtime_events_rate_limit_runs_after_the_paid_plan_gate(pool, monkeypatch):
+    # A free-plan caller should get the 402 that explains the problem, not a
+    # 429 that misattributes it - and should not consume a rate-limit slot.
+    from app_server.db import create_api_token, upsert_installation
+
+    import hashlib
+
+    app.state.db_pool = pool
+    await upsert_installation(pool, 704, "octocat")
+    token = "free-plan-token"
+    await create_api_token(
+        pool, 704, hashlib.sha256(token.encode()).hexdigest(), "laptop", "octocat"
+    )
+    calls = []
+    monkeypatch.setattr(
+        "app_server.runtime_events.is_rate_limited", lambda *a, **k: calls.append(a) or False
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/runtime-events",
+            json={"repo_full_name": "octocat/widgets", "event": _sentry_event()},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 402
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_length_less_request_is_refused_end_to_end(pool):
+    """The 411 path, exercised for real.
+
+    A generator body makes httpx use chunked transfer encoding with no
+    Content-Length - the one shape that would otherwise slip past a cap that
+    can only read a declared size. Passing bytes here does not test this:
+    httpx computes a Content-Length for those and the request sails through.
+    """
+    app.state.db_pool = pool
+
+    async def _chunks():
+        yield b'{"event":"scan","anonymous_id":"abcdefghij"}'
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/telemetry", content=_chunks(), headers={"Content-Type": "application/json"}
+        )
+
+    assert response.status_code == 411
+    assert "content-length" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_the_oversized_and_length_less_paths_return_distinct_codes(pool):
+    # 413 and 411 mean different things to a client: "shrink your payload" vs
+    # "declare its size". Collapsing them into one code would mislead.
+    app.state.db_pool = pool
+
+    async def _chunks():
+        yield b'{"event":"scan","anonymous_id":"abcdefghij"}'
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        length_less = await client.post(
+            "/v1/telemetry", content=_chunks(), headers={"Content-Type": "application/json"}
+        )
+        oversized = await client.post(
+            "/v1/telemetry",
+            content=json.dumps({"event": "scan", "anonymous_id": "z" * 60, "pad": "p" * 5000}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert (length_less.status_code, oversized.status_code) == (411, 413)

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -8,6 +8,7 @@ from scan_worker.scheduler import (
     HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS,
     SCANS_QUEUE_NAME,
     SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
+    TELEMETRY_CLEANUP_JOB_TIMEOUT_SECONDS,
     WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS,
     WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
     WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
@@ -55,7 +56,7 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
 
-    assert scans_queue.enqueue.call_count == 18
+    assert scans_queue.enqueue.call_count == 21
     session_cleanup_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
@@ -80,12 +81,17 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_webhook_delivery_cleanup_job",)
     ]
+    telemetry_cleanup_calls = [
+        c for c in scans_queue.enqueue.call_args_list
+        if c.args == ("scan_worker.jobs.run_telemetry_cleanup_job",)
+    ]
     assert len(session_cleanup_calls) == 3
     assert len(docs_catchup_calls) == 3
     assert len(wiki_catchup_calls) == 3
     assert len(weekly_digest_calls) == 3
     assert len(staleness_check_calls) == 3
     assert len(webhook_cleanup_calls) == 3
+    assert len(telemetry_cleanup_calls) == 3
     for call in session_cleanup_calls:
         assert call.kwargs == {"job_timeout": SESSION_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in docs_catchup_calls:
@@ -98,6 +104,8 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS}
     for call in webhook_cleanup_calls:
         assert call.kwargs == {"job_timeout": WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS}
+    for call in telemetry_cleanup_calls:
+        assert call.kwargs == {"job_timeout": TELEMETRY_CLEANUP_JOB_TIMEOUT_SECONDS}
     # Sleeps between iterations, not after the last one.
     assert sleeps == [42, 42]
 


### PR DESCRIPTION
## Summary

`/v1/telemetry` (unauthenticated) and `/v1/runtime-events` (authenticated but caller-supplied) had no bound on request size, rate, or accepted schema, and `cli_telemetry_events` had no retention at all.

- **Body caps** (2 KiB / 256 KiB) enforced in middleware, before routing — rejected on declared `Content-Length` rather than after the server has read and parsed the body. Missing `Content-Length` → 411 rather than waved through, since a chunked request would otherwise slip past a cap that can only read a declared size.
- **Rate limits** reuse the existing `is_rate_limited`/`client_ip_from_forwarded_for` rather than new machinery. Telemetry keys on the *last* `X-Forwarded-For` hop (the one Caddy appends — an earlier hop is attacker-supplied). Runtime events key by installation, since that's the unit that owns the queue pressure (every accepted event enqueues onto `scans`, the same queue as Flash reviews/AIRview/managed audits) and the only identity an authenticated caller can't change. Both fail open on Redis outage, matching every other rate limit in this service.
- **Schema narrowing**: `extra="forbid"` + length bounds on both models. `runtime_events.event` stays an open dict deliberately — it's whatever a Sentry-compatible sender emits, bounded by the body cap, not a field schema that would reject real senders.
- **Retention**: 365-day sweep on the existing scheduler tick, migration 039 adds the `occurred_at` index the sweep's range delete actually needs (the existing composite index leads with `event_type`, unusable for a range scan on `occurred_at` alone).

## Verified independently, not just written

- Read every changed line, not just the summary.
- Confirmed the rate-limit key reuses `client_ip_from_forwarded_for`, an already-established, already-correct function — verified its "last entry" behavior against the source rather than trusting the claim.
- Confirmed the length-less-request test genuinely exercises the 411 path (async generator body, not bytes — httpx computes `Content-Length` for bytes, which would silently skip it).
- Ran the new test file directly: 24/24 pass.
- Ran the full suite: **1053 passed, 8 skipped** (1029 + 24 new, zero failures) — matches the claimed count exactly.
- `ruff check` clean on all 9 touched files.

No gaps found this time — unlike the previous hardening pass (#154), where this same review process caught a real free-plan data-deletion bug.

## Not in this PR

Migration 039 is new and unapplied in production, same as 035–038 from #154. Not deployed with this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)