### PR TITLE
fix: Marketplace webhook wrong ID space, unmapped plan names

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -37,6 +37,23 @@ async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | N
     return dict(row) if row else None
 
 
+async def get_installation_by_account_login(pool: asyncpg.Pool, account_login: str) -> dict | None:
+    # Relies on installations_account_login_unique (migration 042) for a
+    # well-defined result - before that constraint existed, a duplicate
+    # row here would have made this an arbitrary pick.
+    row = await pool.fetchrow(
+        """
+        SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
+               health_check_base_url, health_check_latency_threshold_ms,
+               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
+        FROM installations
+        WHERE account_login = $1
+        """,
+        account_login,
+    )
+    return dict(row) if row else None
+
+
 async def set_installation_plan(pool: asyncpg.Pool, installation_id: int, plan: str) -> None:
     await pool.execute(
         "UPDATE installations SET plan = $2, updated_at = now() WHERE installation_id = $1",

--- a/github-app/app_server/webhooks/marketplace.py
+++ b/github-app/app_server/webhooks/marketplace.py
@@ -1,20 +1,58 @@
-from app_server.db import add_installation_member, get_installation, set_installation_plan, upsert_installation
+import logging
+
+from app_server.db import add_installation_member, get_installation_by_account_login, set_installation_plan
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_marketplace_plan_name(raw_name: str) -> str:
+    """Marketplace plan display names are configured on GitHub's own
+    listing page, not by our code - `purchase["plan"]["name"]` could be
+    anything an admin typed there, and the only two slugs the rest of the
+    codebase understands are "free" and "air" (see paddle_pricing.py).
+    Writing the raw name straight into installations.plan meant any name
+    that wasn't exactly the lowercase string "free" granted full paid
+    access, including a plan literally named "Free" with a capital F.
+
+    Recognizes anything naming the paid tier ("air", case-insensitive,
+    matching the product's own AIR branding) and defaults everything
+    else to "free" - fail-closed, not fail-open, for a name this doesn't
+    recognize. Whatever the listing's plans are actually named should be
+    confirmed against this function before the Marketplace listing goes
+    live (website copy still says it's pending GitHub's review as of this
+    writing).
+    """
+    if "air" in raw_name.strip().lower():
+        return "air"
+    return "free"
 
 
 async def handle_marketplace_event(payload: dict, pool, redis_url: str, queue=None) -> None:
     action = payload.get("action")
     purchase = payload["marketplace_purchase"]
     account = purchase["account"]
-    installation_id = account["id"]
     account_login = account["login"]
 
-    previous = await get_installation(pool, installation_id)
-    previous_plan = previous["plan"] if previous is not None else "free"
-
-    await upsert_installation(pool, installation_id, account_login)
+    # purchase["account"]["id"] is a GitHub user/org account ID, a
+    # different ID space from the GitHub App installation ID everywhere
+    # else in this codebase uses - the Marketplace webhook carries no
+    # installation ID at all. The only reliable correlation is by
+    # account_login against a row the `installation` webhook already
+    # created (relies on installations_account_login_unique, migration
+    # 042, for a well-defined lookup).
+    installation = await get_installation_by_account_login(pool, account_login)
+    if installation is None:
+        logger.warning(
+            "marketplace_purchase for %s (action=%s) has no matching installation yet - skipping",
+            account_login,
+            action,
+        )
+        return
+    installation_id = installation["installation_id"]
+    previous_plan = installation["plan"]
 
     if action in ("purchased", "changed"):
-        new_plan = purchase["plan"]["name"]
+        new_plan = _normalize_marketplace_plan_name(purchase["plan"]["name"])
         await set_installation_plan(pool, installation_id, new_plan)
 
         # Whoever completed the purchase becomes seat one, so they're never

--- a/github-app/migrations/042_installations_account_login_unique.sql
+++ b/github-app/migrations/042_installations_account_login_unique.sql
@@ -1,0 +1,10 @@
+-- installations.account_login was a per-request lookup key
+-- (_repo_installation_id and now the Marketplace webhook fix) with no
+-- uniqueness guarantee - an unordered fetchrow against a duplicate could
+-- pick either row nondeterministically. GitHub account/org names are also
+-- reusable after deletion, so a login collision was possible even
+-- without a bug. Confirmed no existing duplicates in production before
+-- this migration was written (SELECT account_login, count(*) ... HAVING
+-- count(*) > 1 returned 0 rows).
+CREATE UNIQUE INDEX IF NOT EXISTS installations_account_login_unique
+    ON installations (account_login);

--- a/github-app/tests/test_marketplace_webhook.py
+++ b/github-app/tests/test_marketplace_webhook.py
@@ -3,66 +3,111 @@ from unittest.mock import MagicMock
 import pytest
 
 from app_server.db import get_installation, is_installation_member, set_installation_plan, upsert_installation
-from app_server.webhooks.marketplace import handle_marketplace_event
+from app_server.webhooks.marketplace import _normalize_marketplace_plan_name, handle_marketplace_event
+
+# account_id is deliberately never the same number as installation_id in
+# these fixtures - marketplace_purchase.account.id is a GitHub user/org
+# account ID, a different ID space from the installation ID the handler
+# actually looks up by account_login. A test that happened to use the
+# same number for both would hide a regression back to the old
+# account["id"]-as-installation_id bug.
 
 
-def _payload(action: str, installation_id: int, login: str, plan_name: str = "indie", sender_login: str = "octocat"):
+def _payload(
+    action: str,
+    account_id: int,
+    login: str,
+    plan_name: str = "Aletheore AIR",
+    sender_login: str = "octocat",
+):
     return {
         "action": action,
         "sender": {"login": sender_login},
         "marketplace_purchase": {
-            "account": {"id": installation_id, "login": login},
+            "account": {"id": account_id, "login": login},
             "plan": {"name": plan_name},
         },
     }
 
 
+def test_normalize_marketplace_plan_name_recognizes_air_case_insensitively():
+    assert _normalize_marketplace_plan_name("Aletheore AIR") == "air"
+    assert _normalize_marketplace_plan_name("air") == "air"
+    assert _normalize_marketplace_plan_name("  AIR  ") == "air"
+
+
+def test_normalize_marketplace_plan_name_defaults_unrecognized_names_to_free():
+    # Fail-closed: an unrecognized name must not grant paid access, unlike
+    # the original bug where anything other than the exact lowercase
+    # string "free" did.
+    assert _normalize_marketplace_plan_name("Free") == "free"
+    assert _normalize_marketplace_plan_name("Community") == "free"
+    assert _normalize_marketplace_plan_name("") == "free"
+    assert _normalize_marketplace_plan_name("Enterprise Plus") == "free"
+
+
 @pytest.mark.asyncio
-async def test_purchased_sets_plan(pool):
+async def test_purchased_sets_plan_on_the_real_installation(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 777, "octocat")
-    await handle_marketplace_event(_payload("purchased", 777, "octocat", "indie"), pool, "redis://unused", queue=fake_queue)
+    await handle_marketplace_event(
+        _payload("purchased", 999001, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
     row = await get_installation(pool, 777)
-    assert row["plan"] == "indie"
+    assert row["plan"] == "air"
+
+
+@pytest.mark.asyncio
+async def test_purchased_without_a_matching_installation_is_a_noop(pool):
+    # Previously this silently created a bogus installations row keyed by
+    # the Marketplace account ID (wrong ID space) instead of doing
+    # nothing - now there's no row to correlate the purchase to, so it
+    # must not fabricate one.
+    fake_queue = MagicMock()
+    await handle_marketplace_event(
+        _payload("purchased", 999002, "no-such-installation"), pool, "redis://unused", queue=fake_queue
+    )
+    assert await get_installation(pool, 999002) is None
+    fake_queue.enqueue.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_changed_updates_plan(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 777, "octocat")
-    await handle_marketplace_event(_payload("purchased", 777, "octocat", "indie"), pool, "redis://unused", queue=fake_queue)
-    await handle_marketplace_event(_payload("changed", 777, "octocat", "team"), pool, "redis://unused", queue=fake_queue)
+    await handle_marketplace_event(
+        _payload("purchased", 999003, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
+    await handle_marketplace_event(
+        _payload("changed", 999003, "octocat", plan_name="Aletheore AIR (annual)"), pool, "redis://unused", queue=fake_queue
+    )
     row = await get_installation(pool, 777)
-    assert row["plan"] == "team"
+    assert row["plan"] == "air"
 
 
 @pytest.mark.asyncio
 async def test_cancelled_resets_to_free(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 777, "octocat")
-    await handle_marketplace_event(_payload("purchased", 777, "octocat", "indie"), pool, "redis://unused", queue=fake_queue)
-    await handle_marketplace_event(_payload("cancelled", 777, "octocat"), pool, "redis://unused", queue=fake_queue)
+    await handle_marketplace_event(
+        _payload("purchased", 999004, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
+    await handle_marketplace_event(
+        _payload("cancelled", 999004, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
     row = await get_installation(pool, 777)
     assert row["plan"] == "free"
 
 
 @pytest.mark.asyncio
-async def test_purchased_creates_installation_if_missing(pool):
-    fake_queue = MagicMock()
-    await handle_marketplace_event(_payload("purchased", 888, "neworg", "indie"), pool, "redis://unused", queue=fake_queue)
-    row = await get_installation(pool, 888)
-    assert row is not None
-    assert row["plan"] == "indie"
-
-
-@pytest.mark.asyncio
 async def test_replaying_same_event_is_idempotent(pool):
     fake_queue = MagicMock()
-    payload = _payload("purchased", 777, "octocat", "indie")
+    await upsert_installation(pool, 777, "octocat")
+    payload = _payload("purchased", 999005, "octocat")
     await handle_marketplace_event(payload, pool, "redis://unused", queue=fake_queue)
     await handle_marketplace_event(payload, pool, "redis://unused", queue=fake_queue)
     row = await get_installation(pool, 777)
-    assert row["plan"] == "indie"
+    assert row["plan"] == "air"
 
 
 @pytest.mark.asyncio
@@ -70,7 +115,9 @@ async def test_free_to_paid_transition_triggers_live_wiki_full_build(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 777, "octocat")  # defaults to plan='free'
 
-    await handle_marketplace_event(_payload("purchased", 777, "octocat", "indie"), pool, "redis://unused", queue=fake_queue)
+    await handle_marketplace_event(
+        _payload("purchased", 999006, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
 
     assert fake_queue.enqueue.call_count == 2
     job_names = {call.args[0] for call in fake_queue.enqueue.call_args_list}
@@ -86,28 +133,27 @@ async def test_free_to_paid_transition_triggers_live_wiki_full_build(pool):
 async def test_paid_to_paid_change_does_not_retrigger_live_wiki_build(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 777, "octocat")
-    await set_installation_plan(pool, 777, "indie")
+    await set_installation_plan(pool, 777, "air")
 
-    await handle_marketplace_event(_payload("changed", 777, "octocat", "team"), pool, "redis://unused", queue=fake_queue)
+    await handle_marketplace_event(
+        _payload("changed", 999007, "octocat", plan_name="Aletheore AIR (annual)"),
+        pool,
+        "redis://unused",
+        queue=fake_queue,
+    )
 
     fake_queue.enqueue.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_new_installation_purchasing_paid_plan_triggers_live_wiki_build(pool):
-    fake_queue = MagicMock()
-    await handle_marketplace_event(_payload("purchased", 999, "neworg", "indie"), pool, "redis://unused", queue=fake_queue)
-
-    assert fake_queue.enqueue.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_cancellation_does_not_trigger_live_wiki_build(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 777, "octocat")
-    await set_installation_plan(pool, 777, "indie")
+    await set_installation_plan(pool, 777, "air")
 
-    await handle_marketplace_event(_payload("cancelled", 777, "octocat"), pool, "redis://unused", queue=fake_queue)
+    await handle_marketplace_event(
+        _payload("cancelled", 999008, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
 
     fake_queue.enqueue.assert_not_called()
 
@@ -115,8 +161,12 @@ async def test_cancellation_does_not_trigger_live_wiki_build(pool):
 @pytest.mark.asyncio
 async def test_purchase_seats_the_sender_as_first_member(pool):
     fake_queue = MagicMock()
+    await upsert_installation(pool, 777, "octocat")
     await handle_marketplace_event(
-        _payload("purchased", 777, "octocat", "indie", sender_login="alice"), pool, "redis://unused", queue=fake_queue
+        _payload("purchased", 999009, "octocat", sender_login="alice"),
+        pool,
+        "redis://unused",
+        queue=fake_queue,
     )
     assert await is_installation_member(pool, 777, "alice") is True
 
@@ -125,9 +175,14 @@ async def test_purchase_seats_the_sender_as_first_member(pool):
 async def test_cancellation_does_not_remove_existing_members(pool):
     fake_queue = MagicMock()
     await upsert_installation(pool, 777, "octocat")
-    await set_installation_plan(pool, 777, "indie")
+    await set_installation_plan(pool, 777, "air")
     await handle_marketplace_event(
-        _payload("purchased", 777, "octocat", "indie", sender_login="alice"), pool, "redis://unused", queue=fake_queue
+        _payload("purchased", 999010, "octocat", sender_login="alice"),
+        pool,
+        "redis://unused",
+        queue=fake_queue,
     )
-    await handle_marketplace_event(_payload("cancelled", 777, "octocat"), pool, "redis://unused", queue=fake_queue)
+    await handle_marketplace_event(
+        _payload("cancelled", 999010, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
     assert await is_installation_member(pool, 777, "alice") is True


### PR DESCRIPTION
## Summary
Two compounding, currently-dormant bugs (Marketplace listing still pending GitHub's review) that activate the moment it goes live:

1. `webhooks/marketplace.py` used `marketplace_purchase.account.id` as if it were the GitHub App installation ID — a different ID space entirely. Fixed by correlating on `account_login` against the row the `installation` webhook already created, backed by a new UNIQUE constraint (migration 042, confirmed no existing prod duplicates).
2. The raw Marketplace plan display name was written straight into `installations.plan` with no mapping — any name other than exact lowercase `"free"` granted full paid access. Added `_normalize_marketplace_plan_name`, fail-closed to `"free"` for anything unrecognized.

## Test plan
- [x] Full suite: 1088 passed, 8 skipped, 0 failed
- [x] `ruff check` clean
- [x] Rewrote the test fixture to use distinct account/installation IDs (the old one used the same number for both, hiding exactly this bug) and seed a real installation row
- [x] New tests: no-matching-installation no-ops instead of fabricating a row, plan-name normalization (recognized + fail-closed default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)