### PR TITLE
chore: suppress secrets-scanner noise from own test fixtures/planning docs

### DIFF
--- a/.aletheore.json
+++ b/.aletheore.json
@@ -1,0 +1,13 @@
+{
+  "layer_markers": {},
+  "cluster_resolution": 1.0,
+  "dead_code_entry_points": [],
+  "accepted_secrets": [],
+  "ignored_paths": [
+    "src/tests",
+    "github-app/tests",
+    "docs/superpowers/plans"
+  ],
+  "disabled_checks": [],
+  "severity_threshold": null
+}


### PR DESCRIPTION
## Summary
Dogfooding Aletheore on this repo surfaced 45 secrets findings, all in `src/tests/test_secrets*.py`, `github-app/tests/*` (the secrets detector's own test fixtures), or `docs/superpowers/plans/` (old planning docs with copy-pasted examples). None real — confirmed via `.aletheore/air.json`. Adds `.aletheore.json` using the product's own `ignored_paths` feature to suppress them.

## Test plan
- [x] Re-scanned locally: 0 findings (down from 45), 445 files still scanned