### PR TITLE
feat: self-serve data export, admin action audit log, email-OTP deletion guard

### DIFF
--- a/docs/operations/DATA-HANDLING.md
+++ b/docs/operations/DATA-HANDLING.md
@@ -4,7 +4,7 @@
 **Status:** Active baseline
 **Owner:** Arihant Kaul
 **Related Documents:** [README.md](README.md), [INCIDENT-RESPONSE.md](INCIDENT-RESPONSE.md), [../../SECURITY.md](../../SECURITY.md)
-**Last Updated:** 2026-08-09
+**Last Updated:** 2026-08-10
 
 ## Purpose
 
@@ -21,6 +21,7 @@ This document describes what the hosted GitHub App may process and what must rem
 | Alert targets | Slack/Teams webhook URL, health-check base URL. | Validate before storage; treat as sensitive operational configuration. |
 | LLM usage | Prompt/completion token counts and derived cost. | Store aggregate cost for spend-cap enforcement. |
 | Deletion audit | Installation ID, account login, requesting actor, counts, timestamp. | Retained after a purge as proof of erasure; never itself deleted. |
+| Admin action audit | Actor, action name, non-secret detail (e.g. a token's label, not the token itself), timestamp. | Retained while the installation exists; cascades away if the installation is deleted - unlike the deletion audit, there is no requirement for this to outlive the account it documents. |
 
 ## Data Transfer Rules
 
@@ -57,10 +58,41 @@ deliberately carries no foreign key to `installations` — a cascading one would
 destroy the record of the deletion as part of the deletion itself. It is the
 one place an account login outlives the account, and it is the audit trail.
 
+## Export Baseline
+
+Export is self-serve, reachable from Settings alongside Delete all data, and
+carries the same authorization as deletion - a session with GitHub admin
+rights on the installation, no plan or seat gate. It returns a single
+downloadable JSON file: account and plan, connected repos and their latest
+findings, team members, health check targets, and current-month usage.
+
+Deliberately excluded, because a leaked export must never become a working
+credential: API tokens are listed by label and ID only (`list_api_tokens`
+never returns the hash, let alone the raw token); the alert webhook URL is
+omitted entirely, since a Slack-style webhook URL embeds a secret in its own
+path. Requesting an export writes one `admin_action_log` row (see below).
+
+## Admin Action Audit Log
+
+Every admin-mutating dashboard action other than deletion (which has its own
+permanent `data_deletion_log`, see above) writes one `admin_action_log` row:
+who did it, what the action was, and non-secret detail useful for reading the
+log later. Covers member add/remove, API token create/revoke, webhook URL
+changes, the Docs-repo-commit and managed-audit-suggestions toggles, health
+check target add/remove, extra-seat purchase/removal requests, and data
+exports.
+
+The detail column is held to the same rule as the export: never a secret. A
+token action logs its label and ID, never the token or its hash; a webhook
+URL change logs only whether a URL is now set, never the URL itself.
+
+No customer-facing viewer exists yet - the log is queryable (support,
+compliance, incident response) but not yet surfaced in the dashboard UI,
+same status the deletion audit log has had since it shipped.
+
 ## Open Controls
 
 - Customer-facing retention settings.
-- Self-serve data export.
-- Audit logs for admin actions other than deletion.
 - Enterprise data-processing addendum.
 - Region and subprocessor disclosures.
+- Customer-facing viewer for the admin action log (currently query-only).

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -2,13 +2,18 @@ import asyncio
 import hashlib
 import logging
 import secrets
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from app_server.auth import encrypt_access_token, get_current_session, refresh_github_access_token
 from app_server.config import get_settings
+from app_server.email_client import send_transactional_email
+from app_server.email_templates import deletion_otp_email
 from app_server.db import (
     DEFAULT_HEALTH_CHECK_TARGET_LIMIT,
     DEFAULT_SEAT_LIMIT,
@@ -16,23 +21,29 @@ from app_server.db import (
     INCLUDED_SEATS,
     add_health_check_target,
     add_installation_member,
+    consume_deletion_otp_code,
     count_active_tokens,
     count_health_check_targets,
     count_installation_members,
     create_api_token,
+    create_deletion_otp_code,
     delete_session,
     get_docs_repo_commit_settings,
     get_extra_seats,
     get_flash_review_count_this_month,
+    get_github_user_email,
     get_installation,
+    get_latest_evidence,
     get_llm_spend_this_month,
     get_max_tokens,
     is_installation_member,
     list_api_tokens,
     list_health_check_targets,
+    list_health_check_targets_for_installation,
     list_installation_members,
     list_repos_for_installations,
     purge_installation_data,
+    record_admin_action,
     record_installation_access,
     remove_health_check_target,
     remove_installation_member,
@@ -48,6 +59,7 @@ from app_server.paddle_client import create_portal_session
 from app_server.paddle_client import get_subscription as get_paddle_subscription
 from app_server.paddle_client import update_subscription_items as update_paddle_subscription_items
 from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
+from app_server.rate_limit import is_rate_limited
 from app_server.url_validation import UnsafeURLError, validate_external_https_url
 
 admin_router = APIRouter()
@@ -97,6 +109,7 @@ class SetLLMSuggestionsRequest(BaseModel):
 
 class DeleteInstallationDataRequest(BaseModel):
     confirm: str = Field(min_length=1, max_length=200)
+    otp_code: str = Field(min_length=6, max_length=6)
 
 
 class AddMemberRequest(BaseModel):
@@ -384,6 +397,10 @@ async def add_member(org: str, repo: str, request: Request, body: AddMemberReque
                 ),
             )
         await add_installation_member(pool, installation_id, body.github_login, session["github_login"])
+        await record_admin_action(
+            pool, installation_id, session["github_login"], "member_added",
+            {"github_login": body.github_login},
+        )
     return {"ok": True}
 
 
@@ -456,6 +473,11 @@ async def buy_extra_seat(org: str, repo: str, request: Request):
             detail="Could not update billing right now - please try again, or contact support if this keeps happening.",
         ) from exc
 
+    session = await get_current_session(request)
+    await record_admin_action(
+        request.app.state.db_pool, installation["installation_id"], session["github_login"],
+        "extra_seat_purchase_requested",
+    )
     # extra_seats itself is reconciled from the resulting subscription.updated
     # webhook, not set optimistically here - same pattern installations.plan
     # already follows for the base subscription price.
@@ -488,6 +510,11 @@ async def remove_extra_seat(org: str, repo: str, request: Request):
             detail="Could not update billing right now - please try again, or contact support if this keeps happening.",
         ) from exc
 
+    session = await get_current_session(request)
+    await record_admin_action(
+        request.app.state.db_pool, installation["installation_id"], session["github_login"],
+        "extra_seat_removal_requested",
+    )
     return {"ok": True}
 
 
@@ -542,7 +569,13 @@ async def get_billing_portal_url(org: str, repo: str, request: Request):
 @admin_router.delete("/admin/{org}/{repo}/members/{github_login}")
 async def remove_member(org: str, repo: str, github_login: str, request: Request):
     installation = await _require_admin_installation(request, org, repo)
