### PR TITLE
fix: 5 High findings - token leak, XFF spoof, CSP/SRI, Paddle tolerance, uncached GitHub call

### DIFF
--- a/github-app/Caddyfile
+++ b/github-app/Caddyfile
@@ -6,6 +6,16 @@ aletheore.com, app.aletheore.com {
         X-Frame-Options "DENY"
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
+        # 'unsafe-inline' on script-src/style-src is a real gap, not an
+        # oversight - frontend.py's dashboard pages are built from inline
+        # <script> blocks and don't yet use nonces/hashes, so a strict CSP
+        # would break every page. What this still buys: no script, object,
+        # or frame origin outside what's explicitly listed can load into
+        # this origin at all - the exact class of attack a compromised or
+        # malicious CDN dependency (see mermaid/tabler-icons SRI pins
+        # above) would otherwise be free to exploit even with SRI in place
+        # on the two we do trust.
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.paddle.com; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https:; connect-src 'self' https://*.paddle.com; frame-src https://*.paddle.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
     }
 
     reverse_proxy app-server:8000

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -1,5 +1,7 @@
 import asyncio
+import functools
 import hashlib
+import json
 import logging
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -176,12 +178,60 @@ def _fetch_administered_installation_ids(github_token: str) -> set[int]:
     return {item["id"] for item in response.json().get("installations", [])}
 
 
+_ADMINISTERED_INSTALLATIONS_CACHE_TTL_SECONDS = 30
+
+
+def _administered_installations_cache_key(github_token: str) -> str:
+    # Never the raw token as a cache key - same discipline as API token
+    # storage elsewhere in this file.
+    return "administered-installations:" + hashlib.sha256(github_token.encode()).hexdigest()
+
+
+@functools.lru_cache(maxsize=1)
+def _administered_installations_cache_redis():
+    from redis import Redis
+
+    # lru_cache'd (same convention as get_settings()) so this is one
+    # pooled connection reused across every call, not a fresh TCP
+    # handshake per request. A short connect timeout, not the client
+    # default (multiple seconds) - this cache sits in front of nearly
+    # every dashboard/admin request, so a Redis outage must fail fast
+    # into the live GitHub fallback below rather than stalling every
+    # request behind it.
+    return Redis.from_url(get_settings().redis_url, socket_connect_timeout=0.5, socket_timeout=0.5)
+
+
 async def _administered_installation_ids(github_token: str) -> set[int]:
     # This gates nearly every admin/dashboard route via
