### PR TITLE
fix: revalidate webhook URLs before fetch, make public status API opt-in

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -52,6 +52,7 @@ from app_server.db import (
     revoke_api_token,
     set_docs_repo_commit_enabled,
     set_llm_suggestions_enabled,
+    set_public_status_enabled,
     set_webhook_url,
     update_session_tokens,
 )
@@ -106,6 +107,10 @@ _GITHUB_LOGIN_PATTERN = r"^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
 
 
 class SetLLMSuggestionsRequest(BaseModel):
+    enabled: bool
+
+
+class SetPublicStatusRequest(BaseModel):
     enabled: bool
 
 
@@ -695,6 +700,21 @@ async def test_webhook_url_route(org: str, repo: str, request: Request):
     if not webhook_url:
         raise HTTPException(status_code=400, detail="no alert webhook is configured yet")
 
+    # validate_external_https_url only ran once, when the URL was saved
+    # (set_webhook_url_route) - re-checking here, immediately before the
+    # fetch, closes the DNS-rebinding window down to the gap between this
+    # call and the actual request instead of "until someone edits the URL
+    # again." Same reasoning and pattern as the health-check sweep (see
+    # scan_worker/jobs.py's re-validation right before _endpoint_results).
+    # An attacker who fully controls this webhook URL's domain could
+    # otherwise register one that resolves to a public IP at save time,
+    # pass validation, then repoint DNS at an internal service before
+    # clicking "test."
+    try:
+        validate_external_https_url(webhook_url)
+    except UnsafeURLError:
+        raise HTTPException(status_code=400, detail="this webhook URL no longer resolves to a safe address") from None
+
     from scan_worker.slack import send_health_alert
 
     try:
@@ -702,8 +722,11 @@ async def test_webhook_url_route(org: str, repo: str, request: Request):
             webhook_url,
             {"text": f"*Aletheore*: test notification for `{org}/{repo}` - your alert webhook is configured correctly."},
         )
-    except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail=f"could not reach webhook: {exc}") from exc
+    except httpx.HTTPError:
+        # Not the raw exception message - it's an SSRF oracle otherwise,
+        # distinguishing "connection refused" from "timed out" from an
+        # actual response body/status from whatever the URL resolved to.
+        raise HTTPException(status_code=502, detail="could not reach that webhook URL") from None
     return {"ok": True}
 
 
@@ -797,6 +820,24 @@ async def set_llm_suggestions_route(
         {"enabled": body.enabled},
     )
     return {"ok": True, "llm_suggestions_enabled": body.enabled}
