### PR TITLE
security: verify branch ownership before force-push, allowlist scan subprocess env (NEW-8, NEW-9)

### DIFF
--- a/github-app/scan_worker/docs_repo_commit.py
+++ b/github-app/scan_worker/docs_repo_commit.py
@@ -41,10 +41,14 @@ def sync_docs_to_repo(
     repo_full_name: str,
     modules: dict[str, str],
     settings: dict | None,
+    bot_login: str,
 ) -> tuple[str, int] | None:
     """Returns (content_hash, pr_number) to persist via
     record_docs_repo_commit when a push happened, or None when nothing
-    changed (not opted in, or content identical to the last push)."""
+    changed (not opted in, or content identical to the last push).
+
+    bot_login (e.g. "aletheore[bot]") is used to verify we actually own
+    DOCS_COMMIT_BRANCH before force-pushing over it - see ensure_branch_at."""
     if settings is None or not settings.get("enabled"):
         return None
 
@@ -54,7 +58,7 @@ def sync_docs_to_repo(
         return None
 
     default_branch, base_sha = fetch_default_branch_and_head_sha(client, token, repo_full_name)
-    ensure_branch_at(client, token, repo_full_name, DOCS_COMMIT_BRANCH, base_sha)
+    ensure_branch_at(client, token, repo_full_name, DOCS_COMMIT_BRANCH, base_sha, bot_login)
     upsert_repo_file(
         client, token, repo_full_name, DOCS_COMMIT_PATH, DOCS_COMMIT_BRANCH, markdown, DOCS_COMMIT_MESSAGE,
     )

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -9,6 +9,13 @@ MAX_CONTEXT_FILE_BYTES = 40_000
 MAX_CONTEXT_TOTAL_BYTES = 200_000
 
 
+class BranchNotOwnedByAletheoreError(Exception):
+    """Raised by ensure_branch_at when a branch with our reserved name
+    already exists but its HEAD commit wasn't made by us - force-pushing
+    over it would silently destroy someone else's work (e.g. a
+    contributor who happened to push to a branch with the same name)."""
+
+
 def upsert_pr_comment(
     client: httpx.Client,
     token: str,
@@ -196,11 +203,18 @@ def ensure_branch_at(
     repo_full_name: str,
     branch: str,
     target_sha: str,
+    expected_committer_login: str,
 ) -> None:
     """Points `branch` at target_sha, creating it if it doesn't exist yet or
     force-resetting it if it does - used for a bot-owned branch that should
     always be exactly "latest default branch + our one file change", never
