### PR TITLE
fix: purge persistent repo checkouts on deletion, close OAuth login CSRF

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -945,6 +945,18 @@ async def delete_all_data(
     if result is None:
         raise HTTPException(status_code=404, detail="installation not found")
 
+    # purge_installation_data is SQL-only - app-server has no filesystem
+    # access to the persistent-checkout volume scan-worker owns (see
+    # scan_worker.jobs._ensure_persistent_checkout), so the on-disk purge
+    # runs there instead, same as the uninstall webhook.
+    from rq import Queue
+
+    Queue("scans", connection=Redis.from_url(settings.redis_url)).enqueue(
+        "scan_worker.jobs.purge_persistent_checkouts_job",
+        job_timeout=120,
+        installation_id=installation_id,
+    )
+
     logger.info(
         "purged installation %s (%s) on request of %s: %s repos, %s users",
         result["installation_id"],

--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -4,6 +4,7 @@ import hmac
 import logging
 import secrets
 from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
 
 import httpx
 from cryptography.fernet import Fernet
@@ -298,13 +299,39 @@ async def callback(code: str, request: Request, state: str | None = None, instal
     # GitHub redirects here from two different entry points: our own
     # /auth/login (which always sets this cookie and a matching state) and a
     # direct "Install" click on GitHub's own App page, which never goes
-    # through /auth/login and so has no state to echo back at all. Only
-    # enforce state when we actually set the cookie ourselves.
+    # through /auth/login and so has no state cookie to check against.
+    #
+    # A missing cookie can't be told apart from an OAuth login CSRF attempt:
+    # an attacker who separately authorizes their own GitHub account can
+    # read the resulting `code` out of their own browser's address bar and
+    # send a victim a bare /auth/callback?code=<that code> link. Nothing
+    # about the request looks different from a real direct-install
+    # redirect - GitHub's OAuth `code` isn't bound to the browser that
+    # requested it - so silently trusting it here binds the victim's
+    # browser to a session for the attacker's identity.
+    #
+    # Since this `code` is single-use and about to be discarded either way,
+    # there's nothing to lose by not exchanging it: redirect through
+    # /auth/login instead, which always sets state. A real installer's
+    # browser already has GitHub App authorization, so this round-trip
+    # completes instantly and invisibly; a forged link's code just goes
+    # unused. installation_id isn't threaded through this second hop - the
+    # async `installation` webhook upserts that row independently and
+    # reliably regardless, same as it does for every other install event.
+    # `state` was repurposed as a next-path hint for this stateless entry
+    # point (see github_app_install_url) rather than a CSRF nonce, since
+    # there was never a cookie to verify it against - forward it as
+    # /auth/login's own `next` so that UX survives the extra hop.
     signed_state = request.cookies.get(OAUTH_STATE_COOKIE_NAME)
-    if signed_state is not None:
-        expected_state = unsign_oauth_state(signed_state, settings.session_secret)
-        if not expected_state or not state or not hmac.compare_digest(expected_state, state):
-            raise HTTPException(status_code=400, detail="invalid oauth state")
+    if signed_state is None:
+        login_url = "/auth/login"
+        if state:
+            login_url += f"?next={quote(state, safe='')}"
+        return RedirectResponse(url=login_url, status_code=307)
+
+    expected_state = unsign_oauth_state(signed_state, settings.session_secret)
+    if not expected_state or not state or not hmac.compare_digest(expected_state, state):
+        raise HTTPException(status_code=400, detail="invalid oauth state")
 
     access_token, refresh_token, user, email = await asyncio.to_thread(
         _exchange_code_and_fetch_user, code, settings.github_client_id, settings.github_client_secret

--- a/github-app/app_server/webhooks/installation.py
+++ b/github-app/app_server/webhooks/installation.py
@@ -10,6 +10,23 @@ from app_server.github_auth import generate_app_jwt, get_installation_token
 logger = logging.getLogger(__name__)
 
 
+def _enqueue_checkout_purge(installation_id: int, redis_url: str, queue=None) -> None:
+    """purge_installation_data (app_server/db.py) is SQL-only - app-server
+    has no filesystem access to the persistent-checkout volume that only
+    scan-worker mounts (see scan_worker.jobs._ensure_persistent_checkout),
+    so the on-disk deletion has to happen there instead."""
+    if queue is None:
+        from redis import Redis
+        from rq import Queue
+
+        queue = Queue("scans", connection=Redis.from_url(redis_url))
+    queue.enqueue(
+        "scan_worker.jobs.purge_persistent_checkouts_job",
+        job_timeout=120,
+        installation_id=installation_id,
+    )
+
+
 def _fetch_installation_repos_sync(installation_id: int, app_jwt: str) -> list[str]:
     token = get_installation_token(installation_id, app_jwt)
     response = httpx.Client(base_url="https://api.github.com").get(
@@ -45,6 +62,7 @@ async def handle_installation_event(
         sender = payload.get("sender") or {}
         actor = sender.get("login") or "github:installation.deleted"
         await purge_installation_data(pool, installation_id, actor)
+        _enqueue_checkout_purge(installation_id, redis_url, queue)
         return
 
     await upsert_installation(pool, installation_id, account_login)

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -230,6 +230,28 @@ def _persistent_checkout_dir(installation_id: int, repo_full_name: str) -> Path:
     return root / str(installation_id) / safe_name
 
 
+def _installation_checkout_root(installation_id: int) -> Path:
+    root = Path(os.environ.get(_REPO_CHECKOUT_ROOT_ENV, _DEFAULT_REPO_CHECKOUT_ROOT))
+    return root / str(installation_id)
+
+
+@log_job
+def purge_persistent_checkouts_job(installation_id: int) -> None:
+    """Deletes every persistent checkout (see _ensure_persistent_checkout)
+    for one installation - the on-disk counterpart to
+    purge_installation_data, which is SQL-only and has no filesystem
+    access to this volume from app-server. Enqueued by the uninstall
+    webhook and the self-serve delete-all-data route right after that SQL
+    purge succeeds, since a customer's source code surviving on disk after
+    every DB row about them is gone is exactly the gap this closes.
+
+    ignore_errors=True: a purge that can't find the directory (already
+    gone, or a fallback-to-ephemeral installation that never got a
+    persistent checkout at all) is a no-op, not a failure worth surfacing.
+    """
+    shutil.rmtree(_installation_checkout_root(installation_id), ignore_errors=True)
+
+
 def _ensure_persistent_checkout(url: str, checkout_sha: str, checkout_dir: Path) -> None:
     """Keeps one real checkout per repo, reused across scans, instead of
     the clone-fresh-and-delete pattern _clone_ref/_clone_pr_head use for

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -262,11 +262,13 @@ async def test_callback_rejects_mismatched_state(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_callback_without_state_cookie_succeeds_for_app_install_flow(pool, monkeypatch):
-    # GitHub App "Install" redirects straight to /auth/callback with
-    # installation_id + code, never going through /auth/login first - so
-    # there's no oauth_state cookie and often no state param at all. This
-    # entry point must still work.
+async def test_callback_without_state_cookie_redirects_to_login_instead_of_trusting_the_code(pool, monkeypatch):
+    # No oauth_state cookie means this request either came from GitHub's
+    # direct "Install" redirect, or is a forged OAuth-login-CSRF link - the
+    # two are indistinguishable, so neither gets to exchange the code
+    # in-place. Both get bounced through /auth/login, which always sets
+    # state; a real installer's browser completes that round trip
+    # invisibly, a forged code just goes unused.
     monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -294,33 +296,17 @@ async def test_callback_without_state_cookie_succeeds_for_app_install_flow(pool,
         )
 
     assert response.status_code == 307
-    assert "session" in response.cookies
+    assert response.headers["location"] == "/auth/login"
+    assert "session" not in response.cookies
 
 
 @pytest.mark.asyncio
-async def test_callback_direct_install_honors_state_as_next_path(pool, monkeypatch):
+async def test_callback_without_state_cookie_forwards_state_as_next_on_the_login_redirect(pool, monkeypatch):
     # github_app_install_url() puts our own next_path in `state` for the
     # direct-install entry point (no oauth_state cookie, so state isn't a
-    # CSRF nonce here) - the callback should redirect there instead of the
-    # /dashboard default.
+    # CSRF nonce here) - that destination must survive the extra hop
+    # through /auth/login rather than being silently dropped.
     monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/login/oauth/access_token":
-            return httpx.Response(200, json={"access_token": "gho_faketoken"})
-        if request.url.path == "/user":
-            return httpx.Response(200, json={"id": 42, "login": "octocat"})
-        return httpx.Response(404)
-
-    monkeypatch.setattr(
-        "app_server.auth._github_http_client",
-        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
-    )
-    monkeypatch.setattr(
-        "app_server.auth._github_oauth_http_client",
-        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://github.com"),
-    )
-
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="https://test") as client:
@@ -331,35 +317,18 @@ async def test_callback_direct_install_honors_state_as_next_path(pool, monkeypat
         )
 
     assert response.status_code == 307
-    assert response.headers["location"] == "/subscribe?plan=team&interval=month"
+    assert response.headers["location"] == "/auth/login?next=%2Fsubscribe%3Fplan%3Dteam%26interval%3Dmonth"
 
 
 @pytest.mark.asyncio
-async def test_callback_with_installation_id_upserts_installation_synchronously(pool, monkeypatch):
-    # /subscribe reads installations from our DB, which is normally populated
-    # by the async `installation` webhook - a browser redirect straight back
-    # from GitHub's install flow can land here before that webhook arrives.
-    # The callback must upsert the row itself so /subscribe never sees a gap.
+async def test_callback_without_state_cookie_does_not_reach_the_synchronous_installation_upsert(pool, monkeypatch):
+    # Closing the OAuth login CSRF gap means installation_id can no longer
+    # be trusted on a stateless request either - this scenario used to
+    # synchronously upsert the installations row so /subscribe never saw a
+    # gap before the async `installation` webhook landed. That gap is now
+    # an accepted tradeoff: the webhook alone is the source of truth here.
     monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
     monkeypatch.setattr("app_server.auth.generate_app_jwt", lambda app_id, key: "fake-app-jwt")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/login/oauth/access_token":
-            return httpx.Response(200, json={"access_token": "gho_faketoken"})
-        if request.url.path == "/user":
-            return httpx.Response(200, json={"id": 42, "login": "octocat"})
-        if request.url.path == "/app/installations/999":
-            return httpx.Response(200, json={"id": 999, "account": {"login": "acme-corp"}})
-        return httpx.Response(404)
-
-    monkeypatch.setattr(
-        "app_server.auth._github_http_client",
-        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
-    )
-    monkeypatch.setattr(
-        "app_server.auth._github_oauth_http_client",
-        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://github.com"),
-    )
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
@@ -370,45 +339,8 @@ async def test_callback_with_installation_id_upserts_installation_synchronously(
         )
 
     assert response.status_code == 307
-    installation = await get_installation(pool, 999)
-    assert installation is not None
-    assert installation["account_login"] == "acme-corp"
-
-
-@pytest.mark.asyncio
-async def test_callback_installation_upsert_failure_does_not_break_signin(pool, monkeypatch):
-    # The synchronous upsert is best-effort - the webhook is still the
-    # source of truth. If GitHub's /app/installations/{id} call fails (or
-    # the JWT can't be generated), sign-in must still succeed.
-    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/login/oauth/access_token":
-            return httpx.Response(200, json={"access_token": "gho_faketoken"})
-        if request.url.path == "/user":
-            return httpx.Response(200, json={"id": 42, "login": "octocat"})
-        return httpx.Response(404)
-
-    monkeypatch.setattr(
-        "app_server.auth._github_http_client",
-        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
-    )
-    monkeypatch.setattr(
-        "app_server.auth._github_oauth_http_client",
-        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://github.com"),
-    )
-
-    app.state.db_pool = pool
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="https://test") as client:
-        response = await client.get(
-            "/auth/callback?code=fake-code&installation_id=998&setup_action=install",
-            follow_redirects=False,
-        )
-
-    assert response.status_code == 307
-    assert "session" in response.cookies
-    assert await get_installation(pool, 998) is None
+    assert response.headers["location"] == "/auth/login"
+    assert await get_installation(pool, 999) is None
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_data_deletion.py
+++ b/github-app/tests/test_data_deletion.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -39,6 +40,10 @@ async def _get_otp_code(client, delete_path, monkeypatch):
     """
     monkeypatch.setattr("app_server.admin.secrets.randbelow", lambda _n: 424242)
     monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: False)
+    # delete-all-data itself (called after this helper returns) enqueues a
+    # persistent-checkout purge job - same unreachable-Redis-in-tests
+    # reasoning as is_rate_limited above.
+    monkeypatch.setattr("rq.Queue.enqueue", MagicMock())
     response = await client.post(f"{delete_path}/request-otp")
     assert response.status_code == 200, response.text
     return "424242"
@@ -195,7 +200,12 @@ async def test_uninstall_webhook_purges_user_rows_too(pool):
         "installation": {"id": 905, "account": {"login": "acme"}},
         "sender": {"login": "solo-dev"},
     }
-    await handle_installation_event("installation", payload, pool, "redis://unused")
+    fake_queue = MagicMock()
+    await handle_installation_event("installation", payload, pool, "redis://unused", queue=fake_queue)
+
+    fake_queue.enqueue.assert_called_once_with(
+        "scan_worker.jobs.purge_persistent_checkouts_job", job_timeout=120, installation_id=905
+    )
 
     assert await get_installation(pool, 905) is None
     assert await get_session(pool, "sess-uninstall") is None

--- a/github-app/tests/test_deletion_otp.py
+++ b/github-app/tests/test_deletion_otp.py
@@ -1,4 +1,5 @@
 import hashlib
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -120,6 +121,7 @@ async def test_full_otp_flow_end_to_end(pool, monkeypatch):
         "ON CONFLICT (github_login) DO UPDATE SET email = EXCLUDED.email"
     )
     monkeypatch.setattr("app_server.admin.is_rate_limited", lambda *a, **k: False)
+    monkeypatch.setattr("rq.Queue.enqueue", MagicMock())
     async with client:
         request_response = await client.post("/admin/octocat/hello-world/delete-all-data/request-otp")
         assert request_response.status_code == 200, request_response.text

--- a/github-app/tests/test_installation_webhook.py
+++ b/github-app/tests/test_installation_webhook.py
@@ -31,7 +31,7 @@ async def test_installation_deleted_removes_row(pool):
         "action": "deleted",
         "installation": {"id": 555, "account": {"login": "octocat"}},
     }
-    await handle_installation_event("installation", payload, pool, "redis://unused")
+    await handle_installation_event("installation", payload, pool, "redis://unused", queue=MagicMock())
     assert await get_installation(pool, 555) is None
 
 


### PR DESCRIPTION
## Summary
Two P0 findings from an independent security audit, each verified against current code line-by-line before fixing.

1. **Persistent checkouts survive deletion.** `purge_installation_data` is SQL-only; the on-disk checkout under `/data/aletheore-repo-checkouts/{installation_id}/` was never deleted by uninstall or self-serve delete-all-data, contradicting privacy.html's "immediately discarded" claim. New `purge_persistent_checkouts_job` (scan-worker owns the volume) is enqueued from both deletion paths right after the SQL purge.
2. **OAuth login CSRF at `/auth/callback`.** State was only checked when a cookie was present, which GitHub's direct "Install" redirect never sets — making that branch indistinguishable from a forged `code` link, since GitHub's `code` isn't bound to the requesting browser. Fix: no state cookie now always redirects through `/auth/login` instead of trusting the code. `state`'s existing next-path-hint use on that entry point is preserved by forwarding it as `/auth/login`'s `next`.

## Test plan
- [x] Full suite: 1084 passed, 8 skipped, 0 failed
- [x] `ruff check` clean on all touched files
- [x] Manually verified `purge_persistent_checkouts_job` against a real temp checkout tree
- [x] Rewrote/added tests for the CSRF fix covering: no-cookie redirects to `/auth/login` with no session created, `state` forwarded as `next`, and the now-unreachable synchronous installation upsert on that path

🤖 Generated with [Claude Code](https://claude.com/claude-code)