### PR TITLE
fix: log signature-verification failures on the Paddle webhook route

### DIFF
--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -246,6 +246,16 @@ async def handle_paddle_webhook(request: Request) -> Response:
     signature = request.headers.get("paddle-signature", "")
     settings = get_settings()
     if not signature or not verify_paddle_signature(raw_body, signature, settings.paddle_webhook_secret):
+        # Previously silent - a real signature failure (rotated secret,
+        # clock drift past tolerance, a genuinely forged request) and a
+        # missing header looked identical from the outside with nothing to
+        # go on. header_present/header_len are safe to log (no secret or
+        # payment data); the raw signature and body are not logged.
+        logger.warning(
+            "paddle webhook signature verification failed (header_present=%s, header_len=%d)",
+            bool(signature),
+            len(signature),
+        )
         return Response(status_code=401)
 
     # Defense-in-depth on top of signature verification, not a replacement

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import ipaddress
 import json
+import logging
 import time
 from decimal import Decimal
 from unittest.mock import MagicMock
@@ -206,6 +207,24 @@ async def test_missing_signature_header_rejected(pool):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/webhooks/paddle", content=body)
     assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_signature_failure_is_logged_with_header_presence_and_length(pool, caplog):
+    # Previously silent - a real signature failure (rotated secret, clock
+    # drift past tolerance, a forged request) and a missing header looked
+    # identical from the outside with nothing to go on.
+    app.state.db_pool = pool
+    body = json.dumps(_subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 108)).encode()
+    with caplog.at_level(logging.WARNING, logger="app_server.webhooks.paddle"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/webhooks/paddle", content=body, headers={"paddle-signature": "ts=1;h1=deadbeef"}
+            )
+    assert response.status_code == 401
+    record = next(r for r in caplog.records if "signature verification failed" in r.message)
+    assert "header_present=True" in record.message
+    assert "header_len=16" in record.message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Previously a signature-verification failure on `/webhooks/paddle` returned a silent 401 - no way to tell a missing header from a mismatched signature (rotated secret, clock drift, forged request) from the outside.
- Adds a warning log with `header_present`/`header_len` only - never the raw signature or body.
- Found this gap live while running a real Paddle webhook simulation against production to verify the new affiliate program (PR #184): the simulated `transaction.completed` event got a 401 with zero diagnostic information available.

## Test plan
- [x] New test asserting the warning is logged with correct header_present/header_len on an invalid signature
- [x] Full `test_webhooks_paddle.py` suite passes (42 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)