-    await remove_installation_member(request.app.state.db_pool, installation["installation_id"], github_login)
+    pool = request.app.state.db_pool
+    await remove_installation_member(pool, installation["installation_id"], github_login)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "member_removed",
+        {"github_login": github_login},
+    )
     return {"ok": True}
 
 
@@ -561,13 +594,24 @@ async def generate_token(org: str, repo: str, request: Request, body: GenerateTo
     token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
     await create_api_token(pool, installation_id, token_hash, body.label, session["github_login"])
     token_id = (await list_api_tokens(pool, installation_id))[0]["id"]
+    # Label only - never the raw token or its hash.
+    await record_admin_action(
+        pool, installation_id, session["github_login"], "api_token_created",
+        {"label": body.label, "token_id": token_id},
+    )
     return {"token": raw_token, "id": token_id, "label": body.label}
 
 
 @admin_router.delete("/admin/{org}/{repo}/tokens/{token_id}")
 async def revoke_token(org: str, repo: str, token_id: int, request: Request):
     installation = await _require_admin_installation(request, org, repo)
-    await revoke_api_token(request.app.state.db_pool, installation["installation_id"], token_id)
+    pool = request.app.state.db_pool
+    await revoke_api_token(pool, installation["installation_id"], token_id)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "api_token_revoked",
+        {"token_id": token_id},
+    )
     return {"ok": True}
 
 