-    accumulating drift from earlier runs."""
+    accumulating drift from earlier runs.
+
+    Before force-resetting an existing branch, verifies its HEAD commit was
+    actually made by us (GitHub attributes commits made via an installation
+    token to `{app_slug}[bot]`). Someone else could push a branch with this
+    same reserved name (accidentally, or otherwise) - without this check
+    we'd silently force-push over and destroy whatever was there."""
     headers = {
         "Authorization": f"token {token}",
         "Accept": "application/vnd.github+json",
@@ -215,6 +229,18 @@ def ensure_branch_at(
         response.raise_for_status()
         return
     existing.raise_for_status()
+    existing_sha = existing.json()["object"]["sha"]
+
+    commit = client.get(f"/repos/{repo_full_name}/commits/{existing_sha}", headers=headers)
+    commit.raise_for_status()
+    committer = commit.json().get("committer") or {}
+    if committer.get("login") != expected_committer_login:
+        raise BranchNotOwnedByAletheoreError(
+            f"refusing to force-push {repo_full_name}:{branch}: existing HEAD commit "
+            f"{existing_sha} was committed by {committer.get('login')!r}, not "
+            f"{expected_committer_login!r}"
+        )
+
     response = client.patch(
         f"/repos/{repo_full_name}/git/refs/heads/{branch}",
         headers=headers,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -410,6 +410,15 @@ def _build_unchanged_scan_cache(
     return cache_path
 
 
+# The scan-worker container's own environment holds every secret we have -
+# DATABASE_URL, GITHUB_APP_PRIVATE_KEY, PADDLE_API_KEY, SESSION_SECRET,
+# AUDIT_SIGNING_PRIVATE_KEY, and more - none of which the CLI's static
+# parsing needs. This subprocess's entire job is walking source files from
+# an attacker-controlled, arbitrary customer repo, so it gets an explicit
+# minimal env instead of inheriting all of ours via **os.environ.
+_SCAN_SUBPROCESS_ENV_ALLOWLIST = ("PATH", "HOME", "LANG", "LC_ALL")
+
+
 def _run_scan(repo_dir: Path, unchanged_scan_cache_path: Path | None = None) -> Path:
     # See GRAPH_COLD_SYNC_DEPTH_CAP and SECRETS_HISTORY_DEPTH_CAP - the
     # CLI's own analyze_git and find_secrets_in_history calls (inside this
@@ -417,11 +426,9 @@ def _run_scan(repo_dir: Path, unchanged_scan_cache_path: Path | None = None) -> 
     # Postgres sync below, and run first, so they need the same caps. Both
     # left unset for a developer running `aletheore scan` directly on their
     # own machine (see evidence.py's handling of both env vars).
-    env = {
-        **os.environ,
-        "ALETHEORE_GIT_HISTORY_DEPTH_CAP": str(GRAPH_COLD_SYNC_DEPTH_CAP),
-        "ALETHEORE_SECRETS_HISTORY_DEPTH_CAP": str(SECRETS_HISTORY_DEPTH_CAP),
-    }
+    env = {name: os.environ[name] for name in _SCAN_SUBPROCESS_ENV_ALLOWLIST if name in os.environ}
+    env["ALETHEORE_GIT_HISTORY_DEPTH_CAP"] = str(GRAPH_COLD_SYNC_DEPTH_CAP)
+    env["ALETHEORE_SECRETS_HISTORY_DEPTH_CAP"] = str(SECRETS_HISTORY_DEPTH_CAP)
     if unchanged_scan_cache_path is not None:
         env["ALETHEORE_UNCHANGED_SCAN_CACHE"] = str(unchanged_scan_cache_path)
     subprocess.run(["aletheore", "scan", str(repo_dir)], check=True, env=env)
@@ -2626,7 +2633,8 @@ def _maybe_sync_docs_to_repo(dsn: str, installation_id: int, repo_full_name: str
                 "mode": row["mode"],
             }
         modules = build_api_reference(evidence, ai_descriptions_by_module)
-        result = sync_docs_to_repo(client, token, repo_full_name, modules, settings)
+        bot_login = f"{get_settings().github_app_slug}[bot]"
+        result = sync_docs_to_repo(client, token, repo_full_name, modules, settings, bot_login)
         if result is not None:
             content_hash, pr_number = result
             record_docs_repo_commit(dsn, installation_id, repo_full_name, content_hash, pr_number)

--- a/github-app/tests/test_docs_repo_commit.py
+++ b/github-app/tests/test_docs_repo_commit.py
@@ -1,19 +1,22 @@
 import httpx
+import pytest
 
 from scan_worker.docs_repo_commit import DOCS_COMMIT_BRANCH, DOCS_COMMIT_PATH, sync_docs_to_repo
+from scan_worker.github_api import BranchNotOwnedByAletheoreError
 
 MODULES = {"a.py": "# a.py\n\n## Functions\n\n### `f()`\n\nDoes a thing.\n"}
+BOT_LOGIN = "aletheore[bot]"
 
 
 def test_returns_none_when_settings_missing():
     client = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(500)), base_url="https://api.github.com")
-    assert sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, None) is None
+    assert sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, None, BOT_LOGIN) is None
 
 
 def test_returns_none_when_not_enabled():
     client = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(500)), base_url="https://api.github.com")
     settings = {"enabled": False, "last_content_hash": None, "pr_number": None}
-    assert sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings) is None
+    assert sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings, BOT_LOGIN) is None
 
 
 def test_returns_none_when_content_unchanged_and_makes_no_network_calls():
@@ -31,7 +34,7 @@ def test_returns_none_when_content_unchanged_and_makes_no_network_calls():
     ).hexdigest()
     settings = {"enabled": True, "last_content_hash": current_hash, "pr_number": 3}
 
-    result = sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings)
+    result = sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings, BOT_LOGIN)
 
     assert result is None
     assert calls == []
@@ -63,7 +66,7 @@ def test_pushes_file_and_opens_pr_when_content_changed():
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
     settings = {"enabled": True, "last_content_hash": None, "pr_number": None}
 
-    result = sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings)
+    result = sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings, BOT_LOGIN)
 
     assert result is not None
     content_hash, pr_number = result
@@ -81,6 +84,8 @@ def test_reuses_existing_open_pr_instead_of_creating_new_one():
             return httpx.Response(200, json={"sha": "base-sha"})
         if request.url.path == f"/repos/octocat/hello-world/git/ref/heads/{DOCS_COMMIT_BRANCH}":
             return httpx.Response(200, json={"object": {"sha": "old-branch-sha"}})
