### PR TITLE
security: purge legacy-format secret dismissals orphaned by CLI-3

### DIFF
--- a/github-app/app_server/dismissed_findings.py
+++ b/github-app/app_server/dismissed_findings.py
@@ -9,6 +9,17 @@ def finding_identity_key(finding_type: str, finding: dict) -> str:
     (ecosystem, package, advisory_id) for vulnerabilities. \x1f (unit
     separator) joins fields - not a character any of these fields would
     plausibly contain.
+
+    For secrets, match_preview embeds this server's only knowledge of "which
+    credential" - the raw value never leaves the scan (see
+    src/aletheore/secrets.py's _redact), so if that preview's format ever
+    changes again, a dismissal keyed on the old format becomes permanently
+    unmatchable here, unlike the CLI's own accepted_secrets baseline, which
+    can recompute a legacy-format preview from the value it still has on
+    hand. There's no dual-check to add on this side - see migration 045 for
+    the cleanup this fired once already, and repeat that pattern (a
+    migration that purges now-unreachable rows, not a data migration) if the
+    preview format changes again.
     """
     if finding_type == "secret":
         return f"{finding['path']}\x1f{finding['pattern']}\x1f{finding['match_preview']}"

--- a/github-app/migrations/045_purge_legacy_secret_dismissals.sql
+++ b/github-app/migrations/045_purge_legacy_secret_dismissals.sql
@@ -1,0 +1,23 @@
+-- Purges dismissed_findings rows for secrets that were dismissed before the
+-- CLI-3 fix (match_preview switched from four real leading/trailing
+-- characters of the credential to a salted sha256:<12 hex> preview - see
+-- src/aletheore/secrets.py's _redact).
+--
+-- identity_key for a secret dismissal is "path\x1fpattern\x1fmatch_preview"
+-- (see app_server/dismissed_findings.py's finding_identity_key). Every
+-- finding produced by the scanner now carries a sha256:-prefixed preview, so
+-- a dismissal whose identity_key doesn't end in that shape can never again
+-- match a freshly-computed one - it is not "possibly stale", it is
+-- permanently unreachable dead weight. Unlike the CLI's own accepted_secrets
+-- baseline (which re-derives the real value from the file every scan and can
+-- dual-check old and new preview formats), the server never receives the raw
+-- secret value, only the already-redacted preview - there is no legacy
+-- format to recompute here, so there is nothing to migrate forward. Deleting
+-- these rows doesn't lose anything that migrating could have saved; the
+-- affected findings simply need dismissing again, once, the same as any
+-- secret this installation has never seen before.
+--
+-- chr(31) is \x1f, the unit-separator field delimiter.
+DELETE FROM dismissed_findings
+WHERE finding_type = 'secret'
+  AND split_part(identity_key, chr(31), 3) NOT LIKE 'sha256:%';

--- a/github-app/tests/test_dismissed_findings.py
+++ b/github-app/tests/test_dismissed_findings.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from app_server.db import upsert_installation
@@ -11,6 +13,8 @@ from app_server.dismissed_findings import (
 
 SECRET_FINDING = {"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP"}
 VULN_FINDING = {"ecosystem": "PyPI", "package": "requests", "advisory_id": "GHSA-1"}
+
+MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "migrations"
 
 
 def test_finding_identity_key_secret():
@@ -106,3 +110,29 @@ async def test_dismissed_findings_are_scoped_per_repo(pool):
 
     dismissed = await get_dismissed_identity_keys(pool, 1, "octocat/repo-b")
     assert dismissed["secret"] == set()
+
+
+@pytest.mark.asyncio
+async def test_migration_045_purges_legacy_format_secret_dismissals_only(pool):
+    # SECRET_FINDING's match_preview ("AKIA****...MNOP") is the pre-CLI-3
+    # format - a dismissal keyed on it can never match a finding from the
+    # current scanner (which always produces a sha256:-prefixed preview), so
+    # it's permanently dead weight migration 045 is meant to clear out.
+    await upsert_installation(pool, 1, "octocat")
+    hash_format_finding = {
+        "path": "config.py",
+        "pattern": "aws_access_key_id",
+        "match_preview": "sha256:aaaaaaaaaaaa",
+    }
+    await dismiss_finding(pool, 1, "octocat/repo", "secret", SECRET_FINDING, "octocat")
+    await dismiss_finding(pool, 1, "octocat/repo", "secret", hash_format_finding, "octocat")
+    await dismiss_finding(pool, 1, "octocat/repo", "vulnerability", VULN_FINDING, "octocat")
+
+    migration_sql = (MIGRATIONS_DIR / "045_purge_legacy_secret_dismissals.sql").read_text()
+    await pool.execute(migration_sql)
+
+    dismissed = await get_dismissed_identity_keys(pool, 1, "octocat/repo")
+    assert dismissed["secret"] == {finding_identity_key("secret", hash_format_finding)}
+    # Vulnerability dismissals aren't touched - the legacy-format concern is
+    # specific to secrets' match_preview, which vulnerabilities don't have.
+    assert dismissed["vulnerability"] == {finding_identity_key("vulnerability", VULN_FINDING)}


### PR DESCRIPTION
## Summary
CLI-3 (#176) changed `match_preview` from four real leading/trailing characters of a credential to a salted `sha256:<12 hex>` preview. `finding_identity_key` builds a secret dismissal's identity as `path\x1fpattern\x1fmatch_preview`, so a dismissal made before that change is now permanently unmatchable - every finding the scanner produces has a hash-format preview, and unlike the CLI's own `accepted_secrets` baseline (which re-derives the raw value from the file and can dual-check old and new formats), the server never receives the raw value to recompute a legacy preview from. There's nothing to migrate forward, only dead rows to clear.

- Migration 045 deletes `dismissed_findings` rows where `finding_type = 'secret'` and the identity_key's `match_preview` segment isn't `sha256:`-prefixed.
- Verified against prod directly: `SELECT count(*) FROM dismissed_findings WHERE finding_type = 'secret'` returns 0, so this migration is a provable no-op today - it exists for the next installation that dismisses a secret before a future format change, not because prod has affected rows right now.
- Documented the coupling in `dismissed_findings.py`'s docstring so a future `match_preview` format change points at this same pattern (a purge migration, not a data migration) instead of rediscovering the constraint.

## Test plan
- [x] `ruff check` clean
- [x] New test: migration 045 purges a legacy-format secret dismissal, leaves a hash-format secret dismissal and a vulnerability dismissal untouched
- [x] Full suite: `pytest tests/` - 1108 passed, 8 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)