### PR TITLE
fix: close the DNS-rebinding window in the hosted health-check sweep

### DIFF
--- a/github-app/app_server/url_validation.py
+++ b/github-app/app_server/url_validation.py
@@ -7,7 +7,7 @@ class UnsafeURLError(ValueError):
     pass
 
 
-def validate_external_https_url(raw: str) -> str:
+def _validate_and_resolve(raw: str) -> list[str]:
     parsed = urlparse(raw)
     if parsed.scheme != "https":
         raise UnsafeURLError("URL must use https")
@@ -21,8 +21,10 @@ def validate_external_https_url(raw: str) -> str:
     except socket.gaierror as exc:
         raise UnsafeURLError(f"could not resolve host '{hostname}'") from exc
 
+    resolved_ips = []
     for entry in addresses:
-        ip = ipaddress.ip_address(entry[4][0])
+        ip_str = entry[4][0]
+        ip = ipaddress.ip_address(ip_str)
         if (
             ip.is_private
             or ip.is_loopback
@@ -32,5 +34,26 @@ def validate_external_https_url(raw: str) -> str:
             or ip.is_unspecified
         ):
             raise UnsafeURLError(f"'{hostname}' resolves to a disallowed address")
+        resolved_ips.append(ip_str)
+    return resolved_ips
 
+
+def validate_external_https_url(raw: str) -> str:
+    _validate_and_resolve(raw)
     return raw
+
+
+def validate_and_pin_https_url(raw: str) -> tuple[str, str]:
+    """Same validation as validate_external_https_url, but also returns one
+    of the resolved-safe IPs the caller can pin its actual connection to.
+
+    validate_external_https_url alone only narrows the DNS-rebinding window
+    (a hostname that resolves safely here can still resolve somewhere
+    unsafe by the time the real request's own DNS lookup runs) rather than
+    closing it - resolving once and reusing that exact address for the
+    connection (see aletheore.healthcheck.run_healthcheck's pinned_ip)
+    closes it to zero, since there is no second, independent resolution
+    left to race.
+    """
+    resolved_ips = _validate_and_resolve(raw)
+    return raw, resolved_ips[0]

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -46,7 +46,7 @@ from app_server.rate_limit import (
     cooldown_seconds_for_loc,
     total_loc_from_evidence,
 )