+        if request.url.path == "/repos/octocat/hello-world/commits/old-branch-sha":
+            return httpx.Response(200, json={"committer": {"login": BOT_LOGIN}})
         if request.url.path == f"/repos/octocat/hello-world/git/refs/heads/{DOCS_COMMIT_BRANCH}":
             return httpx.Response(200, json={})
         if request.url.path == f"/repos/octocat/hello-world/contents/{DOCS_COMMIT_PATH}":
@@ -94,8 +99,30 @@ def test_reuses_existing_open_pr_instead_of_creating_new_one():
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
     settings = {"enabled": True, "last_content_hash": "stale-hash", "pr_number": 5}
 
-    result = sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings)
+    result = sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings, BOT_LOGIN)
 
     assert result is not None
     _, pr_number = result
     assert pr_number == 5
+
+
+def test_refuses_to_force_push_a_branch_it_does_not_own():
+    # A branch named DOCS_COMMIT_BRANCH exists but its HEAD commit wasn't
+    # made by our bot - force-pushing over it would destroy someone else's
+    # work, so this must raise instead of silently resetting the branch.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/octocat/hello-world" and request.method == "GET":
+            return httpx.Response(200, json={"default_branch": "main"})
+        if request.url.path == "/repos/octocat/hello-world/commits/main":
+            return httpx.Response(200, json={"sha": "base-sha"})
+        if request.url.path == f"/repos/octocat/hello-world/git/ref/heads/{DOCS_COMMIT_BRANCH}":
+            return httpx.Response(200, json={"object": {"sha": "someone-elses-sha"}})
+        if request.url.path == "/repos/octocat/hello-world/commits/someone-elses-sha":
+            return httpx.Response(200, json={"committer": {"login": "some-contributor"}})
+        raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    settings = {"enabled": True, "last_content_hash": "stale-hash", "pr_number": None}
+
+    with pytest.raises(BranchNotOwnedByAletheoreError):
+        sync_docs_to_repo(client, "token", "octocat/hello-world", MODULES, settings, BOT_LOGIN)

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -2,8 +2,11 @@ import base64
 
 import httpx
 
