### PR TITLE
fix: scan_repository no longer reports different counts on repeated scans

### DIFF
--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -335,6 +335,19 @@ def scan_repository(
     repo_path = repo_path.resolve()
     ignored_paths = load_repo_config(repo_path)["ignored_paths"]
 
+    # Must run before any file-counting walk below (detect_languages is the
+    # first one), not after the scan in write_evidence as before - creating
+    # or appending to .gitignore here is itself a countable file-system
+    # change, and doing it post-scan meant THIS scan's counts (e.g.
+    # scanned_files) reflected the repo's pre-mutation state while the NEXT
+    # scan of the same, otherwise-untouched repo reflected the post-mutation
+    # state - a real repo scanned twice in a row, without a single file of
+    # its own changing, reported different numbers (22 -> 23 -> 23,
+    # confirmed empirically). Running it first makes every scan - including
+    # the very first one - already reflect whatever .gitignore state results,
+    # so counts are stable and reproducible from the first call onward.
+    _ensure_aletheore_dir_gitignored(repo_path)
+
     report("Detecting languages, frameworks, and build tools")
     languages = detect_languages(repo_path, ignored_paths)
     frameworks = detect_frameworks(repo_path)
@@ -517,6 +530,11 @@ def _ensure_aletheore_dir_gitignored(repo_path: Path) -> None:
 
 
 def write_evidence(evidence: dict, repo_path: Path) -> Path:
+    # Usually already a no-op by the time evidence written via
+    # scan_repository() gets here - see the call at the top of
+    # scan_repository for why it moved there. Kept here too as a safety net
+    # for any caller that writes evidence without going through
+    # scan_repository.
     _ensure_aletheore_dir_gitignored(repo_path)
     aletheore_dir = repo_path / ".aletheore"
     aletheore_dir.mkdir(parents=True, exist_ok=True)

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -141,6 +141,28 @@ def test_scan_repository_produces_full_schema(tmp_path):
     assert evidence["git"]["total_commits"] == 1
 
 
+def test_scan_repository_reports_the_same_file_count_across_repeated_scans(tmp_path):
+    # _ensure_aletheore_dir_gitignored used to run only in write_evidence,
+    # after the file-counting walk below had already happened - so the
+    # .gitignore it created was invisible to the scan that created it, but
+    # counted by the NEXT scan of the same, otherwise-untouched repo (a real
+    # repo scanned twice in a row reported 22 -> 23 -> 23, confirmed
+    # empirically). It now runs before any counting, in scan_repository
+    # itself, so every scan - including the first - already reflects it.
+    repo = make_repo(tmp_path)
+    assert not (repo / ".gitignore").exists()
+
+    with patch("aletheore.evidence.check_dependency_vulnerabilities") as mock_check:
+        mock_check.return_value = {"checked": True, "reason": None, "findings": []}
+        first = scan_repository(repo, check_licenses=False)
+        assert (repo / ".gitignore").exists()
+        second = scan_repository(repo, check_licenses=False)
+
+    first_python = next(e for e in first["repository"]["languages"] if e["name"] == "python")
+    second_python = next(e for e in second["repository"]["languages"] if e["name"] == "python")
+    assert first_python["file_count"] == second_python["file_count"]
+
+
 def test_scan_repository_honors_ignored_paths_from_config(tmp_path):
     repo = make_repo(tmp_path)
     vendor = repo / "vendor"


### PR DESCRIPTION
## Summary
- The other-Claude security audit found that scanning a repo mutates it: `_ensure_aletheore_dir_gitignored` ran only in `write_evidence`, after the file-counting walk in `scan_repository` had already happened. A real, otherwise-untouched repo scanned twice in a row reported different `scanned_files` counts (22 -> 23 -> 23, confirmed empirically) because the `.gitignore` created by scan 1 was invisible to scan 1's own count but counted by scan 2.
- Moved the call to the top of `scan_repository`, before any counting walk, so every scan - including the first - already reflects whatever `.gitignore` state results. Counts are now stable and reproducible from the first call onward.
- Left the call in `write_evidence` too, as a safety net for any caller that writes evidence without going through `scan_repository` (it's idempotent, so this is now usually a no-op there).

## Test plan
- [x] New test: scanning a fresh git repo (no `.gitignore`) twice in a row via `scan_repository` reports the same file count both times, and `.gitignore` already exists after the first scan
- [x] Full `test_evidence.py` suite: 50 passed
- [x] Full CLI/scanner suite: 1046 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)