### PR TITLE
fix: terms page understated the extra-seat price by $1

### DIFF
--- a/website/terms.html
+++ b/website/terms.html
@@ -32,7 +32,7 @@
       <p>Aletheore is a repository audit tool: a free, open-source, local-first CLI and a paid GitHub App tier for managed audits, Slack/Teams alerts, branch-protection Check Runs, and endpoint health monitoring. The free tier is available under the terms of its open-source license in the project repository.</p>
 
       <h2>The paid subscription</h2>
-      <p>The paid plan is Aletheore AIR ($29.99/month or $299.90/year, up to 5 team members), with additional members beyond the plan's included seats billed at $3.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>
+      <p>The paid plan is Aletheore AIR ($29.99/month or $299.90/year, up to 5 team members), with additional members beyond the plan's included seats billed at $4.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>
 
       <h2>Acceptable use</h2>
       <p>You may not use Aletheore to scan repositories you do not have the right to scan, or to circumvent security measures of systems you do not own or have explicit permission to test.</p>


### PR DESCRIPTION
`website/terms.html` billed additional team members at **$3.99/month**. Both `pricing.html` and the billing code say **$4.99**:

```
llm_cost.py:24        EXTRA_SEAT_PRICE_USD = 4.99
website/pricing.html  +$4.99/mo per additional team member
website/terms.html    additional members ... billed at $3.99/month each   <- outlier
```

`llm_cost.py`'s own comment already cites pricing.html's "+$4.99/mo per additional team member" as the reference, so the code was right and the Terms of Service was the lone outlier — not a pricing change, just a correction.

Worth landing before anyone buys a seat: this is the legally binding document, and it understated what the billing code actually charges.

Found incidentally while fact-checking a competitor comparison against the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)