+import pytest
+
 from aletheore.pr_comment import COMMENT_MARKER
 from scan_worker.github_api import (
+    BranchNotOwnedByAletheoreError,
     create_check_run,
     create_pull_request,
     ensure_branch_at,
@@ -315,25 +318,40 @@ def test_ensure_branch_at_creates_ref_when_missing():
         return httpx.Response(201, json={"ref": "refs/heads/aletheore/docs-update"})
 
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
-    ensure_branch_at(client, "token", "octocat/hello-world", "aletheore/docs-update", "abc123")
+    ensure_branch_at(client, "token", "octocat/hello-world", "aletheore/docs-update", "abc123", "aletheore[bot]")
     assert [method for method, _ in calls] == ["GET", "POST"]
 
 
-def test_ensure_branch_at_force_updates_existing_ref():
+def test_ensure_branch_at_force_updates_existing_ref_owned_by_us():
     calls = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         calls.append((request.method, str(request.url)))
-        if request.method == "GET":
+        if request.method == "GET" and str(request.url).endswith("/git/ref/heads/aletheore/docs-update"):
             return httpx.Response(200, json={"object": {"sha": "old-sha"}})
+        if request.method == "GET" and str(request.url).endswith("/commits/old-sha"):
+            return httpx.Response(200, json={"committer": {"login": "aletheore[bot]"}})
         assert request.method == "PATCH"
         import json as _json
         assert _json.loads(request.content) == {"sha": "new-sha", "force": True}
         return httpx.Response(200, json={})
 
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
-    ensure_branch_at(client, "token", "octocat/hello-world", "aletheore/docs-update", "new-sha")
-    assert [method for method, _ in calls] == ["GET", "PATCH"]
+    ensure_branch_at(client, "token", "octocat/hello-world", "aletheore/docs-update", "new-sha", "aletheore[bot]")
+    assert [method for method, _ in calls] == ["GET", "GET", "PATCH"]
+
+
+def test_ensure_branch_at_refuses_to_force_push_when_not_owned_by_us():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and str(request.url).endswith("/git/ref/heads/aletheore/docs-update"):
+            return httpx.Response(200, json={"object": {"sha": "old-sha"}})
+        if request.method == "GET" and str(request.url).endswith("/commits/old-sha"):
+            return httpx.Response(200, json={"committer": {"login": "some-contributor"}})
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    with pytest.raises(BranchNotOwnedByAletheoreError):
+        ensure_branch_at(client, "token", "octocat/hello-world", "aletheore/docs-update", "new-sha", "aletheore[bot]")
 
 
 def test_upsert_repo_file_creates_when_no_existing_file():

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3676,7 +3676,8 @@ def test_maybe_sync_docs_to_repo_pushes_and_records_when_enabled(monkeypatch):
     sync_calls = []
     monkeypatch.setattr(
         "scan_worker.jobs.sync_docs_to_repo",
-        lambda client, token, repo, modules, s: sync_calls.append((repo, modules, s)) or ("hash123", 7),
+        lambda client, token, repo, modules, s, bot_login: sync_calls.append((repo, modules, s, bot_login))
+        or ("hash123", 7),
     )
     record_calls = []
     monkeypatch.setattr(
@@ -3687,10 +3688,13 @@ def test_maybe_sync_docs_to_repo_pushes_and_records_when_enabled(monkeypatch):
     _maybe_sync_docs_to_repo("dsn", 1, "octocat/hello-world")
 
     assert len(sync_calls) == 1
-    repo, modules, s = sync_calls[0]
+    repo, modules, s, bot_login = sync_calls[0]
     assert repo == "octocat/hello-world"
     assert "a.py" in modules
     assert s is settings
+    # bot_login gates the force-push ownership check in ensure_branch_at -
+    # must be derived from our own app slug, not left for the caller to guess.
+    assert bot_login == "aletheore[bot]"
     assert record_calls == [(1, "octocat/hello-world", "hash123", 7)]
 
 

--- a/github-app/tests/test_jobs_git_graph_sync.py
+++ b/github-app/tests/test_jobs_git_graph_sync.py
@@ -61,6 +61,25 @@ def test_run_scan_sets_git_history_depth_cap_env_var(tmp_path):
     assert kwargs["env"]["ALETHEORE_SECRETS_HISTORY_DEPTH_CAP"] == str(SECRETS_HISTORY_DEPTH_CAP)
 
 
+def test_run_scan_does_not_leak_our_secrets_into_the_subprocess_env(tmp_path, monkeypatch):
+    # This subprocess parses source files from an arbitrary, attacker-
+    # controlled customer repo - it must not inherit DATABASE_URL,
+    # GITHUB_APP_PRIVATE_KEY, or any other secret from the scan-worker
+    # container's own environment.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://should-not-leak")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "-----BEGIN RSA PRIVATE KEY-----should-not-leak")
+    monkeypatch.setenv("SESSION_SECRET", "should-not-leak")
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    with patch("scan_worker.jobs.subprocess.run") as mock_run:
+        _run_scan(repo_dir)
+    _, kwargs = mock_run.call_args
+    env = kwargs["env"]
+    assert "DATABASE_URL" not in env
+    assert "GITHUB_APP_PRIVATE_KEY" not in env
+    assert "SESSION_SECRET" not in env
+
+
 def _fake_evidence() -> dict:
     return {
         "git": {"available": True},


### PR DESCRIPTION
## Summary
- **NEW-8**: `ensure_branch_at` force-pushes the reserved `aletheore/docs-update` branch whenever it exists, with no check that we actually own it. If anyone else pushed a branch with that exact name, their work would be silently destroyed on the next Docs sync. Now verifies the existing branch's HEAD commit was committed by our own bot identity (`{app_slug}[bot]`, how GitHub attributes commits made via an installation token) before force-resetting. If it wasn't, raises `BranchNotOwnedByAletheoreError` instead — caught by the existing best-effort error handling in `_maybe_sync_docs_to_repo`, so a Docs build never fails because of this, it just skips the repo-commit step for that run.
- **NEW-9**: `_run_scan` built the `aletheore scan` subprocess env as `{**os.environ, ...}`, inheriting every secret the scan-worker container holds (`DATABASE_URL`, `GITHUB_APP_PRIVATE_KEY`, `PADDLE_API_KEY`, `SESSION_SECRET`, `AUDIT_SIGNING_PRIVATE_KEY`, ...) into a subprocess whose entire job is parsing source files from an arbitrary, attacker-controlled customer repo. Replaced with an explicit allowlist (`PATH`, `HOME`, `LANG`, `LC_ALL`, plus the `ALETHEORE_*` vars the scan itself already sets) — none of our secrets are needed to statically parse a repo.

## Test plan
- [x] `ruff check` clean on all touched files
- [x] New test: `ensure_branch_at` raises when the existing branch's HEAD commit wasn't made by our bot login
- [x] New test: `sync_docs_to_repo` propagates that refusal
- [x] New test: `_run_scan`'s subprocess env does not contain `DATABASE_URL`/`GITHUB_APP_PRIVATE_KEY`/`SESSION_SECRET` even when set in the parent process
- [x] Existing `test_github_api.py`, `test_docs_repo_commit.py`, `test_jobs.py`, `test_jobs_git_graph_sync.py` updated for the new `bot_login` parameter and pass
- [x] Full suite: `pytest tests/` — 1103 passed, 8 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)