### PR TITLE
fix: sort detector output arrays for deterministic AIR evidence

### DIFF
--- a/src/aletheore/scanner/detect.py
+++ b/src/aletheore/scanner/detect.py
@@ -412,6 +412,11 @@ def _detect_migration_directories(repo_path: Path) -> list[dict]:
         file_count = sum(1 for f in rails_migrate.iterdir() if f.is_file() and f.suffix == ".rb")
         results.append({"path": "db/migrate", "file_count": file_count})
 
+    # rglob traversal order is filesystem-dependent (APFS vs ext4 can order
+    # the same directory's entries differently) - sorted here so the same
+    # repo produces the same evidence bytes regardless of what it's scanned
+    # on.
+    results.sort(key=lambda entry: entry["path"])
     return results
 
 
@@ -438,6 +443,8 @@ def _detect_docker_compose_services(repo_path: Path) -> list[dict]:
                 results.append(
                     {"file": compose_file.relative_to(repo_path).as_posix(), "services": services}
                 )
+    # See _detect_migration_directories for why this is sorted.
+    results.sort(key=lambda entry: entry["file"])
     return results
 
 
@@ -462,6 +469,8 @@ def _detect_kubernetes_manifests(repo_path: Path) -> list[str]:
                 ):
                     results.append(candidate.relative_to(repo_path).as_posix())
                     break
+    # See _detect_migration_directories for why this is sorted.
+    results.sort()
     return results
 
 
@@ -472,6 +481,8 @@ def _detect_terraform_files(repo_path: Path) -> list[str]:
         if any(part in IGNORED_DIRS for part in rel_parts):
             continue
         results.append(candidate.relative_to(repo_path).as_posix())
+    # See _detect_migration_directories for why this is sorted.
+    results.sort()
     return results
 
 
@@ -482,6 +493,8 @@ def _detect_helm_charts(repo_path: Path) -> list[str]:
         if any(part in IGNORED_DIRS for part in rel_parts):
             continue
         results.append(candidate.relative_to(repo_path).as_posix())
+    # See _detect_migration_directories for why this is sorted.
+    results.sort()
     return results
 
 
@@ -500,6 +513,11 @@ def _detect_declared_env_vars(repo_path: Path) -> list[dict]:
                 name = stripped.split("=", 1)[0].strip()
                 if name and all(c.isalnum() or c == "_" for c in name):
                     results.append({"name": name, "source": source})
+    # Stable sort by source only (not name too) - which file gets visited
+    # first is what's filesystem-dependent and needs pinning down; each
+    # file's own variables should stay in their original declaration order.
+    # See _detect_migration_directories for the general rationale.
+    results.sort(key=lambda entry: entry["source"])
     return results
 
 

--- a/src/tests/test_detect.py
+++ b/src/tests/test_detect.py
@@ -553,6 +553,65 @@ def test_detect_helm_charts_finds_chart_yaml(tmp_path):
     assert result == ["charts/myapp/Chart.yaml"]
 
 
+def test_detect_terraform_files_returns_a_sorted_list(tmp_path):
+    # rglob traversal order is filesystem-dependent (confirmed: the same
+    # repo produced differently-ordered results on APFS vs ext4) - the
+    # detector must sort its own output rather than pass through whatever
+    # order the OS happens to return.
+    from aletheore.scanner.detect import _detect_terraform_files
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for name in ("zulu", "delta", "mike", "alpha"):
+        (repo / f"{name}.tf").write_text('resource "x" "y" {}\n')
+
+    result = _detect_terraform_files(repo)
+
+    assert result == sorted(result)
+    assert result == ["alpha.tf", "delta.tf", "mike.tf", "zulu.tf"]
+
+
+def test_detect_helm_charts_returns_a_sorted_list(tmp_path):
+    from aletheore.scanner.detect import _detect_helm_charts
+
+    repo = tmp_path / "repo"
+    for name in ("zulu", "alpha", "mike"):
+        chart_dir = repo / "charts" / name
+        chart_dir.mkdir(parents=True)
+        (chart_dir / "Chart.yaml").write_text("apiVersion: v2\nname: x\nversion: 0.1.0\n")
+
+    result = _detect_helm_charts(repo)
+
+    assert result == sorted(result)
+    assert result == [
+        "charts/alpha/Chart.yaml",
+        "charts/mike/Chart.yaml",
+        "charts/zulu/Chart.yaml",
+    ]
+
+
+def test_detect_declared_env_vars_orders_by_source_but_preserves_line_order_within_it(tmp_path):
+    # ENV_FILE_MARKERS are exact filenames (".env.example", etc.), not
+    # globs - each source here lives in its own subdirectory so two
+    # differently-named markers can still be told apart by path.
+    from aletheore.scanner.detect import _detect_declared_env_vars
+
+    repo = tmp_path / "repo"
+    (repo / "zulu").mkdir(parents=True)
+    (repo / "zulu" / ".env.example").write_text("SECOND=1\nFIRST=2\n")
+    (repo / "alpha").mkdir(parents=True)
+    (repo / "alpha" / ".env.sample").write_text("FOURTH=3\nTHIRD=4\n")
+
+    result = _detect_declared_env_vars(repo)
+
+    assert result == [
+        {"name": "FOURTH", "source": "alpha/.env.sample"},
+        {"name": "THIRD", "source": "alpha/.env.sample"},
+        {"name": "SECOND", "source": "zulu/.env.example"},
+        {"name": "FIRST", "source": "zulu/.env.example"},
+    ]
+
+
 def test_detect_infrastructure_categories_return_empty_when_nothing_present(tmp_path):
     from aletheore.scanner.detect import (
         _detect_helm_charts,


### PR DESCRIPTION
## Summary
- The other-Claude security audit confirmed that six detectors (migration directories, docker-compose services, kubernetes manifests, terraform files, helm charts, declared env vars) build their result lists in `Path.rglob()` traversal order, which is filesystem-dependent - the same repo yields differently-ordered `terraform_files` (and the other five) on APFS vs ext4.
- Each now sorts its own output before returning. For env vars specifically: sorted by source file only (stable sort), preserving each file's own line-declaration order - only which file gets visited first was the non-deterministic part.

## Test plan
- [x] New tests: terraform files, helm charts, and env vars each get a multi-file case proving sorted (by path/source) output; env var test specifically confirms within-file line order survives the sort
- [x] Full `test_detect.py` suite: 51 passed
- [x] Full CLI/scanner suite: 1047 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)