### PR TITLE
fix: open redirect, decrypt-failure 500s, sandbox concurrency, timing-safe compare, billing default

### DIFF
--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 
 import httpx
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from fastapi import APIRouter, HTTPException, Request
@@ -243,18 +243,40 @@ async def get_current_session(request: Request) -> dict | None:
     row = await get_session(request.app.state.db_pool, session_id)
     if row is None:
         return None
-    row["github_access_token"] = decrypt_access_token(
-        row["github_access_token"], settings.session_secret
-    )
-    if row["github_refresh_token"] is not None:
-        row["github_refresh_token"] = decrypt_access_token(
-            row["github_refresh_token"], settings.session_secret
+    try:
+        row["github_access_token"] = decrypt_access_token(
+            row["github_access_token"], settings.session_secret
         )
+        if row["github_refresh_token"] is not None:
+            row["github_refresh_token"] = decrypt_access_token(
+                row["github_refresh_token"], settings.session_secret
+            )
+    except InvalidToken:
+        # NOT the SESSION_SECRET-rotation case it might look like - the
+        # cookie's own HMAC signature (_signing_secret) and this token's
+        # Fernet key (_fernet_key) are both HKDF-derived from that same
+        # root secret, so a straightforward rotation already fails at
+        # unsign_session_id above and returns None before ever reaching
+        # here. What this guards is a stored token that's undecryptable
+        # for any other reason - corruption, a partial write, a future
+        # encryption-scheme change - which previously reached the global
+        # exception handler (main.py's handle_unexpected_exception) as an
+        # uncaught error: a 500 on every request from that one user,
+        # firing an error alert email each time. Delete the now-unusable
+        # session and let the normal not-logged-in path (a fresh
+        # /auth/login) take over instead.
+        await delete_session(request.app.state.db_pool, session_id)
+        return None
     return row
 
 
 def _is_safe_next_path(next_path: str | None) -> str:
-    if not next_path or not next_path.startswith("/") or next_path.startswith("//"):
+    # Browsers normalize a leading backslash to a forward slash before
+    # resolving a URL, so "/\evil.com" becomes the protocol-relative
+    # "//evil.com" by the time it's followed - "//" alone isn't enough to
+    # block, the character right after the first "/" has to be checked for
+    # either variant.
+    if not next_path or not next_path.startswith("/") or next_path[1:2] in ("/", "\\"):
         return "/dashboard"
     return next_path
 

--- a/github-app/app_server/metrics.py
+++ b/github-app/app_server/metrics.py
@@ -1,3 +1,5 @@
+import hmac
+
 from fastapi import APIRouter, HTTPException, Request
 from redis import Redis
 from rq import Queue, Worker
@@ -15,7 +17,7 @@ async def queue_stats(request: Request):
         raise HTTPException(status_code=404, detail="not found")
 
     auth_header = request.headers.get("Authorization", "")
-    if auth_header != f"Bearer {settings.internal_metrics_token}":
+    if not hmac.compare_digest(auth_header, f"Bearer {settings.internal_metrics_token}"):
         raise HTTPException(status_code=401, detail="missing or invalid token")
 
     redis_conn = Redis.from_url(settings.redis_url)

--- a/github-app/app_server/telemetry.py
+++ b/github-app/app_server/telemetry.py
@@ -11,6 +11,7 @@ body-size cap enforced in middleware (app_server/ingest_limits.py), and
 a schema narrow enough that nothing but the two expected fields is
 accepted at all.
 """
+import hmac
 import logging
 
 from fastapi import APIRouter, HTTPException, Request
@@ -94,7 +95,7 @@ async def telemetry_stats(request: Request, event: str = "scan"):
         raise HTTPException(status_code=404, detail="not found")
 
     auth_header = request.headers.get("Authorization", "")
-    if auth_header != f"Bearer {settings.internal_metrics_token}":
+    if not hmac.compare_digest(auth_header, f"Bearer {settings.internal_metrics_token}"):
         raise HTTPException(status_code=401, detail="missing or invalid token")
 
     return await count_telemetry_events(request.app.state.db_pool, event)

--- a/github-app/scan_worker/demo_sandbox_runner.py
+++ b/github-app/scan_worker/demo_sandbox_runner.py
@@ -26,6 +26,7 @@ import json
 import logging
 import re
 import subprocess
+import threading
 import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
@@ -34,6 +35,16 @@ logger = logging.getLogger(__name__)
 DEMO_SANDBOX_IMAGE = "aletheore-demo-sandbox:latest"
 CONTAINER_TIMEOUT_SECONDS = 90
 PORT = 8090
+
+# ThreadingHTTPServer spawns one thread per request with no cap of its own,
+# and this endpoint's only real cost is `docker run --cpus=1 --memory=1g` -
+# each concurrent sandbox is a full container on the host. In practice
+# demo-scan-worker's single RQ worker already serializes requests to this
+# service, but that's an upstream property of a different process, not
+# something this one enforces - this semaphore is the actual limit,
+# independent of anything upstream.
+MAX_CONCURRENT_SANDBOXES = 4
+_sandbox_slots = threading.Semaphore(MAX_CONCURRENT_SANDBOXES)
 
 # Mirrors app_server.demo_scan_validation._REPO_URL_RE exactly. Re-checked
 # here rather than trusted from the caller: this process, not
@@ -68,6 +79,15 @@ def run_sandboxed_scan(repo_url: str) -> dict:
     if not _REPO_URL_RE.match(repo_url.strip()):
         raise SandboxRunError("invalid_repo_url")
 
+    if not _sandbox_slots.acquire(timeout=CONTAINER_TIMEOUT_SECONDS):
+        raise SandboxRunError("too_many_concurrent_scans")
+    try:
+        return _run_sandboxed_scan_with_slot_held(repo_url)
+    finally:
+        _sandbox_slots.release()
+
+
+def _run_sandboxed_scan_with_slot_held(repo_url: str) -> dict:
     container_name = f"demo-scan-{uuid.uuid4().hex}"
     cmd = [
         "docker",

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1082,7 +1082,11 @@ def _maybe_create_audit_certificate_check_run(
 def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_number: int) -> None:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    plan = installation["plan"] if installation is not None else "air"
+    # A missing row is an anomaly (a real installation should always have
+    # one) - defaulting to "free" here rather than a paid tier is
+    # deliberate fail-closed behavior. Same default used everywhere else
+    # in this file a plan is read off a possibly-missing installation row.
+    plan = installation["plan"] if installation is not None else "free"
     # Read off the row already fetched rather than a second query. Defaults to
     # on for a missing row or an older row, matching the column default - a
     # lookup miss must not silently change what a customer's report contains.
@@ -1188,7 +1192,7 @@ def run_managed_audit_api_job(
 ) -> str:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    plan = installation["plan"] if installation is not None else "air"
+    plan = installation["plan"] if installation is not None else "free"
     # Read off the row already fetched rather than a second query. Defaults to
     # on for a missing row or an older row, matching the column default - a
     # lookup miss must not silently change what a customer's report contains.
@@ -2287,7 +2291,7 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
         return
 
     installation = get_installation_row(dsn, installation_id)
-    plan = installation["plan"] if installation is not None else "air"
+    plan = installation["plan"] if installation is not None else "free"
     model_used = model_for_plan(plan)
 
     try:
@@ -2623,7 +2627,7 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         return  # nothing scanned for this repo yet - nothing to build from
 
     installation = get_installation_row(dsn, installation_id)
-    plan = installation["plan"] if installation is not None else "air"
+    plan = installation["plan"] if installation is not None else "free"
 
     candidate_modules = [
         m for m in evidence["repository"]["modules"]

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -109,6 +109,13 @@ def test_protocol_relative_next_url_rejected():
     assert _is_safe_next_path("//evil.example.com/phish") == "/dashboard"
 
 
+def test_backslash_protocol_relative_next_url_rejected():
+    # Browsers normalize a leading backslash to a forward slash, turning
+    # this into the same protocol-relative "//evil.example.com" attack
+    # test_protocol_relative_next_url_rejected already covers.
+    assert _is_safe_next_path("/\\evil.example.com/phish") == "/dashboard"
+
+
 def test_next_path_not_starting_with_slash_rejected():
     assert _is_safe_next_path("evil.example.com") == "/dashboard"
 
@@ -376,6 +383,33 @@ async def test_get_current_session_decrypts_refresh_token_when_present(pool, mon
 
     session = await get_current_session(FakeRequest())
     assert session["github_refresh_token"] == "ghr_realrefresh"
+
+
+@pytest.mark.asyncio
+async def test_get_current_session_logs_out_gracefully_on_undecryptable_token(pool, monkeypatch):
+    # A cookie with a valid signature but a stored access token that can't
+    # be Fernet-decrypted (corruption, a partial write - see get_current_session's
+    # comment for why this is NOT the same case as a SESSION_SECRET
+    # rotation) must not 500 - it should behave like "not logged in" and
+    # clean up the now-unusable row.
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+    await create_session(
+        pool,
+        "sess-corrupted",
+        42,
+        "octocat",
+        "not-a-valid-fernet-token",
+        datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    signed = sign_session_id("sess-corrupted", "test-session-secret")
+
+    class FakeRequest:
+        cookies = {"session": signed}
+        app = type("App", (), {"state": type("State", (), {"db_pool": pool})()})()
+
+    session = await get_current_session(FakeRequest())
+    assert session is None
+    assert await get_session(pool, "sess-corrupted") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Five Medium-severity findings from the security audit, verified against current code.

1. Open redirect via backslash variant (`/\evil.com`) not blocked, only `//evil.com` was.
2. Undecryptable stored session token caused a 500 + alert-storm per request instead of a graceful logout.
3. `demo_sandbox_runner` had no concurrency cap of its own (each request = a full container).
4. Two internal-metrics token comparisons used `!=` instead of `hmac.compare_digest`.
5. Missing `installations` row defaulted plan to paid (`"air"`) instead of `"free"` in 4 places.

## Test plan
- [x] Full suite: 1087 passed, 8 skipped, 0 failed
- [x] `ruff check` clean
- [x] New tests: backslash open-redirect variant, graceful logout on undecryptable token

🤖 Generated with [Claude Code](https://claude.com/claude-code)