### PR TITLE
fix: cap AIRview/Docs LLM spend against the installation's monthly cap

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2195,18 +2195,37 @@ def run_weekly_digest_sweep_job() -> None:
             )
 
 
-def _live_wiki_naming_adapter() -> OpenAICompatibleAdapter:
-    return writing_adapter_for(live_wiki.FLASH_MODEL)
+def _llm_spend_cap_reached(dsn: str, installation_id: int, plan: str) -> tuple[bool, float]:
+    """(cap_reached, monthly_cap) - caller must hold installation_spend_lock,
+    same as every other spend-gated call site (managed audits, flash
+    review). Factored out because AIRview/Docs builds now have four call
+    sites needing the identical cap computation, where every existing
+    caller only ever needed it once.
+    """
+    extra_seats = get_extra_seats(dsn, installation_id)
+    monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
+    current_spend = get_llm_spend_this_month(dsn, installation_id)
+    return current_spend >= monthly_cap, monthly_cap
 
 
-def _live_wiki_full_build_writing_adapter(plan: str) -> OpenAICompatibleAdapter | AnthropicAdapter:
+def _live_wiki_naming_adapter(
+    on_usage: Callable[[int, int], None] | None = None
+) -> OpenAICompatibleAdapter:
+    return writing_adapter_for(live_wiki.FLASH_MODEL, on_usage=on_usage)
+
+
+def _live_wiki_full_build_writing_adapter(
+    plan: str, on_usage: Callable[[int, int], None] | None = None
+) -> OpenAICompatibleAdapter | AnthropicAdapter:
     # The one-time full build uses the same model as managed audits (see
     # model_tiers.py) - Luna (falling back to DeepSeek Pro), for every plan.
