### PR TITLE
fix: reject non-http(s) base_url in aletheore_healthcheck (SSRF/local-file-read)

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -741,7 +741,11 @@ def _healthcheck(repo_path: str, base_url: str) -> int:
         return 1
 
     endpoints = evidence["repository"].get("api_endpoints", {}).get("endpoints", [])
-    result = run_healthcheck(endpoints, base_url)
+    try:
+        result = run_healthcheck(endpoints, base_url)
+    except ValueError as exc:
+        print(f"error: {exc}")
+        return 1
     save_healthcheck(result, repo)
 
     for entry in result["results"]:

--- a/src/aletheore/healthcheck.py
+++ b/src/aletheore/healthcheck.py
@@ -6,6 +6,7 @@ import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import certifi
 
@@ -13,16 +14,33 @@ from aletheore.history import _save_json_with_rotation
 
 _SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
+# urllib's default opener retains a FileHandler regardless of which extra
+# handlers build_opener() is given - a base_url of file:///etc/passwd or
+# any local path is opened as a local file, not rejected as an invalid
+# health-check target. Scoping to http(s) is deliberately the only
+# restriction: localhost and private-network targets stay allowed, since a
+# developer running this against their own local dev server (http://
+# localhost:5000, matching this module's own tests) is the common case for
+# both the CLI and the MCP tool.
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+def _require_http_scheme(base_url: str) -> None:
+    scheme = urlsplit(base_url).scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValueError(
+            f"base_url must be http or https, got scheme {scheme!r} in {base_url!r}"
+        )
+
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     # Health checks must never follow a redirect: the destination hasn't
-    # gone through validate_external_https_url the way base_url has, so
-    # chasing it would let a monitored endpoint redirect this checker at an
-    # address it has no business reaching (scan_worker shares a network
-    # with postgres/redis/ollama). Returning None here makes the opener
-    # raise HTTPError for the 3xx instead of following it - the redirect
-    # response itself still proves the endpoint is up, which is all
-    # reachability monitoring claims to answer.
+    # been through _require_http_scheme the way base_url has, so chasing it
+    # would let a monitored endpoint redirect this checker at a file:// or
+    # other non-http(s) target. Returning None here makes the opener raise
+    # HTTPError for the 3xx instead of following it - the redirect response
+    # itself still proves the endpoint is up, which is all reachability
+    # monitoring claims to answer.
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         return None
 
@@ -70,6 +88,7 @@ def _response_shape(response) -> list[str] | None:
 
 
 def run_healthcheck(endpoints: list[dict], base_url: str, timeout: float = 5.0) -> dict:
+    _require_http_scheme(base_url)
     results: list[dict] = []
 
     for endpoint in endpoints:

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -404,7 +404,10 @@ def _register_healthcheck_tool(mcp_instance: MCPServer, repo_path: Path) -> None
         """GET-only live health check of mapped API endpoints against a running instance."""
         evidence = read_evidence(repo_path)
         endpoints = evidence["repository"].get("api_endpoints", {}).get("endpoints", [])
-        result = run_healthcheck(endpoints, base_url)
+        try:
+            result = run_healthcheck(endpoints, base_url)
+        except ValueError as exc:
+            return _toon_result({"error": str(exc)})
         save_healthcheck(result, repo_path)
         return _toon_result(result)
 

--- a/src/tests/test_healthcheck.py
+++ b/src/tests/test_healthcheck.py
@@ -1,4 +1,6 @@
 import urllib.error
+
+import pytest
 from unittest.mock import MagicMock, patch
 
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
@@ -382,6 +384,33 @@ def test_run_healthcheck_response_shape_is_none_on_unreachable():
         result = run_healthcheck(endpoints, "http://localhost:9999")
 
     assert result["results"][0]["response_shape"] is None
+
+
+def test_run_healthcheck_rejects_file_scheme(tmp_path):
+    # urllib's default opener retains a FileHandler regardless of which
+    # extra handlers build_opener() is given - without this check, a
+    # file:// base_url is opened as a local file rather than rejected.
+    secret = tmp_path / "secret.json"
+    secret.write_text('{"password": "hunter2"}')
+
+    with pytest.raises(ValueError, match="http or https"):
+        run_healthcheck([], f"file://{secret}")
+
+
+def test_run_healthcheck_rejects_ftp_scheme():
+    with pytest.raises(ValueError, match="http or https"):
+        run_healthcheck([], "ftp://example.com")
+
+
+def test_run_healthcheck_rejects_missing_scheme():
+    with pytest.raises(ValueError, match="http or https"):
+        run_healthcheck([], "example.com")
+
+
+def test_run_healthcheck_accepts_https():
+    with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=_mock_response(200)):
+        result = run_healthcheck([], "https://example.com")
+    assert result["base_url"] == "https://example.com"
 
 
 def test_save_healthcheck_rotates_at_21st_save_keeping_20_newest(tmp_path):

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -771,3 +771,20 @@ async def test_aletheore_healthcheck_tool_returns_results(tmp_path):
 
     body = tool_result_body(result)["result"]
     assert body["results"][0]["status_code"] == 200
+
+
+@pytest.mark.asyncio
+async def test_aletheore_healthcheck_tool_rejects_file_scheme_base_url(tmp_path):
+    # An LLM agent driven by untrusted content in a scanned repo (e.g. a
+    # malicious README) could try to point this tool at file:// to read
+    # local files instead of probing a real HTTP endpoint - this must
+    # surface as a normal tool error, not silently open the local file.
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool(
+        "aletheore_healthcheck", {"base_url": "file:///etc/passwd"}
+    )
+
+    body = tool_result_body(result)["result"]
+    assert "http or https" in body["error"]


### PR DESCRIPTION
## Summary
- The other-Claude security audit found that `aletheore_healthcheck`'s `run_healthcheck` did no URL scheme validation - a `file://` base_url is opened by urllib's default FileHandler as a local file rather than probed as an HTTP health-check target. Reproduced: read a local JSON file's key names through the MCP tool.
- A comment in `healthcheck.py` referenced `validate_external_https_url`, which only exists in `github-app/` - it doesn't exist anywhere in `src/`, so no validation was actually happening for either the CLI or MCP tool caller.
- `run_healthcheck` now rejects any `base_url` whose scheme isn't `http`/`https`. Both callers (CLI, MCP tool) surface this as a normal error rather than crashing or silently reading a local file. Localhost/private-network http(s) targets stay allowed - deliberately, since a developer's own local dev server is the common case for both callers (and what this module's own tests already exercise).

## Test plan
- [x] New tests: rejects `file://` (with a real local file, proving no read occurs), `ftp://`, and a schemeless URL; accepts `https://`
- [x] MCP tool test: `file:///etc/passwd` surfaces as a normal `{"error": ...}` tool result
- [x] Full CLI/scanner suite: 1048 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)