### PR TITLE
security: auto-gitignore .aletheore/, harden Action inputs and PyPI publish pin (CLI-2, CLI-6/7)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,6 +27,10 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to a commit SHA rather than the release/v1 branch - this
+        # step runs with an OIDC trusted-publishing token scoped to PyPI
+        # uploads, so a compromised upstream branch would mean silently
+        # supply-chain-tampered releases to every aletheore user. v1.14.2.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: src/dist

--- a/action.yml
+++ b/action.yml
@@ -76,18 +76,29 @@ runs:
     - name: Diff
       id: diff
       shell: bash
+      env:
+        # Passed via env: and read as shell variables below rather than
+        # interpolated directly into the script (${{ inputs.full }} etc.
+        # inline in `run:`) - a workflow that sets these from something
+        # other than a literal "true"/"false" (a repo variable, an output
+        # of an earlier step) would otherwise have that value spliced
+        # verbatim into the script text before bash ever runs it.
+        ALETHEORE_FULL: ${{ inputs.full }}
+        ALETHEORE_FAIL_ON_NEW_SECRETS: ${{ inputs.fail-on-new-secrets }}
+        ALETHEORE_FAIL_ON_NEW_VULNERABILITIES: ${{ inputs.fail-on-new-vulnerabilities }}
+        ALETHEORE_FAIL_ON_NEW_LAYER_VIOLATIONS: ${{ inputs.fail-on-new-layer-violations }}
       run: |
         ARGS=""
-        if [ "${{ inputs.full }}" = "true" ]; then
+        if [ "$ALETHEORE_FULL" = "true" ]; then
           ARGS="$ARGS --full"
         fi
-        if [ "${{ inputs.fail-on-new-secrets }}" = "true" ]; then
+        if [ "$ALETHEORE_FAIL_ON_NEW_SECRETS" = "true" ]; then
           ARGS="$ARGS --fail-on-new-secrets"
         fi
-        if [ "${{ inputs.fail-on-new-vulnerabilities }}" = "true" ]; then
+        if [ "$ALETHEORE_FAIL_ON_NEW_VULNERABILITIES" = "true" ]; then
           ARGS="$ARGS --fail-on-new-vulnerabilities"
         fi
-        if [ "${{ inputs.fail-on-new-layer-violations }}" = "true" ]; then
+        if [ "$ALETHEORE_FAIL_ON_NEW_LAYER_VIOLATIONS" = "true" ]; then
           ARGS="$ARGS --fail-on-new-layer-violations"
         fi
 

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -478,7 +478,46 @@ def scan_repository(
     }
 
 
+_GITIGNORE_ALETHEORE_ENTRIES = (".aletheore/", ".aletheore", "/.aletheore/", "/.aletheore")
+
+
+def _ensure_aletheore_dir_gitignored(repo_path: Path) -> None:
+    # Best-effort, and only inside an actual git checkout - a plain
+    # directory has no .gitignore worth creating. Without this, .aletheore/'s
+    # scan cache and evidence output (which can include secrets-scan match
+    # previews and the absolute repo path) is one `git add .` away from
+    # landing in a commit.
+    #
+    # Hosted and demo scans DO reach this - they run against real `git clone`
+    # output, so the .git check does not exclude them - but it is inert there:
+    # ephemeral clones are deleted with the job, persistent checkouts are
+    # reset by the `git checkout -f` + `git clean -fdx` that precedes every
+    # reuse, incremental scans diff commit-to-commit rather than against the
+    # working tree, and Docs repo commits are built through the GitHub API
+    # from explicit content rather than pushed from this tree. Anything that
+    # changes one of those - in particular, committing from the checkout -
+    # needs to gate this call rather than assume it never fires server-side.
+    if not (repo_path / ".git").exists():
+        return
+    gitignore_path = repo_path / ".gitignore"
+    existing = ""
+    if gitignore_path.exists():
+        try:
+            existing = gitignore_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return
+        if any(line.strip() in _GITIGNORE_ALETHEORE_ENTRIES for line in existing.splitlines()):
+            return
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    try:
+        with gitignore_path.open("a", encoding="utf-8") as f:
+            f.write(f"{separator}.aletheore/\n")
+    except OSError:
+        pass
+
+
 def write_evidence(evidence: dict, repo_path: Path) -> Path:
+    _ensure_aletheore_dir_gitignored(repo_path)
     aletheore_dir = repo_path / ".aletheore"
     aletheore_dir.mkdir(parents=True, exist_ok=True)
     output_path = aletheore_dir / "air.json"

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -409,6 +409,46 @@ def test_write_evidence_also_writes_a_toon_copy(tmp_path):
     assert toon.decode(toon_path.read_text()) == evidence
 
 
+def test_write_evidence_adds_aletheore_dir_to_a_missing_gitignore(tmp_path):
+    repo = make_repo(tmp_path)
+    evidence = scan_repository(repo, check_vulnerabilities=False, check_licenses=False)
+
+    write_evidence(evidence, repo)
+
+    assert (repo / ".gitignore").read_text() == ".aletheore/\n"
+
+
+def test_write_evidence_appends_to_an_existing_gitignore(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / ".gitignore").write_text("*.pyc\n")
+    evidence = scan_repository(repo, check_vulnerabilities=False, check_licenses=False)
+
+    write_evidence(evidence, repo)
+
+    assert (repo / ".gitignore").read_text() == "*.pyc\n.aletheore/\n"
+
+
+def test_write_evidence_does_not_duplicate_an_existing_aletheore_gitignore_entry(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / ".gitignore").write_text(".aletheore/\n")
+    evidence = scan_repository(repo, check_vulnerabilities=False, check_licenses=False)
+
+    write_evidence(evidence, repo)
+
+    assert (repo / ".gitignore").read_text() == ".aletheore/\n"
+
+
+def test_write_evidence_does_not_touch_gitignore_outside_a_git_repo(tmp_path):
+    repo = tmp_path / "not-a-git-repo"
+    repo.mkdir()
+    (repo / "main.py").write_text("def hello():\n    return 1\n")
+    evidence = scan_repository(repo, check_vulnerabilities=False, check_licenses=False)
+
+    write_evidence(evidence, repo)
+
+    assert not (repo / ".gitignore").exists()
+
+
 def test_scan_repository_includes_security_block(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
Batch 7 of the launch-readiness security audit. Recovered from a stash after the previous session hit its usage limit mid-ship — tests were already green, re-verified here.

## CLI-2 — scan output was one `git add .` from being committed

`aletheore scan` writes `.aletheore/air.json` into the working tree. It contains `repo_path` (absolute, so it leaks username and directory layout) and, per `find_secrets`, one record per detected secret with `path`, `line`, `pattern`, and `match_preview`. Nothing wrote a `.gitignore`, so a user's first scan silently staged a map of every secret in their repo.

`write_evidence` now appends `.aletheore/` to `.gitignore` inside a git checkout, skipping if an equivalent entry already exists.

Hosted and demo scans do reach this path (they run against real `git clone` output), but it's inert there — ephemeral clones are deleted with the job, persistent checkouts are reset by the `git checkout -f` + `git clean -fdx` preceding every reuse, incremental scans diff commit-to-commit rather than against the working tree, and Docs repo commits go through the GitHub API from explicit content. That reasoning is recorded at the call site so a future change that starts committing from the checkout knows to gate it.

## CLI-6 — Action inputs spliced into shell

`action.yml` interpolated `${{ inputs.* }}` directly into `run:` blocks. GitHub substitutes those into the script text *before* bash runs, so a consuming workflow that wired them from a repo variable or an earlier step's output would have had that value executed as shell. Now passed via `env:` and read as shell variables.

## CLI-7 — mutable action ref in the publishing job

`publish-pypi.yml` pinned `pypa/gh-action-pypi-publish@release/v1` — a branch — in the job holding `id-token: write` for OIDC trusted publishing. A compromised upstream branch would mean tampered releases to every user. Pinned to `dc37677b2e1c63e2034f94d8a5b11f265b73ba33`, independently verified as the commit that the `v1.14.2` annotated tag dereferences to.

## Verification

- 4 new tests: missing `.gitignore`, existing one appended, duplicate entry not re-added, non-git directory untouched
- Full suite: **1035 CLI + 1103 github-app passed, 8 skipped**, no regressions
- `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)