### PR TITLE
fix: validate MCP/dashboard evidence reads against full AIR schema + 2 doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ PHP, C, C++, and C#**.
   against your own repo — see [`src/README.md`](src/README.md) for why it isn't wired into CI.
 - **`aletheore query`** / **`aletheore diff`** — answer a targeted question or compare two
   scans from existing evidence, no re-scan or LLM call needed.
-- **`aletheore mcp`** — a stdio MCP server exposing 28 tools (module/symbol/dependency lookups,
+- **`aletheore mcp`** — a stdio MCP server exposing 27 tools by default (28 with
+  `ALETHEORE_MCP_ALLOW=external` enabled) (module/symbol/dependency lookups,
   ownership, clusters, dead code, hotspots, full-text and semantic search, scan and index
   triggers) so a coding agent can query your repo's structure directly instead of shelling out
   or re-reading files on every lookup. `aletheore mcp-install` wires it into Claude Code,

--- a/docs/operations/SLOS.md
+++ b/docs/operations/SLOS.md
@@ -23,6 +23,10 @@ These targets are internal engineering objectives, not customer SLAs.
 
 ## Alert Candidates
 
+**None of these are wired up yet** - this is a proposed list, not a status
+report. No alerting/paging exists in the codebase for any of them as of
+2026-08-11.
+
 - App server unavailable for 2 consecutive checks.
 - Queue depth above threshold for 10 minutes.
 - Failed jobs above threshold for 10 minutes.

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -12,7 +12,13 @@ from mcp.types import ToolAnnotations
 from aletheore.adapters.base import AgentAdapter
 from aletheore.answer import answer_question
 from aletheore.credentials import get_api_key
-from aletheore.evidence import EVIDENCE_VERSION, is_evidence_version_compatible, scan_repository, write_evidence
+from aletheore.evidence import (
+    IncompatibleEvidenceVersionError,
+    MalformedEvidenceError,
+    load_evidence_file,
+    scan_repository,
+    write_evidence,
+)
 from aletheore.healthcheck import run_healthcheck, save_healthcheck
 from aletheore.history import compute_diff, list_snapshots, save_snapshot
 from aletheore.managed_audit_client import run_managed_audit_request
@@ -46,10 +52,6 @@ from aletheore.toon_encoding import to_toon
 _evidence_cache: dict[Path, tuple[tuple[float, int], dict]] = {}
 
 
-class IncompatibleEvidenceVersionError(Exception):
-    pass
-
-
 def read_evidence(repo_path: Path) -> dict:
     evidence_path = repo_path / ".aletheore" / "air.json"
     if not evidence_path.exists():
@@ -62,14 +64,16 @@ def read_evidence(repo_path: Path) -> dict:
     cached = _evidence_cache.get(repo_path)
     if cached is not None and cached[0] == cache_key:
         return cached[1]
-    evidence = json.loads(evidence_path.read_text())
-    written_version = evidence.get("aletheore_version")
-    if not is_evidence_version_compatible(written_version):
-        raise IncompatibleEvidenceVersionError(
-            f"{evidence_path} was written by aletheore_version={written_version!r}, which "
-            f"isn't compatible with this build's evidence schema ({EVIDENCE_VERSION}) - "
-            f"re-run 'aletheore scan {repo_path}' to refresh it"
-        )
+    # Routes through the same version-compatibility AND schema-shape checks
+    # every other evidence reader (CLI query/index/diff/healthcheck) uses,
+    # rather than a bare json.loads - a truncated or hand-edited air.json
+    # with a *compatible* version used to pass straight through here and
+    # only surface as a raw KeyError deep inside whichever tool first
+    # touched the missing/wrong field, instead of one clear, actionable
+    # error up front (IncompatibleEvidenceVersionError / MalformedEvidenceError,
+    # both re-exported from aletheore.evidence so callers of either module
+    # catch the same exception types).
+    evidence = load_evidence_file(evidence_path)
     _evidence_cache[repo_path] = (cache_key, evidence)
     return evidence
 

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -10,6 +10,7 @@ from aletheore.dashboard import (
     build_history_summary,
 )
 from aletheore.evidence import EVIDENCE_VERSION
+from tests.air_fixtures import minimal_air_evidence
 
 
 def make_evidence(scanned_at: str, module_count: int = 2, secrets_count: int = 0) -> dict:
@@ -28,7 +29,11 @@ def make_evidence(scanned_at: str, module_count: int = 2, secrets_count: int = 0
         },
         "git": {
             "total_commits": 10,
-            "commit_cadence": {"weekly_counts": [1, 2, 3], "trend": "steady"},
+            "commit_cadence": {
+                "weekly_counts": [1, 2, 3],
+                "trend": "steady",
+                "most_recent_week_partial": False,
+            },
             "ownership": [{"path": "m0.py", "top_author": "alice"}],
             "branches": [{"name": "main", "ahead_of_main": 0}],
         },
@@ -161,11 +166,27 @@ def test_build_graph_summary_handles_unclustered_node():
     assert result["nodes"] == [{"id": "orphan.py", "cluster": None}]
 
 
+def _deep_merge(base: dict, overrides: dict) -> dict:
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
 def make_repo_with_evidence(tmp_path: Path) -> Path:
+    # Merged onto minimal_air_evidence() (schema-valid, every collection
+    # empty) rather than written as-is - the dashboard API now routes
+    # through read_evidence -> load_evidence_file, which validates full AIR
+    # schema shape. make_evidence()'s hand-rolled dict, used directly (in
+    # memory, never through this file-writing path) by many other tests
+    # here, omits several required keys nothing used to check for.
     repo = tmp_path / "repo"
     aletheore_dir = repo / ".aletheore"
     aletheore_dir.mkdir(parents=True)
-    (aletheore_dir / "air.json").write_text(json.dumps(make_evidence("2026-07-15T12:00:00+00:00")))
+    evidence = _deep_merge(minimal_air_evidence(), make_evidence("2026-07-15T12:00:00+00:00"))
+    (aletheore_dir / "air.json").write_text(json.dumps(evidence))
     return repo
 
 

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -7,9 +7,9 @@ import pytest
 import toon
 from mcp.server.mcpserver.exceptions import ToolError
 
-from aletheore.evidence import EVIDENCE_VERSION
 from aletheore.mcp_server import build_server
 from aletheore.search_index import IndexNotFoundError
+from tests.air_fixtures import minimal_air_evidence
 
 
 def tool_result_body(result):
@@ -24,11 +24,17 @@ def make_repo_with_evidence(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     aletheore_dir = repo / ".aletheore"
     aletheore_dir.mkdir(parents=True)
-    evidence = {
-        "aletheore_version": EVIDENCE_VERSION,
-        "scanned_at": "2026-07-15T10:00:00+00:00",
-        "repo_path": str(repo),
-        "repository": {
+    # Starts from minimal_air_evidence() (schema-valid, every collection
+    # empty) rather than a hand-rolled dict - read_evidence now routes
+    # through load_evidence_file, which validates full AIR schema shape,
+    # not just the version stamp. A hand-rolled dict here previously got
+    # away with omitting several required repository.* keys (ai_usage,
+    # build_tools, frameworks, monorepo, policy_docs) because nothing ever
+    # checked for them.
+    evidence = minimal_air_evidence()
+    evidence["scanned_at"] = "2026-07-15T10:00:00+00:00"
+    evidence["repo_path"] = str(repo)
+    evidence["repository"].update({
             "languages": [{"name": "python", "file_count": 2}],
             "modules": [
                 {
@@ -81,34 +87,35 @@ def make_repo_with_evidence(tmp_path: Path) -> Path:
             "environment_variables": {
                 "declared": [{"name": "FOO", "source": ".env.example"}],
             },
-        },
-        "git": {
-            "branches": [{"name": "main", "ahead_of_main": 0}],
-            "ownership": [{"path": "a.py", "top_author": "alice"}],
-            "total_commits": 5,
-            "hotspots": [
-                {
-                    "path": "a.py",
-                    "churn_count": 3,
-                    "co_change_partners": [{"path": "b.py", "co_occurrences": 2}],
-                    "dependents_count": 0,
-                }
-            ],
-        },
-        "security": {
-            "secrets": {
-                "findings": [],
-                "history_scanned_commits": 0,
-                "history_findings": [],
-            },
-            "dependency_vulnerabilities": {"checked": True, "reason": None, "findings": []},
-        },
-        "architecture": {
-            "clusters": [{"id": 0, "modules": ["a.py", "b.py"]}],
-            "cross_cluster_edges": [],
-            "layer_violations": {"convention_detected": False, "layers": [], "violations": []},
-        },
+    })
+    evidence["git"].update({
+        "branches": [{"name": "main", "ahead_of_main": 0}],
+        "ownership": [{"path": "a.py", "top_author": "alice"}],
+        "total_commits": 5,
+        "hotspots": [
+            {
+                "path": "a.py",
+                "churn_count": 3,
+                "co_change_partners": [{"path": "b.py", "co_occurrences": 2}],
+                "dependents_count": 0,
+            }
+        ],
+    })
+    evidence["security"]["secrets"].update({
+        "findings": [],
+        "history_scanned_commits": 0,
+        "history_findings": [],
+    })
+    evidence["security"]["dependency_vulnerabilities"] = {
+        "checked": True,
+        "reason": None,
+        "findings": [],
     }
+    evidence["architecture"].update({
+        "clusters": [{"id": 0, "modules": ["a.py", "b.py"]}],
+        "cross_cluster_edges": [],
+        "layer_violations": {"convention_detected": False, "layers": [], "violations": []},
+    })
     (aletheore_dir / "air.json").write_text(json.dumps(evidence))
     (repo / "a.py").write_text("def foo():\n    return 1\n")
     return repo
@@ -154,8 +161,29 @@ def test_read_evidence_caches_parsed_result_until_the_file_changes(tmp_path, mon
     assert third["scanned_at"].startswith("2026-07-16")
 
 
+def test_read_evidence_rejects_a_malformed_but_version_compatible_file(tmp_path, monkeypatch):
+    # read_evidence used to only check the version stamp, via its own bare
+    # json.loads - a truncated or hand-edited air.json with a *compatible*
+    # version passed straight through and only failed later as a raw
+    # KeyError deep inside whichever tool first touched the missing/wrong
+    # field, instead of one clear, actionable error naming what's wrong.
+    from aletheore.evidence import MalformedEvidenceError
+    from aletheore.mcp_server import read_evidence
+
+    monkeypatch.setattr("aletheore.mcp_server._evidence_cache", {})
+    repo = make_repo_with_evidence(tmp_path)
+    evidence_path = repo / ".aletheore" / "air.json"
+    evidence = json.loads(evidence_path.read_text())
+    del evidence["repository"]
+    evidence_path.write_text(json.dumps(evidence))
+
+    with pytest.raises(MalformedEvidenceError):
+        read_evidence(repo)
+
+
 def test_read_evidence_rejects_an_incompatible_schema_version(tmp_path, monkeypatch):
-    from aletheore.mcp_server import IncompatibleEvidenceVersionError, read_evidence
+    from aletheore.evidence import IncompatibleEvidenceVersionError
+    from aletheore.mcp_server import read_evidence
 
     monkeypatch.setattr("aletheore.mcp_server._evidence_cache", {})
     repo = make_repo_with_evidence(tmp_path)
@@ -169,7 +197,8 @@ def test_read_evidence_rejects_an_incompatible_schema_version(tmp_path, monkeypa
 
 
 def test_read_evidence_rejects_evidence_with_no_version_field(tmp_path, monkeypatch):
-    from aletheore.mcp_server import IncompatibleEvidenceVersionError, read_evidence
+    from aletheore.evidence import IncompatibleEvidenceVersionError
+    from aletheore.mcp_server import read_evidence
 
     monkeypatch.setattr("aletheore.mcp_server._evidence_cache", {})
     repo = make_repo_with_evidence(tmp_path)


### PR DESCRIPTION
## Summary
Follow-up from the same audit as #195, verified against real code:

- `mcp_server.py`'s `read_evidence` (and, transitively, `dashboard.py` which imports it) only checked the `aletheore_version` stamp via a bare `json.loads` - a truncated or hand-edited `air.json` with a compatible version passed straight through and only surfaced as a raw `KeyError` deep inside whichever tool first touched the missing/wrong field. `evidence.py`'s `load_evidence_file` docstring already claimed every evidence reader including the MCP server routed through it - it didn't. Fixed by routing `read_evidence` through `load_evidence_file` directly (keeping its own mtime/size in-process cache on top).
- Removed `mcp_server`'s own separate `IncompatibleEvidenceVersionError` class, which shadowed `evidence.py`'s exception of the same name - catching one wouldn't catch the other depending which module raised it.
- Test fixtures in `test_mcp_server.py` and `test_dashboard.py` were never AIR-schema-complete (nothing validated shape before), now built on `minimal_air_evidence()` with each fixture's specific data merged on top.
- `SLOS.md`'s "Alert Candidates" now says plainly none of them are wired up yet (confirmed zero matches anywhere in the codebase for any of them).
- README's MCP tool count corrected from a flat "28 tools" to "27 by default (28 with `ALETHEORE_MCP_ALLOW=external`)".

Based on master directly (independent of #195, which is still in review).

## Test plan
- [x] `pytest src/tests/` — 1055 passed
- [x] New schema-validation test confirmed to fail before the fix and pass after