### PR TITLE
docs: record 2026-08-10 production redeploy and re-verification

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 **Status:** Active baseline
 **Owner:** TODO
 **Related Documents:** [.github/ISSUE_TEMPLATE/security-report.md](.github/ISSUE_TEMPLATE/security-report.md), [docs/operations/DATA-HANDLING.md](docs/operations/DATA-HANDLING.md), [docs/operations/INCIDENT-RESPONSE.md](docs/operations/INCIDENT-RESPONSE.md)
-**Last Updated:** 2026-07-23
+**Last Updated:** 2026-08-10
 
 ## Purpose
 

--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
     "AIRview",
     "Arihant",
     "asyncio",
+    "autoheal",
     "BYOK",
     "CODEOWNERS",
     "DeepSeek",

--- a/docs/operations/DEPLOYMENT-VERIFICATION.md
+++ b/docs/operations/DEPLOYMENT-VERIFICATION.md
@@ -4,8 +4,8 @@
 **Status:** Active baseline
 **Owner:** Arihant Kaul
 **Related Documents:** [README.md](README.md), [INCIDENT-RESPONSE.md](INCIDENT-RESPONSE.md), [../../github-app/README.md](../../github-app/README.md)
-**Last Updated:** 2026-08-04
-**Snapshot Freshness:** CURRENT as of 2026-08-04 - production was redeployed to `master` (commit `447d7e9`) and re-verified live via SSH the same day.
+**Last Updated:** 2026-08-10
+**Snapshot Freshness:** CURRENT as of 2026-08-10 - production was redeployed to `master` (commit `1659182`) and re-verified live via SSH the same day.
 
 ## Purpose
 
@@ -30,25 +30,28 @@ Before claiming a hardening change is live, verify:
 
 ## Current Server Snapshot
 
-As of 2026-08-04, following a redeploy to `master` (`git pull --ff-only` + `docker compose build` + `docker compose up -d`), live inspection found:
+As of 2026-08-10, following a redeploy to `master` (`git reset --hard origin/master` + `docker compose build app-server scan-worker health-worker scheduler` + `docker compose up -d --no-deps` for those four), live inspection found:
 
 - Host: `srv1675832`.
 - Deployment path: `/root/aletheore`.
 - Remote: `https://github.com/Aletheore/Aletheore.git`.
 - Branch: `master`.
-- Commit: `447d7e940430be07d14f6c84bdf8ea4bc49144c0`.
+- Commit: `1659182c146601a0817059b09d1d70cd99b25889`.
 - Working tree: clean, no local diffs or stashes.
