### PR TITLE
security: cap scanned file size, stream file hashing, close credentials.json chmod race (CLI-1, CLI-4)

### DIFF
--- a/src/aletheore/credentials.py
+++ b/src/aletheore/credentials.py
@@ -84,8 +84,22 @@ def _save_key(provider_name: str, key: str, credentials_path: Path) -> None:
         except json.JSONDecodeError:
             data = {}
     data[provider_name] = key
-    credentials_path.write_text(json.dumps(data, indent=2))
-    credentials_path.chmod(0o600)
+    content = json.dumps(data, indent=2)
+    # os.open's mode only applies when it creates the file - an existing
+    # file (e.g. one that pre-dates this restrictive-permissions fix, or
+    # was seeded some other way) keeps whatever permissions it already had.
+    # fchmod before writing closes that gap too: permissions are locked
+    # down before any new key content is written, whether the file is new
+    # or pre-existing, instead of write_text() then chmod() after, which
+    # left the file (and the key) briefly world/group-readable in between.
+    fd = os.open(credentials_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+    except BaseException:
+        os.close(fd)
+        raise
+    with os.fdopen(fd, "w") as f:
+        f.write(content)
 
 
 def clear_api_key(provider_name: str, credentials_path: Path = DEFAULT_CREDENTIALS_PATH) -> bool:

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -215,9 +215,23 @@ def _local_scan_cache_path(repo_path: Path) -> Path:
     return repo_path / ".aletheore" / _LOCAL_SCAN_CACHE_FILENAME
 
 
+_HASH_CHUNK_BYTES = 1024 * 1024
+
+
 def _hash_file(path: Path) -> str | None:
+    # Streamed rather than path.read_bytes() - this runs once per module on
+    # every scan (cache-hit check), on the shared scan-worker where an
+    # unusually large committed file (a data dump, a vendored bundle) read
+    # in full would risk OOMing the container for every installation's scan
+    # running alongside it. Chunked hashing keeps memory bounded regardless
+    # of file size instead of skipping large files outright, so caching
+    # still works for them.
     try:
-        return hashlib.blake2b(path.read_bytes(), digest_size=16).hexdigest()
+        hasher = hashlib.blake2b(digest_size=16)
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(_HASH_CHUNK_BYTES), b""):
+                hasher.update(chunk)
+        return hasher.hexdigest()
     except OSError:
         return None
 

--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -33,6 +33,15 @@ BINARY_EXTENSIONS = {
     ".dll",
 }
 
+# iter_all_files feeds full-file reads (find_secrets, mcp_server's
+# aletheore_search) on the shared scan-worker, where every installation's
+# scans compete for the same container's memory - a single unusually large
+# committed file (a data dump, a generated fixture, a vendored bundle) read
+# in full would risk OOMing that container for everyone. Skipped the same
+# way BINARY_EXTENSIONS files are: silently excluded from the walk, not
+# truncated (a truncated secrets scan could misreport line numbers).
+MAX_SCANNED_FILE_BYTES = 10 * 1024 * 1024
+
 PLACEHOLDER_PATH_MARKERS = ("example", "test", "fixture", "mock")
 
 # Substrings that show up in hand-written placeholder values themselves
@@ -92,6 +101,11 @@ def iter_all_files(repo_path: Path, ignored_paths: list[str] | None = None):
             if path.is_symlink() or not path.is_file():
                 continue
             if path.suffix in BINARY_EXTENSIONS:
+                continue
+            try:
+                if path.stat().st_size > MAX_SCANNED_FILE_BYTES:
+                    continue
+            except OSError:
                 continue
             rel_path = path.relative_to(repo_path).as_posix()
             if is_ignored(rel_path, patterns):

--- a/src/tests/test_credentials.py
+++ b/src/tests/test_credentials.py
@@ -119,6 +119,23 @@ def test_save_key_sets_restrictive_permissions(monkeypatch, tmp_path):
     assert mode == 0o600
 
 
