### PR TITLE
fix: telemetry silently dropped on fast scans by the fire-and-forget thread

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -45,7 +45,7 @@ from aletheore.evidence import (
 from aletheore.git_intel.analyzer import GIT_ANALYSIS_RESOURCE_EXIT_CODE, GitAnalysisError
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
 from aletheore.history import compute_diff, list_snapshots, save_snapshot, to_sarif
-from aletheore.telemetry import report_scan_event
+from aletheore.telemetry import report_scan_event_in_background
 from aletheore.managed_audit_client import ManagedAuditError, run_managed_audit_request
 from aletheore.query import (
     BranchNotFoundInEvidenceError,
@@ -328,11 +328,10 @@ def _scan(
             "[yellow]Warning: secrets history scan timed out - findings reflect a partial scan[/yellow]"
         )
     _print_result("Scan complete", result_lines)
-    # Fire-and-forget, off the main thread: report_scan_event already has
-    # its own short timeout and swallows every exception, but a background
-    # thread means even a slow/hanging network path can never add latency
-    # to a real scan.
-    threading.Thread(target=report_scan_event, daemon=True).start()
+    # Off the main thread, but waited on with a bound - see
+    # report_scan_event_in_background for why the previous start-and-return
+    # silently dropped most of the events it looked like it was sending.
+    report_scan_event_in_background()
     return 0, evidence, evidence_path
 
 

--- a/src/aletheore/telemetry.py
+++ b/src/aletheore/telemetry.py
@@ -9,7 +9,9 @@ network, endpoint down, disk unwritable) is silently swallowed - this
 must never affect a real scan's outcome or add noticeable latency.
 """
 import os
+import threading
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 import httpx
@@ -17,6 +19,13 @@ import httpx
 TELEMETRY_API_BASE_URL = "https://app.aletheore.com"
 TELEMETRY_DISABLED_ENV = "ALETHEORE_TELEMETRY_DISABLED"
 DO_NOT_TRACK_ENV = "DO_NOT_TRACK"
+
+# How long a finished scan will wait for its own telemetry report before
+# abandoning it. Comfortably above the observed common case (a warm POST
+# completes in well under half a second) and low enough that a slow or
+# blackholed network path is not something a user notices at the end of a
+# scan that has already printed its result.
+REPORT_WAIT_SECONDS = 2.5
 
 
 def _default_telemetry_id_path() -> Path:
@@ -53,3 +62,30 @@ def report_scan_event(
         client.post("/v1/telemetry", json={"event": "scan", "anonymous_id": anonymous_id}, timeout=timeout)
     except Exception:
         pass
+
+
+def report_scan_event_in_background(
+    *,
+    wait_seconds: float = REPORT_WAIT_SECONDS,
+    report_fn: Callable[[], None] = report_scan_event,
+) -> threading.Thread:
+    """Reports a scan off the main thread, waiting up to `wait_seconds` for it
+    to actually finish, and returns the thread so callers can inspect it.
+
+    The wait is the point. A bare `Thread(daemon=True).start()` followed by an
+    immediate return looks like it reports every scan, but daemon threads are
+    killed outright at interpreter shutdown - so on any scan that finished
+    faster than a cold DNS/TLS handshake plus a POST, the CLI exited before the
+    request left the machine and the event was silently dropped. That biases
+    the loss toward exactly the short, first-run scans that are worth counting,
+    which is the opposite of what a usage signal should do.
+
+    Joining with a bound keeps the original property that motivated the thread
+    (a hanging network path can never stall a scan indefinitely) while giving
+    the report a real chance to land. The thread stays a daemon, so exceeding
+    the bound abandons the report at exit rather than blocking it.
+    """
+    thread = threading.Thread(target=report_fn, daemon=True)
+    thread.start()
+    thread.join(wait_seconds)
+    return thread

--- a/src/tests/test_telemetry.py
+++ b/src/tests/test_telemetry.py
@@ -1,10 +1,13 @@
+import threading
+import time
+
 import httpx
-import pytest
 
 from aletheore.telemetry import (
     is_telemetry_disabled,
     load_or_create_anonymous_id,
     report_scan_event,
+    report_scan_event_in_background,
 )
 
 
@@ -104,3 +107,47 @@ def test_report_scan_event_never_raises_on_network_failure(tmp_path, monkeypatch
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://app.aletheore.com")
 
     report_scan_event(path=id_path, http_client=client)  # must not raise
+
+
+def test_report_scan_event_in_background_waits_for_the_report_to_finish():
+    # The regression this guards: a bare Thread(daemon=True).start() returned
+    # immediately, so a scan that finished before the POST completed exited and
+    # took the unsent event with it.
+    completed = []
+
+    def slow_report() -> None:
+        time.sleep(0.2)
+        completed.append("done")
+
+    thread = report_scan_event_in_background(wait_seconds=5.0, report_fn=slow_report)
+
+    assert completed == ["done"]
+    assert not thread.is_alive()
+
+
+def test_report_scan_event_in_background_gives_up_on_a_hanging_report():
+    started = threading.Event()
+    release = threading.Event()
+
+    def hanging_report() -> None:
+        started.set()
+        release.wait(30)
+
+    start = time.monotonic()
+    thread = report_scan_event_in_background(wait_seconds=0.05, report_fn=hanging_report)
+    elapsed = time.monotonic() - start
+
+    assert started.wait(5), "the report should have been started at all"
+    assert elapsed < 2.0, f"a hanging report held up the scan for {elapsed:.2f}s"
+    # Left running rather than waited on - it is a daemon, so interpreter
+    # shutdown reclaims it instead of the CLI blocking on it.
+    assert thread.daemon
+    release.set()
+
+
+def test_report_scan_event_in_background_defaults_to_the_real_reporter(monkeypatch):
+    monkeypatch.setenv("ALETHEORE_TELEMETRY_DISABLED", "1")
+
+    thread = report_scan_event_in_background(wait_seconds=5.0)
+
+    assert not thread.is_alive()


### PR DESCRIPTION
## Summary
Found this uncommitted in the working tree from earlier work — verified it's complete and correct before shipping.

`report_scan_event` fired on a bare `threading.Thread(daemon=True).start()` with no join. Looked like it reported every scan, but daemon threads are killed outright at interpreter shutdown — any scan finishing faster than a cold DNS/TLS handshake + POST exited before the request left the machine, silently dropping the event. Biases loss toward exactly the short, first-run scans most worth counting.

`report_scan_event_in_background` joins with a bound (2.5s default), giving the report a real chance to land while keeping the original guarantee: a hanging network path can never stall a scan indefinitely.

**Note:** this is a CLI fix (`src/`), not part of the security-audit batches. Merging to master only — not cutting a new PyPI release/version bump as part of this, since that's a separate decision.

## Test plan
- [x] Full CLI suite: 1027 passed
- [x] `ruff check` clean
- [x] 3 new tests: waits for a fast report to finish, gives up on a hanging one within the bound, defaults to the real reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)