+
+
+@admin_router.put("/admin/{org}/{repo}/public-status")
+async def set_public_status_route(org: str, repo: str, request: Request, body: SetPublicStatusRequest):
+    """Opt-in for the unauthenticated /v1/health/{org}/{repo} status API
+    (dashboard.py) - endpoint paths, reachability, and latency derived
+    from this repo are exposed to anyone who knows the org/repo, with no
+    other access control. Off by default (migration 043); this is the
+    only way to turn it on."""
+    installation = await _require_admin_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    await set_public_status_enabled(pool, installation["installation_id"], body.enabled)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "public_status_setting_changed",
+        {"repo_full_name": f"{org}/{repo}", "enabled": body.enabled},
+    )
+    return {"ok": True, "public_status_enabled": body.enabled}
 
 
 @admin_router.get("/admin/{org}/{repo}/export-data")

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -24,6 +24,7 @@ from app_server.db import (
     get_endpoint_health_summary_since,
     get_endpoint_uptime_pct_since,
     get_installation,
+    get_installation_by_account_login,
     get_latest_evidence,
     get_recent_endpoint_health,
     get_recent_history,
@@ -527,6 +528,21 @@ async def get_public_health(org: str, repo: str, request: Request, response: Res
         )
 
     repo_full_name = f"{org}/{repo}"
+
+    # Off by default (migration 043) - endpoint paths, reachability, and
+    # latency derived from a customer's private repository must not be
+    # exposed to anyone who knows the org/repo without an explicit
+    # opt-in. Same 404 shape as "no health data" below, rather than a
+    # distinct status, so this doesn't itself disclose whether the repo
+    # has simply never opted in vs never been scanned.
+    installation = await get_installation_by_account_login(request.app.state.db_pool, org)
+    if installation is None or not installation["public_status_enabled"]:
+        raise HTTPException(
+            status_code=404,
+            detail="no health data for this repo",
+            headers={"Access-Control-Allow-Origin": "*"},
+        )
+
     rows = await request.app.state.db_pool.fetch(
         """
         SELECT DISTINCT ON (endpoint_method, endpoint_path)

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -28,7 +28,7 @@ async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | N
         """
         SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
                health_check_base_url, health_check_latency_threshold_ms,
-               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
+               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled, public_status_enabled
         FROM installations
         WHERE installation_id = $1
         """,
@@ -45,7 +45,7 @@ async def get_installation_by_account_login(pool: asyncpg.Pool, account_login: s
         """
         SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
                health_check_base_url, health_check_latency_threshold_ms,
-               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
+               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled, public_status_enabled
         FROM installations
         WHERE account_login = $1
         """,
@@ -104,6 +104,19 @@ async def delete_installation(pool: asyncpg.Pool, installation_id: int) -> None:
     remains as the raw primitive for cascade tests.
     """
     await pool.execute("DELETE FROM installations WHERE installation_id = $1", installation_id)
+
+
+async def set_public_status_enabled(pool: asyncpg.Pool, installation_id: int, enabled: bool) -> None:
+    """Opts an installation's repos into (or out of) the public,
+    unauthenticated /v1/health/{org}/{repo} status API. Off by default
+    (see migration 043) - endpoint paths, reachability, and latency
+    derived from a customer's private repository must never be exposed
+    without an explicit choice to do so."""
+    await pool.execute(
+        "UPDATE installations SET public_status_enabled = $2, updated_at = now() WHERE installation_id = $1",
+        installation_id,
+        enabled,
+    )
 
 
 async def set_llm_suggestions_enabled(

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1110,16 +1110,40 @@ async function loadTargets() {{
 
   const origin = window.location.origin;
   const statusUrl = origin + data.public_status_url;
-  statusApiBody.innerHTML = '<div class="copy-box"><input class="field" id="status-url-field" value="' + escapeHtml(statusUrl) + '" readonly>' +
-    '<button class="btn" id="copy-status-url">Copy</button></div>' +
-    '<div class="settings-block-hint">Unauthenticated and CORS-enabled - safe to call from a public status page.</div>';
-  document.getElementById('copy-status-url').addEventListener('click', function () {{
-    navigator.clipboard.writeText(statusUrl).then(function () {{
-      const btn = document.getElementById('copy-status-url');
-      btn.textContent = 'Copied';
-      setTimeout(function () {{ btn.textContent = 'Copy'; }}, 1500);
+  const publicStatusEnabled = data.installation.public_status_enabled === true;
+  statusApiBody.innerHTML =
+    '<label style="display:flex;align-items:center;gap:7px;font-size:12.5px;">' +
+    '<input type="checkbox" id="public-status-toggle"' +
+    (publicStatusEnabled ? ' checked' : '') +
+    '> Make this repo\\'s endpoint status publicly readable</label>' +
+    '<div id="public-status-status" class="settings-block-hint"></div>' +
+    (publicStatusEnabled
+      ? '<div class="copy-box"><input class="field" id="status-url-field" value="' + escapeHtml(statusUrl) + '" readonly>' +
+        '<button class="btn" id="copy-status-url">Copy</button></div>' +
+        '<div class="settings-block-hint">Unauthenticated and CORS-enabled - safe to call from a public status page.</div>'
+      : '<div class="settings-block-hint">Off by default. Endpoint paths, reachability, and latency for this repo are only visible in this dashboard until you turn this on.</div>');
+
+  document.getElementById('public-status-toggle').addEventListener('change', async function (e) {{
+    const statusEl = document.getElementById('public-status-status');
+    statusEl.textContent = 'Saving...';
+    const res = await fetch(adminBase + '/public-status', {{
+      method: 'PUT', headers: {{ 'Content-Type': 'application/json' }},
+      body: JSON.stringify({{ enabled: e.target.checked }}),
     }});
+    if (!res.ok) {{ statusEl.textContent = 'Could not save.'; e.target.checked = !e.target.checked; return; }}
+    statusEl.textContent = 'Saved.';
+    loadTargets();
   }});
+
+  const copyBtn = document.getElementById('copy-status-url');
+  if (copyBtn) {{
+    copyBtn.addEventListener('click', function () {{
+      navigator.clipboard.writeText(statusUrl).then(function () {{
+        copyBtn.textContent = 'Copied';
+        setTimeout(function () {{ copyBtn.textContent = 'Copy'; }}, 1500);
+      }});
+    }});
+  }}
 }}
 
 async function loadResults() {{

--- a/github-app/migrations/043_public_status_opt_in.sql
+++ b/github-app/migrations/043_public_status_opt_in.sql
@@ -1,0 +1,7 @@
+-- GET /v1/health/{org}/{repo} (dashboard.py) was unauthenticated,
+-- CORS *, and gated on nothing but "does this repo have any health-check
+-- data" - any repo a customer monitors was publicly exposed (endpoint
+-- paths, status, latency) by default, with no way to turn it off.
+-- Defaults to false: existing installations must explicitly opt in.
+ALTER TABLE installations
+    ADD COLUMN IF NOT EXISTS public_status_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -1,5 +1,6 @@
 import socket
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -12,6 +13,7 @@ from app_server.admin import (
     _repo_installation_id,
 )
 from app_server.auth import decrypt_access_token, encrypt_access_token, sign_session_id
+from app_server.url_validation import UnsafeURLError
 from app_server.db import (
     add_paddle_ids_to_installation,
     create_session,
@@ -417,7 +419,11 @@ async def test_send_test_notification_reports_delivery_failure(pool, monkeypatch
     client = await _logged_in_client(pool, monkeypatch)
 
     def fake_send_health_alert(webhook_url, message, http_client=None):
-        raise httpx.HTTPStatusError("bad gateway", request=None, response=httpx.Response(502))
+        raise httpx.HTTPStatusError(
+            "internal secret detail that must never reach the caller",
+            request=None,
+            response=httpx.Response(502),
+        )
 
     monkeypatch.setattr("scan_worker.slack.send_health_alert", fake_send_health_alert)
     async with client:
@@ -428,6 +434,36 @@ async def test_send_test_notification_reports_delivery_failure(pool, monkeypatch
         response = await client.post("/admin/octocat/hello-world/webhook-url/test")
 
     assert response.status_code == 502
+    # The raw exception message is an SSRF oracle (distinguishes refused
+    # vs timed out vs an actual response from whatever the URL resolved
+    # to) - must never be echoed back to the caller.
+    assert "internal secret detail" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_send_test_notification_revalidates_the_url_right_before_fetching(pool, monkeypatch):
+    # Same DNS-rebinding defense as the health-check sweep: a URL that
+    # validated fine when saved could resolve somewhere unsafe by the
+    # time "test" is clicked. This must be caught here too, not just at
+    # save time.
+    client = await _logged_in_client(pool, monkeypatch)
+
+    def fake_send_health_alert(webhook_url, message, http_client=None):
+        raise AssertionError("must not fetch a webhook URL that just failed revalidation")
+
+    monkeypatch.setattr("scan_worker.slack.send_health_alert", fake_send_health_alert)
+    async with client:
+        await client.put(
+            "/admin/octocat/hello-world/webhook-url",
+            json={"webhook_url": "https://hooks.slack.com/services/x"},
+        )
+        monkeypatch.setattr(
+            "app_server.admin.validate_external_https_url",
+            MagicMock(side_effect=UnsafeURLError("now resolves internally")),
+        )
+        response = await client.post("/admin/octocat/hello-world/webhook-url/test")
+
+    assert response.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -436,6 +472,30 @@ async def test_send_test_notification_requires_login(pool):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post("/admin/octocat/hello-world/webhook-url/test")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_set_public_status_route_toggles_the_flag(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        on_response = await client.put(
+            "/admin/octocat/hello-world/public-status", json={"enabled": True}
+        )
+        dashboard_response = await client.get("/admin/octocat/hello-world")
+    assert on_response.status_code == 200
+    assert on_response.json()["public_status_enabled"] is True
+    assert dashboard_response.json()["installation"]["public_status_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_public_status_route_requires_login(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/admin/octocat/hello-world/public-status", json={"enabled": True}
+        )
     assert response.status_code == 401
 
 

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -5,7 +5,13 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app_server.auth import encrypt_access_token, sign_session_id
-from app_server.db import create_session, insert_repo_history, set_installation_plan, upsert_installation
+from app_server.db import (
+    create_session,
+    insert_repo_history,
+    set_installation_plan,
+    set_public_status_enabled,
+    upsert_installation,
+)
 from app_server.main import app
 
 
@@ -665,6 +671,7 @@ async def test_undismiss_finding_route_removes_it(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_public_health_returns_latest_per_endpoint(pool):
     await upsert_installation(pool, 500, "octocat")
+    await set_public_status_enabled(pool, 500, True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -710,6 +717,7 @@ async def test_public_health_returns_latest_per_endpoint(pool):
 @pytest.mark.asyncio
 async def test_public_health_uptime_pct_excludes_checks_older_than_7_days(pool):
     await upsert_installation(pool, 507, "octocat")
+    await set_public_status_enabled(pool, 507, True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -741,6 +749,7 @@ async def test_public_health_excludes_endpoints_not_checked_recently(pool):
     # sweep has stopped checking it, and this public API shouldn't keep
     # reporting it as "up" forever off one ancient row.
     await upsert_installation(pool, 508, "octocat")
+    await set_public_status_enabled(pool, 508, True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -768,6 +777,7 @@ async def test_public_health_rate_limits_after_threshold(pool, monkeypatch, redi
     from app_server import dashboard
 
     await upsert_installation(pool, 508, "octocat")
+    await set_public_status_enabled(pool, 508, True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -800,6 +810,7 @@ async def test_public_health_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis
     from app_server import dashboard
 
     await upsert_installation(pool, 509, "octocat")
+    await set_public_status_enabled(pool, 509, True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -833,6 +844,7 @@ async def test_public_health_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis
 @pytest.mark.asyncio
 async def test_public_health_fails_open_when_redis_is_unreachable(pool, monkeypatch):
     await upsert_installation(pool, 510, "octocat")
+    await set_public_status_enabled(pool, 510, True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -863,6 +875,57 @@ async def test_public_health_404s_with_no_data(pool):
         response = await client.get("/v1/health/octocat/no-such-repo")
     assert response.status_code == 404
     assert response.headers["access-control-allow-origin"] == "*"
+
+
+@pytest.mark.asyncio
+async def test_public_health_404s_when_not_opted_in(pool):
+    # Off by default (migration 043) - real health data exists, but the
+    # installation never turned public status on.
+    await upsert_installation(pool, 511, "octocat")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES (511, 'octocat/hello-world', 'GET', '/api/users', true)
+            """
+        )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/health/octocat/hello-world")
+
+    assert response.status_code == 404
+    # Same detail text as "no data at all" - not opted in must not be
+    # distinguishable from never-scanned by an outside prober.
+    assert response.json()["detail"] == "no health data for this repo"
+
+
+@pytest.mark.asyncio
+async def test_public_health_opting_in_then_out_toggles_visibility(pool):
+    await upsert_installation(pool, 512, "octocat")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES (512, 'octocat/hello-world', 'GET', '/api/users', true)
+            """
+        )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        before = await client.get("/v1/health/octocat/hello-world")
+        await set_public_status_enabled(pool, 512, True)
+        during = await client.get("/v1/health/octocat/hello-world")
+        await set_public_status_enabled(pool, 512, False)
+        after = await client.get("/v1/health/octocat/hello-world")
+
+    assert before.status_code == 404
+    assert during.status_code == 200
+    assert after.status_code == 404
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Two more security-audit findings.

1. **SSRF revalidation gap**: `webhook-url/test` had no re-validation before fetching (unlike the health-check sweep, which already does), and echoed raw exception text back — a semi-blind SSRF oracle. Fixed to match the sweep's own pattern, and genericized the error message.
2. **Public status API always-on**: `GET /v1/health/{org}/{repo}` was unauthenticated, CORS `*`, with no opt-out. Added `installations.public_status_enabled` (migration 043, default `false`), gated the endpoint on it, and added a dashboard toggle.

## Behavioral note
This flips a default. Any installation currently relying on the public status URL — including Aletheore's own status page — needs to be explicitly re-enabled post-deploy. I'll do that as part of the deploy verification, not in this PR.

## Test plan
- [x] Full suite: 1093 passed, 8 skipped, 0 failed
- [x] `ruff check` clean
- [x] New tests: SSRF revalidation blocks a URL that fails the pre-fetch check, error message doesn't leak exception text, opt-in gate (404 when off, 200 when on, back to 404 when toggled off), toggle route

🤖 Generated with [Claude Code](https://claude.com/claude-code)