+def test_save_key_tightens_permissions_on_a_pre_existing_looser_file(monkeypatch, tmp_path):
+    # A file that already exists (e.g. from before this restrictive-
+    # permissions fix, or seeded some other way) with looser permissions
+    # must still end up at 0o600 - os.open's mode argument is a no-op on
+    # an existing file, so this only holds if _save_key explicitly chmods.
+    monkeypatch.delenv("TESTPROVIDER_API_KEY", raising=False)
+    creds_path = tmp_path / "creds.json"
+    creds_path.write_text(json.dumps({}))
+    creds_path.chmod(0o644)
+    responses = iter(["sk-entered", "save"])
+
+    get_api_key("TESTPROVIDER_API_KEY", "testprovider", creds_path, lambda _msg: next(responses))
+
+    mode = creds_path.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
 def test_save_key_preserves_other_providers_existing_keys(monkeypatch, tmp_path):
     monkeypatch.delenv("PROVIDER_B_KEY", raising=False)
     creds_path = tmp_path / "creds.json"

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -6,6 +7,7 @@ from unittest.mock import patch
 from aletheore.evidence import (
     EVIDENCE_VERSION,
     IncompatibleEvidenceVersionError,
+    _hash_file,
     is_evidence_version_compatible,
     load_evidence,
     load_evidence_file,
@@ -13,6 +15,21 @@ from aletheore.evidence import (
     write_evidence,
 )
 from tests.air_fixtures import minimal_air_evidence
+
+
+def test_hash_file_matches_a_plain_blake2b_of_the_full_content(tmp_path):
+    # _hash_file streams the file in chunks (to stay memory-bounded on
+    # arbitrarily large committed files) instead of reading it all at once -
+    # must still produce the exact same digest either way.
+    path = tmp_path / "f.py"
+    content = b"x = 1\n" * 1000
+    path.write_bytes(content)
+
+    assert _hash_file(path) == hashlib.blake2b(content, digest_size=16).hexdigest()
+
+
+def test_hash_file_returns_none_for_a_missing_file(tmp_path):
+    assert _hash_file(tmp_path / "does-not-exist.py") is None
 
 
 def run(repo: Path, *args: str):

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -1,6 +1,6 @@
 import json
-from pathlib import Path
 
+import aletheore.secrets as secrets_module
 from aletheore.secrets import find_secrets, load_secrets_baseline
 
 
@@ -114,6 +114,23 @@ def test_find_secrets_ignores_ignored_dirs_and_binary_extensions(tmp_path):
 
     assert result["findings"] == []
     assert result["scanned_files"] == 1
+
+
+def test_find_secrets_skips_files_over_the_size_cap(tmp_path, monkeypatch):
+    # A single unusually large committed file (a data dump, a vendored
+    # bundle) read in full would risk OOMing the shared scan-worker
+    # container - files over the cap are excluded from the walk entirely,
+    # the same way binary extensions already are.
+    monkeypatch.setattr(secrets_module, "MAX_SCANNED_FILE_BYTES", 10)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "huge.py").write_text('KEY = "AKIAABCDEFGHIJKLMNOP"\n' * 5)
+    (repo / "small.py").write_text("x = 1\n")
+
+    result = find_secrets(repo)
+
+    assert result["scanned_files"] == 1
+    assert result["findings"] == []
 
 
 def test_find_secrets_no_matches_in_ordinary_file(tmp_path):


### PR DESCRIPTION
## Summary
- **CLI-1**: `find_secrets` and `mcp_server`'s `aletheore_search` both walk every file in a repo via `iter_all_files`, reading each one in full via `read_text()`. On the shared scan-worker, where every installation's scans compete for the same container's memory, a single unusually large committed file would risk OOMing that container for everyone. `iter_all_files` now skips files over 10MB, the same way it already skips known binary extensions.
- Also streamed `evidence.py`'s `_hash_file` (used for the local scan cache's change-detection, once per module on every scan) via chunked reads instead of `path.read_bytes()` — same OOM exposure, but memory-bounded hashing is the better fix here since it keeps caching working for large files instead of skipping them.
- **CLI-4**: `credentials.py`'s `_save_key` wrote the API key via `write_text()` then `chmod(0o600)` after — a window where the file was briefly world/group-readable with the key already on disk. Now uses `os.open` with `mode=0o600` plus an explicit `fchmod` before writing, so permissions are locked down before any key content is written, whether the file is newly created or already existed with looser permissions.

## Test plan
- [x] `ruff check` clean on all touched files
- [x] New test: `find_secrets` skips files over the size cap
- [x] New test: `_hash_file` streamed output matches a plain `blake2b` of the full content, and returns `None` for a missing file
- [x] New test: `_save_key` tightens permissions on a pre-existing file that had looser permissions (not just newly-created files)
- [x] Full CLI suite: `pytest tests/` — 1031 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)