-from app_server.url_validation import UnsafeURLError, validate_external_https_url
+from app_server.url_validation import UnsafeURLError, validate_and_pin_https_url
 from aletheore.docs_reference import build_api_reference
 from scan_worker import live_docs, live_wiki
 from scan_worker.db import (
@@ -1489,11 +1489,11 @@ def _send_if_webhook_configured(installation: dict, message: dict) -> None:
         send_health_alert(webhook_url, message)
 
 
-def _endpoint_results(evidence: dict, base_url: str) -> list[dict]:
+def _endpoint_results(evidence: dict, base_url: str, pinned_ip: str) -> list[dict]:
     endpoints = evidence.get("repository", {}).get("api_endpoints", {}).get("endpoints", [])
     if not endpoints:
         return []
-    results = run_healthcheck(endpoints, base_url).get("results", [])
+    results = run_healthcheck(endpoints, base_url, pinned_ip=pinned_ip).get("results", [])
     for endpoint, result in zip(endpoints, results, strict=False):
         if endpoint.get("file") is not None:
             result["file"] = endpoint["file"]
@@ -1534,9 +1534,9 @@ def _latency_flipped(
     return (prior["latency_ms"] > threshold_ms) != now_over
 
 
-def _recheck_single_endpoint(entry: dict, base_url: str) -> dict:
+def _recheck_single_endpoint(entry: dict, base_url: str, pinned_ip: str) -> dict:
     minimal_endpoint = {"method": entry.get("method"), "path": entry["path"]}
-    results = run_healthcheck([minimal_endpoint], base_url).get("results", [])
+    results = run_healthcheck([minimal_endpoint], base_url, pinned_ip=pinned_ip).get("results", [])
     if not results:
         return {
             "reachable": False,
@@ -1850,15 +1850,23 @@ def _run_health_check_sweep_for_target(
 ) -> None:
     # validate_external_https_url only ever ran once, when the target was
     # saved (admin.py) - re-checking here, immediately before every fetch,
-    # closes the DNS-rebinding window down to the gap between this call and
-    # the actual request instead of "until someone edits the target again."
-    # A customer could otherwise register a domain that resolves to a public
-    # IP at save time, pass validation, then repoint DNS at an internal
-    # service or cloud metadata endpoint before the next sweep - whose
-    # response would then get echoed back to that customer's own dashboard
-    # via response_shape.
+    # closes the DNS-rebinding window down to the gap between this
+    # validation and the actual request instead of "until someone edits the
+    # target again." A customer could otherwise register a domain that
+    # resolves to a public IP at save time, pass validation, then repoint
+    # DNS at an internal service or cloud metadata endpoint before the next
+    # sweep - whose response would then get echoed back to that customer's
+    # own dashboard via response_shape.
+    #
+    # validate_and_pin_https_url (rather than validate_external_https_url)
+    # closes that remaining gap too: the actual health-check requests below
+    # connect to pinned_ip directly instead of re-resolving base_url's
+    # hostname themselves, so there is no second, independent DNS lookup
+    # left for a rebind to win. Reused for every request this sweep makes
+    # (including retries) - re-resolving mid-sweep would just reopen the
+    # window this was meant to close.
     try:
-        validate_external_https_url(base_url)
+        _, pinned_ip = validate_and_pin_https_url(base_url)
     except UnsafeURLError as exc:
         logging.getLogger("scan_worker.jobs").warning(
             "skipping health check for installation=%s repo=%s target=%s - %s",
@@ -1873,7 +1881,7 @@ def _run_health_check_sweep_for_target(
     if evidence is None:
         return
 
-    for entry in _endpoint_results(evidence, base_url):
+    for entry in _endpoint_results(evidence, base_url, pinned_ip):
         if entry.get("skipped"):
             continue
         method = entry["method"]
@@ -1901,7 +1909,7 @@ def _run_health_check_sweep_for_target(
         if reachability_flipped and not reachable:
             for _ in range(HEALTH_CHECK_DOWN_RETRY_ATTEMPTS):
                 time.sleep(HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS)
-                retry_result = _recheck_single_endpoint(entry, base_url)
+                retry_result = _recheck_single_endpoint(entry, base_url, pinned_ip)
                 if retry_result.get("reachable"):
                     reachable = True
                     status_code = retry_result.get("status_code")

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1893,7 +1893,9 @@ def _patch_sweep(
     monkeypatch.setattr("scan_worker.jobs.time.sleep", lambda *a, **k: None)
     # Real DNS resolution has no place in a unit test - SSRF re-validation
     # itself is covered by its own dedicated tests below.
-    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", lambda url: url)
+    monkeypatch.setattr(
+        "scan_worker.jobs.validate_and_pin_https_url", lambda url: (url, "93.184.216.34")
+    )
     monkeypatch.setattr(
         "scan_worker.jobs.list_health_check_targets_all",
         lambda dsn: [
@@ -1923,7 +1925,7 @@ def _patch_sweep(
     }
     calls = {"count": 0}
 
-    def fake_healthcheck(endpoints, base_url):
+    def fake_healthcheck(endpoints, base_url, pinned_ip=None):
         calls["count"] += 1
         if calls["count"] == 1 or retry_result_entry is None:
             return {"results": [default_first]}
@@ -2021,7 +2023,7 @@ def test_sweep_does_not_retry_a_recovery_flip(monkeypatch):
     )
     monkeypatch.setattr(
         "scan_worker.jobs.run_healthcheck",
-        lambda endpoints, base_url: healthcheck_calls.append(True)
+        lambda endpoints, base_url, pinned_ip=None: healthcheck_calls.append(True)
         or {
             "results": [
                 {
@@ -2306,7 +2308,9 @@ def test_sweep_isolates_one_targets_failure_from_others(monkeypatch):
     # take down the sweep for every other installation - this job runs
     # every HEALTH_SWEEP_INTERVAL_SECONDS for the whole customer base.
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", lambda url: url)
+    monkeypatch.setattr(
+        "scan_worker.jobs.validate_and_pin_https_url", lambda url: (url, "93.184.216.34")
+    )
     monkeypatch.setattr(
         "scan_worker.jobs.list_health_check_targets_all",
         lambda dsn: [
@@ -2339,7 +2343,7 @@ def test_sweep_isolates_one_targets_failure_from_others(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", fake_get_latest_evidence)
     monkeypatch.setattr(
         "scan_worker.jobs.run_healthcheck",
-        lambda endpoints, base_url: {
+        lambda endpoints, base_url, pinned_ip=None: {
             "results": [{"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 90.0}]
         },
     )
@@ -2386,7 +2390,7 @@ def test_sweep_revalidates_target_url_before_every_fetch_and_skips_on_ssrf_failu
     def fake_validate(url):
         raise UnsafeURLError(f"'{url}' now resolves to a disallowed address")
 
-    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", fake_validate)
+    monkeypatch.setattr("scan_worker.jobs.validate_and_pin_https_url", fake_validate)
 
     evidence_calls = []
     monkeypatch.setattr(
@@ -2397,7 +2401,7 @@ def test_sweep_revalidates_target_url_before_every_fetch_and_skips_on_ssrf_failu
     fetch_calls = []
     monkeypatch.setattr(
         "scan_worker.jobs.run_healthcheck",
-        lambda endpoints, base_url: fetch_calls.append(True)
+        lambda endpoints, base_url, pinned_ip=None: fetch_calls.append(True)
         or {"results": [{"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 1.0}]},
     )
     monkeypatch.setattr("scan_worker.jobs.insert_endpoint_health", lambda *a, **k: None)
@@ -2431,8 +2435,8 @@ def test_sweep_proceeds_when_target_url_still_passes_validation(monkeypatch):
 
     validated_urls = []
     monkeypatch.setattr(
-        "scan_worker.jobs.validate_external_https_url",
-        lambda url: validated_urls.append(url) or url,
+        "scan_worker.jobs.validate_and_pin_https_url",
+        lambda url: validated_urls.append(url) or (url, "93.184.216.34"),
     )
     monkeypatch.setattr(
         "scan_worker.jobs.get_latest_evidence",
@@ -2440,7 +2444,7 @@ def test_sweep_proceeds_when_target_url_still_passes_validation(monkeypatch):
     )
     monkeypatch.setattr(
         "scan_worker.jobs.run_healthcheck",
-        lambda endpoints, base_url: {
+        lambda endpoints, base_url, pinned_ip=None: {
             "results": [{"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 1.0}]
         },
     )
@@ -2530,7 +2534,9 @@ def test_sweep_checks_every_target_independently(monkeypatch):
     # one up - must each be checked and alerted on their own, not merged or
     # short-circuited after the first.
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.validate_external_https_url", lambda url: url)
+    monkeypatch.setattr(
+        "scan_worker.jobs.validate_and_pin_https_url", lambda url: (url, "93.184.216.34")
+    )
     monkeypatch.setattr(
         "scan_worker.jobs.list_health_check_targets_all",
         lambda dsn: [
@@ -2560,7 +2566,7 @@ def test_sweep_checks_every_target_independently(monkeypatch):
         lambda dsn, iid, repo: {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
     )
 
-    def fake_healthcheck(endpoints, base_url):
+    def fake_healthcheck(endpoints, base_url, pinned_ip=None):
         reachable = base_url == "https://staging.example.com"
         return {
             "results": [

--- a/github-app/tests/test_url_validation.py
+++ b/github-app/tests/test_url_validation.py
@@ -2,7 +2,7 @@ import socket
 
 import pytest
 
-from app_server.url_validation import UnsafeURLError, validate_external_https_url
+from app_server.url_validation import UnsafeURLError, validate_and_pin_https_url, validate_external_https_url
 
 
 def _fake_addrinfo(ip: str):
@@ -57,3 +57,27 @@ def test_allows_public_address(monkeypatch):
         lambda *a, **k: _fake_addrinfo("93.184.216.34"),
     )
     assert validate_external_https_url("https://api.example.com") == "https://api.example.com"
+
+
+def test_validate_and_pin_returns_the_resolved_ip_alongside_the_url(monkeypatch):
+    monkeypatch.setattr(
+        "app_server.url_validation.socket.getaddrinfo",
+        lambda *a, **k: _fake_addrinfo("93.184.216.34"),
+    )
+    url, pinned_ip = validate_and_pin_https_url("https://api.example.com")
+    assert url == "https://api.example.com"
+    assert pinned_ip == "93.184.216.34"
+
+
+def test_validate_and_pin_rejects_internal_addresses_same_as_validate(monkeypatch):
+    monkeypatch.setattr(
+        "app_server.url_validation.socket.getaddrinfo",
+        lambda *a, **k: _fake_addrinfo("169.254.169.254"),
+    )
+    with pytest.raises(UnsafeURLError, match="disallowed"):
+        validate_and_pin_https_url("https://internal.example.com")
+
+
+def test_validate_and_pin_rejects_non_https_scheme():
+    with pytest.raises(UnsafeURLError, match="https"):
+        validate_and_pin_https_url("http://api.example.com")

--- a/src/aletheore/healthcheck.py
+++ b/src/aletheore/healthcheck.py
@@ -1,3 +1,4 @@
+import http.client
 import json
 import re
 import ssl
@@ -53,6 +54,70 @@ _NO_REDIRECT_OPENER = urllib.request.build_opener(
     _NoRedirectHandler, urllib.request.HTTPSHandler(context=_SSL_CONTEXT)
 )
 
+
+def _pinned_connection_class(base_class: type, pinned_ip: str) -> type:
+    # A caller that already resolved and validated a hostname (rejecting
+    # private/internal IPs - see app_server/url_validation.py) still hands
+    # this module a hostname, not an IP: http.client.HTTPConnection.connect()
+    # calls self._create_connection((self.host, self.port), ...), which
+    # re-resolves DNS independently of - and later than - that validation. A
+    # DNS record that changes between the two lookups (a "rebind") would then
+    # have this module connect somewhere the caller never actually validated.
+    #
+    # _create_connection is set as an INSTANCE attribute in HTTPConnection's
+    # own __init__ (its own comment: "to allow unit tests to replace it with
+    # a suitable mockup"), so overriding it as a class-level method would be
+    # silently shadowed by every new instance re-setting it in __init__.
+    # Wrapping it right after super().__init__() runs, as intended, closes
+    # the gap to zero: resolution and connection become the same step
+    # instead of two. HTTPS still verifies the certificate against the
+    # original hostname (self.host, untouched) via SNI, so this only changes
+    # which address is dialed, not what identity is trusted.
+    class _Pinned(base_class):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            _real_create_connection = self._create_connection
+
+            def _create_connection(address, *cc_args, **cc_kwargs):
+                _hostname, port = address
+                return _real_create_connection((pinned_ip, port), *cc_args, **cc_kwargs)
+
+            self._create_connection = _create_connection
+
+    _Pinned.__name__ = f"Pinned{base_class.__name__}"
+    return _Pinned
+
+
+def _opener_for(pinned_ip: str | None) -> urllib.request.OpenerDirector:
+    if pinned_ip is None:
+        return _NO_REDIRECT_OPENER
+    pinned_https = _pinned_connection_class(http.client.HTTPSConnection, pinned_ip)
+    pinned_http = _pinned_connection_class(http.client.HTTPConnection, pinned_ip)
+    return urllib.request.build_opener(
+        _NoRedirectHandler,
+        _PinnedHTTPSHandler(pinned_https, context=_SSL_CONTEXT),
+        _PinnedHTTPHandler(pinned_http),
+    )
+
+
+class _PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    def __init__(self, connection_class: type, **kwargs):
+        super().__init__(**kwargs)
+        self._connection_class = connection_class
+
+    def https_open(self, req):
+        return self.do_open(self._connection_class, req, context=self._context)
+
+
+class _PinnedHTTPHandler(urllib.request.HTTPHandler):
+    def __init__(self, connection_class: type):
+        super().__init__()
+        self._connection_class = connection_class
+
+    def http_open(self, req):
+        return self.do_open(self._connection_class, req)
+
+
 _PATH_PARAM_PATTERNS = (
     re.compile(r"<[^>]+>"),
     re.compile(r"\{[^}]+\}"),
@@ -87,8 +152,17 @@ def _response_shape(response) -> list[str] | None:
     return None
 
 
-def run_healthcheck(endpoints: list[dict], base_url: str, timeout: float = 5.0) -> dict:
+def run_healthcheck(
+    endpoints: list[dict], base_url: str, timeout: float = 5.0, *, pinned_ip: str | None = None
+) -> dict:
+    """pinned_ip: when given, every request connects to this literal IP
+    instead of letting the connection resolve base_url's hostname itself -
+    for callers (the hosted health-sweep) that already resolved and
+    validated the hostname and need the actual request to hit the exact
+    address that was validated, not a fresh, unvalidated resolution. Plain
+    CLI/MCP callers pass nothing and keep today's normal DNS behavior."""
     _require_http_scheme(base_url)
+    opener = _opener_for(pinned_ip)
     results: list[dict] = []
 
     for endpoint in endpoints:
@@ -133,7 +207,7 @@ def run_healthcheck(endpoints: list[dict], base_url: str, timeout: float = 5.0) 
         start = time.monotonic()
         try:
             request = urllib.request.Request(url)
-            with _NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:
+            with opener.open(request, timeout=timeout) as response:
                 entry["status_code"] = response.status
                 entry["reachable"] = True
                 entry["response_shape"] = None if reachability_only else _response_shape(response)

--- a/src/tests/test_healthcheck.py
+++ b/src/tests/test_healthcheck.py
@@ -1,3 +1,5 @@
+import http.server
+import threading
 import urllib.error
 
 import pytest
@@ -411,6 +413,62 @@ def test_run_healthcheck_accepts_https():
     with patch("aletheore.healthcheck._NO_REDIRECT_OPENER.open", return_value=_mock_response(200)):
         result = run_healthcheck([], "https://example.com")
     assert result["base_url"] == "https://example.com"
+
+
+class _OKHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *args):  # quiet test output
+        pass
+
+
+@pytest.fixture
+def local_http_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _OKHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+# ".invalid" is reserved by RFC 2606 to never resolve - the strongest
+# available guarantee that a real network DNS lookup for this hostname
+# fails, which is exactly what these tests need to prove: with pinning, the
+# request must succeed anyway (proving the connection never asked the
+# resolver about the hostname at all); without it, the request must fail
+# with the resolver's own error (proving these aren't accidentally passing
+# for some unrelated reason).
+_UNRESOLVABLE_HOSTNAME = "this-host-does-not-exist.invalid"
+
+
+def test_run_healthcheck_with_pinned_ip_never_resolves_the_hostname(local_http_server):
+    endpoints = [{"method": "GET", "path": "/health", "unresolved": False}]
+    base_url = f"http://{_UNRESOLVABLE_HOSTNAME}:{local_http_server}"
+
+    result = run_healthcheck(endpoints, base_url, pinned_ip="127.0.0.1")
+
+    entry = result["results"][0]
+    assert entry["reachable"] is True
+    assert entry["status_code"] == 200
+
+
+def test_run_healthcheck_without_pinning_still_resolves_the_hostname_normally(local_http_server):
+    # Baseline for the test above: without pinned_ip, the same unresolvable
+    # hostname fails exactly as a real DNS-dependent connection should -
+    # proving the prior test's success came from pinning, not from
+    # something incidental (e.g. the request never actually going out).
+    endpoints = [{"method": "GET", "path": "/health", "unresolved": False}]
+    base_url = f"http://{_UNRESOLVABLE_HOSTNAME}:{local_http_server}"
+
+    result = run_healthcheck(endpoints, base_url)
+
+    entry = result["results"][0]
+    assert entry["reachable"] is False
 
 
 def test_save_healthcheck_rotates_at_21st_save_keeping_20_newest(tmp_path):


### PR DESCRIPTION
## Summary
**M-6**: validate_external_https_url resolved a health-check target's hostname once to reject private/internal IPs, then discarded the result. The actual request went out via urllib.request.Request(url), which re-resolves the hostname independently at connect time. A DNS record that changed between the two lookups (a rebind) would have the real request connect somewhere validation never actually checked.

- aletheore.healthcheck.run_healthcheck gains an optional pinned_ip kwarg: when given, every request connects to that literal IP via a custom http.client connection instead of letting the connection resolve the hostname itself. TLS certificate verification still checks the original hostname via SNI - only which address gets dialed changes, not what identity is trusted. Free CLI/MCP callers pass nothing and keep today's normal DNS behavior.
- app_server.url_validation gains validate_and_pin_https_url, same validation as the existing function but also returning one of the resolved-safe IPs.
- scan_worker/jobs.py's health-check sweep resolves once via validate_and_pin_https_url and reuses that single IP for every request the sweep makes (including down-retries) - closing the window to zero instead of narrowing it.

## Test plan
- [x] New tests in test_healthcheck.py prove the property directly: a request to an RFC 2606 .invalid (guaranteed-unresolvable) hostname succeeds when pinned to a real local server's IP, and fails with the resolver's own error when not pinned.
- [x] src/tests/test_healthcheck.py - 26 passed (21 existing unmodified + 5 new)
- [x] github-app/tests/test_url_validation.py + test_jobs.py -k "sweep or health" - 40 passed
- [ ] CI green