-    return writing_adapter_for_plan(plan)
+    return writing_adapter_for_plan(plan, on_usage=on_usage)
 
 
-def _live_wiki_update_writing_adapter() -> OpenAICompatibleAdapter:
-    return writing_adapter_for(live_wiki.UPDATE_MODEL)
+def _live_wiki_update_writing_adapter(
+    on_usage: Callable[[int, int], None] | None = None
+) -> OpenAICompatibleAdapter:
+    return writing_adapter_for(live_wiki.UPDATE_MODEL, on_usage=on_usage)
 
 
 def _real_line_count_fetcher(
@@ -2338,36 +2357,55 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
     plan = installation["plan"] if installation is not None else "free"
     model_used = model_for_plan(plan)
 
-    try:
-        naming_adapter = _live_wiki_naming_adapter()
-        writing_adapter = _live_wiki_full_build_writing_adapter(plan)
-        fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
-        records = live_wiki.generate_subsystems(
-            evidence,
-            naming_adapter,
-            writing_adapter,
-            cluster_ids=cluster_ids,
-            cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
-            cache_write=lambda packet, output, used: store_result(
-                dsn, installation_id, repo_full_name, packet, output, used
-            ),
-            model_used=model_used,
-            fetch_line_count=fetch_line_count,
-        )
-        _store_wiki_generation(
-            dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
-            fetch_line_count=fetch_line_count,
-        )
-    except Exception as exc:  # noqa: BLE001
-        # Without this, a failed build (LLM error, DB error) just leaves the
-        # AIRview page permanently blank with no way for the customer to
-        # tell "still building" apart from "broke and is never coming back".
-        logging.getLogger("scan_worker.jobs").warning(
-            "live wiki full build failed for installation=%s repo=%s (%s)",
-            installation_id, repo_full_name, exc,
-        )
-        set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-        return
+    with installation_spend_lock(dsn, installation_id):
+        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+        if cap_reached:
+            logging.getLogger("scan_worker.jobs").info(
+                "live wiki full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
+                installation_id, repo_full_name, monthly_cap,
+            )
+            set_wiki_build_status(
+                dsn, installation_id, repo_full_name, "failed",
+                f"monthly spend cap reached (${monthly_cap:.2f})",
+            )
+            return
+
+        spend_accumulator = {"total": 0.0}
+
+        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+            spend_accumulator["total"] += cost_for_usage(model_used, prompt_tokens, completion_tokens)
+
+        try:
+            naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
+            writing_adapter = _live_wiki_full_build_writing_adapter(plan, on_usage=_on_usage)
+            fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
+            records = live_wiki.generate_subsystems(
+                evidence,
+                naming_adapter,
+                writing_adapter,
+                cluster_ids=cluster_ids,
+                cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
+                cache_write=lambda packet, output, used: store_result(
+                    dsn, installation_id, repo_full_name, packet, output, used
+                ),
+                model_used=model_used,
+                fetch_line_count=fetch_line_count,
+            )
+            record_llm_spend(dsn, installation_id, spend_accumulator["total"])
+            _store_wiki_generation(
+                dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
+                fetch_line_count=fetch_line_count,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Without this, a failed build (LLM error, DB error) just leaves the
+            # AIRview page permanently blank with no way for the customer to
+            # tell "still building" apart from "broke and is never coming back".
+            logging.getLogger("scan_worker.jobs").warning(
+                "live wiki full build failed for installation=%s repo=%s (%s)",
+                installation_id, repo_full_name, exc,
+            )
+            set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+            return
     set_wiki_build_status(dsn, installation_id, repo_full_name, "ready")
 
 
@@ -2448,38 +2486,60 @@ def _maybe_update_live_wiki(
         return
 
     dsn = settings.database_url
-    try:
-        naming_adapter = _live_wiki_naming_adapter()
-        writing_adapter = _live_wiki_update_writing_adapter()
-        fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
-        records = live_wiki.generate_subsystems(
-            evidence,
-            naming_adapter,
-            writing_adapter,
-            cluster_ids=cluster_ids,
-            cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
-            cache_write=lambda packet, output, used: store_result(
-                dsn, installation_id, repo_full_name, packet, output, used
-            ),
-            model_used=resolve_model(live_wiki.UPDATE_MODEL),
-            fetch_line_count=fetch_line_count,
-        )
-        _store_wiki_generation(
-            dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
-            fetch_line_count=fetch_line_count,
-        )
-    except Exception as exc:  # noqa: BLE001
-        # Without this, a failed incremental update just leaves stale
-        # content in place with zero signal - the customer (and
-        # wiki_build_status) has no way to tell "stale" apart from
-        # "current", especially once a first full build has already
-        # succeeded and populated an overview.
-        logging.getLogger("scan_worker.jobs").warning(
-            "live wiki incremental update failed for installation=%s repo=%s (%s)",
-            installation_id, repo_full_name, exc,
-        )
-        set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-        return
+    plan = installation["plan"]
+    with installation_spend_lock(dsn, installation_id):
+        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+        if cap_reached:
+            logging.getLogger("scan_worker.jobs").info(
+                "live wiki incremental update skipped for installation=%s repo=%s - "
+                "monthly spend cap reached (${%.2f})",
+                installation_id, repo_full_name, monthly_cap,
+            )
+            set_wiki_build_status(
+                dsn, installation_id, repo_full_name, "failed",
+                f"monthly spend cap reached (${monthly_cap:.2f})",
+            )
+            return
+
+        update_model = resolve_model(live_wiki.UPDATE_MODEL)
+        spend_accumulator = {"total": 0.0}
+
+        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+            spend_accumulator["total"] += cost_for_usage(update_model, prompt_tokens, completion_tokens)
+
+        try:
+            naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
+            writing_adapter = _live_wiki_update_writing_adapter(on_usage=_on_usage)
+            fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
+            records = live_wiki.generate_subsystems(
+                evidence,
+                naming_adapter,
+                writing_adapter,
+                cluster_ids=cluster_ids,
+                cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
+                cache_write=lambda packet, output, used: store_result(
+                    dsn, installation_id, repo_full_name, packet, output, used
+                ),
+                model_used=update_model,
+                fetch_line_count=fetch_line_count,
+            )
+            record_llm_spend(dsn, installation_id, spend_accumulator["total"])
+            _store_wiki_generation(
+                dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
+                fetch_line_count=fetch_line_count,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Without this, a failed incremental update just leaves stale
+            # content in place with zero signal - the customer (and
+            # wiki_build_status) has no way to tell "stale" apart from
+            # "current", especially once a first full build has already
+            # succeeded and populated an overview.
+            logging.getLogger("scan_worker.jobs").warning(
+                "live wiki incremental update failed for installation=%s repo=%s (%s)",
+                installation_id, repo_full_name, exc,
+            )
+            set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+            return
     set_wiki_build_status(dsn, installation_id, repo_full_name, "ready")
 
 
@@ -2494,12 +2554,16 @@ def _maybe_update_live_wiki(
 MAX_DOCS_FULL_BUILD_FILES = 50
 
 
-def _live_docs_full_build_writing_adapter(plan: str) -> OpenAICompatibleAdapter:
-    return writing_adapter_for_plan(plan)
+def _live_docs_full_build_writing_adapter(
+    plan: str, on_usage: Callable[[int, int], None] | None = None
+) -> OpenAICompatibleAdapter:
+    return writing_adapter_for_plan(plan, on_usage=on_usage)
 
 
-def _live_docs_update_writing_adapter() -> OpenAICompatibleAdapter:
-    return writing_adapter_for(live_docs.FLASH_MODEL)
+def _live_docs_update_writing_adapter(
+    on_usage: Callable[[int, int], None] | None = None
+) -> OpenAICompatibleAdapter:
+    return writing_adapter_for(live_docs.FLASH_MODEL, on_usage=on_usage)
 
 
 def _github_client_and_token(installation_id: int) -> tuple[httpx.Client, str] | None:
@@ -2698,19 +2762,39 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         return
     client, token = client_and_token
 
-    try:
-        writing_adapter = _live_docs_full_build_writing_adapter(plan)
-    except Exception as exc:  # noqa: BLE001
-        logging.getLogger("scan_worker.jobs").warning(
-            "live docs full build could not start for installation=%s repo=%s (%s)",
-            installation_id, repo_full_name, exc,
-        )
-        set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-        return
+    with installation_spend_lock(dsn, installation_id):
+        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+        if cap_reached:
+            logging.getLogger("scan_worker.jobs").info(
+                "live docs full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
+                installation_id, repo_full_name, monthly_cap,
+            )
+            set_docs_build_status(
+                dsn, installation_id, repo_full_name, "failed",
+                f"monthly spend cap reached (${monthly_cap:.2f})",
+            )
+            return
 
-    succeeded, last_error = _run_docs_build_for_modules(
-        dsn, installation_id, repo_full_name, modules, writing_adapter, client, token, None
-    )
+        spend_accumulator = {"total": 0.0}
+        full_build_model = model_for_plan(plan)
+
+        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+            spend_accumulator["total"] += cost_for_usage(full_build_model, prompt_tokens, completion_tokens)
+
+        try:
+            writing_adapter = _live_docs_full_build_writing_adapter(plan, on_usage=_on_usage)
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger("scan_worker.jobs").warning(
+                "live docs full build could not start for installation=%s repo=%s (%s)",
+                installation_id, repo_full_name, exc,
+            )
+            set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+            return
+
+        succeeded, last_error = _run_docs_build_for_modules(
+            dsn, installation_id, repo_full_name, modules, writing_adapter, client, token, None
+        )
+        record_llm_spend(dsn, installation_id, spend_accumulator["total"])
     if succeeded == 0 and last_error is not None:
         # Every module in this run failed - genuinely nothing new landed,
         # unlike a partial run where some succeeded and persisted already.
@@ -2808,26 +2892,48 @@ def _maybe_update_live_docs(
     client, token = client_and_token
 
     dsn = settings.database_url
-    try:
-        writing_adapter = _live_docs_update_writing_adapter()
-    except Exception as exc:  # noqa: BLE001
-        logging.getLogger("scan_worker.jobs").warning(
-            "live docs incremental update could not start for installation=%s repo=%s (%s)",
-            installation_id, repo_full_name, exc,
-        )
-        set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-        return
+    plan = installation["plan"]
+    with installation_spend_lock(dsn, installation_id):
+        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+        if cap_reached:
+            logging.getLogger("scan_worker.jobs").info(
+                "live docs incremental update skipped for installation=%s repo=%s - "
+                "monthly spend cap reached (${%.2f})",
+                installation_id, repo_full_name, monthly_cap,
+            )
+            set_docs_build_status(
+                dsn, installation_id, repo_full_name, "failed",
+                f"monthly spend cap reached (${monthly_cap:.2f})",
+            )
+            return
 
-    # Per-module resilience matters here too, even for a typically-small
-    # changed-file list: one file's transient API failure shouldn't
-    # discard descriptions already generated for the others in the same
-    # push. Deliberately doesn't skip already-covered symbols the way the
-    # full build does - these files just changed, so an existing stored
-    # description may no longer match the new source and needs a fresh
-    # look regardless of whether a docs_symbols row already exists.
-    succeeded, last_error = _run_docs_build_for_modules(
-        dsn, installation_id, repo_full_name, changed_modules, writing_adapter, client, token, head_sha
-    )
+        spend_accumulator = {"total": 0.0}
+        update_model = resolve_model(live_docs.FLASH_MODEL)
+
+        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+            spend_accumulator["total"] += cost_for_usage(update_model, prompt_tokens, completion_tokens)
+
+        try:
+            writing_adapter = _live_docs_update_writing_adapter(on_usage=_on_usage)
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger("scan_worker.jobs").warning(
+                "live docs incremental update could not start for installation=%s repo=%s (%s)",
+                installation_id, repo_full_name, exc,
+            )
+            set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+            return
+
+        # Per-module resilience matters here too, even for a typically-small
+        # changed-file list: one file's transient API failure shouldn't
+        # discard descriptions already generated for the others in the same
+        # push. Deliberately doesn't skip already-covered symbols the way the
+        # full build does - these files just changed, so an existing stored
+        # description may no longer match the new source and needs a fresh
+        # look regardless of whether a docs_symbols row already exists.
+        succeeded, last_error = _run_docs_build_for_modules(
+            dsn, installation_id, repo_full_name, changed_modules, writing_adapter, client, token, head_sha
+        )
+        record_llm_spend(dsn, installation_id, spend_accumulator["total"])
     if succeeded == 0 and last_error is not None:
         set_docs_build_status(dsn, installation_id, repo_full_name, "failed", last_error)
         return

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -18,6 +18,18 @@ def _noop_spend_lock(*args, **kwargs):
     yield
 
 
+def _patch_no_spend_cap(monkeypatch) -> None:
+    """AIRview/Docs build jobs now gate on the same installation monthly
+    LLM spend cap managed audits and flash review already used - real
+    DB-backed functions the rest of this file's tests never had to mock
+    before this. Well under any cap, so the gate is always a no-op here;
+    the cap-reached path gets its own dedicated tests."""
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+
+
 class _FakeCodeGraphStore:
     """Stands in for scan_worker.code_graph_store.CodeGraphStore so
     _sync_code_graph's wiring can be tested without a real database - the
@@ -1827,6 +1839,7 @@ def _wiki_evidence():
 
 
 def test_run_live_wiki_full_build_job_skips_model_call_on_cache_hit(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import run_live_wiki_full_build_job
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -1854,8 +1867,10 @@ def test_run_live_wiki_full_build_job_skips_model_call_on_cache_hit(monkeypatch)
         def simple_completion(self, *a, **k):
             return json.dumps({"0": "Auth"})
 
-    monkeypatch.setattr("scan_worker.jobs._live_wiki_full_build_writing_adapter", lambda plan: _SpyAdapter())
-    monkeypatch.setattr("scan_worker.jobs._live_wiki_naming_adapter", lambda: _NamingAdapter())
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_wiki_full_build_writing_adapter", lambda plan, on_usage=None: _SpyAdapter()
+    )
+    monkeypatch.setattr("scan_worker.jobs._live_wiki_naming_adapter", lambda on_usage=None: _NamingAdapter())
     monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_wiki_build_status", lambda *a, **k: None)
 
@@ -2632,6 +2647,7 @@ def test_maybe_update_live_wiki_skips_when_no_clusters_affected(monkeypatch):
 
 
 def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -2669,6 +2685,7 @@ def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monke
 
 
 def test_maybe_update_live_wiki_records_failure_status_on_exception(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -2690,6 +2707,32 @@ def test_maybe_update_live_wiki_records_failure_status_on_exception(monkeypatch)
     _maybe_update_live_wiki(1, "octocat/hello-world", _wiki_evidence(), ["auth/login.py"], "sha1")
 
     assert status_calls == [("failed", "LLM API unavailable")]
+
+
+def test_maybe_update_live_wiki_skips_llm_call_when_spend_cap_reached(monkeypatch):
+    from scan_worker.jobs import _maybe_update_live_wiki
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 999.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+
+    llm_called = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.generate_subsystems", lambda *a, **k: llm_called.append(True)
+    )
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error_message=None: status_calls.append((status, error_message)),
+    )
+
+    _maybe_update_live_wiki(1, "octocat/hello-world", _wiki_evidence(), ["auth/login.py"], "sha1")
+
+    assert llm_called == []
+    assert status_calls[0][0] == "failed"
+    assert "spend cap" in status_calls[0][1]
 
 
 def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_with_two_commits, monkeypatch):
@@ -2995,6 +3038,7 @@ def test_run_live_wiki_full_build_job_skips_without_evidence(monkeypatch):
 
 
 def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import run_live_wiki_full_build_job
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3036,6 +3080,7 @@ def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
 
 
 def test_run_live_wiki_full_build_job_records_failed_status_on_error(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import run_live_wiki_full_build_job
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3056,6 +3101,37 @@ def test_run_live_wiki_full_build_job_records_failed_status_on_error(monkeypatch
     run_live_wiki_full_build_job(1, "octocat/hello-world")
 
     assert build_status_calls == [("failed", "model provider unavailable")]
+
+
+def test_run_live_wiki_full_build_job_skips_llm_call_when_spend_cap_reached(monkeypatch):
+    # H-4: AIRview/Docs builds had no dollar spend cap at all, unlike
+    # managed audits and flash review - this is the same gate those
+    # already had, now closing that gap.
+    from scan_worker.jobs import run_live_wiki_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 999.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+
+    llm_called = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.generate_subsystems", lambda *a, **k: llm_called.append(True)
+    )
+    build_status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error=None: build_status_calls.append((status, error)),
+    )
+
+    run_live_wiki_full_build_job(1, "octocat/hello-world")
+
+    assert llm_called == []
+    assert build_status_calls[0][0] == "failed"
+    assert "spend cap" in build_status_calls[0][1]
 
 
 def test_real_line_count_fetcher_returns_none_when_token_setup_fails(monkeypatch):
@@ -3087,6 +3163,7 @@ def test_real_line_count_fetcher_returns_real_line_count(monkeypatch):
 
 
 def test_run_live_wiki_full_build_job_passes_fetch_line_count_through(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import run_live_wiki_full_build_job
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3168,6 +3245,7 @@ def test_clusters_with_uncovered_wiki_work_empty_when_everything_covered():
 
 
 def test_run_live_wiki_full_build_job_only_requests_uncovered_clusters(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import run_live_wiki_full_build_job
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3272,6 +3350,7 @@ def test_live_wiki_catchup_sweep_job_survives_one_repo_failing(monkeypatch):
 
 
 def test_maybe_update_live_wiki_passes_fetch_line_count_through(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3484,7 +3563,41 @@ def test_run_live_docs_full_build_job_excludes_test_files_from_candidate_modules
     assert status_calls == [("ready", None)]
 
 
+def test_run_live_docs_full_build_job_skips_llm_call_when_spend_cap_reached(monkeypatch):
+    from scan_worker.jobs import run_live_docs_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    module = _docs_module(functions=[{"name": "f", "is_public": True, "docstring": None}])
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _docs_evidence([module]))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_docs_symbols", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
+    )
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 999.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+
+    adapter_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_docs_full_build_writing_adapter",
+        lambda plan, on_usage=None: adapter_calls.append(True),
+    )
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_docs_build_status",
+        lambda dsn, iid, repo, status, error=None: status_calls.append((status, error)),
+    )
+
+    run_live_docs_full_build_job(1, "octocat/hello-world")
+
+    assert adapter_calls == []
+    assert status_calls[0][0] == "failed"
+    assert "spend cap" in status_calls[0][1]
+
+
 def test_run_live_docs_full_build_job_survives_one_module_failing(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import run_live_docs_full_build_job
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3499,7 +3612,7 @@ def test_run_live_docs_full_build_job_survives_one_module_failing(monkeypatch):
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
     monkeypatch.setattr(
-        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan: object()
+        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan, on_usage=None: object()
     )
 
     def fake_fetch(client, token, repo, path, ref):
@@ -3533,6 +3646,7 @@ def test_run_live_docs_full_build_job_survives_one_module_failing(monkeypatch):
 
 
 def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import run_live_docs_full_build_job
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3544,7 +3658,7 @@ def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(mon
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
     monkeypatch.setattr(
-        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan: object()
+        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan, on_usage=None: object()
     )
     monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: "source")
 
@@ -3563,7 +3677,7 @@ def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(mon
     assert status_calls == [("failed", "model provider unavailable")]
 
 
-def test_maybe_update_live_docs_survives_one_module_failing(monkeypatch):
+def test_maybe_update_live_docs_skips_llm_call_when_spend_cap_reached(monkeypatch):
     from scan_worker.jobs import _maybe_update_live_docs
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3571,7 +3685,40 @@ def test_maybe_update_live_docs_survives_one_module_failing(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
-    monkeypatch.setattr("scan_worker.jobs._live_docs_update_writing_adapter", lambda: object())
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 999.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+
+    adapter_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_docs_update_writing_adapter",
+        lambda on_usage=None: adapter_calls.append(True),
+    )
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_docs_build_status",
+        lambda dsn, iid, repo, status, error=None: status_calls.append((status, error)),
+    )
+
+    evidence = _docs_evidence([_docs_module("good.py")])
+
+    _maybe_update_live_docs(1, "octocat/hello-world", evidence, ["good.py"], "sha1")
+
+    assert adapter_calls == []
+    assert status_calls[0][0] == "failed"
+    assert "spend cap" in status_calls[0][1]
+
+
+def test_maybe_update_live_docs_survives_one_module_failing(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
+    from scan_worker.jobs import _maybe_update_live_docs
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr(
+        "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
+    )
+    monkeypatch.setattr("scan_worker.jobs._live_docs_update_writing_adapter", lambda on_usage=None: object())
     monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: "source")
 
     def fake_store(dsn, iid, repo, module, adapter, source_lines, commit):
@@ -3598,6 +3745,7 @@ def test_maybe_update_live_docs_survives_one_module_failing(monkeypatch):
 
 
 def test_maybe_update_live_docs_excludes_test_files_from_changed_modules(monkeypatch):
+    _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import _maybe_update_live_docs
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -3605,7 +3753,7 @@ def test_maybe_update_live_docs_excludes_test_files_from_changed_modules(monkeyp
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
-    monkeypatch.setattr("scan_worker.jobs._live_docs_update_writing_adapter", lambda: object())
+    monkeypatch.setattr("scan_worker.jobs._live_docs_update_writing_adapter", lambda on_usage=None: object())
 
     fetched_for = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
H-4: managed audits and PR review both check the same installation's monthly LLM spend cap before running (installation_spend_lock + get_llm_spend_this_month, see run_managed_audit_api_job/run_flash_review_job) - AIRview and Docs builds never did. The only existing ceiling was a per-call item count (MAX_WIKI_FULL_BUILD_CLUSTERS / MAX_DOCS_FULL_BUILD_FILES), explicitly noted in jobs.py's own comment as "real follow-up work, not designed blind here." A paying installation could trigger effectively unbounded LLM spend by repeatedly triggering AIRview/Docs builds (each push, plus the 48h catch-up sweep), unlike every other LLM-calling surface in this codebase.

Wires the same installation_spend_lock/get_llm_spend_this_month/record_llm_spend pattern into all four entry points: run_live_wiki_full_build_job, _maybe_update_live_wiki, run_live_docs_full_build_job, _maybe_update_live_docs. The adapter helpers already forward on_usage straight into writing_adapter_for/writing_adapter_for_plan, which the same managed-audit/flash-review machinery already relies on - no new spend-tracking plumbing needed, only wiring the existing hooks up.

Spend is recorded right after generation succeeds (before the subsequent DB store step), matching managed_audit's placement.

## Test plan
- [x] One dedicated cap-reached test per entry point (4 new tests)
- [x] Twelve existing tests that now reach the new gate updated to mock the spend-cap machinery, matching how managed-audit/flash-review tests already did
- [x] Full `test_jobs.py` - 133 passed
- [x] Full clean single-process suite run (no concurrent interference) - 1159 passed, 8 skipped
- [ ] CI green