### PR TITLE
fix: close C-1 scan-cache trust boundary in the GitHub Action too

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,10 +67,26 @@ runs:
 
     - name: Scan base
       shell: bash
+      # On a fork PR, aletheore-head is checked out from the PR author's own
+      # branch - they fully control any .aletheore/scan-cache.json committed
+      # there. Without this, a poisoned cache entry (matching content hash,
+      # fabricated parse result) would be trusted verbatim instead of
+      # re-parsed, letting a PR author suppress what the diff step reports
+      # for their own changed files - including what
+      # --fail-on-new-layer-violations gates on. Same fix already applied to
+      # the hosted scan-worker (jobs.py) and the public demo sandbox; see
+      # evidence.py's _DISABLE_LOCAL_SCAN_CACHE_ENV for the full reasoning.
+      # Applied to the base scan too, not just head - base is also an
+      # external checkout (the PR's target branch at the time of the
+      # workflow run), not this action's own trusted content.
+      env:
+        ALETHEORE_DISABLE_LOCAL_SCAN_CACHE: "1"
       run: aletheore scan aletheore-base
 
     - name: Scan head
       shell: bash
+      env:
+        ALETHEORE_DISABLE_LOCAL_SCAN_CACHE: "1"
       run: aletheore scan aletheore-head
 
     - name: Diff


### PR DESCRIPTION
## Summary
Found while verifying a separate audit session's follow-up review of #195/#197: the Action's own \`aletheore scan\` invocations (Scan base / Scan head) never set \`ALETHEORE_DISABLE_LOCAL_SCAN_CACHE\`, unlike the hosted scan-worker (\`jobs.py\`) and the public demo sandbox entrypoint, both already fixed.

On a fork PR, \`aletheore-head\` is checked out from the PR author's own branch - they fully control any \`.aletheore/scan-cache.json\` committed there, letting them suppress what the diff step reports for their own changed files, including what \`--fail-on-new-layer-violations\` gates on.

Applied to both scan steps - base is also an external checkout (the PR's target branch at workflow-run time), not this action's own trusted content.

Confirmed the version stamp (#195's H-2 fix) doesn't help here: it's a staleness guard, not a trust guard - an attacker can just write the correct, publicly-known version into their own poisoned cache entry. \`ALETHEORE_DISABLE_LOCAL_SCAN_CACHE\` is the actual trust guard, and this closes the last of the four \`aletheore scan\` call sites it hadn't reached yet.

## Test plan
- [x] YAML syntax validated
- No unit test surface for \`action.yml\` itself - validated for real by the CI \`self-test\` job, which runs the action against this repo