### PR TITLE
security: serialize concurrent migration runs with an advisory lock

### DIFF
--- a/github-app/scripts/migrate.py
+++ b/github-app/scripts/migrate.py
@@ -25,31 +25,59 @@ import psycopg
 MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
 
 
+# Arbitrary but fixed: any process running this script takes the same lock, and
+# it must not collide with the per-installation advisory locks taken elsewhere
+# (those use installation_id, which is a GitHub installation id and never this).
+_MIGRATION_LOCK_ID = 8_675_309
+
+
 def run_migrations(database_url: str, migrations_dir: Path = MIGRATIONS_DIR) -> list[str]:
     migration_files = sorted(migrations_dir.glob("*.sql"))
 
     with psycopg.connect(database_url) as conn:
+        # Session-level advisory lock held for the whole run. This script is the
+        # app-server container's entrypoint (`migrate.py && exec uvicorn`), so
+        # starting a second replica - or any restart overlapping an in-flight
+        # one - runs it concurrently against the same database. Without the
+        # lock, two processes both read schema_migrations, both see the same
+        # file as pending, and both execute it: fine for the idempotent
+        # CREATE TABLE IF NOT EXISTS bodies, but a duplicate-key error on the
+        # INSERT below, which fails the container's startup command and puts it
+        # into a crash-loop rather than starting the server.
+        #
+        # Deliberately blocking rather than pg_try_advisory_lock: the loser
+        # should wait for the winner to finish and then find nothing pending,
+        # not skip migrating and boot against a schema it does not match.
         with conn.cursor() as cur:
-            cur.execute(
-                """
-                CREATE TABLE IF NOT EXISTS schema_migrations (
-                    filename    TEXT PRIMARY KEY,
-                    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
-                )
-                """
-            )
-            cur.execute("SELECT filename FROM schema_migrations")
-            applied = {row[0] for row in cur.fetchall()}
+            cur.execute("SELECT pg_advisory_lock(%s)", (_MIGRATION_LOCK_ID,))
         conn.commit()
 
-        pending = [f for f in migration_files if f.name not in applied]
-        for migration_file in pending:
+        try:
             with conn.cursor() as cur:
-                cur.execute(migration_file.read_text())
                 cur.execute(
-                    "INSERT INTO schema_migrations (filename) VALUES (%s)",
-                    (migration_file.name,),
+                    """
+                    CREATE TABLE IF NOT EXISTS schema_migrations (
+                        filename    TEXT PRIMARY KEY,
+                        applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+                    )
+                    """
                 )
+                cur.execute("SELECT filename FROM schema_migrations")
+                applied = {row[0] for row in cur.fetchall()}
+            conn.commit()
+
+            pending = [f for f in migration_files if f.name not in applied]
+            for migration_file in pending:
+                with conn.cursor() as cur:
+                    cur.execute(migration_file.read_text())
+                    cur.execute(
+                        "INSERT INTO schema_migrations (filename) VALUES (%s)",
+                        (migration_file.name,),
+                    )
+                conn.commit()
+        finally:
+            with conn.cursor() as cur:
+                cur.execute("SELECT pg_advisory_unlock(%s)", (_MIGRATION_LOCK_ID,))
             conn.commit()
 
     return [f.name for f in pending]

--- a/github-app/tests/test_migrate.py
+++ b/github-app/tests/test_migrate.py
@@ -97,3 +97,45 @@ def test_run_migrations_backfills_schema_migrations_for_already_bootstrapped_db(
 
     second = run_migrations(fresh_database)
     assert second == []
+
+
+def test_concurrent_migrate_runs_do_not_collide(tmp_path):
+    """Two processes running migrate.py against the same database at once -
+    the shape of starting a second app-server replica, or a restart
+    overlapping an in-flight one. Without the advisory lock both read
+    schema_migrations, both see the same file pending, and the second one's
+    INSERT fails on the primary key, crash-looping the container.
+    """
+    import threading
+    import uuid
+
+    # Unique per run: schema_migrations persists across tests in the shared
+    # test database, so fixed filenames would be "already applied" on the
+    # second run and the assertion below would pass vacuously.
+    run_id = uuid.uuid4().hex[:8]
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    names = [f"{i:03d}_{run_id}.sql" for i in range(6)]
+    for i, name in enumerate(names):
+        (migrations_dir / name).write_text(
+            f"CREATE TABLE IF NOT EXISTS concurrent_t{run_id}_{i} (id INT);"
+        )
+
+    results: list = []
+    errors: list = []
+
+    def run():
+        try:
+            results.append(run_migrations(TEST_DATABASE_URL, migrations_dir))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert errors == [], f"concurrent migration raised: {errors}"
+    # Exactly one runner applies each file; the others wait, then find nothing.
+    assert sorted(sum(results, [])) == sorted(names)


### PR DESCRIPTION
Batch 11 (partial) of the launch-readiness audit — the migration-safety half.

## Problem

`scripts/migrate.py` is the app-server container's entrypoint (`python scripts/migrate.py && exec uvicorn ...`), so it runs on every start. Two processes running it concurrently — a second replica, or a restart overlapping an in-flight one — both read `schema_migrations`, both compute the same pending list, and both execute it.

The migration bodies are idempotent (`CREATE TABLE IF NOT EXISTS` etc.), so that part is harmless. The `INSERT INTO schema_migrations` is not: the loser takes a primary-key violation, which fails the startup command and puts the container into a crash-loop.

This is latent at one replica and immediate at two — worth closing before it's the thing standing between you and horizontal scaling.

## Fix

A session-level `pg_advisory_lock` held across the whole run.

Blocking rather than `pg_try_advisory_lock` deliberately: a process that can't acquire it should wait for the winner and then find nothing pending — not skip migrating and boot the server against a schema it doesn't match. Released in a `finally`, and the connection closing would release it regardless.

## On the test

It spawns three concurrent runners against the same database. I verified it actually catches the bug rather than passing vacuously: **removed the lock → test fails; restored it → test passes.**

First version of it was wrong in an instructive way. `schema_migrations` persists across tests in the shared database, so fixed migration filenames were "already applied" on any second run, and the assertion passed without proving anything. Filenames are now unique per run.

## Verification

- Full github-app suite: **1107 passed, 8 skipped**

## Not included

The other Batch 11 item — pooling the ~20 per-request `Redis.from_url()` / `httpx.Client()` constructions that currently leak a connection pool each — is a broader refactor across 10 files and is better as its own reviewable change than tacked onto this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)