### PR TITLE
fix: read Paddle discount id from nested discount.id, not flat discount_id

### DIFF
--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -129,7 +129,7 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         # re-attribute or steal credit - record_referral is also itself a
         # database-enforced no-op past the first row (installation_id is
         # that table's primary key).
-        discount_id = data.get("discount_id")
+        discount_id = (data.get("discount") or {}).get("id")
         if discount_id:
             affiliate = await get_affiliate_by_discount_id(pool, discount_id)
             if affiliate is not None:

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -52,7 +52,11 @@ def _subscription_created_payload(
         },
     }
     if discount_id is not None:
-        payload["data"]["discount_id"] = discount_id
+        # Real Paddle subscription payloads nest this under a `discount`
+        # object (`data.discount.id`) - there is no flat `discount_id`
+        # field. Matching that shape here is what caught the production
+        # bug where the handler read the flat field and never found it.
+        payload["data"]["discount"] = {"id": discount_id}
     return payload
 
 


### PR DESCRIPTION
## Summary
- Real Paddle `subscription.created` payloads nest the discount code under `data.discount.id`, not a flat `data.discount_id`. The affiliate referral-attribution code read the flat field, which was always `None` in production — so no free→paid checkout has ever recorded an affiliate referral, even with a valid discount code applied.
- Caught via a real live checkout today: applied a 100%-off test discount tied to a test affiliate, completed a real Paddle checkout, and found `affiliate_referrals` had zero rows despite Paddle confirming the discount was correctly applied to the subscription.
- Test fixtures built the same flat shape the buggy code expected, which is why CI never caught this. Updated the fixture to match Paddle's real payload shape (`data.discount.id`), which is what actually exercises the fix.

## Test plan
- [x] `pytest tests/test_webhooks_paddle.py tests/test_affiliates.py tests/test_admin_affiliates.py` — 65 passed
- [ ] Full suite running
- [ ] Re-run the real checkout against the fixed code once deployed, confirm `affiliate_referrals` and `affiliate_commissions` populate correctly