-- Services running: `app-server`, `scan-worker`, `scheduler`, `demo-scan-worker`, `demo-sandbox-runner`, `postgres`, `redis`, `caddy`, `ollama` - all `Up`, `postgres` reporting `healthy`.
-- App server starts via `python scripts/migrate.py && exec uvicorn ...`; startup logs show `no pending migrations` (schema already current, no errors).
-- `demo-scan-worker` has **no** Docker socket mount (`docker inspect` confirms empty `Mounts`); `demo-sandbox-runner` is the sole holder of `/var/run/docker.sock`, publishes no host ports (internal-only on the Compose network), and is reachable from `demo-scan-worker` at `http://demo-sandbox-runner:8090` (verified with a live TCP connect from inside the `demo-scan-worker` container).
-- `app-server` and `scan-worker` run as the non-root `aletheore` user; `demo-sandbox-runner` runs as `root` (required to reach the Docker socket - the one service designed to need it).
-- CPU/mem limits present: `app-server` 768MiB, `scan-worker` 1GiB, `demo-scan-worker` 512MiB, `demo-sandbox-runner` 256MiB.
-- `scripts/backup-postgres.sh` present at the expected path.
-- `app-server`/`scan-worker` base images (`Dockerfile.app-server`, `Dockerfile.scan-worker`) are digest-pinned (`python:3.12-slim@sha256:...`), not just tag-pinned.
+- Services running: `app-server`, `scan-worker`, `health-worker`, `scheduler`, `autoheal`, `demo-scan-worker`, `demo-sandbox-runner`, `postgres`, `redis`, `caddy`, `ollama` - all `Up`; `app-server`, `scan-worker`, `health-worker`, `scheduler`, `autoheal`, and `postgres` reporting Docker-healthcheck `healthy`. All four rebuilt services show `RestartCount: 0` since redeploy.
+- App server starts via `python scripts/migrate.py && exec uvicorn ...`; this redeploy carried 5 pending migrations (`035_data_deletion_log.sql` through `039_telemetry_retention_index.sql`), all applied cleanly on startup with no errors (`applied 5 migration(s)` in logs). Confirmed live in Postgres afterward: `data_deletion_log`, `webhook_deliveries`, and `installation_access_log` tables exist; `cli_telemetry_events_occurred_at_idx` index exists; `installations.llm_suggestions_enabled` column exists.
+- This redeploy shipped: self-serve data deletion (Settings -> Delete all data, and identically on uninstall) with a plan-independent purge that covers free-plan installations, not just paid seats; AIR evidence schema validation; webhook replay/duplicate protection for GitHub and Paddle; an MCP consent boundary (`ALETHEORE_MCP_ALLOW`) gating tools that transmit repository evidence externally; and body-size/rate-limit/retention controls on the two ingestion endpoints (`/v1/telemetry`, `/v1/runtime-events`).
+- The two new abuse controls were verified live against the public endpoint post-deploy, not just via test suite: an oversized `/v1/telemetry` POST returned `413`; a chunked request with no `Content-Length` returned `411`; a valid small request returned `200` and inserted normally.
+- The data-deletion fix (purging PII for free-plan installations, not just paid seats) was verified pre-deploy via the test suite and a red/green check against a local test database, not re-exercised against a real production installation - deleting a live customer's data to prove the code path would be destructive and out of proportion to what the test suite already demonstrates.
+- `demo-scan-worker` has **no** Docker socket mount (`docker inspect` confirms empty `Mounts`); `demo-sandbox-runner` is the sole holder of `/var/run/docker.sock`, publishes no host ports (internal-only on the Compose network) - unchanged this pass, not re-verified with a fresh TCP connect since neither service nor its Dockerfile was touched by this redeploy.
+- `app-server` and `scan-worker` run as the non-root `aletheore` user (re-confirmed live via `docker compose exec ... whoami`); `demo-sandbox-runner` runs as `root` (required to reach the Docker socket - the one service designed to need it, unchanged).
+- CPU/mem limits present and re-confirmed via `docker inspect`: `app-server` 768MiB, `scan-worker` 1GiB. `demo-scan-worker`/`demo-sandbox-runner` limits not re-checked this pass - neither was touched by this redeploy.
+- `scripts/backup-postgres.sh` present at the expected path (re-confirmed).
+- `app-server`/`scan-worker` base image digest-pinning not re-verified this pass - neither Dockerfile changed in this redeploy's diff (confirmed via `git diff` against the prior deployed commit), so the prior verification stands.
 - Restore drill target database availability was **not** re-verified this pass - out of scope for a routine redeploy; still needs an explicit check per its own runbook item.
-- Health checks: internal `http://127.0.0.1:8000/healthz` and public `https://app.aletheore.com/healthz` both return `200 {"status":"ok","checks":{"database":"ok","redis":"ok"}}`. (The bare `aletheore.com` domain resolves to the marketing site's Vercel deployment, not this host - expected, not a routing bug.)
-- No errors, tracebacks, or exceptions in `app-server`, `scan-worker`, `scheduler`, `demo-scan-worker`, `demo-sandbox-runner`, or `caddy` logs since restart.
-- Disk: 144G available of 193G (26% used).
+- Health checks: internal `http://127.0.0.1:8000/healthz` and public `https://app.aletheore.com/healthz` both return `200 {"status":"ok","checks":{"database":"ok","redis":"ok"}}`.
+- No errors, tracebacks, or exceptions in `app-server`, `scan-worker`, `health-worker`, or `scheduler` logs since restart.
+- Disk: 129G available of 193G (34% used).
 
 ## Recovery Rule
 


### PR DESCRIPTION
## Summary

Updates DEPLOYMENT-VERIFICATION.md with a fresh, live-inspected snapshot after deploying #154 and #155 to production (commit `1659182`).

- All 5 pending migrations (035–039) applied cleanly on this deploy, confirmed live in Postgres afterward (tables/index/column all present).
- All four rebuilt services (app-server, scan-worker, health-worker, scheduler) healthy, zero restarts, no errors in logs since redeploy.
- The two new ingestion abuse controls verified against the live public endpoint post-deploy: oversized body → 413, missing Content-Length → 411, valid request → 200.
- Explicitly noted what was *not* re-verified this pass and why (restore drill, demo-sandbox Docker socket TCP connect, base-image digest pinning — none touched by this deploy's diff, confirmed via `git diff` against the prior deployed commit).
- Also fixed SECURITY.md's stale `Last Updated` date, which hadn't moved when the webhook-handling and audit-signature sections were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)