### PR TITLE
security: replace leaky secret preview with a salted hash (CLI-3)

### DIFF
--- a/src/aletheore/history.py
+++ b/src/aletheore/history.py
@@ -106,7 +106,9 @@ def _compute_curated_diff(old: dict, new: dict) -> dict:
     new_secrets, resolved_secrets = _new_and_resolved(
         old["security"]["secrets"]["findings"],
         new["security"]["secrets"]["findings"],
-        ("path", "pattern", "match_preview"),
+        _secret_identity_fields(
+            old["security"]["secrets"]["findings"], new["security"]["secrets"]["findings"]
+        ),
     )
     result["secrets"] = {"new": new_secrets, "resolved": resolved_secrets}
 
@@ -195,6 +197,42 @@ def _compute_full_diff(old: dict, new: dict) -> dict:
     ]
 
     return {"added": added, "removed": removed, "changed": changed}
+
+
+_HASHED_PREVIEW_PREFIX = "sha256:"
+
+
+def _has_legacy_previews(findings: list[dict]) -> bool:
+    return any(
+        not str(finding.get("match_preview", "")).startswith(_HASHED_PREVIEW_PREFIX)
+        for finding in findings
+    )
+
+
+def _secret_identity_fields(old_findings: list[dict], new_findings: list[dict]) -> tuple[str, ...]:
+    """Which fields identify "the same secret" across two scans.
+
+    Normally (path, pattern, match_preview). But match_preview's format
+    changed - it used to be four real leading and trailing characters of the
+    value, and is now a salted hash (see secrets._redact) - so on the single
+    scan that straddles that change, every previously-known secret has a
+    different identity than its own prior record. Diffed naively, that
+    reports the entire existing findings list as newly added and the entire
+    prior list as resolved: PR comments naming every long-known secret as
+    new, and `--fail-on-new-secrets` failing a build that introduced nothing.
+
+    Detected from the data rather than a version number, so it also covers a
+    snapshot written by any older build regardless of what version string it
+    carries. Falling back to (path, pattern) for that one diff still surfaces
+    a genuinely new secret (new file, or a new pattern in a known file) while
+    matching the pre-existing ones to their old records. It is coarser only
+    in that two secrets of the same pattern in the same file collapse
+    together for that scan; the next scan compares hash-to-hash and this
+    stops applying on its own.
+    """
+    if _has_legacy_previews(old_findings) and not _has_legacy_previews(new_findings):
+        return ("path", "pattern")
+    return ("path", "pattern", "match_preview")
 
 
 def compute_diff(old: dict, new: dict, full: bool = False) -> dict:

--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -1,3 +1,4 @@
+import hashlib
 import math
 import os
 import re
@@ -141,7 +142,32 @@ def _is_likely_placeholder(rel_path: str, value: str) -> bool:
     return _value_looks_like_a_placeholder(value)
 
 
-def _redact(value: str) -> str:
+def _redact(value: str, salt: str) -> str:
+    # Salted with the finding's own (path, pattern) rather than a fixed or
+    # global salt - two identical secret values at different locations (or
+    # in different repos) hash differently, so match_preview can't be used
+    # as a lookup key to correlate/deanonymize a value across scan output.
+    # This is a display truncation, not a real cryptographic protection
+    # (whoever owns the repo can always read the raw value straight from
+    # path:line); the point is only that a match_preview pasted into a PR
+    # comment or dashboard, or scraped from either, no longer hands out 8
+    # real characters of the secret the way the old first4...last4 format
+    # did.
+    digest = hashlib.sha256(f"{salt}:{value}".encode("utf-8")).hexdigest()[:12]
+    return f"sha256:{digest}"
+
+
+def _legacy_redact(value: str) -> str:
+    # The pre-hash preview format (first 4 + last 4 raw characters) - kept
+    # only so an accepted_secrets baseline entry written before this fix
+    # still matches on the next scan. A finding's live value is re-derived
+    # fresh from the file every scan, so this can be recomputed and checked
+    # alongside the new format without needing to store or migrate
+    # anything; there's no way to derive it FROM an old match_preview
+    # (only 8 of the value's characters ever left the scan), so baseline
+    # entries can't be rewritten automatically - they keep working via this
+    # dual check indefinitely, and naturally end up in the new format
+    # whenever someone re-baselines from current scan output.
     if len(value) <= 8:
         return "*" * len(value)
     return f"{value[:4]}{'*' * 4}...{value[-4:]}"
@@ -157,6 +183,13 @@ def _baseline_keys(baseline: list[dict] | None) -> set[tuple]:
     # about that specific value at that path, not about one particular commit that happens to
     # surface it.
     return {(entry.get("path"), entry.get("pattern"), entry.get("match_preview")) for entry in (baseline or [])}
