### PR TITLE
fix: close C-1 scan-cache trust boundary in the public demo sandbox too

### DIFF
--- a/github-app/scripts/demo_sandbox_entrypoint.sh
+++ b/github-app/scripts/demo_sandbox_entrypoint.sh
@@ -9,6 +9,17 @@ set -eu
 
 REPO_URL="$1"
 
+# This clones and scans an arbitrary public repo a stranger on the internet
+# just typed into the website demo - the repo author fully controls its
+# content, including any .aletheore/scan-cache.json they choose to commit.
+# Without this, a poisoned cache entry (matching content hash, fabricated
+# parse result) would be trusted verbatim instead of re-parsed, letting
+# anyone make the demo show a fake "clean" result for their own repo. See
+# aletheore.evidence's _DISABLE_LOCAL_SCAN_CACHE_ENV for the full reasoning
+# - this is the same fix applied to the hosted scan-worker's own subprocess
+# calls, applied here too since this path never goes through jobs.py at all.
+export ALETHEORE_DISABLE_LOCAL_SCAN_CACHE=1
+
 git clone -q --depth 1 --single-branch "$REPO_URL" /work/repo 1>&2
 aletheore scan /work/repo --no-check-vulnerabilities 1>&2
 cat /work/repo/.aletheore/air.json


### PR DESCRIPTION
## Summary
#195 fixed the hosted scan-worker's own subprocess calls but missed a second, more directly exposed instance of the same bug: the public unauthenticated "paste a repo" demo runs \`aletheore scan\` on an arbitrary attacker-supplied repo via a completely separate path (\`demo_sandbox_entrypoint.sh\`, invoked by \`demo_sandbox_runner.py\`'s \`docker run --runtime=runsc\`) that never touches \`jobs.py\` at all.

Anyone can commit a poisoned \`.aletheore/scan-cache.json\` to their own public repo and get the live demo to show a fabricated "clean" result for it - directly undermining the one thing the demo exists to showcase.

Same fix as #195 (\`ALETHEORE_DISABLE_LOCAL_SCAN_CACHE=1\`), set in the entrypoint script itself since this container has no `docker run -e` env passthrough and never goes through the Python subprocess-env path #195 touched.

**Deploy note:** requires rebuilding the \`aletheore-demo-sandbox\` image specifically - it's built ad-hoc by \`demo_sandbox_runner.py\`, not part of the \`docker compose --build scan-worker app-server\` set already deployed for #195.

## Test plan
- [x] `sh -n` syntax check passes
- No existing test directly exercises this shell entrypoint (integration-tested only); the fix is a minimal, obviously-correct one-line env var addition mirroring the already-tested Python-side fix in #195