@@ -579,10 +623,13 @@ async def set_webhook_url_route(org: str, repo: str, request: Request, body: Set
             validate_external_https_url(body.webhook_url)
         except UnsafeURLError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-    await set_webhook_url(
-        request.app.state.db_pool,
-        installation["installation_id"],
-        body.webhook_url,
+    pool = request.app.state.db_pool
+    await set_webhook_url(pool, installation["installation_id"], body.webhook_url)
+    session = await get_current_session(request)
+    # Never the URL itself - it can carry a token/secret in its query string.
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "webhook_url_changed",
+        {"cleared": body.webhook_url is None},
     )
     return {"ok": True}
 
@@ -628,8 +675,12 @@ async def set_docs_repo_commit_route(org: str, repo: str, request: Request, body
     # .aletheore/docs/), unlike every other Docs surface which only reads
     # evidence - opt-in and reversible at any time, never defaulted on.
     installation = await _require_admin_installation(request, org, repo)
-    await set_docs_repo_commit_enabled(
-        request.app.state.db_pool, installation["installation_id"], f"{org}/{repo}", body.enabled
+    pool = request.app.state.db_pool
+    await set_docs_repo_commit_enabled(pool, installation["installation_id"], f"{org}/{repo}", body.enabled)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "docs_repo_commit_setting_changed",
+        {"repo_full_name": f"{org}/{repo}", "enabled": body.enabled},
     )
     return {"ok": True}
 
@@ -655,14 +706,23 @@ async def add_health_check_target_route(org: str, repo: str, request: Request, b
     target_id = await add_health_check_target(
         pool, installation_id, repo_full_name, body.label, body.base_url, body.latency_threshold_ms
     )
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation_id, session["github_login"], "health_check_target_added",
+        {"repo_full_name": repo_full_name, "label": body.label, "target_id": target_id},
+    )
     return {"id": target_id}
 
 
 @admin_router.delete("/admin/{org}/{repo}/health-targets/{target_id}")
 async def remove_health_check_target_route(org: str, repo: str, target_id: int, request: Request):
     installation = await _require_admin_installation(request, org, repo)
-    await remove_health_check_target(
-        request.app.state.db_pool, installation["installation_id"], f"{org}/{repo}", target_id
+    pool = request.app.state.db_pool
+    await remove_health_check_target(pool, installation["installation_id"], f"{org}/{repo}", target_id)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "health_check_target_removed",
+        {"repo_full_name": f"{org}/{repo}", "target_id": target_id},
     )
     return {"ok": True}
 
@@ -679,10 +739,66 @@ async def set_llm_suggestions_route(
     audits to configure has nothing to set here.
     """
     installation = await _require_admin_installation(request, org, repo)
-    await set_llm_suggestions_enabled(
-        request.app.state.db_pool, installation["installation_id"], body.enabled
+    pool = request.app.state.db_pool
+    await set_llm_suggestions_enabled(pool, installation["installation_id"], body.enabled)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "llm_suggestions_setting_changed",
+        {"enabled": body.enabled},
     )
     return {"ok": True, "llm_suggestions_enabled": body.enabled}
+
+
+@admin_router.get("/admin/{org}/{repo}/export-data")
+async def export_data(org: str, repo: str, request: Request):
+    """Self-serve export of what the hosted service holds for this
+    installation, as a single downloadable JSON file.
+
+    Gated on _require_authorized_installation, same as deletion-preview and
+    delete-all-data: no plan or seat gate. Exporting your own data isn't a
+    paid feature to unlock, and a customer whose payment failed still owns
+    what's already here.
+
+    Deliberately excludes anything a leaked export would turn into a
+    working credential: API tokens are listed by label/id only, never the
+    token or its hash (list_api_tokens never returns either); the webhook
+    URL is omitted entirely, since Slack-style webhook URLs embed a secret
+    in the path itself.
+    """
+    session, installation = await _require_authorized_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    installation_id = installation["installation_id"]
+
+    repos = await list_repos_for_installations(pool, [installation_id])
+    repo_full_names = [row["repo_full_name"] for row in repos]
+    findings_by_repo = {}
+    for full_name in repo_full_names:
+        evidence = await get_latest_evidence(pool, installation_id, full_name)
+        if evidence is not None:
+            findings_by_repo[full_name] = evidence
+
+    extra_seats = await get_extra_seats(pool, installation_id)
+    export = {
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "account_login": installation["account_login"],
+        "plan": installation["plan"],
+        "connected_repos": repo_full_names,
+        "latest_findings_by_repo": findings_by_repo,
+        "members": await list_installation_members(pool, installation_id),
+        "api_tokens": await list_api_tokens(pool, installation_id),
+        "health_check_targets": await list_health_check_targets_for_installation(pool, installation_id),
+        "extra_seats": extra_seats,
+        "llm_spend_month_to_date": await get_llm_spend_this_month(pool, installation_id),
+        "flash_reviews_month_to_date": await get_flash_review_count_this_month(pool, installation_id),
+    }
+
+    await record_admin_action(pool, installation_id, session["github_login"], "data_exported")
+
+    filename = f"aletheore-export-{installation['account_login']}-{datetime.now(timezone.utc).strftime('%Y%m%d')}.json"
+    return JSONResponse(
+        content=jsonable_encoder(export),
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @admin_router.get("/admin/{org}/{repo}/deletion-preview")
@@ -704,6 +820,79 @@ async def deletion_preview(org: str, repo: str, request: Request):
     }
 
 
+DELETION_OTP_RATE_LIMIT = 5
+DELETION_OTP_RATE_LIMIT_WINDOW_SECONDS = 3600
+DELETION_OTP_ATTEMPT_LIMIT = 10
+DELETION_OTP_ATTEMPT_WINDOW_SECONDS = 3600
+DELETION_OTP_VALIDITY_MINUTES = 10
+
+
+@admin_router.post("/admin/{org}/{repo}/delete-all-data/request-otp")
+async def request_deletion_otp(org: str, repo: str, request: Request):
+    """Emails a one-time code required to actually run delete-all-data.
+
+    The typed account-login confirmation on delete-all-data defends against
+    an accidental click - the name is right there on the page. It proves
+    nothing about who's asking, since anyone holding a stolen session
+    cookie can read that name and type it back. This closes that gap: the
+    code goes to the acting session's own captured email (not necessarily
+    the account owner's - a teammate with their own seat can delete too),
+    so completing a delete requires proving control of that inbox right
+    now, not just possession of a session.
+    """
+    session, installation = await _require_authorized_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    installation_id = installation["installation_id"]
+
+    from redis import Redis
+
+    settings = get_settings()
+    try:
+        rate_limited = is_rate_limited(
+            Redis.from_url(settings.redis_url),
+            f"ratelimit:deletion-otp:{installation_id}",
+            DELETION_OTP_RATE_LIMIT,
+            DELETION_OTP_RATE_LIMIT_WINDOW_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("deletion OTP rate limit check failed (%s); allowing request", exc)
+        rate_limited = False
+    if rate_limited:
+        raise HTTPException(status_code=429, detail="too many code requests - try again later")
+
+    to_email = await get_github_user_email(pool, session["github_login"])
+    if not to_email:
+        raise HTTPException(
+            status_code=400,
+            detail="no verified email on file for your GitHub account - contact support@aletheore.com",
+        )
+
+    code = f"{secrets.randbelow(1_000_000):06d}"
+    code_hash = hashlib.sha256(code.encode()).hexdigest()
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=DELETION_OTP_VALIDITY_MINUTES)
+    await create_deletion_otp_code(pool, installation_id, session["github_login"], code_hash, expires_at)
+
+    if settings.resend_api_key:
+        message = deletion_otp_email(installation["account_login"], code)
+        await asyncio.to_thread(
+            send_transactional_email,
+            settings.resend_api_key,
+            settings.email_from_address,
+            settings.email_reply_to_address,
+            to_email,
+            message["subject"],
+            message["html"],
+            message["text"],
+        )
+    else:
+        # No email provider configured (local dev) - log it instead of
+        # silently succeeding with a code nobody can ever receive.
+        logger.warning("RESEND_API_KEY not configured, deletion OTP not sent: %s", code)
+
+    masked = to_email[0] + "***" + to_email[to_email.index("@"):] if "@" in to_email else "***"
+    return {"ok": True, "sent_to": masked}
+
+
 @admin_router.post("/admin/{org}/{repo}/delete-all-data")
 async def delete_all_data(
     org: str, repo: str, request: Request, body: DeleteInstallationDataRequest
@@ -717,6 +906,8 @@ async def delete_all_data(
     their data. A 402 on this route would be indefensible.
     """
     session, installation = await _require_authorized_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    installation_id = installation["installation_id"]
 
     # The typed confirmation is the account login, not the repo name: the
     # blast radius is the whole installation, and making someone type the
@@ -727,11 +918,30 @@ async def delete_all_data(
             detail=f"type {installation['account_login']} exactly to confirm deletion",
         )
 
-    result = await purge_installation_data(
-        request.app.state.db_pool,
-        installation["installation_id"],
-        session["github_login"],
-    )
+    from redis import Redis
+
+    settings = get_settings()
+    try:
+        attempt_limited = is_rate_limited(
+            Redis.from_url(settings.redis_url),
+            f"ratelimit:deletion-otp-attempt:{installation_id}",
+            DELETION_OTP_ATTEMPT_LIMIT,
+            DELETION_OTP_ATTEMPT_WINDOW_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("deletion OTP attempt rate limit check failed (%s); allowing request", exc)
+        attempt_limited = False
+    if attempt_limited:
+        raise HTTPException(status_code=429, detail="too many incorrect codes - try again later")
+
+    code_hash = hashlib.sha256(body.otp_code.strip().encode()).hexdigest()
+    if not await consume_deletion_otp_code(pool, installation_id, code_hash):
+        raise HTTPException(
+            status_code=400,
+            detail="that code is invalid, expired, or already used - request a new one",
+        )
+
+    result = await purge_installation_data(pool, installation_id, session["github_login"])
     if result is None:
         raise HTTPException(status_code=404, detail="installation not found")
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -176,6 +176,56 @@ async def record_installation_access(
     )
 
 
+async def record_admin_action(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    actor_login: str,
+    action: str,
+    detail: dict | None = None,
+) -> None:
+    """Record one admin-mutating dashboard action - member/token/setting
+    changes, not the data-deletion path, which already writes its own
+    permanent data_deletion_log row.
+
+    `detail` is for context that helps read the log later (a target login,
+    a token label, a changed setting's new value) - never a secret. Callers
+    must not pass a raw API token or webhook URL containing credentials.
+    """
+    await pool.execute(
+        """
+        INSERT INTO admin_action_log (installation_id, actor_login, action, detail)
+        VALUES ($1, $2, $3, $4::jsonb)
+        """,
+        installation_id,
+        actor_login,
+        action,
+        json.dumps(detail) if detail is not None else None,
+    )
+
+
+async def list_admin_actions(
+    pool: asyncpg.Pool, installation_id: int, limit: int = 200
+) -> list[dict]:
+    rows = await pool.fetch(
+        """
+        SELECT id, actor_login, action, detail, created_at
+        FROM admin_action_log
+        WHERE installation_id = $1
+        ORDER BY created_at DESC
+        LIMIT $2
+        """,
+        installation_id,
+        limit,
+    )
+    actions = []
+    for row in rows:
+        action = dict(row)
+        detail = action["detail"]
+        action["detail"] = json.loads(detail) if isinstance(detail, str) else detail
+        actions.append(action)
+    return actions
+
+
 async def purge_installation_data(
     pool: asyncpg.Pool, installation_id: int, actor_login: str
 ) -> dict | None:
@@ -620,6 +670,24 @@ async def list_health_check_targets(pool: asyncpg.Pool, installation_id: int, re
     return [dict(row) for row in rows]
 
 
+async def list_health_check_targets_for_installation(pool: asyncpg.Pool, installation_id: int) -> list[dict]:
+    """Every health check target across every repo this installation has,
+    for the data-export route - list_health_check_targets is scoped to one
+    repo_full_name and would silently return nothing if called without one,
+    not every target the installation actually has.
+    """
+    rows = await pool.fetch(
+        """
+        SELECT id, repo_full_name, label, base_url, latency_threshold_ms, created_at
+        FROM health_check_targets
+        WHERE installation_id = $1
+        ORDER BY repo_full_name ASC, created_at ASC
+        """,
+        installation_id,
+    )
+    return [dict(row) for row in rows]
+
+
 async def count_health_check_targets(pool: asyncpg.Pool, installation_id: int, repo_full_name: str) -> int:
     row = await pool.fetchrow(
         "SELECT count(*) AS n FROM health_check_targets WHERE installation_id = $1 AND repo_full_name = $2",
@@ -834,6 +902,55 @@ async def upsert_github_user_email(pool: asyncpg.Pool, github_login: str, email:
         email,
     )
     return row["inserted"]
+
+
+async def get_github_user_email(pool: asyncpg.Pool, github_login: str) -> str | None:
+    return await pool.fetchval(
+        "SELECT email FROM github_user_emails WHERE github_login = $1", github_login
+    )
+
+
+async def create_deletion_otp_code(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    requested_by: str,
+    code_hash: str,
+    expires_at: datetime,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO deletion_otp_codes (installation_id, requested_by, code_hash, expires_at)
+        VALUES ($1, $2, $3, $4)
+        """,
+        installation_id,
+        requested_by,
+        code_hash,
+        expires_at,
+    )
+
+
+async def consume_deletion_otp_code(pool: asyncpg.Pool, installation_id: int, code_hash: str) -> bool:
+    """Atomically claims one matching, unused, unexpired code. True means
+    this call won it; a second call with the same code (a replay, or a
+    double-submit) gets False, since used_at is now set.
+    """
+    row = await pool.fetchrow(
+        """
+        UPDATE deletion_otp_codes
+        SET used_at = now()
+        WHERE id = (
+            SELECT id FROM deletion_otp_codes
+            WHERE installation_id = $1 AND code_hash = $2
+              AND used_at IS NULL AND expires_at > now()
+            ORDER BY created_at DESC
+            LIMIT 1
+        )
+        RETURNING id
+        """,
+        installation_id,
+        code_hash,
+    )
+    return row is not None
 
 
 async def get_session(pool: asyncpg.Pool, session_id: str) -> dict | None:

--- a/github-app/app_server/email_templates.py
+++ b/github-app/app_server/email_templates.py
@@ -164,6 +164,30 @@ def payment_failed_email(account_login: str) -> dict:
     return {"subject": subject, "html": html, "text": text}
 
 
+def deletion_otp_email(account_login: str, code: str) -> dict:
+    subject = f"Your Aletheore deletion code: {code}"
+    preheader = f"Confirm you want to permanently delete all data for {account_login}."
+    text = (
+        f"Someone requested deletion of all Aletheore data for {account_login}.\n\n"
+        f"Confirmation code: {code}\n\n"
+        "This code expires in 10 minutes and can be used once. If you didn't "
+        "request this, ignore this email - nothing is deleted without it."
+        f"{_FOOTER_TEXT}"
+    )
+    body_html = (
+        f'<p style="margin:0 0 16px;">Someone requested deletion of all Aletheore '
+        f'data for <strong>{account_login}</strong>.</p>'
+        f'<p style="margin:0 0 8px;color:{_TEXT_MUTED};font-size:14px;">Confirmation code</p>'
+        f'<p style="margin:0 0 24px;font-size:32px;font-weight:700;letter-spacing:4px;'
+        f'font-family:{_FONT};">{code}</p>'
+        f'<p style="margin:0;color:{_TEXT_MUTED};font-size:14px;">This code expires in 10 '
+        'minutes and can be used once. If you didn\'t request this, ignore this email '
+        '&mdash; nothing is deleted without it.</p>'
+    )
+    html = _shell(preheader, body_html)
+    return {"subject": subject, "html": html, "text": text}
+
+
 def weekly_digest_email(
     account_login: str,
     scans_this_week: int,

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1900,6 +1900,22 @@ async function openBillingPortal() {{
 // someone out of erasing their own data because their card failed is not
 // defensible. It hangs off its own endpoint for the same reason: the main
 // /admin GET is plan-gated, this one isn't.
+// Same reasoning as loadDangerZone: gated on session + admin rights only,
+// no plan or seat check - a payment-failed customer still owns their data
+// and needs to be able to leave with it, not just delete it.
+function loadExportZone() {{
+  const host = document.getElementById('export-zone');
+  if (!host) return;
+  host.innerHTML =
+    '<div class="settings-block">' +
+      '<div class="settings-block-label">Export your data</div>' +
+      '<div class="settings-block-hint">Download everything stored for this installation - ' +
+      'connected repos and their latest findings, team members, health check targets, and ' +
+      'usage - as one JSON file. Never includes API tokens themselves or your alert webhook URL.</div>' +
+      '<a class="btn" href="' + adminBase + '/export-data" download>Download my data</a>' +
+    '</div>';
+}}
+
 async function loadDangerZone() {{
   const host = document.getElementById('danger-zone');
   if (!host) return;
@@ -1926,6 +1942,14 @@ async function loadDangerZone() {{
         '<input class="field" id="delete-confirm-input" autocomplete="off" ' +
         'placeholder="Type ' + escapeHtml(data.account_login) + ' to confirm" ' +
         'oninput="syncDeleteButton()">' +
+        '<button class="btn" id="send-otp-btn" disabled onclick="requestDeletionOtp()">Send code</button>' +
+      '</div>' +
+      // Typing the org name only proves you can see this page - it says
+      // nothing about who's holding the session. The code, sent to the
+      // account's own verified email, is what actually gates the button.
+      '<div id="otp-row" class="form-row" style="margin-top:10px;display:none;">' +
+        '<input class="field" id="delete-otp-input" autocomplete="off" inputmode="numeric" ' +
+        'maxlength="6" placeholder="6-digit code from your email" oninput="syncDeleteButton()">' +
         '<button class="btn btn-danger" id="delete-all-btn" disabled onclick="deleteAllData()">Delete</button>' +
       '</div>' +
       '<div id="delete-status" class="settings-block-hint"></div>' +
@@ -1933,14 +1957,41 @@ async function loadDangerZone() {{
 }}
 
 function syncDeleteButton() {{
-  const input = document.getElementById('delete-confirm-input');
-  const btn = document.getElementById('delete-all-btn');
-  if (!input || !btn) return;
-  btn.disabled = input.value.trim() !== window._deleteConfirmPhrase;
+  const confirmInput = document.getElementById('delete-confirm-input');
+  const otpInput = document.getElementById('delete-otp-input');
+  const sendBtn = document.getElementById('send-otp-btn');
+  const deleteBtn = document.getElementById('delete-all-btn');
+  if (!confirmInput || !sendBtn) return;
+  const confirmed = confirmInput.value.trim() === window._deleteConfirmPhrase;
+  sendBtn.disabled = !confirmed;
+  if (deleteBtn) {{
+    deleteBtn.disabled = !confirmed || !otpInput || otpInput.value.trim().length !== 6;
+  }}
+}}
+
+async function requestDeletionOtp() {{
+  const btn = document.getElementById('send-otp-btn');
+  const status = document.getElementById('delete-status');
+  btn.disabled = true;
+  status.textContent = 'Sending code...';
+  status.style.color = 'var(--slate-600)';
+  const res = await fetch(adminBase + '/delete-all-data/request-otp', {{ method: 'POST' }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  if (!res.ok) {{
+    status.textContent = data.detail || 'Could not send a code.';
+    status.style.color = 'var(--critical)';
+    syncDeleteButton();
+    return;
+  }}
+  status.textContent = 'Code sent to ' + (data.sent_to || 'your email') + ' - expires in 10 minutes.';
+  status.style.color = 'var(--slate-600)';
+  document.getElementById('otp-row').style.display = '';
+  document.getElementById('delete-otp-input').focus();
 }}
 
 async function deleteAllData() {{
-  const input = document.getElementById('delete-confirm-input');
+  const confirmInput = document.getElementById('delete-confirm-input');
+  const otpInput = document.getElementById('delete-otp-input');
   const btn = document.getElementById('delete-all-btn');
   const status = document.getElementById('delete-status');
   btn.disabled = true;
@@ -1949,7 +2000,10 @@ async function deleteAllData() {{
   const res = await fetch(adminBase + '/delete-all-data', {{
     method: 'POST',
     headers: {{ 'Content-Type': 'application/json' }},
-    body: JSON.stringify({{ confirm: input.value.trim() }}),
+    body: JSON.stringify({{
+      confirm: confirmInput.value.trim(),
+      otp_code: otpInput.value.trim(),
+    }}),
   }});
   const data = await res.json().catch(function () {{ return {{}}; }});
   if (!res.ok) {{
@@ -1982,7 +2036,9 @@ async function loadSettings() {{
       '<div class="settings-block-hint" style="text-align:center;margin-top:12px;">' +
       'Already subscribed? <a href="#" onclick="openBillingPortal(); return false;">Manage billing</a>' +
       '</div>' +
+      '<div id="export-zone"></div>' +
       '<div id="danger-zone"></div>';
+    loadExportZone();
     loadDangerZone();
     return;
   }}
@@ -2067,7 +2123,9 @@ async function loadSettings() {{
         '</div>' +
       '</div>' +
     '</div>' +
+    '<div id="export-zone"></div>' +
     '<div id="danger-zone"></div>';
+  loadExportZone();
   loadDangerZone();
   document.querySelectorAll('[data-href]').forEach(function (el) {{ el.href = pageBase + el.dataset.href; }});
 }}

--- a/github-app/migrations/040_admin_action_log.sql
+++ b/github-app/migrations/040_admin_action_log.sql
@@ -1,0 +1,18 @@
+-- Audit trail for admin-mutating dashboard actions other than deletion
+-- (which already has its own data_deletion_log - see 035).
+--
+-- Unlike data_deletion_log, this cascades with the installation: there is
+-- no "prove we destroyed everything" requirement here, the installation
+-- still exists, and its own action history going with it on a real delete
+-- is the expected, correct behavior, not a gap to design around.
+CREATE TABLE IF NOT EXISTS admin_action_log (
+    id               BIGSERIAL PRIMARY KEY,
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    actor_login      TEXT NOT NULL,
+    action           TEXT NOT NULL,
+    detail           JSONB,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS admin_action_log_installation_idx
+    ON admin_action_log (installation_id, created_at DESC);

--- a/github-app/migrations/041_deletion_otp_codes.sql
+++ b/github-app/migrations/041_deletion_otp_codes.sql
@@ -1,0 +1,27 @@
+-- One-time codes required, alongside the existing typed account-login
+-- confirmation, to actually run a full-installation delete.
+--
+-- The typed confirmation defends against an accidental click - the account
+-- login is right there on the page, so typing it back proves intent, not
+-- identity. It does nothing against a stolen session cookie: an attacker
+-- holding one can read the org name off the same page and type it back.
+-- This table closes that gap by requiring proof the caller still controls
+-- the account's own email right now, independent of the session itself.
+--
+-- Cascades with the installation - if the installation is gone there's
+-- nothing left to guard a delete against, and an outstanding code for a
+-- dead installation isn't of interest to anyone.
+CREATE TABLE IF NOT EXISTS deletion_otp_codes (
+    id               BIGSERIAL PRIMARY KEY,
+    installation_id  BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    code_hash        TEXT NOT NULL,
+    requested_by     TEXT NOT NULL,
+    expires_at       TIMESTAMPTZ NOT NULL,
+    used_at          TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Supports the verification lookup: unused, unexpired codes for this
+-- installation, newest first.
+CREATE INDEX IF NOT EXISTS deletion_otp_codes_installation_idx
+    ON deletion_otp_codes (installation_id, created_at DESC);

--- a/github-app/tests/test_admin_action_log.py
+++ b/github-app/tests/test_admin_action_log.py
@@ -1,0 +1,193 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app_server.db import (
+    add_installation_member,
+    insert_repo_history,
+    list_admin_actions,
+    record_admin_action,
+    upsert_installation,
+)
+from test_admin import _logged_in_client
+
+
+async def _seed_installation(pool, installation_id, account_login, repo_full_name):
+    await upsert_installation(pool, installation_id, account_login)
+    await insert_repo_history(
+        pool, installation_id, repo_full_name, datetime.now(timezone.utc), {"scanned_at": "x"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_admin_action_stores_detail_as_jsonb(pool):
+    await _seed_installation(pool, 950, "acme", "acme/api")
+
+    await record_admin_action(pool, 950, "octocat", "member_added", {"github_login": "friend"})
+
+    actions = await list_admin_actions(pool, 950)
+    assert len(actions) == 1
+    assert actions[0]["actor_login"] == "octocat"
+    assert actions[0]["action"] == "member_added"
+    assert actions[0]["detail"] == {"github_login": "friend"}
+
+
+@pytest.mark.asyncio
+async def test_record_admin_action_allows_no_detail(pool):
+    await _seed_installation(pool, 951, "acme", "acme/api")
+
+    await record_admin_action(pool, 951, "octocat", "data_exported")
+
+    actions = await list_admin_actions(pool, 951)
+    assert actions[0]["detail"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_admin_actions_orders_newest_first(pool):
+    await _seed_installation(pool, 952, "acme", "acme/api")
+
+    await record_admin_action(pool, 952, "octocat", "first_action")
+    await record_admin_action(pool, 952, "octocat", "second_action")
+
+    actions = await list_admin_actions(pool, 952)
+    assert [a["action"] for a in actions] == ["second_action", "first_action"]
+
+
+@pytest.mark.asyncio
+async def test_admin_action_log_cascades_with_installation(pool):
+    await _seed_installation(pool, 953, "acme", "acme/api")
+    await record_admin_action(pool, 953, "octocat", "member_added")
+
+    await pool.execute("DELETE FROM installations WHERE installation_id = 953")
+
+    remaining = await pool.fetchval(
+        "SELECT count(*) FROM admin_action_log WHERE installation_id = 953"
+    )
+    assert remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_add_member_route_records_admin_action(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        response = await client.post(
+            "/admin/octocat/hello-world/members", json={"github_login": "newteammate"}
+        )
+    assert response.status_code == 200, response.text
+
+    actions = await list_admin_actions(pool, 100)
+    matching = [a for a in actions if a["action"] == "member_added"]
+    assert len(matching) == 1
+    assert matching[0]["detail"] == {"github_login": "newteammate"}
+    assert matching[0]["actor_login"] == "octocat"
+
+
+@pytest.mark.asyncio
+async def test_remove_member_route_records_admin_action(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    # octocat must be seated first, or _require_seat_if_paid's
+    # first-admin-auto-seat never triggers for them (someone else already
+    # has a seat), and their own request 403s before reaching the route.
+    await add_installation_member(pool, 100, "octocat", "octocat")
+    await add_installation_member(pool, 100, "leaving-member", "octocat")
+    async with client:
+        response = await client.delete("/admin/octocat/hello-world/members/leaving-member")
+    assert response.status_code == 200, response.text
+
+    actions = await list_admin_actions(pool, 100)
+    matching = [a for a in actions if a["action"] == "member_removed"]
+    assert len(matching) == 1
+    assert matching[0]["detail"] == {"github_login": "leaving-member"}
+
+
+@pytest.mark.asyncio
+async def test_generate_token_route_records_admin_action_without_the_raw_token(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        response = await client.post(
+            "/admin/octocat/hello-world/tokens", json={"label": "CI token"}
+        )
+    assert response.status_code == 200, response.text
+    raw_token = response.json()["token"]
+
+    actions = await list_admin_actions(pool, 100)
+    matching = [a for a in actions if a["action"] == "api_token_created"]
+    assert len(matching) == 1
+    assert matching[0]["detail"]["label"] == "CI token"
+    # The whole point: the audit trail must never carry a working credential.
+    assert raw_token not in str(matching[0]["detail"])
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_route_records_admin_action(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        create_response = await client.post(
+            "/admin/octocat/hello-world/tokens", json={"label": "to revoke"}
+        )
+        token_id = create_response.json()["id"]
+        response = await client.delete(f"/admin/octocat/hello-world/tokens/{token_id}")
+    assert response.status_code == 200, response.text
+
+    actions = await list_admin_actions(pool, 100)
+    matching = [a for a in actions if a["action"] == "api_token_revoked"]
+    assert len(matching) == 1
+    assert matching[0]["detail"] == {"token_id": token_id}
+
+
+@pytest.mark.asyncio
+async def test_set_webhook_url_route_records_action_without_the_url_itself(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    secret_url = "https://hooks.slack.com/services/T000/B000/superrsecrettoken"
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/webhook-url", json={"webhook_url": secret_url}
+        )
+    assert response.status_code == 200, response.text
+
+    actions = await list_admin_actions(pool, 100)
+    matching = [a for a in actions if a["action"] == "webhook_url_changed"]
+    assert len(matching) == 1
+    # A Slack-style webhook URL embeds a secret in its path - it must never
+    # land in an audit log entry.
+    assert secret_url not in str(matching[0]["detail"])
+    assert matching[0]["detail"] == {"cleared": False}
+
+
+@pytest.mark.asyncio
+async def test_set_llm_suggestions_route_records_admin_action(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/llm-suggestions", json={"enabled": False}
+        )
+    assert response.status_code == 200, response.text
+
+    actions = await list_admin_actions(pool, 100)
+    matching = [a for a in actions if a["action"] == "llm_suggestions_setting_changed"]
+    assert len(matching) == 1
+    assert matching[0]["detail"] == {"enabled": False}
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_health_target_routes_record_admin_actions(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        create_response = await client.post(
+            "/admin/octocat/hello-world/health-targets",
+            json={"label": "prod", "base_url": "https://app.example.com"},
+        )
+        target_id = create_response.json()["id"]
+        remove_response = await client.delete(
+            f"/admin/octocat/hello-world/health-targets/{target_id}"
+        )
+    assert create_response.status_code == 200, create_response.text
+    assert remove_response.status_code == 200, remove_response.text
+
+    actions = await list_admin_actions(pool, 100)
+    added = [a for a in actions if a["action"] == "health_check_target_added"]
+    removed = [a for a in actions if a["action"] == "health_check_target_removed"]
+    assert len(added) == 1
+    assert added[0]["detail"]["label"] == "prod"
+    assert len(removed) == 1
+    assert removed[0]["detail"]["target_id"] == target_id

--- a/github-app/tests/test_data_deletion.py
+++ b/github-app/tests/test_data_deletion.py
@@ -29,6 +29,21 @@ async def _seed_installation(pool, installation_id, account_login, repo_full_nam
     )
 
 
+async def _get_otp_code(client, delete_path, monkeypatch):
+    """Drives the real request-otp endpoint and returns the real code it
+    generated. The code is deliberately never returned by the API (it only
+    goes out by email) - randbelow is pinned so the test can know it
+    without needing to intercept an actual email send. is_rate_limited is
+    mocked to skip a real (unreachable in this test env) Redis round-trip -
+    rate limiting itself has its own dedicated test.
+    """
+    monkeypatch.setattr("app_server.admin.secrets.randbelow", lambda _n: 424242)
+    monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: False)
+    response = await client.post(f"{delete_path}/request-otp")
+    assert response.status_code == 200, response.text
+    return "424242"
+
+
 async def _seed_user(pool, session_id, login, email, user_id=1):
     await create_session(
         pool,
@@ -193,10 +208,15 @@ async def test_uninstall_webhook_purges_user_rows_too(pool):
 @pytest.mark.asyncio
 async def test_delete_all_data_route_purges_on_correct_confirmation(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
     async with client:
+        otp_code = await _get_otp_code(client, "/admin/octocat/hello-world/delete-all-data", monkeypatch)
         response = await client.post(
             "/admin/octocat/hello-world/delete-all-data",
-            json={"confirm": "octocat"},
+            json={"confirm": "octocat", "otp_code": otp_code},
         )
 
     assert response.status_code == 200, response.text
@@ -206,15 +226,61 @@ async def test_delete_all_data_route_purges_on_correct_confirmation(pool, monkey
 
 @pytest.mark.asyncio
 async def test_delete_all_data_route_rejects_wrong_confirmation(pool, monkeypatch):
+    # A wrong confirm phrase is rejected before the OTP is ever checked -
+    # any syntactically valid code works here, since it's never consumed.
     client = await _logged_in_client(pool, monkeypatch)
     async with client:
         response = await client.post(
             "/admin/octocat/hello-world/delete-all-data",
-            json={"confirm": "hello-world"},
+            json={"confirm": "hello-world", "otp_code": "000000"},
         )
 
     assert response.status_code == 400
     assert await get_installation(pool, 100) is not None, "deleted without confirmation"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_data_route_rejects_missing_otp(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
+    async with client:
+        # Confirm phrase is correct, but no code was ever requested - the
+        # typed name alone must never be enough to delete.
+        response = await client.post(
+            "/admin/octocat/hello-world/delete-all-data",
+            json={"confirm": "octocat", "otp_code": "000000"},
+        )
+
+    assert response.status_code == 400
+    assert "code" in response.json()["detail"]
+    assert await get_installation(pool, 100) is not None, "deleted without a valid code"
+
+
+@pytest.mark.asyncio
+async def test_consume_deletion_otp_code_is_single_use(pool):
+    from app_server.db import consume_deletion_otp_code, create_deletion_otp_code
+
+    await _seed_installation(pool, 955, "acme-otp", "acme-otp/api")
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+    await create_deletion_otp_code(pool, 955, "octocat", "hash-of-424242", expires_at)
+
+    assert await consume_deletion_otp_code(pool, 955, "hash-of-424242") is True
+    assert await consume_deletion_otp_code(pool, 955, "hash-of-424242") is False, \
+        "the same code was accepted twice"
+
+
+@pytest.mark.asyncio
+async def test_consume_deletion_otp_code_rejects_an_expired_code(pool):
+    from app_server.db import consume_deletion_otp_code, create_deletion_otp_code
+
+    await _seed_installation(pool, 956, "acme-expired", "acme-expired/api")
+    expired_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    await create_deletion_otp_code(pool, 956, "octocat", "hash-of-424242", expired_at)
+
+    assert await consume_deletion_otp_code(pool, 956, "hash-of-424242") is False
 
 
 @pytest.mark.asyncio
@@ -232,9 +298,10 @@ async def test_delete_all_data_route_works_on_the_free_plan(pool, monkeypatch):
         "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
     )
     async with client:
+        otp_code = await _get_otp_code(client, "/admin/octocat/hello-world/delete-all-data", monkeypatch)
         response = await client.post(
             "/admin/octocat/hello-world/delete-all-data",
-            json={"confirm": "octocat"},
+            json={"confirm": "octocat", "otp_code": otp_code},
         )
 
     assert response.status_code == 200, response.text
@@ -248,6 +315,9 @@ async def test_delete_all_data_route_works_on_the_free_plan(pool, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_delete_all_data_route_rejects_non_administrator(pool, monkeypatch):
+    # 403 fires inside _require_authorized_installation, before the OTP is
+    # ever looked at - "000000" just needs to be syntactically valid so
+    # Pydantic doesn't 422 the request before that check even runs.
     client = await _logged_in_client(pool, monkeypatch, installation_id=100)
     # A second installation this session does not administer - the mocked
     # GitHub /user/installations response only ever returns id 100.
@@ -255,7 +325,7 @@ async def test_delete_all_data_route_rejects_non_administrator(pool, monkeypatch
     async with client:
         response = await client.post(
             "/admin/globex/web/delete-all-data",
-            json={"confirm": "globex"},
+            json={"confirm": "globex", "otp_code": "000000"},
         )
 
     assert response.status_code == 403
@@ -269,7 +339,7 @@ async def test_delete_all_data_route_requires_login(pool, monkeypatch):
         client.cookies.clear()
         response = await client.post(
             "/admin/octocat/hello-world/delete-all-data",
-            json={"confirm": "octocat"},
+            json={"confirm": "octocat", "otp_code": "000000"},
         )
 
     assert response.status_code == 401
@@ -278,18 +348,24 @@ async def test_delete_all_data_route_requires_login(pool, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_delete_all_data_route_404s_if_installation_vanishes_mid_request(pool, monkeypatch):
-    # Concurrent uninstall: authorization passed, but the row is gone by the
-    # time the purge runs. Must not report success for a delete that no-oped.
+    # Concurrent uninstall: authorization and the OTP both passed, but the
+    # row is gone by the time the purge runs. Must not report success for
+    # a delete that no-oped.
     client = await _logged_in_client(pool, monkeypatch)
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
 
     async def _already_gone(*_args, **_kwargs):
         return None
 
-    monkeypatch.setattr("app_server.admin.purge_installation_data", _already_gone)
     async with client:
+        otp_code = await _get_otp_code(client, "/admin/octocat/hello-world/delete-all-data", monkeypatch)
+        monkeypatch.setattr("app_server.admin.purge_installation_data", _already_gone)
         response = await client.post(
             "/admin/octocat/hello-world/delete-all-data",
-            json={"confirm": "octocat"},
+            json={"confirm": "octocat", "otp_code": otp_code},
         )
 
     assert response.status_code == 404

--- a/github-app/tests/test_data_export.py
+++ b/github-app/tests/test_data_export.py
@@ -1,0 +1,138 @@
+import hashlib
+
+import pytest
+
+from app_server.db import list_admin_actions
+from test_admin import _logged_in_client
+
+
+@pytest.mark.asyncio
+async def test_export_requires_login(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        client.cookies.clear()
+        response = await client.get("/admin/octocat/hello-world/export-data")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_non_administrator(pool, monkeypatch):
+    from app_server.db import upsert_installation
+
+    client = await _logged_in_client(pool, monkeypatch, installation_id=100)
+    await upsert_installation(pool, 101, "globex")
+    async with client:
+        response = await client.get("/admin/globex/web/export-data")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_export_works_on_the_free_plan(pool, monkeypatch):
+    # Same reasoning as delete-all-data and deletion-preview: exporting
+    # your own data isn't a paid feature to unlock.
+    client = await _logged_in_client(pool, monkeypatch, plan="free")
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/export-data")
+
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
+async def test_export_contains_expected_shape_and_findings(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/export-data")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["account_login"] == "octocat"
+    assert body["plan"] == "air"
+    assert "octocat/hello-world" in body["connected_repos"]
+    assert body["latest_findings_by_repo"]["octocat/hello-world"] == {"scanned_at": "x"}
+    assert "exported_at" in body
+    for key in ("members", "api_tokens", "health_check_targets"):
+        assert key in body
+
+
+@pytest.mark.asyncio
+async def test_export_download_headers_name_the_file(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/export-data")
+
+    disposition = response.headers["content-disposition"]
+    assert "attachment" in disposition
+    assert "octocat" in disposition
+    assert disposition.endswith('.json"')
+
+
+@pytest.mark.asyncio
+async def test_export_never_leaks_a_working_api_token_or_its_hash(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        create_response = await client.post(
+            "/admin/octocat/hello-world/tokens", json={"label": "export test token"}
+        )
+        raw_token = create_response.json()["token"]
+        token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+
+        export_response = await client.get("/admin/octocat/hello-world/export-data")
+
+    assert export_response.status_code == 200, export_response.text
+    body = export_response.json()
+    assert len(body["api_tokens"]) == 1
+    assert body["api_tokens"][0]["label"] == "export test token"
+    raw_text = export_response.text
+    assert raw_token not in raw_text
+    assert token_hash not in raw_text
+    assert "hash" not in body["api_tokens"][0]
+
+
+@pytest.mark.asyncio
+async def test_export_never_leaks_the_webhook_url(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    secret_url = "https://hooks.slack.com/services/T000/B000/supersecrettoken"
+    async with client:
+        await client.put("/admin/octocat/hello-world/webhook-url", json={"webhook_url": secret_url})
+        export_response = await client.get("/admin/octocat/hello-world/export-data")
+
+    assert secret_url not in export_response.text
+
+
+@pytest.mark.asyncio
+async def test_export_records_an_admin_action(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    async with client:
+        await client.get("/admin/octocat/hello-world/export-data")
+
+    actions = await list_admin_actions(pool, 100)
+    matching = [a for a in actions if a["action"] == "data_exported"]
+    assert len(matching) == 1
+    assert matching[0]["actor_login"] == "octocat"
+
+
+@pytest.mark.asyncio
+async def test_export_health_targets_span_every_connected_repo(pool, monkeypatch):
+    from app_server.db import insert_repo_history
+    from datetime import datetime, timezone
+
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    await insert_repo_history(
+        pool, 100, "octocat/second-repo", datetime.now(timezone.utc), {"scanned_at": "y"}
+    )
+    async with client:
+        await client.post(
+            "/admin/octocat/hello-world/health-targets",
+            json={"label": "repo1-target", "base_url": "https://one.example.com"},
+        )
+        await client.post(
+            "/admin/octocat/second-repo/health-targets",
+            json={"label": "repo2-target", "base_url": "https://two.example.com"},
+        )
+        response = await client.get("/admin/octocat/hello-world/export-data")
+
+    body = response.json()
+    labels = {t["label"] for t in body["health_check_targets"]}
+    assert labels == {"repo1-target", "repo2-target"}

--- a/github-app/tests/test_deletion_otp.py
+++ b/github-app/tests/test_deletion_otp.py
@@ -1,0 +1,132 @@
+import hashlib
+
+import pytest
+
+from test_admin import _logged_in_client
+
+
+@pytest.mark.asyncio
+async def test_request_otp_requires_login(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        client.cookies.clear()
+        response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_request_otp_rejects_non_administrator(pool, monkeypatch):
+    from app_server.db import upsert_installation
+
+    client = await _logged_in_client(pool, monkeypatch, installation_id=100)
+    await upsert_installation(pool, 101, "globex")
+    async with client:
+        response = await client.post("/admin/globex/web/delete-all-data/request-otp")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_request_otp_works_on_the_free_plan(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, plan="free")
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
+    monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: False)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
+
+    assert response.status_code == 200, response.text
+
+
+@pytest.mark.asyncio
+async def test_request_otp_requires_a_verified_email_on_file(pool, monkeypatch):
+    # _logged_in_client seeds a session for octocat but no email row -
+    # exactly the state of a real user who's never had their email captured.
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
+
+    assert response.status_code == 400
+    assert "email" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_request_otp_masks_the_email_in_its_response(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
+    monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: False)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
+
+    assert response.status_code == 200, response.text
+    sent_to = response.json()["sent_to"]
+    assert "octocat@example.com" not in sent_to
+    assert sent_to.endswith("@example.com")
+
+
+@pytest.mark.asyncio
+async def test_request_otp_stores_a_hash_not_the_plaintext_code(pool, monkeypatch):
+    monkeypatch.setattr("app_server.admin.secrets.randbelow", lambda _n: 424242)
+    client = await _logged_in_client(pool, monkeypatch)
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
+    monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: False)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
+    assert response.status_code == 200, response.text
+
+    row = await pool.fetchrow(
+        "SELECT code_hash, requested_by FROM deletion_otp_codes WHERE installation_id = 100 "
+        "ORDER BY created_at DESC LIMIT 1"
+    )
+    assert row["requested_by"] == "octocat"
+    assert row["code_hash"] == hashlib.sha256(b"424242").hexdigest()
+    assert row["code_hash"] != "424242"
+
+
+@pytest.mark.asyncio
+async def test_request_otp_is_rate_limited(pool, monkeypatch):
+    # Same pattern as test_ingest_abuse_controls.py: mock is_rate_limited
+    # itself rather than driving a real Redis six times - it's the
+    # response to a True verdict this test is checking, not is_rate_limited's
+    # own counting logic (that's rate_limit.py's own test coverage).
+    client = await _logged_in_client(pool, monkeypatch)
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
+    monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: True)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
+
+    assert response.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_full_otp_flow_end_to_end(pool, monkeypatch):
+    """The real path a browser drives: request a code, then use it."""
+    monkeypatch.setattr("app_server.admin.secrets.randbelow", lambda _n: 424242)
+    client = await _logged_in_client(pool, monkeypatch)
+    await pool.execute(
+        "INSERT INTO github_user_emails (github_login, email) VALUES ('octocat', 'octocat@example.com') "
+        "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
+    )
+    monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: False)
+    async with client:
+        request_response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
+        assert request_response.status_code == 200, request_response.text
+
+        delete_response = await client.post(
+            "/admin/octocat/hello-world/delete-all-data",
+            json={"confirm": "octocat", "otp_code": "424242"},
+        )
+
+    assert delete_response.status_code == 200, delete_response.text

--- a/github-app/tests/test_email_templates.py
+++ b/github-app/tests/test_email_templates.py
@@ -1,4 +1,5 @@
 from app_server.email_templates import (
+    deletion_otp_email,
     payment_failed_email,
     subscription_canceled_email,
     weekly_digest_email,
@@ -23,6 +24,17 @@ def test_payment_failed_email_names_account_and_does_not_promise_a_grace_period(
     # grace period) - the copy must say so, not imply access is still on.
     assert "resubscribe" in message["text"].lower()
     assert "pricing.html" in message["html"]
+
+
+def test_deletion_otp_email_includes_the_code_and_a_10_minute_expiry():
+    message = deletion_otp_email("acme-corp", "424242")
+    assert "424242" in message["subject"]
+    assert "424242" in message["html"]
+    assert "424242" in message["text"]
+    assert "acme-corp" in message["text"]
+    assert "10 minutes" in message["text"]
+    for key in ("subject", "html", "text"):
+        assert message[key]
 
 
 def test_subscription_canceled_email_names_account_and_lists_what_is_lost():


### PR DESCRIPTION
## Summary
- Self-serve data export (`GET /admin/{org}/{repo}/export-data`): downloads a JSON snapshot of connected repos, latest findings, members, API token labels (never raw tokens/hashes), health check targets, extra seats, and usage stats. Webhook URLs excluded (they embed a secret path).
- Admin action audit log (`admin_action_log`, migration 040): records member add/remove, token create/revoke, webhook URL changes, docs-repo setting, health check target add/remove, LLM suggestion toggle, extra-seat purchase/removal. Cascades with installation deletion. Sensitive values never written to `detail`.
- Email OTP on delete-all-data (migration 041): defense-in-depth against a stolen session cookie — a 6-digit code sent to the acting session's own verified email, on top of the existing typed-confirmation. sha256-hashed at rest, single-use, 10-minute expiry, separately rate-limited for requests (5/hr) and verify attempts (10/hr).

Closes the two open items in `docs/operations/DATA-HANDLING.md` ("self-serve data export", "audit logs for admin actions other than deletion").

## Test plan
- [x] Full suite: 1085 passed, 8 skipped, 0 failed
- [x] `ruff check` clean on all touched files
- [x] New tests assert raw tokens/hashes and webhook URLs never leak into export or audit log
- [x] New tests cover OTP hash storage, single-use enforcement, expiry, rate limiting, full end-to-end flow
- [ ] Post-merge: verify migrations 040/041 apply cleanly on prod, smoke-test export + OTP endpoints live

🤖 Generated with [Claude Code](https://claude.com/claude-code)