### PR TITLE
chore(deps): bump fastapi, uvicorn and redis to current releases

### DIFF
--- a/github-app/requirements.txt
+++ b/github-app/requirements.txt
@@ -1,8 +1,8 @@
-fastapi>=0.115.0,<0.136.3
-uvicorn[standard]>=0.30.0,<1.0
+fastapi>=0.141.1,<0.142.0
+uvicorn[standard]>=0.52.1,<1.0
 asyncpg>=0.31.0,<1.0
 psycopg[binary]>=3.3.4,<4.0
-redis>=5.0.0,<9.0
+redis>=8.1.0,<9.0
 rq>=2.10.0,<3.0
 httpx>=0.28.1,<1.0
 pyjwt[crypto]>=2.13.0,<3.0


### PR DESCRIPTION
Supersedes Dependabot #163 (fastapi), #165 (uvicorn) and #162 (redis).

Combined into one change deliberately: those three were opened at 12:16Z, before today's ten merges, so their CI ran against a stale base. Merging them individually would mean three rebase-and-rerun cycles and three production deploys. This runs once, against current master.

| Package | Was | Now |
|---|---|---|
| fastapi | `>=0.115.0,<0.136.3` | `>=0.141.1,<0.142.0` |
| uvicorn[standard] | `>=0.30.0,<1.0` | `>=0.52.1,<1.0` |
| redis | `>=5.0.0,<9.0` | `>=8.1.0,<9.0` |

**On the fastapi bound:** Dependabot proposed `>=0.141.1,<0.141.2`, which pins one exact version and needs a new PR for every patch release. Pre-1.0 fastapi puts breaking changes in *minor* bumps, so `<0.142.0` is the boundary that actually corresponds to compatibility, and it matches how every other entry in this file is bounded.

This is a real jump for fastapi (0.115→0.141), which is why it's isolated from the security batches rather than folded in — if anything regresses after deploy, the cause is unambiguous.

CI's pytest 3.11 and 3.12 jobs install these fresh in a clean runner, which is the verification that matters here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)