### PR TITLE
security: pool Redis and GitHub API clients instead of one per request/job

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -1,5 +1,4 @@
 import asyncio
-import functools
 import hashlib
 import json
 import logging
@@ -14,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from app_server.auth import encrypt_access_token, get_current_session, refresh_github_access_token
 from app_server.config import get_settings
+from app_server.http_client import get_github_api_client
 from app_server.email_client import send_transactional_email
 from app_server.email_templates import deletion_otp_email
 from app_server.db import (
@@ -63,6 +63,7 @@ from app_server.paddle_client import get_subscription as get_paddle_subscription
 from app_server.paddle_client import update_subscription_items as update_paddle_subscription_items
 from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
 from app_server.rate_limit import is_rate_limited
+from app_server.redis_client import get_redis_client
 from app_server.url_validation import UnsafeURLError, validate_external_https_url
 
 admin_router = APIRouter()
@@ -137,7 +138,7 @@ BRANCH_PROTECTION_DISCLOSURE = (
 
 
 def _github_http_client() -> httpx.Client:
-    return httpx.Client(base_url="https://api.github.com")
+    return get_github_api_client()
 
 
 async def _repo_installation_id(pool, org: str, repo: str) -> int:
@@ -192,20 +193,6 @@ def _administered_installations_cache_key(github_token: str) -> str:
     return "administered-installations:" + hashlib.sha256(github_token.encode()).hexdigest()
 
 
-@functools.lru_cache(maxsize=1)
-def _administered_installations_cache_redis():
-    from redis import Redis
-
-    # lru_cache'd (same convention as get_settings()) so this is one
-    # pooled connection reused across every call, not a fresh TCP
-    # handshake per request. A short connect timeout, not the client
-    # default (multiple seconds) - this cache sits in front of nearly
-    # every dashboard/admin request, so a Redis outage must fail fast
-    # into the live GitHub fallback below rather than stalling every
-    # request behind it.
-    return Redis.from_url(get_settings().redis_url, socket_connect_timeout=0.5, socket_timeout=0.5)
-
-
 async def _administered_installation_ids(github_token: str) -> set[int]:
     # This gates nearly every admin/dashboard route via
     # _require_admin_installation - a single dashboard page can fire
@@ -218,7 +205,7 @@ async def _administered_installation_ids(github_token: str) -> set[int]:
     # other in-flight request on this single-worker server.
     cache_key = _administered_installations_cache_key(github_token)
     try:
-        cached = await asyncio.to_thread(_administered_installations_cache_redis().get, cache_key)
+        cached = await asyncio.to_thread(get_redis_client().get, cache_key)
         if cached is not None:
             return {int(installation_id) for installation_id in json.loads(cached)}
     except Exception as exc:  # noqa: BLE001
@@ -228,7 +215,7 @@ async def _administered_installation_ids(github_token: str) -> set[int]:
 
     try:
         await asyncio.to_thread(
-            _administered_installations_cache_redis().set,
+            get_redis_client().set,
             cache_key,
             json.dumps(list(installation_ids)),
             _ADMINISTERED_INSTALLATIONS_CACHE_TTL_SECONDS,
@@ -935,12 +922,10 @@ async def request_deletion_otp(org: str, repo: str, request: Request):
     pool = request.app.state.db_pool
     installation_id = installation["installation_id"]
 
-    from redis import Redis
-
     settings = get_settings()
     try:
         rate_limited = is_rate_limited(
-            Redis.from_url(settings.redis_url),
+            get_redis_client(),
             f"ratelimit:deletion-otp:{installation_id}",
             DELETION_OTP_RATE_LIMIT,
             DELETION_OTP_RATE_LIMIT_WINDOW_SECONDS,
@@ -1009,12 +994,9 @@ async def delete_all_data(
             detail=f"type {installation['account_login']} exactly to confirm deletion",
         )
 
-    from redis import Redis
-
-    settings = get_settings()
     try:
         attempt_limited = is_rate_limited(
-            Redis.from_url(settings.redis_url),
+            get_redis_client(),
             f"ratelimit:deletion-otp-attempt:{installation_id}",
             DELETION_OTP_ATTEMPT_LIMIT,
             DELETION_OTP_ATTEMPT_WINDOW_SECONDS,
@@ -1042,7 +1024,7 @@ async def delete_all_data(
     # runs there instead, same as the uninstall webhook.
     from rq import Queue
 
-    Queue("scans", connection=Redis.from_url(settings.redis_url)).enqueue(
+    Queue("scans", connection=get_redis_client()).enqueue(
         "scan_worker.jobs.purge_persistent_checkouts_job",
         job_timeout=120,
         installation_id=installation_id,

--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -24,8 +24,10 @@ from app_server.db import (
 )
 from app_server.email_queue import enqueue_transactional_email
 from app_server.github_auth import generate_app_jwt, get_installation_details
+from app_server.http_client import get_github_api_client, get_github_oauth_client
 from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for
 from app_server.rate_limit import is_rate_limited
+from app_server.redis_client import get_redis_client
 
 SESSION_COOKIE_NAME = "session"
 SESSION_TTL = timedelta(days=30)
@@ -48,16 +50,13 @@ logger = logging.getLogger(__name__)
 
 
 def _enforce_auth_rate_limit(request: Request) -> None:
-    from redis import Redis
-
-    settings = get_settings()
     client_ip = client_ip_from_forwarded_for(
         request.headers.get("x-forwarded-for"),
         request.client.host if request.client else "",
     )
     try:
         rate_limited = is_rate_limited(
-            Redis.from_url(settings.redis_url),
+            get_redis_client(),
             f"ratelimit:auth:{client_ip}",
             AUTH_RATE_LIMIT,
             AUTH_RATE_LIMIT_WINDOW_SECONDS,
@@ -106,11 +105,11 @@ def decrypt_access_token(encrypted: str, session_secret: str) -> str:
 
 
 def _github_oauth_http_client() -> httpx.Client:
-    return httpx.Client(base_url="https://github.com")
+    return get_github_oauth_client()
 
 
 def _github_http_client() -> httpx.Client:
-    return httpx.Client(base_url="https://api.github.com")
+    return get_github_api_client()
 
 
 def _fetch_primary_verified_email(access_token: str) -> str | None:

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -492,10 +492,9 @@ PUBLIC_HEALTH_STALE_AFTER = timedelta(minutes=15)
 async def get_public_health(org: str, repo: str, request: Request, response: Response):
     response.headers["Access-Control-Allow-Origin"] = "*"
 
-    from redis import Redis
-
     from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for
     from app_server.rate_limit import is_rate_limited
+    from app_server.redis_client import get_redis_client
 
     client_ip = client_ip_from_forwarded_for(
         request.headers.get("x-forwarded-for"),
@@ -503,7 +502,7 @@ async def get_public_health(org: str, repo: str, request: Request, response: Res
     )
     try:
         rate_limited = is_rate_limited(
-            Redis.from_url(get_settings().redis_url),
+            get_redis_client(),
             f"ratelimit:public_health:{client_ip}",
             PUBLIC_HEALTH_RATE_LIMIT,
             PUBLIC_HEALTH_RATE_LIMIT_WINDOW_SECONDS,

--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -40,17 +40,19 @@ def _client_ip(request: Request) -> str:
 
 
 def _get_queue(redis_url: str):
-    from redis import Redis
     from rq import Queue
 
-    return Queue(DEMO_SCAN_QUEUE_NAME, connection=Redis.from_url(redis_url))
+    from app_server.redis_client import get_redis_client
+
+    return Queue(DEMO_SCAN_QUEUE_NAME, connection=get_redis_client())
 
 
 def _fetch_job(job_id: str, redis_url: str):
-    from redis import Redis
     from rq.job import Job
 
-    return Job.fetch(job_id, connection=Redis.from_url(redis_url))
+    from app_server.redis_client import get_redis_client
+
+    return Job.fetch(job_id, connection=get_redis_client())
 
 
 _GENERIC_FAILURE_DETAIL = "scan failed - the repo may be invalid, private, or too large"

--- a/github-app/app_server/email_client.py
+++ b/github-app/app_server/email_client.py
@@ -1,5 +1,7 @@
 import httpx
 
+from app_server.http_client import get_generic_http_client
+
 RESEND_API_URL = "https://api.resend.com/emails"
 
 
@@ -19,12 +21,15 @@ def send_transactional_email(
     send_health_alert/send_slack_alert - the caller (the RQ job) is what
     decides retry/dedupe behavior, not this function.
     """
+    client = http_client or get_generic_http_client()
     # httpx's 5s default (confirmed too tight against a real, otherwise-
     # healthy Resend call in prod - a ReadTimeout on this container's
     # first-ever request to a new external host, most likely DNS/TLS cold
     # start) is a needless failure here: this runs in a background job,
     # not a live request path, so there's no user waiting on the clock.
-    client = http_client or httpx.Client(timeout=15.0)
+    # Passed per-call rather than baked into a dedicated client - the
+    # shared client here is also reused by Slack alerts, which don't need
+    # this override.
     response = client.post(
         RESEND_API_URL,
         headers={"Authorization": f"Bearer {api_key}"},
@@ -36,6 +41,7 @@ def send_transactional_email(
             "html": html,
             "text": text,
         },
+        timeout=15.0,
     )
     response.raise_for_status()
     return response.json()

--- a/github-app/app_server/email_queue.py
+++ b/github-app/app_server/email_queue.py
@@ -15,10 +15,11 @@ def enqueue_transactional_email(
     to_email: str,
     installation_id: int | None = None,
 ) -> None:
-    from redis import Redis
     from rq import Queue
 
-    Queue("email", connection=Redis.from_url(redis_url)).enqueue(
+    from app_server.redis_client import get_redis_client
+
+    Queue("email", connection=get_redis_client()).enqueue(
         "scan_worker.jobs.send_transactional_email_job",
         dedupe_key=dedupe_key,
         template_name=template_name,

--- a/github-app/app_server/github_auth.py
+++ b/github-app/app_server/github_auth.py
@@ -3,6 +3,8 @@ import time
 import httpx
 import jwt
 
+from app_server.http_client import get_github_api_client
+
 
 def generate_app_jwt(app_id: str, private_key_pem: str) -> str:
     now = int(time.time())
@@ -19,7 +21,7 @@ def get_installation_token(
     app_jwt: str,
     http_client: httpx.Client | None = None,
 ) -> str:
-    client = http_client or httpx.Client(base_url="https://api.github.com")
+    client = http_client or get_github_api_client()
     response = client.post(
         f"/app/installations/{installation_id}/access_tokens",
         headers={
@@ -36,7 +38,7 @@ def get_installation_details(
     app_jwt: str,
     http_client: httpx.Client | None = None,
 ) -> dict:
-    client = http_client or httpx.Client(base_url="https://api.github.com")
+    client = http_client or get_github_api_client()
     response = client.get(
         f"/app/installations/{installation_id}",
         headers={
@@ -62,7 +64,7 @@ def get_repo_permission_for_user(
     should be able to spend an installation's paid LLM budget or occupy
     its managed-audit cooldown slot.
     """
-    client = http_client or httpx.Client(base_url="https://api.github.com")
+    client = http_client or get_github_api_client()
     response = client.get(
         f"/repos/{repo_full_name}/collaborators/{username}/permission",
         headers={

--- a/github-app/app_server/http_client.py
+++ b/github-app/app_server/http_client.py
@@ -1,0 +1,35 @@
+import functools
+
+import httpx
+
+
+@functools.lru_cache(maxsize=1)
+def get_github_api_client() -> httpx.Client:
+    """Process-wide pooled client for https://api.github.com.
+
+    Every GitHub API call across app_server and scan_worker used to
+    construct its own httpx.Client(base_url=...) per request or per job -
+    9 separate call sites in scan_worker/jobs.py alone - each opening a
+    fresh connection pool and, in every case but one, never explicitly
+    closing it. lru_cache makes this a singleton exactly once per process,
+    reused across every caller instead.
+    """
+    return httpx.Client(base_url="https://api.github.com")
+
+
+@functools.lru_cache(maxsize=1)
+def get_github_oauth_client() -> httpx.Client:
+    """Process-wide pooled client for https://github.com (OAuth endpoints -
+    distinct host from the API client above, so it needs its own pool)."""
+    return httpx.Client(base_url="https://github.com")
+
+
+@functools.lru_cache(maxsize=1)
+def get_generic_http_client() -> httpx.Client:
+    """Process-wide pooled client with no base_url, for one-off requests to
+    an arbitrary external host (a customer's Slack webhook, Resend's API) -
+    reused across calls instead of each one opening its own connection.
+    Per-call timeout overrides (client.post(url, ..., timeout=X)) still
+    work normally against a shared client.
+    """
+    return httpx.Client()

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -146,9 +146,9 @@ async def healthz(request: Request):
         checks["database"] = "error"
 
     try:
-        from redis import Redis
+        from app_server.redis_client import get_redis_client
 
-        Redis.from_url(settings.redis_url).ping()
+        get_redis_client().ping()
     except Exception:
         checks["redis"] = "error"
 

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -34,17 +34,19 @@ class StartManagedAuditRequest(BaseModel):
 
 
 def _get_queue(redis_url: str):
-    from redis import Redis
     from rq import Queue
 
-    return Queue("scans", connection=Redis.from_url(redis_url))
+    from app_server.redis_client import get_redis_client
+
+    return Queue("scans", connection=get_redis_client())
 
 
 def _fetch_job(job_id: str, redis_url: str):
-    from redis import Redis
     from rq.job import Job
 
-    return Job.fetch(job_id, connection=Redis.from_url(redis_url))
+    from app_server.redis_client import get_redis_client
+
+    return Job.fetch(job_id, connection=get_redis_client())
 
 
 async def _authenticate_token(request: Request) -> tuple[dict, str]:

--- a/github-app/app_server/metrics.py
+++ b/github-app/app_server/metrics.py
@@ -1,11 +1,11 @@
 import hmac
 
 from fastapi import APIRouter, HTTPException, Request
-from redis import Redis
 from rq import Queue, Worker
 from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegistry
 
 from app_server.config import get_settings
+from app_server.redis_client import get_redis_client
 
 metrics_router = APIRouter()
 
@@ -20,7 +20,7 @@ async def queue_stats(request: Request):
     if not hmac.compare_digest(auth_header, f"Bearer {settings.internal_metrics_token}"):
         raise HTTPException(status_code=401, detail="missing or invalid token")
 
-    redis_conn = Redis.from_url(settings.redis_url)
+    redis_conn = get_redis_client()
     # "health" runs on its own queue/worker, separate from "scans" (see
     # scan_worker/scheduler.py) so a slow AI job never delays the endpoint
     # health sweep - reported separately here too, since a stat that only

--- a/github-app/app_server/redis_client.py
+++ b/github-app/app_server/redis_client.py
@@ -1,0 +1,28 @@
+import functools
+
+from redis import Redis
+
+from app_server.config import get_settings
+
+
+@functools.lru_cache(maxsize=1)
+def get_redis_client() -> Redis:
+    """Process-wide pooled Redis client.
+
+    Every caller across app_server and scan_worker used to construct its
+    own Redis.from_url(...) per request or per job - each one opening a
+    fresh connection pool and never explicitly closing it, relying on GC to
+    eventually close the underlying socket. Under load, connections pile up
+    faster than GC reclaims them. lru_cache makes this a singleton exactly
+    once per process (same convention as get_settings()), so every caller
+    shares the same pooled connection instead.
+
+    Short connect/socket timeouts rather than redis-py's multi-second
+    default: every use of this client is a fast, simple operation (a rate-
+    limit INCR, an RQ enqueue, a healthcheck ping) that should fail fast
+    into a fallback or a 5xx if Redis is slow or unreachable, not hang a
+    request behind it. First applied narrowly to admin.py's installation-id
+    cache; every other caller needs the exact same property, so it's the
+    default here rather than something each caller opts into separately.
+    """
+    return Redis.from_url(get_settings().redis_url, socket_connect_timeout=0.5, socket_timeout=0.5)

--- a/github-app/app_server/runtime_events.py
+++ b/github-app/app_server/runtime_events.py
@@ -55,12 +55,11 @@ class RuntimeEventRequest(BaseModel):
 
 
 def _enforce_runtime_event_rate_limit(installation_id: int) -> None:
-    from redis import Redis
+    from app_server.redis_client import get_redis_client
 
-    settings = get_settings()
     try:
         rate_limited = is_rate_limited(
-            Redis.from_url(settings.redis_url),
+            get_redis_client(),
             f"ratelimit:runtime-events:{installation_id}",
             RUNTIME_EVENT_RATE_LIMIT,
             RUNTIME_EVENT_RATE_LIMIT_WINDOW_SECONDS,

--- a/github-app/app_server/telemetry.py
+++ b/github-app/app_server/telemetry.py
@@ -50,16 +50,15 @@ class TelemetryEvent(BaseModel):
 
 
 def _enforce_telemetry_rate_limit(request: Request) -> None:
-    from redis import Redis
+    from app_server.redis_client import get_redis_client
 
-    settings = get_settings()
     client_ip = client_ip_from_forwarded_for(
         request.headers.get("x-forwarded-for"),
         request.client.host if request.client else "",
     )
     try:
         rate_limited = is_rate_limited(
-            Redis.from_url(settings.redis_url),
+            get_redis_client(),
             f"ratelimit:telemetry:{client_ip}",
             TELEMETRY_RATE_LIMIT,
             TELEMETRY_RATE_LIMIT_WINDOW_SECONDS,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -38,6 +38,7 @@ from app_server.db import MAX_SCANNED_REPOS_PER_MONTH
 from app_server.dismissed_findings import filter_dismissed
 from app_server.error_alerts import send_error_alert
 from app_server.github_auth import generate_app_jwt, get_installation_token
+from app_server.http_client import get_github_api_client
 from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation
 from app_server.logging_config import log_job
 from app_server.rate_limit import (
@@ -720,7 +721,7 @@ def _post_failure_comment(
 ) -> None:
     app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
     token = _token_sync(installation_id, app_jwt)
-    client = httpx.Client(base_url="https://api.github.com")
+    client = get_github_api_client()
     upsert_pr_comment(client, token, repo_full_name, pr_number, _failure_body(error))
 
 
@@ -733,7 +734,7 @@ def _post_flash_review_failure_comment(
 ) -> None:
     app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
     token = _token_sync(installation_id, app_jwt)
-    client = httpx.Client(base_url="https://api.github.com")
+    client = get_github_api_client()
     body = (
         f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n\n"
         f"Aletheore couldn't complete this flash review: {error}"
@@ -800,7 +801,7 @@ def run_pr_scan_job(
             diff["vulnerabilities"]["new"], "vulnerability", dismissed["vulnerability"]
         )
 
-        client = httpx.Client(base_url="https://api.github.com")
+        client = get_github_api_client()
         upsert_pr_comment(client, token, repo_full_name, pr_number, format_diff_comment(diff))
         new = _sync_persistent_git_graph(installation_id, repo_full_name, head_dir, new)
         _sync_code_graph(installation_id, repo_full_name, head_sha, new)
@@ -908,7 +909,7 @@ def run_initial_scan_job(installation_id: int, repo_full_name: str) -> None:
     try:
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
         token = _token_sync(installation_id, app_jwt)
-        client = httpx.Client(base_url="https://api.github.com")
+        client = get_github_api_client()
 
         head_sha = fetch_default_branch_head_sha(client, token, repo_full_name)
         clone_url = _clone_url(repo_full_name, token)
@@ -1138,7 +1139,7 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
 
         evidence = json.loads(evidence_path.read_text())
         cooldown_seconds = cooldown_seconds_for_loc(total_loc_from_evidence(evidence))
-        client = httpx.Client(base_url="https://api.github.com")
+        client = get_github_api_client()
         if not check_and_reserve_managed_audit(
             settings.database_url, installation_id, repo_full_name, cooldown_seconds
         ):
@@ -1330,7 +1331,7 @@ def _run_flash_review(
 ) -> None:
     app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
     token = _token_sync(installation_id, app_jwt)
-    client = httpx.Client(base_url="https://api.github.com")
+    client = get_github_api_client()
 
     last_reviewed_sha = get_last_reviewed_sha(
         settings.database_url, installation_id, repo_full_name, pr_number
@@ -1665,8 +1666,8 @@ def _fix_suggestion_attachment(
         settings = get_settings()
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
         token = _token_sync(installation_id, app_jwt)
-        with httpx.Client(base_url="https://api.github.com") as client:
-            file_content = fetch_file_content(client, token, repo_full_name, source_file)
+        client = get_github_api_client()
+        file_content = fetch_file_content(client, token, repo_full_name, source_file)
         if not file_content:
             return None
 
@@ -2210,7 +2211,7 @@ def _real_line_count_fetcher(
         settings = get_settings()
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
         token = _token_sync(installation_id, app_jwt)
-        client = httpx.Client(base_url="https://api.github.com")
+        client = get_github_api_client()
     except Exception as exc:  # noqa: BLE001
         logging.getLogger("scan_worker.jobs").warning(
             "could not set up line-count fetcher (%s); citations checked for file existence only",
@@ -2358,10 +2359,11 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
 
 @log_job
 def _scans_queue(redis_url: str):
-    from redis import Redis
     from rq import Queue
 
-    return Queue("scans", connection=Redis.from_url(redis_url))
+    from app_server.redis_client import get_redis_client
+
+    return Queue("scans", connection=get_redis_client())
 
 
 def run_live_wiki_full_build_for_installation_job(installation_id: int) -> None:
@@ -2491,7 +2493,7 @@ def _github_client_and_token(installation_id: int) -> tuple[httpx.Client, str] |
         settings = get_settings()
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
         token = _token_sync(installation_id, app_jwt)
-        return httpx.Client(base_url="https://api.github.com"), token
+        return get_github_api_client(), token
     except Exception as exc:  # noqa: BLE001
         logging.getLogger("scan_worker.jobs").warning(
             "live docs: could not set up GitHub client for installation=%s (%s)",

--- a/github-app/scan_worker/slack.py
+++ b/github-app/scan_worker/slack.py
@@ -2,6 +2,8 @@ import re
 
 import httpx
 
+from app_server.http_client import get_generic_http_client
+
 
 def _detect_platform(webhook_url: str) -> str:
     # Slack incoming webhooks are always hooks.slack.com. Modern Teams
@@ -134,7 +136,7 @@ def send_slack_alert(
 ) -> None:
     if not _has_new_findings(diff):
         return
-    client = http_client or httpx.Client()
+    client = http_client or get_generic_http_client()
     payload = _render_payload(webhook_url, format_slack_message(diff, repo_full_name, pr_number))
     response = client.post(webhook_url, json=payload)
     response.raise_for_status()
@@ -257,7 +259,7 @@ def send_health_alert(
     message: dict,
     http_client: httpx.Client | None = None,
 ) -> None:
-    client = http_client or httpx.Client()
+    client = http_client or get_generic_http_client()
     payload = _render_payload(webhook_url, message)
     response = client.post(webhook_url, json=payload)
     response.raise_for_status()

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -84,6 +84,23 @@ def _clear_settings_cache():
 
 
 @pytest.fixture(autouse=True)
+def _clear_redis_client_cache():
+    # Same reasoning as _clear_settings_cache above, for get_redis_client()
+    # (also @lru_cache'd, for the same "one pooled connection instead of a
+    # fresh one per caller" reason). Without this, whichever test calls it
+    # first in the whole session permanently pins every later test to that
+    # first real connection - a test that monkeypatches get_redis_client to
+    # simulate a Redis outage would silently have no effect, since the
+    # cached real client from an earlier test is what every caller actually
+    # gets.
+    from app_server.redis_client import get_redis_client
+
+    get_redis_client.cache_clear()
+    yield
+    get_redis_client.cache_clear()
+
+
+@pytest.fixture(autouse=True)
 def _no_real_paddle_ip_fetch(monkeypatch):
     # Without this, every full-route webhook test would make a real network
     # call to Paddle's /ips endpoint on the first request (module-level

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -587,7 +587,7 @@ async def test_login_rate_limits_after_threshold(pool, monkeypatch, redis_conn):
 
     monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
     monkeypatch.setattr(auth_module, "AUTH_RATE_LIMIT", 2)
-    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+    monkeypatch.setattr("app_server.auth.get_redis_client", lambda: redis_conn)
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
@@ -612,7 +612,7 @@ async def test_auth_rate_limit_is_shared_between_login_and_callback(pool, monkey
 
     monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
     monkeypatch.setattr(auth_module, "AUTH_RATE_LIMIT", 1)
-    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+    monkeypatch.setattr("app_server.auth.get_redis_client", lambda: redis_conn)
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
@@ -634,7 +634,7 @@ async def test_auth_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis_conn):
 
     monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
     monkeypatch.setattr(auth_module, "AUTH_RATE_LIMIT", 1)
-    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+    monkeypatch.setattr("app_server.auth.get_redis_client", lambda: redis_conn)
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
@@ -661,10 +661,10 @@ async def test_login_fails_open_when_redis_is_unreachable(pool, monkeypatch):
 
     monkeypatch.setattr(auth_module, "is_rate_limited", real_is_rate_limited)
 
-    def _boom(url):
+    def _boom():
         raise ConnectionError("redis unreachable")
 
-    monkeypatch.setattr("redis.Redis.from_url", _boom)
+    monkeypatch.setattr("app_server.auth.get_redis_client", _boom)
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -788,7 +788,7 @@ async def test_public_health_rate_limits_after_threshold(pool, monkeypatch, redi
         )
 
     monkeypatch.setattr(dashboard, "PUBLIC_HEALTH_RATE_LIMIT", 2)
-    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+    monkeypatch.setattr("app_server.redis_client.get_redis_client", lambda: redis_conn)
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
@@ -821,7 +821,7 @@ async def test_public_health_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis
         )
 
     monkeypatch.setattr(dashboard, "PUBLIC_HEALTH_RATE_LIMIT", 1)
-    monkeypatch.setattr("redis.Redis.from_url", lambda url: redis_conn)
+    monkeypatch.setattr("app_server.redis_client.get_redis_client", lambda: redis_conn)
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)
@@ -854,10 +854,10 @@ async def test_public_health_fails_open_when_redis_is_unreachable(pool, monkeypa
             """
         )
 
-    def _boom(url):
+    def _boom():
         raise ConnectionError("redis unreachable")
 
-    monkeypatch.setattr("redis.Redis.from_url", _boom)
+    monkeypatch.setattr("app_server.redis_client.get_redis_client", _boom)
 
     app.state.db_pool = pool
     transport = ASGITransport(app=app)

--- a/github-app/tests/test_http_client.py
+++ b/github-app/tests/test_http_client.py
@@ -1,0 +1,36 @@
+from app_server.http_client import (
+    get_generic_http_client,
+    get_github_api_client,
+    get_github_oauth_client,
+)
+
+
+def test_get_github_api_client_returns_the_same_instance_across_calls():
+    assert get_github_api_client() is get_github_api_client()
+
+
+def test_get_github_api_client_has_the_right_base_url():
+    assert str(get_github_api_client().base_url) == "https://api.github.com"
+
+
+def test_get_github_oauth_client_returns_the_same_instance_across_calls():
+    assert get_github_oauth_client() is get_github_oauth_client()
+
+
+def test_get_github_oauth_client_has_the_right_base_url():
+    assert str(get_github_oauth_client().base_url) == "https://github.com"
+
+
+def test_get_github_api_client_and_oauth_client_are_distinct():
+    # Different hosts need different pools - conflating them would mean a
+    # relative-path request meant for one host silently resolving against
+    # the other's base_url.
+    assert get_github_api_client() is not get_github_oauth_client()
+
+
+def test_get_generic_http_client_returns_the_same_instance_across_calls():
+    assert get_generic_http_client() is get_generic_http_client()
+
+
+def test_get_generic_http_client_has_no_base_url():
+    assert str(get_generic_http_client().base_url) == ""

--- a/github-app/tests/test_main.py
+++ b/github-app/tests/test_main.py
@@ -108,7 +108,7 @@ async def test_healthz_returns_200_when_dependencies_are_healthy(monkeypatch):
     app.state.db_pool = MagicMock()
     app.state.db_pool.fetchval = AsyncMock(return_value=1)
     fake_redis = MagicMock()
-    monkeypatch.setattr("redis.Redis.from_url", lambda url: fake_redis)
+    monkeypatch.setattr("app_server.redis_client.get_redis_client", lambda: fake_redis)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -123,7 +123,7 @@ async def test_healthz_returns_503_when_database_is_unreachable(monkeypatch):
     app.state.db_pool = MagicMock()
     app.state.db_pool.fetchval = AsyncMock(side_effect=Exception("connection refused"))
     fake_redis = MagicMock()
-    monkeypatch.setattr("redis.Redis.from_url", lambda url: fake_redis)
+    monkeypatch.setattr("app_server.redis_client.get_redis_client", lambda: fake_redis)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -141,10 +141,10 @@ async def test_healthz_returns_503_when_redis_is_unreachable(monkeypatch):
     app.state.db_pool = MagicMock()
     app.state.db_pool.fetchval = AsyncMock(return_value=1)
 
-    def _raise(url):
+    def _raise():
         raise ConnectionError("redis unreachable")
 
-    monkeypatch.setattr("redis.Redis.from_url", _raise)
+    monkeypatch.setattr("app_server.redis_client.get_redis_client", _raise)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/github-app/tests/test_metrics.py
+++ b/github-app/tests/test_metrics.py
@@ -61,7 +61,7 @@ async def test_queue_stats_returns_counts_for_valid_token(monkeypatch):
 
         return _factory
 
-    monkeypatch.setattr("app_server.metrics.Redis.from_url", lambda url: MagicMock())
+    monkeypatch.setattr("app_server.metrics.get_redis_client", lambda: MagicMock())
     monkeypatch.setattr("app_server.metrics.Queue", _fake_queue)
     monkeypatch.setattr(
         "app_server.metrics.StartedJobRegistry", _by_queue({"scans": 1, "health": 0})

--- a/github-app/tests/test_redis_client.py
+++ b/github-app/tests/test_redis_client.py
@@ -1,0 +1,13 @@
+from app_server.redis_client import get_redis_client
+
+
+def test_get_redis_client_returns_the_same_instance_across_calls():
+    # The whole point of lru_cache-ing this is one pooled connection shared
+    # by every caller, not a fresh Redis.from_url() (and fresh TCP
+    # handshake) each time - proven by identity, not just equal config.
+    assert get_redis_client() is get_redis_client()
+
+
+def test_get_redis_client_is_a_working_connection():
+    client = get_redis_client()
+    assert client.ping() is True


### PR DESCRIPTION
## Summary
~20 sites across `app_server` and `scan_worker` constructed a fresh `Redis.from_url()` or `httpx.Client()` per request or per RQ job - each one opening its own connection pool and, in every case but two (both already using `with`), never explicitly closing it. Under load, unclosed connections pile up faster than GC reclaims them. `scan_worker/jobs.py` alone had 9 separate identical `httpx.Client(base_url="https://api.github.com")` sites, one per job function.

Two new shared, `lru_cache`'d singletons (same convention as `get_settings()`, and generalizing/removing the duplicate of `admin.py`'s earlier `_administered_installations_cache_redis()`):

- `app_server/redis_client.get_redis_client()` - one pooled Redis client reused by every rate-limit check, RQ enqueue, and healthcheck ping across both `app_server` and `scan_worker`. Short connect/socket timeouts (0.5s, previously specific to the admin cache) are now the default everywhere - every use here should fail fast into a fallback rather than hang a request behind a slow/unreachable Redis.
- `app_server/http_client.get_github_api_client()` / `get_github_oauth_client()` / `get_generic_http_client()` - one pooled client per distinct host. Existing `http_client=None` DI parameters (used for test injection in `github_auth.py`, `email_client.py`, `slack.py`) are unchanged - only what each function constructs when nothing is injected changed.

**Not touched, deliberately**: 4 `Redis.from_url()` sites in `health_worker.py`/`demo_scan_worker.py`/`scheduler.py`/`worker.py` are one-time, module-level worker-process startup (`if __name__ == "__main__":`), not per-request - already correct. `scan_worker/embedding_client.py`'s Ollama client already self-closes via `with`, so it wasn't leaking, just not pooled - left as-is to keep this change scoped to actual leaks.

**A real test-isolation bug this surfaced**: `get_redis_client` being `lru_cache`'d meant several existing tests broke - they patched `redis.Redis.from_url` directly to simulate a specific connection or an outage, but once any earlier test in the suite populated the cache with a real client, that patch was never consulted again. Added a `_clear_redis_client_cache` autouse fixture (mirroring the existing `_clear_settings_cache`) and updated the affected tests (`test_auth.py`, `test_dashboard.py`, `test_main.py`, `test_metrics.py`) to patch the new `get_redis_client` boundary instead.

## Test plan
- [x] `ruff check` clean on all touched files
- [x] New tests: `get_redis_client`/`get_github_api_client`/`get_github_oauth_client`/`get_generic_http_client` each return the same instance across calls (proving pooling), correct `base_url` per client, and distinct instances per host
- [x] Fixed 5 pre-existing tests that broke from the `lru_cache` (isolated, not masked - the failures were caught by the first full-suite run and traced to the actual test-isolation bug, not worked around)
- [x] Full suite: `pytest tests/` - 1117 passed, 8 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)