### PR TITLE
security: record the signing key on each audit report so rotation is possible (NEW-6)

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -1114,7 +1114,7 @@ async def get_audit_report_by_token(
 ) -> dict | None:
     row = await pool.fetchrow(
         """
-        SELECT repo_full_name, report_text, content_hash, signature, created_at
+        SELECT repo_full_name, report_text, content_hash, signature, signing_public_key, created_at
         FROM audit_reports
         WHERE verification_token = $1
         """,

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -124,7 +124,14 @@ async def verify_audit_report(verification_token: str, request: Request):
         raise HTTPException(status_code=404, detail="report not found")
 
     settings = get_settings()
-    public_key_hex = public_key_hex_from_private(settings.audit_signing_private_key)
+    # The key recorded on the report itself, not whichever key is current.
+    # Deriving it from AUDIT_SIGNING_PRIVATE_KEY at request time meant a
+    # rotation would report verified=false for every certificate ever issued -
+    # so the only safe operation on the signing key was never to rotate it.
+    # Rows written before migration 044 carry no key and were signed by the
+    # current one; that fallback applies to them alone.
+    current_public_key_hex = public_key_hex_from_private(settings.audit_signing_private_key)
+    public_key_hex = report["signing_public_key"] or current_public_key_hex
     verified = verify_report(report["report_text"], report["signature"], public_key_hex)
 
     # A signature attests "Aletheore produced this exact text" - not "every
@@ -145,12 +152,36 @@ async def verify_audit_report(verification_token: str, request: Request):
         if has_opinion_section
         else [],
         # Included so this is an actual verifiable certificate, not just an
-        # "our database says so" boolean - anyone can independently confirm
-        # signature over content_hash using this public key, without
-        # trusting this endpoint's own "verified" field.
+        # "our database says so" boolean - anyone can confirm signature over
+        # content_hash using this public key, without trusting this endpoint's
+        # own "verified" field.
+        #
+        # That independence is only real if the verifier obtained the key from
+        # somewhere other than this response, so /v1/audit/signing-key serves
+        # the current one at a stable URL to pin out-of-band, and is_current_key
+        # says whether this report was signed by it. A false here is not a
+        # problem - it means the report predates a rotation and was checked
+        # against its own recorded key, exactly as intended.
         "algorithm": "Ed25519",
         "signature": report["signature"],
         "public_key": public_key_hex,
+        "is_current_key": public_key_hex == current_public_key_hex,
+    }
+
+
+@managed_audit_router.get("/v1/audit/signing-key")
+async def audit_signing_key():
+    """The public half of the key currently signing audit reports.
+
+    Exists so a consumer can pin the key out-of-band and verify a certificate
+    without taking the verifying endpoint's word for either the key or the
+    result. Public and unauthenticated by design: a public key is not a secret,
+    and a verifier who has to authenticate to fetch it is back to trusting us.
+    """
+    settings = get_settings()
+    return {
+        "algorithm": "Ed25519",
+        "public_key": public_key_hex_from_private(settings.audit_signing_private_key),
     }
 
 

--- a/github-app/migrations/044_audit_report_signing_key.sql
+++ b/github-app/migrations/044_audit_report_signing_key.sql
@@ -1,0 +1,17 @@
+-- Records which public key signed each audit report.
+--
+-- /v1/audit/{token}/verify derived the public key from whatever
+-- AUDIT_SIGNING_PRIVATE_KEY happened to be set to at request time, and the row
+-- stored only the signature. That made key rotation retroactively destructive:
+-- rotating the signing key would have reported verified=false for every
+-- certificate ever issued, because they were checked against a key that had
+-- never signed them. There was no rotation path at all - the only safe move was
+-- never to rotate, which is not a property you want on a signing key.
+--
+-- Nullable rather than NOT NULL DEFAULT: rows written before this migration
+-- were signed by the key currently in the environment, but that key lives in
+-- env, not in SQL, so it cannot be backfilled here. NULL means "signed by
+-- whatever the current key is", which is exactly the pre-migration behaviour,
+-- and the verify endpoint keeps that fallback for those rows only. Every row
+-- written from now on names its key explicitly.
+ALTER TABLE audit_reports ADD COLUMN IF NOT EXISTS signing_public_key TEXT;

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -239,6 +239,7 @@ def insert_audit_report(
     report_text: str,
     content_hash: str,
     signature: str,
+    signing_public_key: str,
 ) -> None:
     import psycopg
 