+
+
+def _is_accepted(accepted_keys: set[tuple], path: str | None, pattern_name: str, value: str) -> bool:
+    salt = f"{path}:{pattern_name}"
+    if (path, pattern_name, _redact(value, salt)) in accepted_keys:
+        return True
+    return (path, pattern_name, _legacy_redact(value)) in accepted_keys
 
 
 def find_secrets(repo_path: Path, baseline: list[dict] | None = None) -> dict:
@@ -178,7 +211,7 @@ def find_secrets(repo_path: Path, baseline: list[dict] | None = None) -> dict:
                 match = pattern.search(line)
                 if match:
                     value = match.group(value_group)
-                    match_preview = _redact(value)
+                    match_preview = _redact(value, f"{rel_path}:{pattern_name}")
                     findings.append(
                         {
                             "path": rel_path,
@@ -186,7 +219,7 @@ def find_secrets(repo_path: Path, baseline: list[dict] | None = None) -> dict:
                             "pattern": pattern_name,
                             "match_preview": match_preview,
                             "likely_placeholder": _is_likely_placeholder(rel_path, value),
-                            "accepted": (rel_path, pattern_name, match_preview) in accepted_keys,
+                            "accepted": _is_accepted(accepted_keys, rel_path, pattern_name, value),
                         }
                     )
 
