### PR TITLE
feat: affiliate program - 15% recurring commission via Paddle discount codes

### DIFF
--- a/docs/superpowers/specs/2026-08-10-aletheore-affiliate-program-design.md
+++ b/docs/superpowers/specs/2026-08-10-aletheore-affiliate-program-design.md
@@ -1,0 +1,188 @@
+# Aletheore Affiliate Program Design
+
+## Goal
+
+Let a small, manually-onboarded group of content creators earn 15% recurring
+commission on every customer they refer, for as long as that customer stays
+subscribed to Aletheore AIR — using a real Paddle discount code as both the
+customer-facing hook (10% off the first month) and the attribution mechanism,
+with no new checkout UI, cookies, or query-param threading required.
+
+## Background
+
+Aletheore has one paid plan today (AIR, $29.99/mo + $4.99/mo per extra
+seat), billed through Paddle. Checkout happens on `app.aletheore.com`
+(`app_server/frontend.py`'s `/subscribe` route), which calls
+`Paddle.Checkout.open()` with `customData: {installation_id}`.
+`app_server/webhooks/paddle.py` already handles `subscription.created`,
+`subscription.updated`, `subscription.canceled`, `subscription.paused`, and
+`subscription.resumed` — reading `custom_data.installation_id` off each
+event to keep `installations.plan` in sync. It does **not** currently
+handle `transaction.completed`, so there is no stored record anywhere
+today of the actual dollar amount Paddle collects per billing cycle.
+
+Paddle itself has no built-in affiliate/referral program (it's billing
+infrastructure, not a marketing platform), but its Discounts API supports
+everything this needs natively: a merchant-defined code, a percentage
+discount restricted to exactly one billing period (`recur: true`,
+`maximum_recurring_intervals: 1`), and a `discount_id` that appears
+directly on every subsequent transaction for that subscription. That
+`discount_id` is the attribution key this design uses — no custom
+tracking link, cookie, or session state needed anywhere.
+
+## Scope decisions (from brainstorming)
+
+- **Build custom, not a third-party affiliate platform.** A third-party
+  platform (Rewardful/FirstPromoter/Tapfiliate) mostly sells self-serve
+  signup, automated payouts, and affiliate-facing dashboards — none of
+  which this program needs given the choices below. What's left to build
+  is small and reuses the webhook infrastructure already in production.
+- **Affiliates are manually onboarded**, a small handful of creators, not
+  an open self-serve program. No public signup page, no affiliate login.
+- **Payouts are manual and off-platform.** The system computes and
+  displays what's owed; no money moves through the app. Building payout
+  automation (Stripe Connect, PayPal Payouts, KYC) is a separate, much
+  larger project not justified for a handful of partners.
+- **Commission is 15% of the full transaction amount** Paddle actually
+  collects (base plan + extra seats, net of that transaction's own
+  discount), not just the base plan price.
+- **Reporting is one simple admin-only page** — no self-serve affiliate
+  dashboard.
+- **Attribution is the Paddle discount code itself**, not a tracked link.
+  A customer manually enters the creator's code at Paddle's own checkout.
+
+## How it works
+
+1. **Onboarding a creator.** An admin route calls Paddle's
+   `discounts.create` API with a merchant-chosen code (e.g. `SARAH10`),
+   `type: "percentage"`, `amount: "10"`, `recur: true`,
+   `maximum_recurring_intervals: 1`, `enabled_for_checkout: true`. The
+   returned discount ID (`dsc_...`) is stored locally against the new
+   `affiliates` row. The creator is handed their code; nothing else is
+   configured.
+
+2. **A referred signup.** The customer types the code into Paddle's
+   existing checkout UI (no product-side changes needed) and gets 10%
+   off their first month.
+
+3. **Attribution.** On the existing `subscription.created` webhook, the
+   first time a given installation transitions free → paid, if
+   `data.discount_id` matches a known affiliate's `paddle_discount_id`,
+   a row is written linking that installation to that affiliate —
+   first-touch, permanent, enforced by a unique constraint so it can
+   never be silently overwritten by a later event.
+
+4. **Commission.** `webhooks/paddle.py` gains a new branch handling
+   `transaction.completed` (not handled today). If the transaction's
+   installation has a referral row, 15% of `data.details.totals.total`
+   is recorded as a commission, deduplicated on Paddle's transaction ID
+   (Paddle retries webhook delivery on any non-2xx response, so this
+   dedup is required, not optional).
+
+5. **Getting paid.** A new admin report page lists each affiliate, how
+   many installations they've referred, total commission accrued, and
+   how much has been marked paid. The admin pays affiliates manually
+   (bank transfer, PayPal, etc.) outside the app, then marks the
+   corresponding commission rows as paid.
+
+## Data model
+
+```sql
+CREATE TABLE affiliates (
+    id                  BIGSERIAL PRIMARY KEY,
+    code                TEXT NOT NULL UNIQUE,       -- mirrors the Paddle discount's own code, for display
+    paddle_discount_id  TEXT NOT NULL UNIQUE,        -- dsc_... - the actual attribution key on webhooks
+    name                TEXT NOT NULL,               -- admin's own reference for who this is
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE affiliate_referrals (
+    installation_id  BIGINT PRIMARY KEY REFERENCES installations(installation_id) ON DELETE CASCADE,
+    affiliate_id     BIGINT NOT NULL REFERENCES affiliates(id),
+    referred_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE affiliate_commissions (
+    id                    BIGSERIAL PRIMARY KEY,
+    affiliate_id          BIGINT NOT NULL REFERENCES affiliates(id),
+    installation_id       BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    paddle_transaction_id TEXT NOT NULL UNIQUE,
+    amount_usd            NUMERIC(10,2) NOT NULL,
+    transaction_date      TIMESTAMPTZ NOT NULL,
+    paid                  BOOLEAN NOT NULL DEFAULT false
+);
+```
+
+`installation_id` as the primary key on `affiliate_referrals` is what
+makes "first-touch, never overwritten" an `INSERT ... ON CONFLICT DO
+NOTHING` rather than something application code has to remember to
+check. `paddle_transaction_id UNIQUE` on commissions does the same job
+for webhook retries.
+
+## Components
+
+- **Migration** — the three tables above.
+- **`app_server/paddle_client.py`** — new `create_discount(api_key,
+  code, description)` function, following the existing
+  `get_subscription`/`create_portal_session`/`update_subscription_items`
+  pattern (same base URL, same `_headers` helper, same
+  `PaddleAPINotConfigured` error on a missing API key).
+- **`app_server/affiliates.py`** (new module) — DB helpers:
+  `create_affiliate`, `get_affiliate_by_discount_id`,
+  `record_referral`, `record_commission`, `list_affiliates_with_totals`
+  (for the report).
+- **`app_server/webhooks/paddle.py`** — extended:
+  - `subscription.created` branch (existing): on a free→paid
+    transition, if `data.discount_id` resolves to a known affiliate,
+    call `record_referral`.
+  - New `transaction.completed` branch: if the installation has a
+    referral row, call `record_commission` with 15% of the transaction
+    total.
+- **`app_server/admin.py`** — new routes:
+  - `POST /admin/affiliates` — create a new affiliate (calls Paddle,
+    then stores the result).
+  - `GET /admin/affiliates` — the report page (affiliate, referral
+    count, total owed, total paid).
+  - `POST /admin/affiliates/{id}/mark-paid` — marks a set of commission
+    rows as paid.
+
+## Explicitly out of scope for this pass
+
+- **Retroactive attribution.** A customer who already subscribed before
+  this program existed can't be attributed after the fact — there's no
+  `transaction.completed` history stored before this ships. Only new
+  subscribers going forward can be attributed, which matches the
+  manual-onboarding model (affiliates get credit for people they
+  actually bring in via their code, not existing customers).
+- **Refunds and chargebacks.** If Paddle refunds a transaction that
+  already generated a commission row, this design does not automatically
+  claw it back. Given manual payouts, the admin is expected to account
+  for this by eye when actually paying someone. Automatic reconciliation
+  can be added later if refund volume ever makes manual tracking
+  unreliable.
+- **Fraud/abuse detection** (self-referral, code sharing beyond the
+  intended creator). Not a v1 concern given the small, manually-vetted
+  group of affiliates.
+- **Self-serve affiliate signup, login, or dashboard.** Affiliates never
+  authenticate into Aletheore; they only ever see their code and
+  whatever the admin tells them directly.
+- **Automated payouts.** No payment-out integration of any kind.
+
+## Testing
+
+- `paddle_client.create_discount` — mocked Paddle API call, same style
+  as existing `paddle_client` tests.
+- `affiliates.py` DB helpers — real-Postgres tests via the existing
+  `pool` fixture, covering: creating an affiliate, recording a referral
+  (and that a second referral for the same installation is a no-op),
+  recording a commission (and that a duplicate `paddle_transaction_id`
+  is a no-op), and the totals query.
+- `webhooks/paddle.py` — extend existing webhook tests: a
+  `subscription.created` event with a `discount_id` matching a known
+  affiliate creates a referral; one with an unrecognized `discount_id`
+  does not error and does not create a referral; a `transaction.completed`
+  event for a referred installation creates a commission at exactly 15%
+  of the transaction total; a repeated `transaction.completed` (same
+  `paddle_transaction_id`) does not double-count.
+- Admin routes — standard route tests following the existing admin.py
+  patterns (auth required, correct response shape).

--- a/github-app/.env.example
+++ b/github-app/.env.example
@@ -43,3 +43,11 @@ INTERNAL_METRICS_TOKEN=
 RESEND_API_KEY=
 EMAIL_FROM_ADDRESS=Aletheore <hello@notify.aletheore.com>
 EMAIL_REPLY_TO_ADDRESS=support@aletheore.com
+
+# Optional. Set to enable the internal affiliate-program admin routes
+# (POST/GET /admin/affiliates, POST /admin/affiliates/{id}/mark-paid).
+# Routes return 404 if this is unset. Bearer token, deliberately separate
+# from INTERNAL_METRICS_TOKEN - this one can create real Paddle discount
+# codes and see revenue, a different privilege level than read-only queue
+# stats. Also requires PADDLE_API_KEY to be set.
+AFFILIATE_ADMIN_TOKEN=

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -1,16 +1,19 @@
 import asyncio
 import hashlib
+import hmac
 import json
 import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 
+import asyncpg
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
+from app_server.affiliates import create_affiliate, list_affiliates_with_totals, mark_commissions_paid
 from app_server.auth import encrypt_access_token, get_current_session, refresh_github_access_token
 from app_server.config import get_settings
 from app_server.http_client import get_github_api_client
@@ -58,6 +61,7 @@ from app_server.db import (
 )
 from app_server.llm_cost import EXTRA_SEAT_PRICE_USD, base_cap_for_plan, monthly_cap_for_installation
 from app_server.paddle_client import PaddleAPIError
+from app_server.paddle_client import create_discount as create_paddle_discount
 from app_server.paddle_client import create_portal_session
 from app_server.paddle_client import get_subscription as get_paddle_subscription
 from app_server.paddle_client import update_subscription_items as update_paddle_subscription_items
@@ -122,6 +126,12 @@ class DeleteInstallationDataRequest(BaseModel):
 
 class AddMemberRequest(BaseModel):
     github_login: str = Field(min_length=1, max_length=39, pattern=_GITHUB_LOGIN_PATTERN)
+
+
+# Paddle discount codes accept up to 32 alphanumeric characters.
+class CreateAffiliateRequest(BaseModel):
+    code: str = Field(min_length=1, max_length=32, pattern=r"^[A-Za-z0-9]+$")
+    name: str = Field(min_length=1, max_length=200, pattern=_LABEL_PATTERN)
 
 
 BRANCH_PROTECTION_DISCLOSURE = (
@@ -1082,3 +1092,65 @@ async def create_cli_token(request: Request, body: CreateCliTokenRequest):
     await create_api_token(pool, installation_id, token_hash, body.label, installation["account_login"])
     token_id = (await list_api_tokens(pool, installation_id))[0]["id"]
     return {"token": raw_token, "id": token_id, "label": body.label}
+
+
+# ---------------------------------------------------------------------------
+# Affiliate program - internal admin only, not scoped to a customer
+# installation. Same optional/404-if-unset bearer-token pattern as
+# /v1/internal/queue-stats in metrics.py, gated on its own dedicated
+# affiliate_admin_token rather than reusing internal_metrics_token: this
+# token can create real Paddle discount codes and see revenue, a different
+# privilege level than read-only queue stats. See
+# docs/superpowers/specs/2026-08-10-aletheore-affiliate-program-design.md.
+# ---------------------------------------------------------------------------
+
+
+def _require_affiliate_admin_token(request: Request) -> None:
+    settings = get_settings()
+    if not settings.affiliate_admin_token:
+        raise HTTPException(status_code=404, detail="not found")
+    auth_header = request.headers.get("Authorization", "")
+    if not hmac.compare_digest(auth_header, f"Bearer {settings.affiliate_admin_token}"):
+        raise HTTPException(status_code=401, detail="missing or invalid token")
+
+
+@admin_router.post("/admin/affiliates")
+async def create_affiliate_route(request: Request, body: CreateAffiliateRequest):
+    _require_affiliate_admin_token(request)
+    settings = get_settings()
+    try:
+        # Off the event loop: create_paddle_discount is a blocking httpx
+        # call, same reasoning as every other synchronous paddle_client
+        # call in this file (see _adjust_extra_seat_sync and
+        # get_billing_portal_url above).
+        discount = await asyncio.to_thread(
+            create_paddle_discount, settings.paddle_api_key, body.code, f"Affiliate: {body.name}"
+        )
+    except PaddleAPIError as exc:
+        logger.error("affiliate discount creation failed for code %s: %s", body.code, exc)
+        raise HTTPException(
+            status_code=502, detail="Could not create the Paddle discount code right now."
+        ) from exc
+
+    pool = request.app.state.db_pool
+    try:
+        affiliate = await create_affiliate(pool, body.code, discount["id"], body.name)
+    except asyncpg.UniqueViolationError as exc:
+        raise HTTPException(status_code=409, detail="an affiliate with that code already exists") from exc
+    return jsonable_encoder(affiliate)
+
+
+@admin_router.get("/admin/affiliates")
+async def list_affiliates_route(request: Request):
+    _require_affiliate_admin_token(request)
+    pool = request.app.state.db_pool
+    affiliates = await list_affiliates_with_totals(pool)
+    return {"affiliates": jsonable_encoder(affiliates)}
+
+
+@admin_router.post("/admin/affiliates/{affiliate_id}/mark-paid")
+async def mark_affiliate_paid_route(affiliate_id: int, request: Request):
+    _require_affiliate_admin_token(request)
+    pool = request.app.state.db_pool
+    marked_count = await mark_commissions_paid(pool, affiliate_id)
+    return {"marked_paid_count": marked_count}

--- a/github-app/app_server/affiliates.py
+++ b/github-app/app_server/affiliates.py
@@ -1,0 +1,111 @@
+import asyncpg
+
+
+async def create_affiliate(pool: asyncpg.Pool, code: str, paddle_discount_id: str, name: str) -> dict:
+    row = await pool.fetchrow(
+        """
+        INSERT INTO affiliates (code, paddle_discount_id, name)
+        VALUES ($1, $2, $3)
+        RETURNING id, code, paddle_discount_id, name, created_at
+        """,
+        code,
+        paddle_discount_id,
+        name,
+    )
+    return dict(row)
+
+
+async def get_affiliate_by_discount_id(pool: asyncpg.Pool, paddle_discount_id: str) -> dict | None:
+    row = await pool.fetchrow(
+        "SELECT id, code, paddle_discount_id, name, created_at FROM affiliates WHERE paddle_discount_id = $1",
+        paddle_discount_id,
+    )
+    return dict(row) if row is not None else None
+
+
+async def record_referral(pool: asyncpg.Pool, installation_id: int, affiliate_id: int) -> None:
+    """First-touch, permanent attribution. installation_id is the table's
+    primary key, so a second referral for an installation that already has
+    one (e.g. a re-delivered webhook, or a later subscription.created for
+    the same installation) is a no-op rather than overwriting who gets
+    credit."""
+    await pool.execute(
+        """
+        INSERT INTO affiliate_referrals (installation_id, affiliate_id)
+        VALUES ($1, $2)
+        ON CONFLICT (installation_id) DO NOTHING
+        """,
+        installation_id,
+        affiliate_id,
+    )
+
+
+async def get_referral(pool: asyncpg.Pool, installation_id: int) -> dict | None:
+    row = await pool.fetchrow(
+        "SELECT installation_id, affiliate_id, referred_at FROM affiliate_referrals WHERE installation_id = $1",
+        installation_id,
+    )
+    return dict(row) if row is not None else None
+
+
+async def record_commission(
+    pool: asyncpg.Pool,
+    affiliate_id: int,
+    installation_id: int,
+    paddle_transaction_id: str,
+    amount_usd: float,
+    transaction_date,
+) -> None:
+    """paddle_transaction_id is UNIQUE, so a retried transaction.completed
+    delivery (Paddle retries on any non-2xx response) can't double-count
+    the same commission."""
+    await pool.execute(
+        """
+        INSERT INTO affiliate_commissions
+            (affiliate_id, installation_id, paddle_transaction_id, amount_usd, transaction_date)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (paddle_transaction_id) DO NOTHING
+        """,
+        affiliate_id,
+        installation_id,
+        paddle_transaction_id,
+        amount_usd,
+        transaction_date,
+    )
+
+
+async def list_affiliates_with_totals(pool: asyncpg.Pool) -> list[dict]:
+    """One row per affiliate for the admin report page: how many
+    installations they've referred, and total commission accrued vs. paid
+    so far. LEFT JOINs so an affiliate with no referrals/commissions yet
+    still shows up with zeroes rather than being dropped."""
+    rows = await pool.fetch(
+        """
+        SELECT
+            a.id,
+            a.code,
+            a.name,
+            a.created_at,
+            COUNT(DISTINCT r.installation_id) AS referral_count,
+            COALESCE(SUM(c.amount_usd) FILTER (WHERE NOT c.paid), 0) AS total_owed_usd,
+            COALESCE(SUM(c.amount_usd) FILTER (WHERE c.paid), 0) AS total_paid_usd
+        FROM affiliates a
+        LEFT JOIN affiliate_referrals r ON r.affiliate_id = a.id
+        LEFT JOIN affiliate_commissions c ON c.affiliate_id = a.id
+        GROUP BY a.id, a.code, a.name, a.created_at
+        ORDER BY a.created_at
+        """
+    )
+    return [dict(row) for row in rows]
+
+
+async def mark_commissions_paid(pool: asyncpg.Pool, affiliate_id: int) -> int:
+    """Marks every currently-unpaid commission for one affiliate as paid,
+    after the admin has sent that amount manually outside the app. Returns
+    the number of rows updated, for the route to confirm back to the
+    caller."""
+    result = await pool.execute(
+        "UPDATE affiliate_commissions SET paid = true WHERE affiliate_id = $1 AND NOT paid",
+        affiliate_id,
+    )
+    return int(result.split()[-1])

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -25,6 +25,7 @@ class Settings:
     resend_api_key: str | None
     email_from_address: str
     email_reply_to_address: str
+    affiliate_admin_token: str | None
 
 
 def _required_env(name: str) -> str:
@@ -127,4 +128,11 @@ def get_settings() -> Settings:
             "EMAIL_FROM_ADDRESS", "Aletheore <hello@notify.aletheore.com>"
         ),
         email_reply_to_address=os.environ.get("EMAIL_REPLY_TO_ADDRESS", "support@aletheore.com"),
+        # Gates the internal affiliate-program admin routes (create
+        # affiliate, view report, mark paid) - same optional/404-if-unset
+        # pattern as internal_metrics_token, and deliberately a separate
+        # secret from it: this token can create real Paddle discount codes
+        # and see revenue, a different privilege level than read-only queue
+        # stats.
+        affiliate_admin_token=os.environ.get("AFFILIATE_ADMIN_TOKEN", "").strip() or None,
     )

