### PR TITLE
security: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/action-self-test.yml
+++ b/.github/workflows/action-self-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Run Aletheore action against this PR's own base/head
         id: aletheore

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -26,13 +26,13 @@ jobs:
             tag: aletheore-scan-worker:ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build image
         run: docker build -f "${{ matrix.dockerfile }}" -t "${{ matrix.tag }}" .
 
       - name: Scan image report
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.tag }}
           format: table
@@ -41,7 +41,7 @@ jobs:
           exit-code: "0"
 
       - name: Enforce image scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ matrix.tag }}
           format: sarif
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           sarif_file: trivy-${{ matrix.image }}.sarif
 
@@ -72,20 +72,20 @@ jobs:
             tag: aletheore-scan-worker:ci
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Build image
         run: docker build -f "${{ matrix.dockerfile }}" -t "${{ matrix.tag }}" .
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0.24.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ matrix.tag }}
           format: spdx-json
           output-file: sbom-${{ matrix.image }}.spdx.json
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-${{ matrix.image }}
           path: sbom-${{ matrix.image }}.spdx.json

--- a/.github/workflows/github-app-tests.yml
+++ b/.github/workflows/github-app-tests.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-github-app
           path: github-app/coverage.xml

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
       - name: Check aletheore dependency licenses

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Link check
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: --config lychee.toml "README.md" "website/**/*.html" "docs/**/*.md"
         env:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Markdown lint
-        uses: DavidAnson/markdownlint-cli2-action@v24
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24
         with:
           globs: |
             *.md

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Check formatting
         run: >
           npx --yes prettier@3.3.3 --check ".github/**/*.{yml,yaml}" "package.json"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,9 +14,9 @@ jobs:
     permissions:
       id-token: write # trusted publishing (OIDC) - no PyPI token stored anywhere
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Spell check
-        uses: streetsidesoftware/cspell-action@v8
+        uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8
         with:
           config: cspell.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-src-py${{ matrix.python-version }}
           path: src/coverage.xml

--- a/action.yml
+++ b/action.yml
@@ -45,19 +45,19 @@ runs:
   using: "composite"
   steps:
     - name: Checkout base
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ inputs.base-ref }}
         path: aletheore-base
 
     - name: Checkout head
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ inputs.head-ref }}
         path: aletheore-head
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: "3.12"
 
@@ -182,7 +182,7 @@ runs:
     - name: Post PR comment
       if: always() && inputs.post-pr-comment == 'true' && github.event_name == 'pull_request'
       continue-on-error: true
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           const fs = require('fs');


### PR DESCRIPTION
## Summary
CLI-7 pinned `pypa/gh-action-pypi-publish` (the one holding an OIDC publishing token) to a SHA, but left every other action - across every workflow, and `action.yml` itself - on a mutable major-version tag (`@v7`, `@v8`, ...). A compromised upstream branch for any of these would silently run different code on the next push. Most of these jobs don't hold a sensitive token, but pinning every action to a SHA is standard hardening regardless (per GitHub's own security hardening guide), not something worth reserving for the one job that happens to hold a token today.

Every pin keeps a trailing `# vX.Y.Z` comment - Dependabot reads that to know what to bump on a real upstream release (`github-actions` ecosystem is already configured in `.github/dependabot.yml`), so update automation keeps working exactly as before, just against a SHA instead of a tag.

Actions pinned (11 files):
- `actions/checkout@v7`, `actions/setup-python@v7`, `actions/upload-artifact@v7`, `actions/github-script@v9`
- `aquasecurity/trivy-action@v0.36.0`, `github/codeql-action/upload-sarif@v4`, `anchore/sbom-action@v0.24.0`
- `DavidAnson/markdownlint-cli2-action@v24`, `lycheeverse/lychee-action@v2`, `streetsidesoftware/cspell-action@v8`

Several of these are annotated tags, where the tag ref's own SHA differs from the commit it actually points to - resolved each via `git ls-remote <repo> refs/tags/<tag>^{}` (the peeled/dereferenced form) rather than the tag object SHA, same care taken for the CLI-7 pin.

## Test plan
- [x] `grep` confirms zero remaining `uses:` lines on a bare `@vX` tag across `.github/workflows/*.yml` and `action.yml`
- [x] All 11 changed YAML files parse successfully (`yaml.safe_load`)
- [x] This PR's own CI run is the real verification - every workflow here executes against its newly-pinned SHA, so a wrong SHA fails immediately and visibly rather than needing a separate test

🤖 Generated with [Claude Code](https://claude.com/claude-code)