@@ -247,8 +248,9 @@ def insert_audit_report(
             cur.execute(
                 """
                 INSERT INTO audit_reports
-                    (installation_id, repo_full_name, verification_token, report_text, content_hash, signature)
-                VALUES (%s, %s, %s, %s, %s, %s)
+                    (installation_id, repo_full_name, verification_token, report_text,
+                     content_hash, signature, signing_public_key)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     installation_id,
@@ -257,6 +259,7 @@ def insert_audit_report(
                     report_text,
                     content_hash,
                     signature,
+                    signing_public_key,
                 ),
             )
         conn.commit()

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -16,7 +16,7 @@ from urllib.parse import urlsplit, urlunsplit
 import httpx
 from rq import get_current_job
 
-from app_server.audit_signing import content_hash, sign_report
+from app_server.audit_signing import content_hash, public_key_hex_from_private, sign_report
 from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from aletheore.code_graph_diff import diff_endpoints, diff_modules
@@ -1033,6 +1033,10 @@ def _sign_and_persist_audit_report(
         verification_token = secrets.token_hex(32)
         report_hash = content_hash(report_text)
         signature = sign_report(report_text, settings.audit_signing_private_key)
+        # Recorded per report so a later key rotation can't retroactively
+        # invalidate this certificate - the verifier checks against the key
+        # that actually signed it, not whichever key is current when someone
+        # happens to look.
         insert_audit_report(
             settings.database_url,
             installation_id,
@@ -1041,6 +1045,7 @@ def _sign_and_persist_audit_report(
             report_text,
             report_hash,
             signature,
+            public_key_hex_from_private(settings.audit_signing_private_key),
         )
         return verification_token
     except Exception as exc:  # noqa: BLE001

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -813,11 +813,12 @@ def test_managed_audit_api_job_signs_and_persists_the_report(monkeypatch):
     stored = {}
     monkeypatch.setattr(
         "scan_worker.jobs.insert_audit_report",
-        lambda dsn, iid, repo, token, text, chash, sig: stored.update(
+        lambda dsn, iid, repo, token, text, chash, sig, pubkey: stored.update(
             installation_id=iid,
             repo_full_name=repo,
             token=token,
             text=text,
+            signing_public_key=pubkey,
         ),
     )
 
@@ -990,13 +991,14 @@ def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_pat
     stored = {}
     monkeypatch.setattr(
         "scan_worker.jobs.insert_audit_report",
-        lambda dsn, iid, repo, token, text, chash, sig: stored.update(
+        lambda dsn, iid, repo, token, text, chash, sig, pubkey: stored.update(
             installation_id=iid,
             repo_full_name=repo,
             token=token,
             text=text,
             hash=chash,
             sig=sig,
+            signing_public_key=pubkey,
         ),
     )
     check_runs = []

--- a/github-app/tests/test_managed_audit_api.py
+++ b/github-app/tests/test_managed_audit_api.py
@@ -505,3 +505,92 @@ async def test_whoami_returns_account_login_and_plan_for_valid_token(pool):
 
     assert response.status_code == 200
     assert response.json() == {"account_login": "acme", "plan": "indie"}
+
+
+@pytest.mark.asyncio
+async def test_verify_uses_the_key_that_signed_the_report_after_a_rotation(pool, monkeypatch):
+    # The regression: the public key was derived from whatever
+    # AUDIT_SIGNING_PRIVATE_KEY was set to at request time, so rotating the
+    # signing key reported verified=false for every certificate ever issued.
+    old_key = "11" * 32
+    new_key = "22" * 32
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", old_key)
+    await upsert_installation(pool, 611, "octocat")
+    report_text = "signed before the rotation"
+    await pool.execute(
+        """
+        INSERT INTO audit_reports
+            (installation_id, repo_full_name, verification_token, report_text,
+             content_hash, signature, signing_public_key)
+        VALUES (611, 'octocat/hello-world', 'tok-rotated', $1, $2, $3, $4)
+        """,
+        report_text,
+        content_hash(report_text),
+        sign_report(report_text, old_key),
+        public_key_hex_from_private(old_key),
+    )
+
+    # The key rotates; the already-issued certificate must still verify.
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", new_key)
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/audit/tok-rotated/verify")
+
+    body = response.json()
+    assert body["verified"] is True
+    assert body["public_key"] == public_key_hex_from_private(old_key)
+    assert body["is_current_key"] is False
+
+
+@pytest.mark.asyncio
+async def test_verify_falls_back_to_the_current_key_for_pre_migration_rows(pool, monkeypatch):
+    # Rows written before migration 044 have no recorded key and were signed
+    # by whatever key is current - the pre-migration behaviour, preserved for
+    # those rows alone.
+    key = "33" * 32
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", key)
+    await upsert_installation(pool, 612, "octocat")
+    report_text = "signed before migration 044"
+    await pool.execute(
+        """
+        INSERT INTO audit_reports
+            (installation_id, repo_full_name, verification_token, report_text, content_hash, signature)
+        VALUES (612, 'octocat/hello-world', 'tok-legacy', $1, $2, $3)
+        """,
+        report_text,
+        content_hash(report_text),
+        sign_report(report_text, key),
+    )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/audit/tok-legacy/verify")
+
+    body = response.json()
+    assert body["verified"] is True
+    assert body["is_current_key"] is True
+
+
+@pytest.mark.asyncio
+async def test_signing_key_endpoint_serves_the_current_public_key(monkeypatch):
+    key = "44" * 32
+    monkeypatch.setenv("AUDIT_SIGNING_PRIVATE_KEY", key)
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/audit/signing-key")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "algorithm": "Ed25519",
+        "public_key": public_key_hex_from_private(key),
+    }

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -343,6 +343,7 @@ async def test_insert_audit_report(pool):
         "the report text",
         "hash-1",
         "sig-1",
+        "pubkey-1",
     )
 
     row = await pool.fetchrow(
@@ -353,6 +354,8 @@ async def test_insert_audit_report(pool):
     assert row["report_text"] == "the report text"
     assert row["content_hash"] == "hash-1"
     assert row["signature"] == "sig-1"
+    # Recorded per report so a later key rotation can't invalidate it.
+    assert row["signing_public_key"] == "pubkey-1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Batch 9 of the launch-readiness security audit.

## The problem

`/v1/audit/{verification_token}/verify` derived the public key from whatever `AUDIT_SIGNING_PRIVATE_KEY` was set to **at request time**, while `audit_reports` stored only the signature:

```python
public_key_hex = public_key_hex_from_private(settings.audit_signing_private_key)
verified = verify_report(report["report_text"], report["signature"], public_key_hex)
```

So rotating the signing key would have reported `verified: false` for **every certificate ever issued** — genuine reports, checked against a key that never signed them. The only safe operation on the key was never to rotate it, including after a suspected compromise. For a product selling cryptographically verifiable audit certificates, that's the wrong failure mode.

The crypto itself was fine — Ed25519, signing over a SHA-256 content hash, `ValueError` handled alongside `InvalidSignature`. This is purely key management.

## Fix

Migration 044 adds `audit_reports.signing_public_key`, written at sign time and used at verify time.

Nullable rather than backfilled: rows written before this were signed by the key currently in the environment, and that key lives in env, not SQL — it can't be backfilled in a migration. `NULL` therefore means "signed by the current key", which is exactly the pre-migration behaviour, and the fallback applies to those rows alone. Every row written from now on names its key explicitly.

## Independent verification

The verify response already returned `public_key` so a consumer could check the signature rather than trust the `verified` boolean. But a key handed over by the same response isn't an independent trust anchor — you're still trusting this endpoint for both.

`GET /v1/audit/signing-key` now serves the current public key at a stable, unauthenticated URL so it can be pinned out-of-band. Public by design: a public key isn't a secret, and requiring auth to fetch it puts you back to trusting us. The response also gains `is_current_key`, so a verifier can tell a pre-rotation certificate from a mismatch — `false` there is informational, not a failure.

## Verification

- 3 new tests: a report signed before a rotation still verifies against its own key; pre-migration rows fall back to the current key; the key endpoint serves what it should
- Existing `insert_audit_report` mocks and the direct db test updated for the new column, and now assert the key is actually recorded
- Full suite: **1106 passed, 8 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)