-    # _require_admin_installation - run off the event loop via
-    # asyncio.to_thread so one slow GitHub API round-trip can't stall
-    # every other in-flight request on this single-worker server.
-    return await asyncio.to_thread(_fetch_administered_installation_ids, github_token)
+    # _require_admin_installation - a single dashboard page can fire
+    # several requests, each previously making its own live GitHub API
+    # round-trip here (latency, a hard GitHub-availability dependency for
+    # the whole app, and burned user rate limit for no reason - the
+    # answer barely changes install-to-install). A short cache absorbs
+    # that fan-out; run off the event loop via asyncio.to_thread so one
+    # slow GitHub round-trip (on a cache miss) still can't stall every
+    # other in-flight request on this single-worker server.
+    cache_key = _administered_installations_cache_key(github_token)
+    try:
+        cached = await asyncio.to_thread(_administered_installations_cache_redis().get, cache_key)
+        if cached is not None:
+            return {int(installation_id) for installation_id in json.loads(cached)}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("administered-installations cache read failed (%s); falling back to GitHub", exc)
+
+    installation_ids = await asyncio.to_thread(_fetch_administered_installation_ids, github_token)
+
+    try:
+        await asyncio.to_thread(
+            _administered_installations_cache_redis().set,
+            cache_key,
+            json.dumps(list(installation_ids)),
+            _ADMINISTERED_INSTALLATIONS_CACHE_TTL_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("administered-installations cache write failed (%s)", exc)
+
+    return installation_ids
 
 
 async def _administered_installation_ids_or_401(github_token: str) -> set[int]:

--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -31,13 +31,12 @@ class StartDemoScanRequest(BaseModel):
 
 
 def _client_ip(request: Request) -> str:
-    # app-server is only reachable via Caddy's reverse_proxy inside the
-    # docker network (bound to 127.0.0.1:8000 on the host) - Caddy is the
-    # only thing that can set this header, so trusting it here is safe.
-    forwarded_for = request.headers.get("x-forwarded-for")
-    if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+    from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for
+
+    return client_ip_from_forwarded_for(
+        request.headers.get("x-forwarded-for"),
+        request.client.host if request.client else "unknown",
+    )
 
 
 def _get_queue(redis_url: str):

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -32,11 +32,24 @@ frontend_router = APIRouter()
 
 PRICING_URL = "https://www.aletheore.com/pricing"
 
+# Both pinned to an exact version with a Subresource Integrity hash - a
+# floating "@10"/"@latest" tag would let jsdelivr (or anyone who
+# compromised it) serve different, unverified code into the authenticated
+# dashboard origin at any time. SRI would be no-op against a floating tag
+# anyway: the hash would go stale the moment the CDN's "latest" pointer
+# moved. Regenerate the hash (openssl dgst -sha384 -binary <file> | openssl
+# base64 -A) any time the pinned version bumps.
 ICONS_LINK = (
     '<link rel="stylesheet" '
-    'href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.45.0/dist/tabler-icons.min.css">'
+    'href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3.45.0/dist/tabler-icons.min.css" '
+    'integrity="sha384-Ty9WrQxUB1vb9rF2T/wNBTcyJbiR5tK7e3gTrDGAbepOnWoasjD9lNXP4z0QkZML" '
+    'crossorigin="anonymous">'
 )
-MERMAID_SCRIPT = '<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>'
+MERMAID_SCRIPT = (
+    '<script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.8/dist/mermaid.min.js" '
+    'integrity="sha384-N3QqR/7q+xm3BGX+CBbNI8AUmRRqcsDzToy+0z1NLDI0QmTKW8zvwLvqulJgk3dP" '
+    'crossorigin="anonymous"></script>'
+)
 
 STYLE = """
 <style>

--- a/github-app/app_server/paddle_webhook_verify.py
+++ b/github-app/app_server/paddle_webhook_verify.py
@@ -9,7 +9,11 @@ def verify_paddle_signature(
     raw_body: bytes,
     signature_header: str,
     secret: str,
-    tolerance_seconds: int = 5,
+    # Paddle's own retry ledger (claim_webhook_delivery) already blocks
+    # replay, so widening this only trades a little freshness for not
+    # 401ing every billing webhook on modest host clock drift - 5s was
+    # tight enough that a customer could pay and never get upgraded.
+    tolerance_seconds: int = 60,
 ) -> bool:
     try:
         parts = dict(part.split("=", 1) for part in signature_header.split(";") if "=" in part)

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -212,8 +212,30 @@ def _url_without_credentials(url: str) -> str:
     return urlunsplit(parts._replace(netloc=parts.hostname))
 
 
+def _run_git(args: list[str], **kwargs) -> None:
+    """subprocess.run wrapper for git invocations whose argv may embed a
+    credentialed clone URL (see _clone_url). A failing git command raises
+    CalledProcessError, whose __str__ includes the full argv verbatim -
+    unredacted, that string is what logging_config.log_job both writes to
+    the structured job-failure log and emails via
+    error_alerts.send_error_alert, so a transient clone/fetch failure (a
+    network blip, not a security event) would otherwise plaintext a live
+    installation token to an inbox and a log store. Scrubs any arg that
+    parses as a URL with embedded credentials before letting the error
+    propagate.
+    """
+    try:
+        subprocess.run(args, check=True, **kwargs)
+    except subprocess.CalledProcessError as exc:
+        exc.cmd = [
+            _url_without_credentials(arg) if isinstance(arg, str) and urlsplit(arg).username else arg
+            for arg in exc.cmd
+        ]
+        raise
+
+
 def _clone_ref(url: str, ref: str, dest: Path) -> None:
-    subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(dest)], check=True)
+    _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
     subprocess.run(["git", "checkout", "-q", ref], cwd=dest, check=True)
 
 
@@ -286,7 +308,7 @@ def _ensure_persistent_checkout(url: str, checkout_sha: str, checkout_dir: Path)
     """
     credential_free_url = _url_without_credentials(url)
     if (checkout_dir / ".git").exists():
-        subprocess.run(["git", "remote", "set-url", "origin", url], cwd=checkout_dir, check=True)
+        _run_git(["git", "remote", "set-url", "origin", url], cwd=checkout_dir)
         try:
             subprocess.run(["git", "fetch", "-q", "origin"], cwd=checkout_dir, check=True)
             subprocess.run(["git", "checkout", "-q", "-f", checkout_sha], cwd=checkout_dir, check=True)
@@ -298,7 +320,7 @@ def _ensure_persistent_checkout(url: str, checkout_sha: str, checkout_dir: Path)
     else:
         checkout_dir.mkdir(parents=True, exist_ok=True)
         try:
-            subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(checkout_dir)], check=True)
+            _run_git(["git", "clone", "-q", "--no-checkout", url, str(checkout_dir)])
             subprocess.run(["git", "checkout", "-q", checkout_sha], cwd=checkout_dir, check=True)
         finally:
             if (checkout_dir / ".git").exists():