@@ -276,7 +309,7 @@ def find_secrets_in_history(
                 match = pattern.search(content)
                 if match:
                     value = match.group(value_group)
-                    match_preview = _redact(value)
+                    match_preview = _redact(value, f"{current_file}:{pattern_name}")
                     findings.append(
                         {
                             "commit": current_commit,
@@ -285,7 +318,7 @@ def find_secrets_in_history(
                             "pattern": pattern_name,
                             "match_preview": match_preview,
                             "likely_placeholder": _is_likely_placeholder(current_file or "", value),
-                            "accepted": (current_file, pattern_name, match_preview) in accepted_keys,
+                            "accepted": _is_accepted(accepted_keys, current_file, pattern_name, value),
                         }
                     )
     finally:

--- a/src/tests/test_history.py
+++ b/src/tests/test_history.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 from aletheore.history import compute_diff, list_snapshots, save_snapshot, to_sarif
 
@@ -506,3 +505,58 @@ def test_to_sarif_ignores_resolved_findings():
     }
 
     assert to_sarif(curated)["runs"][0]["results"] == []
+
+
+def _evidence_with_secrets(findings):
+    evidence = json.loads(json.dumps(base_evidence()))
+    evidence["security"]["secrets"]["findings"] = findings
+    return evidence
+
+
+def test_diff_does_not_report_every_secret_as_new_when_the_preview_format_changes():
+    # The upgrade that replaced the first4...last4 preview with a salted hash
+    # changes the identity of every already-known secret. Diffed naively, a
+    # scan that introduced nothing would report the whole findings list as new
+    # - flooding PR comments and failing --fail-on-new-secrets everywhere.
+    old = _evidence_with_secrets(
+        [{"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP"}]
+    )
+    new = _evidence_with_secrets(
+        [{"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "sha256:abc123def456"}]
+    )
+
+    result = compute_diff(old, new)
+
+    assert result["secrets"]["new"] == []
+    assert result["secrets"]["resolved"] == []
+
+
+def test_diff_still_reports_a_genuinely_new_secret_across_the_format_change():
+    old = _evidence_with_secrets(
+        [{"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP"}]
+    )
+    new = _evidence_with_secrets(
+        [
+            {"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "sha256:abc123def456"},
+            {"path": "new.py", "pattern": "github_token", "match_preview": "sha256:999888777666"},
+        ]
+    )
+
+    result = compute_diff(old, new)
+
+    assert [f["path"] for f in result["secrets"]["new"]] == ["new.py"]
+
+
+def test_diff_uses_the_full_identity_once_both_sides_are_hashed():
+    # Self-healing: the fallback only applies to the one straddling scan.
+    old = _evidence_with_secrets(
+        [{"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "sha256:aaaaaaaaaaaa"}]
+    )
+    new = _evidence_with_secrets(
+        [{"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "sha256:bbbbbbbbbbbb"}]
+    )
+
+    result = compute_diff(old, new)
+
+    assert len(result["secrets"]["new"]) == 1
+    assert len(result["secrets"]["resolved"]) == 1

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -44,8 +44,13 @@ def test_find_secrets_redacts_the_match(tmp_path):
 
     preview = result["findings"][0]["match_preview"]
     assert "AKIAABCDEFGHIJKLMNOP" not in preview
-    assert preview.startswith("AKIA")
-    assert preview.endswith("MNOP")
+    # Previously this asserted the preview started with "AKIA" and ended with
+    # "MNOP" - i.e. that four real leading and four real trailing characters
+    # of the credential were published. That is the leak the salted hash
+    # replaced, so the assertion is now the inverse.
+    assert preview.startswith("sha256:")
+    assert "AKIA" not in preview
+    assert "MNOP" not in preview
 
 
 def test_find_secrets_flags_test_fixture_paths_as_likely_placeholder(tmp_path):
@@ -176,25 +181,24 @@ def test_find_secrets_does_not_descend_into_a_symlinked_directory_outside_the_re
 
 
 def test_find_secrets_generic_credential_preview_previews_the_value_not_the_keyword(tmp_path):
+    # The property under test is unchanged: the preview must be derived from
+    # the credential VALUE, not from the "secret"/"password"/"api_key" keyword
+    # that happens to precede it on the line. It used to be checked by
+    # asserting the preview began with the value's own first four characters,
+    # which is no longer true (and was itself the leak). Checked here instead
+    # by holding the keyword fixed and varying only the value: a preview keyed
+    # off the keyword would be identical across both files.
     repo = tmp_path / "repo"
     repo.mkdir()
-    real_value = "totallyrealvalue1234567890tailend"
-    (repo / "config.py").write_text(f'secret = "{real_value}"\n')
+    (repo / "a.py").write_text('secret = "totallyrealvalue1234567890tailend"\n')
+    (repo / "b.py").write_text('secret = "adifferentvalue0987654321tailend"\n')
 
-    result = find_secrets(repo)
+    previews = {f["path"]: f for f in find_secrets(repo)["findings"]}
 
-    finding = result["findings"][0]
-    assert finding["pattern"] == "generic_credential_assignment"
-    # the full value must never appear in the preview
-    assert real_value not in finding["match_preview"]
-    # the preview must reflect the credential VALUE's own prefix (matching the
-    # redaction scheme used by every other pattern), not the "secret"/"password"/
-    # "api_key" keyword that happens to precede it in the source line - a keyword
-    # prefix reveals nothing useful and previously meant the last chars shown were
-    # an accidental mix of real value characters and a stray closing quote rather
-    # than a clean, intentional preview of the value itself
-    assert finding["match_preview"].startswith(real_value[:4])
-    assert not finding["match_preview"].lower().startswith("secr")
+    assert previews["a.py"]["pattern"] == "generic_credential_assignment"
+    assert "totallyrealvalue1234567890tailend" not in previews["a.py"]["match_preview"]
+    assert previews["a.py"]["match_preview"] != previews["b.py"]["match_preview"]
+    assert not previews["a.py"]["match_preview"].lower().startswith("secr")
 
 
 def test_find_secrets_always_includes_accepted_key_defaulting_false(tmp_path):
@@ -269,3 +273,76 @@ def test_load_secrets_baseline_filters_out_non_dict_entries(tmp_path):
     (repo / ".aletheore.json").write_text(json.dumps({"accepted_secrets": [entry, "garbage", 5]}))
 
     assert load_secrets_baseline(repo) == [entry]
+
+
+def test_match_preview_no_longer_leaks_characters_of_the_value(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text('AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+
+    findings = find_secrets(repo)["findings"]
+
+    assert findings, "expected the planted secret to be detected"
+    preview = findings[0]["match_preview"]
+    assert preview.startswith("sha256:")
+    # The specific regression: the old format emitted the first four and last
+    # four real characters, so these must not survive anywhere in the preview.
+    assert "AKIA" not in preview
+    assert "MNOP" not in preview
+
+
+def test_match_preview_is_salted_so_the_same_value_differs_by_location(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    secret = 'AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n'
+    (repo / "a.py").write_text(secret)
+    (repo / "b.py").write_text(secret)
+
+    previews = {f["path"]: f["match_preview"] for f in find_secrets(repo)["findings"]}
+
+    assert len(previews) == 2
+    assert previews["a.py"] != previews["b.py"]
+
+
+def test_match_preview_is_stable_across_scans_of_the_same_file(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text('AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+
+    first = find_secrets(repo)["findings"][0]["match_preview"]
+    second = find_secrets(repo)["findings"][0]["match_preview"]
+
+    assert first == second, "baseline matching depends on this being deterministic"
+
+
+def test_a_baseline_written_in_the_old_preview_format_still_matches(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    value = "AKIAABCDEFGHIJKLMNOP"
+    (repo / "app.py").write_text(f'AWS_KEY = "{value}"\n')
+    detected = find_secrets(repo)["findings"][0]
+    legacy_baseline = [
+        {
+            "path": "app.py",
+            "pattern": detected["pattern"],
+            "match_preview": f"{value[:4]}{'*' * 4}...{value[-4:]}",
+        }
+    ]
+
+    findings = find_secrets(repo, baseline=legacy_baseline)["findings"]
+
+    assert findings[0]["accepted"] is True
+
+
+def test_a_baseline_written_in_the_new_preview_format_matches(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text('AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    detected = find_secrets(repo)["findings"][0]
+    baseline = [
+        {"path": "app.py", "pattern": detected["pattern"], "match_preview": detected["match_preview"]}
+    ]
+
+    findings = find_secrets(repo, baseline=baseline)["findings"]
+
+    assert findings[0]["accepted"] is True

--- a/src/tests/test_secrets_history.py
+++ b/src/tests/test_secrets_history.py
@@ -61,7 +61,10 @@ def test_find_secrets_in_history_finds_a_secret_added_then_removed(tmp_path):
     assert finding["path"] == "main.py"
     assert finding["pattern"] == "aws_access_key_id"
     assert "AKIAABCDEFGHIJKLMNOP" not in finding["match_preview"]
-    assert finding["match_preview"].startswith("AKIA")
+    # Was startswith("AKIA") - history findings use the same salted-hash
+    # preview as live ones, so no real characters of the value are published.
+    assert finding["match_preview"].startswith("sha256:")
+    assert "AKIA" not in finding["match_preview"]
     assert finding["likely_placeholder"] is False
     assert result["history_scanned_commits"] == 3
 


### PR DESCRIPTION
Batch 8 of the launch-readiness security audit.

## The leak

`match_preview` published the first four and last four **real characters** of every detected credential:

```python
return f"{value[:4]}{'*' * 4}...{value[-4:]}"
```

Most credential formats have a fixed prefix (`ghp_`, `sk-`, `AKIA`, `glpat`), so the leading four carry no entropy and this effectively published **the last four characters of the real secret** — into `.aletheore/air.json` (which, before #175, was one `git add .` from being committed), into evidence uploaded to the hosted service, and into LLM prompts. For a 9–12 character value it's a large fraction of the whole thing.

Now `sha256:<12 hex>`, salted with the finding's own `(path, pattern)` so the same value at two locations doesn't produce a correlatable identifier. This is display redaction, not cryptographic protection — whoever owns the repo can read the value at `path:line` — but a preview pasted into a PR comment or scraped from a dashboard no longer hands out real characters.

## Transition, which is most of this change

`match_preview` is an identity key in four places. Changing its format breaks each one differently:

| Consumer | Handling |
|---|---|
| CLI `accepted_secrets` baseline | Live value is re-derived from the file every scan, so both new and legacy previews are computed and **either matches**. Old baselines keep working indefinitely; nothing stored is migrated. |
| `history.py` new/resolved diffing | **Would have broken every consumer's CI.** See below. |
| `history_findings` | Identity is `(commit, path, pattern)` — unaffected. |
| Server-side dismissals | Cannot be recomputed; see caveat below. |

### The diffing break

A snapshot written before this change holds legacy previews. Diffed naively against a fresh scan, *every* previously-known secret has a new identity — so `compute_diff` reports the entire findings list as newly added and the entire prior list as resolved. In practice: PR comments naming every long-known secret as new, and **`--fail-on-new-secrets` failing builds that introduced nothing**.

`_secret_identity_fields` detects this from the data (legacy previews on one side, hashed on the other — no version plumbing, so it also covers snapshots from any older build) and falls back to `(path, pattern)` for that one straddling diff. That still surfaces a genuinely new secret while matching pre-existing ones to their records. Self-healing: the next scan compares hash to hash and the fallback stops applying.

### Caveat — pre-existing dismissals reset once

`finding_identity_key` for secrets is `path\x1fpattern\x1fmatch_preview`, and the server only ever sees the finding dict — never the raw value — so it cannot recompute the legacy key. **Secrets dismissed on the dashboard before this ships will reappear once and need re-dismissing.** Stale rows are left in place (inert) rather than deleted, so nothing is destroyed. Given `dismissed_findings` shipped days ago in migration 033 against a single-digit installation base, the alternative — emitting the legacy preview alongside the hash for a migration window — would have kept leaking the thing this fixes, for longer, to migrate near-zero rows.

## Three tests were pinning the leak in place

These asserted the vulnerable behaviour directly and failed against the fix:

- `test_find_secrets_redacts_the_match` — `assert preview.startswith("AKIA")` / `endswith("MNOP")`
- `test_find_secrets_generic_credential_preview_previews_the_value_not_the_keyword` — `assert match_preview.startswith(real_value[:4])`
- `test_find_secrets_in_history_finds_a_secret_added_then_removed` — `assert match_preview.startswith("AKIA")`

Each was rewritten to assert the property it actually existed for. The generic-credential one still verifies the preview derives from the *value* rather than the preceding keyword — now by holding the keyword fixed and varying the value.

## Verification

- 8 new tests: no leaked characters, salted per location, deterministic across scans, legacy and new baselines both match, and three covering the diff transition
- Full suite: **1039 CLI + 1103 github-app passed, 8 skipped**
- `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)