--- a/github-app/app_server/paddle_client.py
+++ b/github-app/app_server/paddle_client.py
@@ -52,6 +52,31 @@ def create_portal_session(
     return response.json()["data"]
 
 
+def create_discount(api_key: str | None, code: str, description: str) -> dict:
+    """Creates a merchant-defined percentage discount code in Paddle for an
+    affiliate: 10% off, applied to exactly one billing period
+    (maximum_recurring_intervals=1), enabled for checkout entry. The
+    returned discount's id (dsc_...) is the attribution key stored against
+    the affiliates row - see app_server/affiliates.py."""
+    if not api_key:
+        raise PaddleAPINotConfigured("PADDLE_API_KEY is not configured")
+    payload = {
+        "description": description,
+        "type": "percentage",
+        "amount": "10",
+        "code": code,
+        "recur": True,
+        "maximum_recurring_intervals": 1,
+        "enabled_for_checkout": True,
+    }
+    try:
+        response = httpx.post(f"{_PADDLE_API_BASE}/discounts", headers=_headers(api_key), json=payload)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise PaddleAPIError(f"could not create discount {code}: {exc}") from exc
+    return response.json()["data"]
+
+
 def update_subscription_items(
     api_key: str | None,
     subscription_id: str,

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -1,7 +1,10 @@
 import logging
+from datetime import datetime
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 
 from fastapi import APIRouter, Request, Response
 
+from app_server.affiliates import get_affiliate_by_discount_id, get_referral, record_commission, record_referral
 from app_server.config import get_settings
 from app_server.db import (
     add_paddle_ids_to_installation,
@@ -41,9 +44,17 @@ _SUBSCRIPTION_EVENT_TYPES = {
 # silently extending it is the safer default for a paid feature.
 _ACTIVE_SUBSCRIPTION_STATUSES = {"active", "trialing"}
 
+# The affiliate's payout share of what Paddle actually collects per
+# transaction (net of that transaction's own discount) - see
+# docs/superpowers/specs/2026-08-10-aletheore-affiliate-program-design.md.
+_AFFILIATE_COMMISSION_RATE = Decimal("0.15")
+
 
 async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue=None) -> None:
     event_type = payload.get("event_type")
+    if event_type == "transaction.completed":
+        await _handle_transaction_completed(payload.get("data") or {}, pool)
+        return
     if event_type not in _SUBSCRIPTION_EVENT_TYPES:
         return
 
@@ -110,6 +121,20 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     # installation's wiki stayed limited to whatever clusters an
     # incremental push happened to touch after the fact.
     if previous_plan == "free" and plan != "free":
+        # Attribution: first time this installation goes free -> paid, if it
+        # was checked out with a known affiliate's discount code, credit
+        # that affiliate. Gated the same free -> paid transition as the
+        # wiki/docs build below, so a later subscription.updated for the
+        # same installation (e.g. switching monthly <-> annual) can't
+        # re-attribute or steal credit - record_referral is also itself a
+        # database-enforced no-op past the first row (installation_id is
+        # that table's primary key).
+        discount_id = data.get("discount_id")
+        if discount_id:
+            affiliate = await get_affiliate_by_discount_id(pool, discount_id)
+            if affiliate is not None:
+                await record_referral(pool, installation_id, affiliate["id"])
+
         if queue is None:
             from redis import Redis
             from rq import Queue
@@ -156,6 +181,63 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
                     to_email=member_email,
                     installation_id=installation_id,
                 )
+
+
+async def _handle_transaction_completed(data: dict, pool) -> None:
+    """Records an affiliate commission for one completed transaction, if
+    and only if the paying installation has a referral on file. Every other
+    (unreferred) transaction.completed event - the overwhelming majority -
+    is a fast no-op after the referral lookup.
+
+    15% of `details.totals.total`, Paddle's collected amount net of that
+    transaction's own discount, in the currency's minor unit (cents) as a
+    string - matches the "15% of everything Paddle actually collects"
+    scope decision for both a discounted first month and every undiscounted
+    month after it, without special-casing either.
+    """
+    installation_id_raw = (data.get("custom_data") or {}).get("installation_id")
+    installation_id = None
+    if installation_id_raw is not None:
+        try:
+            installation_id = int(installation_id_raw)
+        except (TypeError, ValueError):
+            installation_id = None
+    if installation_id is None:
+        return
+
+    referral = await get_referral(pool, installation_id)
+    if referral is None:
+        return
+
+    transaction_id = data.get("id")
+    total_raw = ((data.get("details") or {}).get("totals") or {}).get("total")
+    billed_at_raw = data.get("billed_at") or data.get("created_at")
+    if not transaction_id or total_raw is None or not billed_at_raw:
+        logger.warning(
+            "transaction.completed for a referred installation is missing fields "
+            "needed for commission calculation"
+        )
+        return
+
+    try:
+        total_minor_units = Decimal(str(total_raw))
+        billed_at = datetime.fromisoformat(billed_at_raw)
+    except (InvalidOperation, ValueError):
+        logger.warning("transaction.completed has an unparseable total or billed_at")
+        return
+
+    commission_usd = (total_minor_units / Decimal(100) * _AFFILIATE_COMMISSION_RATE).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+
+    await record_commission(
+        pool,
+        referral["affiliate_id"],
+        installation_id,
+        transaction_id,
+        commission_usd,
+        billed_at,
+    )
 
 
 @paddle_webhook_router.post("/webhooks/paddle")

--- a/github-app/migrations/046_affiliate_program.sql
+++ b/github-app/migrations/046_affiliate_program.sql
@@ -1,0 +1,36 @@
+-- Affiliate program: manually-onboarded creators earn 15% recurring
+-- commission on customers referred via their own Paddle discount code. See
+-- docs/superpowers/specs/2026-08-10-aletheore-affiliate-program-design.md.
+
+CREATE TABLE IF NOT EXISTS affiliates (
+    id                  BIGSERIAL PRIMARY KEY,
+    code                TEXT NOT NULL UNIQUE,
+    paddle_discount_id  TEXT NOT NULL UNIQUE,
+    name                TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- installation_id as the PRIMARY KEY (not just a unique column) makes
+-- first-touch attribution an INSERT ... ON CONFLICT DO NOTHING - a second
+-- referral for the same installation is a database-enforced no-op, not
+-- something application code has to remember to check.
+CREATE TABLE IF NOT EXISTS affiliate_referrals (
+    installation_id  BIGINT PRIMARY KEY REFERENCES installations(installation_id) ON DELETE CASCADE,
+    affiliate_id     BIGINT NOT NULL REFERENCES affiliates(id),
+    referred_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- paddle_transaction_id UNIQUE does the same job for transaction.completed
+-- webhook retries (Paddle retries any non-2xx response, re-delivering the
+-- same transaction id) - a repeat delivery can't double-count a commission.
+CREATE TABLE IF NOT EXISTS affiliate_commissions (
+    id                    BIGSERIAL PRIMARY KEY,
+    affiliate_id          BIGINT NOT NULL REFERENCES affiliates(id),
+    installation_id       BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    paddle_transaction_id TEXT NOT NULL UNIQUE,
+    amount_usd            NUMERIC(10,2) NOT NULL,
+    transaction_date      TIMESTAMPTZ NOT NULL,
+    paid                  BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS affiliate_commissions_affiliate_id ON affiliate_commissions (affiliate_id);

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -40,14 +40,17 @@ async def pool():
         migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
         for migration in sorted(migrations_dir.glob("*.sql")):
             await conn.execute(migration.read_text())
-        # data_deletion_log and webhook_deliveries are listed explicitly
-        # because neither has an FK to installations (see
-        # 035_data_deletion_log.sql and 036_webhook_deliveries.sql) - the
-        # CASCADE from installations doesn't reach them, so without this
-        # their rows would leak from one test into the next.
+        # data_deletion_log, webhook_deliveries, and affiliates are listed
+        # explicitly because none has an FK to installations (see
+        # 035_data_deletion_log.sql, 036_webhook_deliveries.sql, and
+        # 046_affiliate_program.sql) - the CASCADE from installations
+        # doesn't reach them, so without this their rows would leak from
+        # one test into the next. affiliate_referrals/affiliate_commissions
+        # need no separate entry: both DO have an installations FK with ON
+        # DELETE CASCADE, so truncating installations already clears them.
         await conn.execute(
             "TRUNCATE installations, sessions, demo_scan_rate_limits, cli_telemetry_events, "
-            "github_user_emails, sent_emails, data_deletion_log, webhook_deliveries CASCADE"
+            "github_user_emails, sent_emails, data_deletion_log, webhook_deliveries, affiliates CASCADE"
         )
     yield p
     await p.close()

--- a/github-app/tests/test_admin_affiliates.py
+++ b/github-app/tests/test_admin_affiliates.py
@@ -1,0 +1,190 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app_server.affiliates import create_affiliate, record_commission, record_referral
+from app_server.db import upsert_installation
+from app_server.main import app
+from app_server.paddle_client import PaddleAPIError
+
+ADMIN_TOKEN = "test-affiliate-admin-token"
+
+
+def _mock_create_discount(monkeypatch, discount_id: str = "dsc_mocked"):
+    monkeypatch.setattr(
+        "app_server.admin.create_paddle_discount",
+        lambda api_key, code, description: {"id": discount_id, "code": code},
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_returns_404_when_token_not_configured(pool, monkeypatch):
+    monkeypatch.delenv("AFFILIATE_ADMIN_TOKEN", raising=False)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/admin/affiliates", json={"code": "SARAH10", "name": "Sarah"})
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_requires_bearer_token(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/admin/affiliates", json={"code": "SARAH10", "name": "Sarah"})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_rejects_wrong_token(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/admin/affiliates",
+            json={"code": "SARAH10", "name": "Sarah"},
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_creates_paddle_discount_and_db_row(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    _mock_create_discount(monkeypatch, discount_id="dsc_sarah_admin")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/admin/affiliates",
+            json={"code": "SARAH10", "name": "Sarah"},
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] == "SARAH10"
+    assert body["paddle_discount_id"] == "dsc_sarah_admin"
+    assert body["name"] == "Sarah"
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_rejects_duplicate_code(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    await create_affiliate(pool, "MAYA10", "dsc_maya_existing", "Maya")
+    _mock_create_discount(monkeypatch, discount_id="dsc_maya_new")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/admin/affiliates",
+            json={"code": "MAYA10", "name": "Maya Again"},
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_surfaces_paddle_api_error_as_502(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+
+    def _raise(api_key, code, description):
+        raise PaddleAPIError("could not create discount")
+
+    monkeypatch.setattr("app_server.admin.create_paddle_discount", _raise)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/admin/affiliates",
+            json={"code": "TOM10", "name": "Tom"},
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_rejects_invalid_code(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    _mock_create_discount(monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/admin/affiliates",
+            json={"code": "not valid!", "name": "Nina"},
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_affiliates_requires_bearer_token(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/admin/affiliates")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_affiliates_returns_report_data(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    affiliate = await create_affiliate(pool, "OMAR10", "dsc_omar_admin", "Omar")
+    await upsert_installation(pool, 920, "acme")
+    await record_referral(pool, 920, affiliate["id"])
+    await record_commission(
+        pool, affiliate["id"], 920, "txn_admin_1", Decimal("4.05"), datetime.now(timezone.utc)
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/admin/affiliates", headers={"Authorization": f"Bearer {ADMIN_TOKEN}"}
+        )
+
+    assert response.status_code == 200
+    rows = {row["id"]: row for row in response.json()["affiliates"]}
+    assert rows[affiliate["id"]]["referral_count"] == 1
+    assert rows[affiliate["id"]]["total_owed_usd"] == 4.05
+
+
+@pytest.mark.asyncio
+async def test_mark_paid_requires_bearer_token(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/admin/affiliates/1/mark-paid")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_mark_paid_marks_commissions_and_reflects_in_report(pool, monkeypatch):
+    monkeypatch.setenv("AFFILIATE_ADMIN_TOKEN", ADMIN_TOKEN)
+    app.state.db_pool = pool
+    affiliate = await create_affiliate(pool, "PIA10", "dsc_pia_admin", "Pia")
+    await upsert_installation(pool, 921, "acme")
+    await record_referral(pool, 921, affiliate["id"])
+    await record_commission(
+        pool, affiliate["id"], 921, "txn_admin_2", Decimal("4.05"), datetime.now(timezone.utc)
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        mark_response = await client.post(
+            f"/admin/affiliates/{affiliate['id']}/mark-paid",
+            headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+        )
+        list_response = await client.get(
+            "/admin/affiliates", headers={"Authorization": f"Bearer {ADMIN_TOKEN}"}
+        )
+
+    assert mark_response.status_code == 200
+    assert mark_response.json() == {"marked_paid_count": 1}
+    rows = {row["id"]: row for row in list_response.json()["affiliates"]}
+    assert rows[affiliate["id"]]["total_owed_usd"] == 0
+    assert rows[affiliate["id"]]["total_paid_usd"] == 4.05

--- a/github-app/tests/test_affiliates.py
+++ b/github-app/tests/test_affiliates.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app_server.affiliates import (
+    create_affiliate,
+    get_affiliate_by_discount_id,
+    get_referral,
+    list_affiliates_with_totals,
+    mark_commissions_paid,
+    record_commission,
+    record_referral,
+)
+from app_server.db import upsert_installation
+
+
+@pytest.mark.asyncio
+async def test_create_affiliate_returns_the_inserted_row(pool):
+    affiliate = await create_affiliate(pool, "SARAH10", "dsc_sarah", "Sarah")
+    assert affiliate["code"] == "SARAH10"
+    assert affiliate["paddle_discount_id"] == "dsc_sarah"
+    assert affiliate["name"] == "Sarah"
+    assert affiliate["id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_affiliate_by_discount_id_finds_a_match(pool):
+    created = await create_affiliate(pool, "MAYA10", "dsc_maya", "Maya")
+    found = await get_affiliate_by_discount_id(pool, "dsc_maya")
+    assert found["id"] == created["id"]
+
+
+@pytest.mark.asyncio
+async def test_get_affiliate_by_discount_id_returns_none_for_unknown_id(pool):
+    assert await get_affiliate_by_discount_id(pool, "dsc_unknown") is None
+
+
+@pytest.mark.asyncio
+async def test_record_referral_creates_a_row(pool):
+    affiliate = await create_affiliate(pool, "TOM10", "dsc_tom", "Tom")
+    await upsert_installation(pool, 900, "acme")
+
+    await record_referral(pool, 900, affiliate["id"])
+
+    referral = await get_referral(pool, 900)
+    assert referral["affiliate_id"] == affiliate["id"]
+
+
+@pytest.mark.asyncio
+async def test_second_referral_for_the_same_installation_is_a_no_op(pool):
+    # First-touch attribution: installation_id is the table's primary key,
+    # so a later event (e.g. a re-delivered webhook, or a second
+    # subscription for the same installation) can't steal credit from
+    # whichever affiliate referred it first.
+    first_affiliate = await create_affiliate(pool, "FIRST10", "dsc_first", "First")
+    second_affiliate = await create_affiliate(pool, "SECOND10", "dsc_second", "Second")
+    await upsert_installation(pool, 901, "acme")
+
+    await record_referral(pool, 901, first_affiliate["id"])
+    await record_referral(pool, 901, second_affiliate["id"])
+
+    referral = await get_referral(pool, 901)
+    assert referral["affiliate_id"] == first_affiliate["id"]
+
+
+@pytest.mark.asyncio
+async def test_get_referral_returns_none_when_unreferred(pool):
+    await upsert_installation(pool, 902, "acme")
+    assert await get_referral(pool, 902) is None
+
+
+@pytest.mark.asyncio
+async def test_record_commission_creates_a_row_reflected_in_totals(pool):
+    affiliate = await create_affiliate(pool, "NINA10", "dsc_nina", "Nina")
+    await upsert_installation(pool, 903, "acme")
+    await record_referral(pool, 903, affiliate["id"])
+
+    await record_commission(
+        pool, affiliate["id"], 903, "txn_1", Decimal("4.50"), datetime.now(timezone.utc)
+    )
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.50")
+    assert totals[affiliate["id"]]["total_paid_usd"] == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_duplicate_paddle_transaction_id_does_not_double_count(pool):
+    # Paddle retries webhook delivery on any non-2xx response, re-sending
+    # the same transaction id - this must not double the commission.
+    affiliate = await create_affiliate(pool, "OMAR10", "dsc_omar", "Omar")
+    await upsert_installation(pool, 904, "acme")
+    await record_referral(pool, 904, affiliate["id"])
+    now = datetime.now(timezone.utc)
+
+    await record_commission(pool, affiliate["id"], 904, "txn_dupe", Decimal("4.50"), now)
+    await record_commission(pool, affiliate["id"], 904, "txn_dupe", Decimal("4.50"), now)
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.50")
+
+
+@pytest.mark.asyncio
+async def test_list_affiliates_with_totals_counts_distinct_referrals(pool):
+    affiliate = await create_affiliate(pool, "PAT10", "dsc_pat", "Pat")
+    await upsert_installation(pool, 905, "acme")
+    await upsert_installation(pool, 906, "beta")
+    await record_referral(pool, 905, affiliate["id"])
+    await record_referral(pool, 906, affiliate["id"])
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["referral_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_affiliates_with_totals_includes_affiliates_with_no_referrals(pool):
+    affiliate = await create_affiliate(pool, "QUINN10", "dsc_quinn", "Quinn")
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["referral_count"] == 0
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_mark_commissions_paid_moves_owed_to_paid(pool):
+    affiliate = await create_affiliate(pool, "RIA10", "dsc_ria", "Ria")
+    await upsert_installation(pool, 907, "acme")
+    await record_referral(pool, 907, affiliate["id"])
+    now = datetime.now(timezone.utc)
+    await record_commission(pool, affiliate["id"], 907, "txn_a", Decimal("3.00"), now)
+    await record_commission(pool, affiliate["id"], 907, "txn_b", Decimal("2.00"), now)
+
+    marked = await mark_commissions_paid(pool, affiliate["id"])
+
+    assert marked == 2
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("0")
+    assert totals[affiliate["id"]]["total_paid_usd"] == Decimal("5.00")
+
+
+@pytest.mark.asyncio
+async def test_mark_commissions_paid_does_not_touch_other_affiliates(pool):
+    affiliate_a = await create_affiliate(pool, "SAM10", "dsc_sam", "Sam")
+    affiliate_b = await create_affiliate(pool, "UMA10", "dsc_uma", "Uma")
+    await upsert_installation(pool, 908, "acme")
+    await upsert_installation(pool, 909, "beta")
+    await record_referral(pool, 908, affiliate_a["id"])
+    await record_referral(pool, 909, affiliate_b["id"])
+    now = datetime.now(timezone.utc)
+    await record_commission(pool, affiliate_a["id"], 908, "txn_c", Decimal("3.00"), now)
+    await record_commission(pool, affiliate_b["id"], 909, "txn_d", Decimal("7.00"), now)
+
+    await mark_commissions_paid(pool, affiliate_a["id"])
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate_a["id"]]["total_paid_usd"] == Decimal("3.00")
+    assert totals[affiliate_b["id"]]["total_owed_usd"] == Decimal("7.00")
+    assert totals[affiliate_b["id"]]["total_paid_usd"] == Decimal("0")

--- a/github-app/tests/test_paddle_client.py
+++ b/github-app/tests/test_paddle_client.py
@@ -4,6 +4,7 @@ import pytest
 from app_server.paddle_client import (
     PaddleAPIError,
     PaddleAPINotConfigured,
+    create_discount,
     create_portal_session,
     get_subscription,
     update_subscription_items,
@@ -13,6 +14,62 @@ from app_server.paddle_client import (
 def test_get_subscription_requires_api_key():
     with pytest.raises(PaddleAPINotConfigured):
         get_subscription(None, "sub_123")
+
+
+def test_create_discount_requires_api_key():
+    with pytest.raises(PaddleAPINotConfigured):
+        create_discount(None, "SARAH10", "Affiliate: Sarah")
+
+
+def test_create_discount_sends_post_with_expected_body(monkeypatch):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        import json
+
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"data": {"id": "dsc_123", "code": "SARAH10"}})
+
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, headers, json: httpx.Client(transport=httpx.MockTransport(handler)).post(
+            url, headers=headers, json=json
+        ),
+    )
+
+    result = create_discount("test_key", "SARAH10", "Affiliate: Sarah")
+
+    assert result == {"id": "dsc_123", "code": "SARAH10"}
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/discounts"
+    assert captured["body"] == {
+        "description": "Affiliate: Sarah",
+        "type": "percentage",
+        "amount": "10",
+        "code": "SARAH10",
+        "recur": True,
+        "maximum_recurring_intervals": 1,
+        "enabled_for_checkout": True,
+    }
+
+
+def test_create_discount_wraps_http_errors(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, json={"error": "code already exists"})
+
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda url, headers, json: httpx.Client(transport=httpx.MockTransport(handler)).post(
+            url, headers=headers, json=json
+        ),
+    )
+
+    with pytest.raises(PaddleAPIError):
+        create_discount("test_key", "SARAH10", "Affiliate: Sarah")
 
 
 def test_create_portal_session_requires_api_key():

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -3,12 +3,14 @@ import hmac
 import ipaddress
 import json
 import time
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app_server import paddle_ip_allowlist
+from app_server.affiliates import create_affiliate, get_referral, list_affiliates_with_totals, record_referral
 from app_server.db import (
     add_installation_member,
     claim_webhook_delivery,
@@ -32,9 +34,12 @@ def _sign(raw_body: bytes, secret: str = WEBHOOK_SECRET) -> str:
 
 
 def _subscription_created_payload(
-    price_id: str, installation_id: int, event_id: str = "evt_created_default"
+    price_id: str,
+    installation_id: int,
+    event_id: str = "evt_created_default",
+    discount_id: str | None = None,
 ) -> dict:
-    return {
+    payload = {
         "event_id": event_id,
         "event_type": "subscription.created",
         "data": {
@@ -43,6 +48,27 @@ def _subscription_created_payload(
             "status": "active",
             "custom_data": {"installation_id": str(installation_id)},
             "items": [{"price": {"id": price_id}}],
+        },
+    }
+    if discount_id is not None:
+        payload["data"]["discount_id"] = discount_id
+    return payload
+
+
+def _transaction_completed_payload(
+    installation_id: int,
+    total_cents: str,
+    transaction_id: str = "txn_test_1",
+    event_id: str = "evt_txn_default",
+) -> dict:
+    return {
+        "event_id": event_id,
+        "event_type": "transaction.completed",
+        "data": {
+            "id": transaction_id,
+            "custom_data": {"installation_id": str(installation_id)},
+            "details": {"totals": {"total": total_cents}},
+            "billed_at": "2026-08-10T12:00:00Z",
         },
     }
 
@@ -701,3 +727,140 @@ async def test_failed_paddle_handler_releases_the_claim_for_retry(pool, monkeypa
 
     assert second.status_code == 200
     assert len(attempts) == 2, "retry of a failed Paddle event was wrongly suppressed"
+
+
+# ---------------------------------------------------------------------------
+# Affiliate program: referral attribution on subscription.created, and
+# commission recording on transaction.completed. See
+# docs/superpowers/specs/2026-08-10-aletheore-affiliate-program-design.md.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscription_created_with_known_discount_id_records_referral(pool):
+    fake_queue = MagicMock()
+    affiliate = await create_affiliate(pool, "SARAH10", "dsc_sarah_wh", "Sarah")
+    await upsert_installation(pool, 900, "acme")
+
+    payload = _subscription_created_payload(
+        "pri_01kyhevc8bkcghfpwjymz16y2h", 900, discount_id="dsc_sarah_wh"
+    )
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    referral = await get_referral(pool, 900)
+    assert referral is not None
+    assert referral["affiliate_id"] == affiliate["id"]
+
+
+@pytest.mark.asyncio
+async def test_subscription_created_with_unknown_discount_id_creates_no_referral(pool):
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 901, "acme")
+
+    payload = _subscription_created_payload(
+        "pri_01kyhevc8bkcghfpwjymz16y2h", 901, discount_id="dsc_totally_unknown"
+    )
+    # Must not raise despite the discount id not matching any affiliate.
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_referral(pool, 901) is None
+
+
+@pytest.mark.asyncio
+async def test_subscription_created_without_discount_id_creates_no_referral(pool):
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 902, "acme")
+
+    payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 902)
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_referral(pool, 902) is None
+
+
+@pytest.mark.asyncio
+async def test_paid_to_paid_change_with_discount_id_does_not_attribute(pool):
+    # Referral attribution is gated on the free -> paid transition, same as
+    # the one-time wiki build - a later subscription.updated for an
+    # already-paid installation must not create or steal a referral.
+    affiliate = await create_affiliate(pool, "TINA10", "dsc_tina_wh", "Tina")
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (903, 'acme', 'air')"
+    )
+
+    payload = _subscription_created_payload(
+        "pri_01kyhevc9xn6z2nghmy8057jvp", 903, discount_id="dsc_tina_wh"
+    )
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    assert await get_referral(pool, 903) is None
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_for_referred_installation_records_commission(pool):
+    affiliate = await create_affiliate(pool, "NORA10", "dsc_nora_wh", "Nora")
+    await upsert_installation(pool, 910, "acme")
+    await record_referral(pool, 910, affiliate["id"])
+
+    # $26.99 (2699 cents) net of that transaction's own discount - 15% of it
+    # is $4.05 (rounded from 4.0485).
+    payload = _transaction_completed_payload(910, "2699")
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.05")
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_for_unreferred_installation_records_nothing(pool):
+    await upsert_installation(pool, 911, "acme")
+
+    payload = _transaction_completed_payload(911, "2699")
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    assert await list_affiliates_with_totals(pool) == []
+
+
+@pytest.mark.asyncio
+async def test_repeated_transaction_completed_delivery_does_not_double_commission(pool):
+    # Paddle retries webhook delivery on any non-2xx response, re-sending
+    # the same transaction id - the route-level dedupe (webhook_deliveries)
+    # already guards this at the HTTP layer, but the handler itself must
+    # also be safe if ever called twice for the same transaction.
+    affiliate = await create_affiliate(pool, "OLA10", "dsc_ola_wh", "Ola")
+    await upsert_installation(pool, 912, "acme")
+    await record_referral(pool, 912, affiliate["id"])
+
+    payload = _transaction_completed_payload(912, "2699", transaction_id="txn_repeat")
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.05")
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_missing_installation_id_does_not_error(pool):
+    payload = _transaction_completed_payload(913, "2699")
+    del payload["data"]["custom_data"]["installation_id"]
+
+    # Must not raise.
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+
+@pytest.mark.asyncio
+async def test_full_webhook_route_records_commission_for_referred_installation(pool, monkeypatch):
+    monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
+    app.state.db_pool = pool
+    affiliate = await create_affiliate(pool, "PIA10", "dsc_pia_wh", "Pia")
+    await upsert_installation(pool, 914, "acme")
+    await record_referral(pool, 914, affiliate["id"])
+
+    body = json.dumps(_transaction_completed_payload(914, "2699", event_id="evt_txn_route")).encode()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)}
+        )
+
+    assert response.status_code == 200
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.05")


### PR DESCRIPTION
## Summary
- Manually-onboarded affiliates get a Paddle discount code (10% off first month) that doubles as the attribution key - no custom checkout UI, cookies, or query-param threading.
- `subscription.created` now attributes a first-touch, permanent referral on a free -> paid signup when the discount code matches a known affiliate.
- `transaction.completed` (not handled at all before this PR) records a 15% commission per billing cycle for referred installations, deduped on Paddle's transaction id (Paddle retries webhook delivery on any non-2xx response).
- New internal admin routes (`POST/GET /admin/affiliates`, `POST /admin/affiliates/{id}/mark-paid`) behind a dedicated `AFFILIATE_ADMIN_TOKEN` (separate privilege from `INTERNAL_METRICS_TOKEN` - this one creates real Paddle discount codes and sees revenue). Payouts stay manual and off-platform.

Design doc: `docs/superpowers/specs/2026-08-10-aletheore-affiliate-program-design.md`

## Test plan
- [x] 35 new tests: `paddle_client.create_discount`, `affiliates.py` DB helpers (incl. referral/commission dedup no-ops), extended `webhooks/paddle.py` coverage, admin route tests
- [x] Full suite: 1152 passed, 8 skipped, 0 failed
- [ ] CI green on this PR
- [ ] Post-merge: deploy to prod, real E2E verification against Paddle sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)