@@ -970,7 +992,7 @@ def run_push_scan_job(
 
 
 def _clone_pr_head(url: str, pr_number: int, dest: Path) -> None:
-    subprocess.run(["git", "clone", "-q", "--no-checkout", url, str(dest)], check=True)
+    _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
     subprocess.run(
         ["git", "fetch", "-q", "origin", f"refs/pull/{pr_number}/head"],
         cwd=dest,

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -115,6 +115,41 @@ def _no_real_auth_rate_limiting(monkeypatch):
     monkeypatch.setattr("app_server.auth.is_rate_limited", lambda *a, **k: False)
 
 
+@pytest.fixture(scope="session")
+def _test_redis_connection():
+    # One real connection reused for the whole run - reconnecting fresh
+    # per test (as a function-scoped fixture would) adds a TCP handshake
+    # to every single test in the suite for what's otherwise a single
+    # flushdb() round trip.
+    from redis import Redis
+
+    try:
+        conn = Redis.from_url(TEST_REDIS_URL, socket_connect_timeout=0.5, socket_timeout=0.5)
+        conn.ping()
+    except Exception:
+        yield None
+        return
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _flush_test_redis(_test_redis_connection):
+    # Real, persistent state in Redis (the administered-installations
+    # cache, deletion OTP codes, etc.) otherwise survives between tests -
+    # unlike `pool`, which truncates Postgres per test, nothing previously
+    # cleared Redis, so a cache entry written by one test (often reusing
+    # the same literal token/session fixtures as many others) could be
+    # read back by a later, unrelated test. No-ops if no test Redis is
+    # reachable, same as `redis_conn` above.
+    if _test_redis_connection is None:
+        yield
+        return
+    _test_redis_connection.flushdb()
+    yield
+    _test_redis_connection.flushdb()
+
+
 def _make_git_repo(path: Path, files: dict[str, str]) -> str:
     path.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "-q"], cwd=path, check=True)

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3824,3 +3824,14 @@ def test_run_health_sweep_staleness_check_job_does_not_alert_when_no_data_yet(mo
     run_health_sweep_staleness_check_job()
 
     assert alerts == []
+
+
+def test_run_git_scrubs_credentialed_url_from_a_failed_clone_error(tmp_path):
+    from scan_worker.jobs import _run_git
+
+    credentialed_url = "https://x-access-token:supersecrettoken@github.com/acme/does-not-exist.git"
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        _run_git(["git", "clone", "-q", credentialed_url, str(tmp_path / "dest")])
+
+    assert "supersecrettoken" not in str(exc_info.value)
+    assert "https://github.com/acme/does-not-exist.git" in exc_info.value.cmd


### PR DESCRIPTION
## Summary
Five High-severity findings from an independent security audit, verified against current code before fixing.

1. **Installation tokens leaked into error-alert emails/logs** on a failed git clone/fetch (`CalledProcessError` embeds the credentialed URL). New `_run_git` wrapper scrubs credentials before the error propagates.
2. **Demo-scan rate limit bypassable** via spoofed `X-Forwarded-For` (read first entry instead of last). Now uses the shared, correct helper.
3. **No CSP, no SRI** on jsdelivr-loaded mermaid/tabler-icons (floating version tag). Pinned both to exact versions with real SHA-384 hashes, added a CSP restricting script/object/frame origins.
4. **Paddle webhook signature tolerance was 5s** — clock drift could silently 401 real billing webhooks. Widened to 60s (idempotency ledger already covers replay).
5. **Every dashboard/admin request made a live GitHub API call** with no caching. Added a 30s Redis cache keyed on a token hash.

## Test plan
- [x] Full suite: 1085 passed, 8 skipped, 0 failed (144s — no regression)
- [x] `ruff check` clean on all touched files
- [x] New test for `_run_git`'s credential scrubbing (real failing clone, asserts token absent from the exception)
- [x] Fixed a real cross-test leakage bug the new cache exposed: added an autouse Redis-flush fixture (nothing previously cleared Redis between tests, unlike Postgres)
- [x] Computed SRI hashes against the actual pinned-version CDN files, not guessed

🤖 Generated with [Claude Code](https://claude.com/claude-code)