### PR TITLE
feat: aletheore watch - keep evidence current while you work

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -63,6 +63,7 @@ from aletheore.report import (
     select_adapter,
 )
 from aletheore.toon_encoding import to_toon
+from aletheore.watch import DEBOUNCE_SECONDS as WATCH_DEBOUNCE_SECONDS
 
 KNOWN_ADAPTERS = [
     ClaudeCodeAdapter(),
@@ -250,6 +251,7 @@ _COMMAND_SUMMARIES = [
     ("mcp-install", "write MCP client config for Claude Code, Cursor, VS Code, Kiro, Opencode, or Codex CLI"),
     ("dashboard", "a live local web UI over the same evidence"),
     ("healthcheck", "GET-only live check of mapped API endpoints"),
+    ("watch", "re-scan and re-index automatically as files change"),
     ("init", "scaffold a repository-local .aletheore.json config file"),
     ("login", "authenticate and save a managed-audit API token"),
     ("logout", "clear the locally saved managed-audit API token"),
@@ -1034,6 +1036,24 @@ def _port_is_available(host: str, port: int) -> bool:
             return False
 
 
+def _watch(repo_path: str, debounce: float) -> int:
+    from aletheore.watch import watch as run_watch
+
+    repo = Path(repo_path).resolve()
+
+    def report(message: str) -> None:
+        console.print(f"[dim]{time.strftime('%H:%M:%S')}[/dim] {message}")
+
+    try:
+        run_watch(repo, report, debounce_seconds=debounce)
+    except KeyboardInterrupt:
+        # Ctrl-C is how this command is meant to end, so it exits 0 with a
+        # word rather than a traceback - the dashboard's own Ctrl-C handling
+        # was a bug worth not repeating.
+        console.print("stopped")
+    return 0
+
+
 def _dashboard(repo_path: str, port: int) -> int:
     from aletheore.dashboard import build_app
 
@@ -1216,6 +1236,22 @@ def scan(
         path, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints
     )
     raise typer.Exit(code=exit_code)
+
+
+@app.command(
+    help="re-scan and re-index automatically whenever source files change"
+)
+def watch(
+    path: str = typer.Argument(".", help="repository path"),
+    path_option: Optional[str] = _PATH_OPTION,
+    debounce: float = typer.Option(
+        WATCH_DEBOUNCE_SECONDS,
+        "--debounce",
+        help="seconds of quiet before rebuilding, so one burst of saves is one rebuild",
+    ),
+) -> None:
+    path = _resolve_path(path, path_option)
+    raise typer.Exit(code=_watch(path, debounce))
 
 
 @app.command(help="scaffold a .aletheore.json config file in a repository")

--- a/src/aletheore/watch.py
+++ b/src/aletheore/watch.py
@@ -1,0 +1,213 @@
+"""`aletheore watch` - keep evidence and the search index current while you work.
+
+A scan is only true at the moment it ran. Between scans, every consumer -
+`query`, the MCP server an agent is driving, the dashboard - is answering
+from a snapshot of a repository that has since moved. This closes that gap
+without asking anyone to remember a command.
+
+Why OS file events rather than polling: measured on this repository, walking
+and stat-ing the tree costs 841 ms for 644 files. A two-second poll would
+burn roughly 40% of a core, continuously, on a laptop that is also running a
+compiler and an editor - and worse on a monorepo. watchdog uses FSEvents on
+macOS and inotify on Linux, so idle cost is essentially zero and cost scales
+with edits rather than repository size.
+"""
+
+import threading
+import time
+from collections.abc import Callable
+from functools import lru_cache
+from pathlib import Path
+
+# Every aletheore and watchdog import in this module is deliberately inside a
+# function. cli.py imports DEBOUNCE_SECONDS at module scope to use as a typer
+# default, and search_index pulls in lancedb, pyarrow and pandas - importing
+# any of that here would drag the whole stack into `aletheore --help` and
+# every other command. test_cli.py guards exactly this.
+
+# How long the tree must be quiet before a rebuild starts. A single save in
+# an editor is one event; "format on save" across a package, a branch
+# checkout, or a rebase is hundreds within a second or two. Debouncing turns
+# any of those into one rebuild instead of hundreds of overlapping ones.
+DEBOUNCE_SECONDS = 2.0
+
+@lru_cache(maxsize=1)
+def _watched_suffixes() -> frozenset[str]:
+    """Extensions the scanner can parse.
+
+    Read from the scanner's own table rather than restated, so a language
+    added there is watched without anyone remembering to update this. Cached
+    and lazy: the import is not cheap and must not happen at module scope.
+    """
+    from aletheore.scanner.graph import LANGUAGE_BY_EXTENSION
+
+    return frozenset(LANGUAGE_BY_EXTENSION)
+
+
+@lru_cache(maxsize=1)
+def _ignored_dirs() -> frozenset[str]:
+    from aletheore.scanner.detect import IGNORED_DIRS
+
+    return frozenset(IGNORED_DIRS)
+
+
+def _is_relevant(repo_path: Path, changed: Path) -> bool:
+    """Whether a filesystem event should trigger a rebuild.
+
+    `.aletheore/` is excluded first and deliberately: a scan writes
+    air.json, air.toon, scan-cache.json, a history snapshot and the LanceDB
+    index into it. Without this the rebuild's own output retriggers the
+    watcher, which rebuilds, which writes - a loop that never settles and
+    burns a core until the process is killed.
+    """
+    try:
+        relative = changed.resolve().relative_to(repo_path.resolve())
+    except ValueError:
+        return False
+    parts = relative.parts
+    if ".aletheore" in parts or any(part in _ignored_dirs() for part in parts):
+        return False
+    return changed.suffix in _watched_suffixes()
+
+
+class _DebouncedHandler:
+    """Records that something changed; the run loop decides when to act.
+
+    Deliberately not a FileSystemEventHandler subclass, so this module needs
+    no watchdog import at module scope and the collapsing logic is testable
+    without an observer. watchdog calls `dispatch`, not `on_any_event`, so
+    _observer_handler below adapts this to the real interface rather than
+    duck-typing it - relying on the observer to call the method we happen to
+    have defined is how this silently stopped receiving events once.
+    """
+
+    def __init__(self, repo_path: Path) -> None:
+        self.repo_path = repo_path
+        self._lock = threading.Lock()
+        self._last_event_at: float | None = None
+        self._changed: set[Path] = set()
+
+    def on_any_event(self, event) -> None:  # noqa: ANN001 - watchdog event, kept untyped to avoid the import
+        if event.is_directory:
+            return
+        # A move reports both ends; both matter, since one file left a path
+        # and another arrived at one.
+        candidates = [Path(str(event.src_path))]
+        destination = getattr(event, "dest_path", None)
+        if destination:
+            candidates.append(Path(str(destination)))
+        relevant = [path for path in candidates if _is_relevant(self.repo_path, path)]
+        if not relevant:
+            return
+        with self._lock:
+            self._changed.update(relevant)
+            self._last_event_at = time.monotonic()
+
+    def take_settled_batch(self, debounce_seconds: float) -> set[Path] | None:
+        """The pending changes, once the tree has been quiet long enough."""
+        with self._lock:
+            if self._last_event_at is None:
+                return None
+            if time.monotonic() - self._last_event_at < debounce_seconds:
+                return None
+            batch, self._changed = self._changed, set()
+            self._last_event_at = None
+            return batch
+
+
+def _observer_handler(handler: "_DebouncedHandler"):
+    """Adapt _DebouncedHandler to watchdog's real handler interface.
+
+    Built here rather than at module scope so the watchdog import stays
+    inside watch(), and subclassed rather than duck-typed because the
+    observer dispatches through FileSystemEventHandler.dispatch - a plain
+    object with on_any_event is accepted by schedule() and then never
+    called, which is a failure that looks exactly like "no file events".
+    """
+    from watchdog.events import FileSystemEventHandler
+
+    class _Adapter(FileSystemEventHandler):
+        def on_any_event(self, event) -> None:  # noqa: ANN001 - watchdog event type
+            handler.on_any_event(event)
+
+    return _Adapter()
+
+
+def rebuild(repo_path: Path, report: Callable[[str], None]) -> None:
+    """One scan-and-reindex cycle.
+
+    Vulnerability, license and git-history checks are skipped. They are the
+    network-bound and history-bound parts of a scan, they take seconds to
+    minutes, and none of them change because a function body was edited -
+    running them on every save would make the loop unusable while adding
+    nothing. A full `aletheore scan` still does all of them.
+
+    The index is only refreshed if one already exists. Building a first
+    index means embedding every chunk, which needs a provider and real time;
+    starting that unasked because someone edited a file would be a surprise.
+    """
+    from aletheore.evidence import scan_repository, write_evidence
+
+    evidence = scan_repository(
+        repo_path,
+        check_vulnerabilities=False,
+        check_licenses=False,
+        scan_git_history=False,
+    )
+    write_evidence(evidence, repo_path)
+    report("evidence updated")
+
+    if not (repo_path / ".aletheore" / "index.lancedb").exists():
+        return
+    from aletheore.search_index import build_index
+
+    try:
+        count = build_index(repo_path, evidence)
+    except Exception as exc:  # noqa: BLE001
+        # An unreachable embedding provider must not end the watch. Evidence
+        # is already current, which is most of the value, and the next edit
+        # retries.
+        report(f"index not updated ({type(exc).__name__}: {exc})")
+        return
+    report(f"index updated ({count} chunks)")
+
+
+def watch(
+    repo_path: Path,
+    report: Callable[[str], None],
+    debounce_seconds: float = DEBOUNCE_SECONDS,
+    stop: threading.Event | None = None,
+    poll_seconds: float = 0.25,
+) -> None:
+    """Rebuild evidence whenever watched source files settle after changing.
+
+    Returns when `stop` is set, so a caller (and a test) can end it without
+    depending on a signal.
+    """
+    from watchdog.observers import Observer
+
+    stop = stop or threading.Event()
+    handler = _DebouncedHandler(repo_path)
+    observer = Observer()
+    observer.schedule(_observer_handler(handler), str(repo_path), recursive=True)
+    observer.start()
+    report(f"watching {repo_path} - Ctrl-C to stop")
+
+    try:
+        while not stop.is_set():
+            batch = handler.take_settled_batch(debounce_seconds)
+            if batch:
+                names = sorted(path.name for path in batch)
+                shown = ", ".join(names[:3]) + (f" +{len(names) - 3} more" if len(names) > 3 else "")
+                report(f"{len(names)} file(s) changed ({shown})")
+                try:
+                    rebuild(repo_path, report)
+                except Exception as exc:  # noqa: BLE001
+                    # A scan that fails on one bad edit - a half-written
+                    # file, a syntax error mid-keystroke - should not end a
+                    # session that the next save would fix.
+                    report(f"rebuild failed ({type(exc).__name__}: {exc})")
+            stop.wait(poll_seconds)
+    finally:
+        observer.stop()
+        observer.join(timeout=5)

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -47,6 +47,12 @@ dependencies = [
     "python-toon>=0.1.3,<0.2",
     "pyyaml>=6.0,<7.0",
     "typer>=0.24,<0.28",
+    # `aletheore watch` only. OS-level file events (FSEvents on macOS,
+    # inotify on Linux) rather than polling: measured on this repository,
+    # walking and stat-ing the tree costs 841 ms for 644 files, so a
+    # two-second poll would burn ~40% of a core continuously on a laptop
+    # already running an editor and a compiler.
+    "watchdog>=4.0,<7.0",
     "rich>=13.0",
     "tomli-w>=1.0,<2.0",
 ]

--- a/src/tests/test_watch.py
+++ b/src/tests/test_watch.py
@@ -1,0 +1,192 @@
+import subprocess
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aletheore.watch import _DebouncedHandler, _is_relevant, rebuild, watch
+
+# Patched at their source modules, not on aletheore.watch: every heavy import
+# in watch.py is function-local so that `aletheore --help` does not drag in
+# lancedb (see test_cli.py's import-weight guard). A function-local import
+# resolves the patched attribute at call time, so this works and the module
+# stays cheap to import.
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (tmp_path / "app.py").write_text("def f():\n    return 1\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "path, relevant",
+    [
+        ("app.py", True),
+        ("pkg/mod.ts", True),
+        ("main.go", True),
+        # The loop-breaker: a scan writes air.json, air.toon, scan-cache.json,
+        # a history snapshot and the LanceDB index in here. Without this
+        # exclusion the rebuild's own output retriggers the watcher forever.
+        (".aletheore/air.json", False),
+        (".aletheore/index.lancedb/chunks.lance/data.bin", False),
+        (".aletheore/history/2026-01-01.json", False),
+        ("node_modules/x/index.js", False),
+        (".git/COMMIT_EDITMSG", False),
+        ("README.md", False),
+        ("image.png", False),
+    ],
+)
+def test_only_source_files_outside_aletheore_are_relevant(tmp_path, path, relevant):
+    target = tmp_path / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x")
+    assert _is_relevant(tmp_path, target) is relevant
+
+
+def test_a_burst_of_saves_becomes_one_rebuild(tmp_path):
+    """Format-on-save across a package, a branch checkout, or a rebase is
+    hundreds of events within a second. Each must not be its own rebuild."""
+    handler = _DebouncedHandler(tmp_path)
+
+    for index in range(50):
+        target = tmp_path / f"f{index}.py"
+        target.write_text("x")
+        handler.on_any_event(type("E", (), {"is_directory": False, "src_path": str(target)})())
+
+    # Still settling: nothing handed over yet.
+    assert handler.take_settled_batch(debounce_seconds=5.0) is None
+
+    batch = handler.take_settled_batch(debounce_seconds=0.0)
+    assert batch is not None and len(batch) == 50
+    # Drained, so the next cycle does not rebuild the same batch again.
+    assert handler.take_settled_batch(debounce_seconds=0.0) is None
+
+
+def test_a_move_records_both_ends(tmp_path):
+    """One file left a path and another arrived at one; both matter."""
+    handler = _DebouncedHandler(tmp_path)
+    (tmp_path / "old.py").write_text("x")
+    (tmp_path / "new.py").write_text("x")
+
+    handler.on_any_event(
+        type("E", (), {
+            "is_directory": False,
+            "src_path": str(tmp_path / "old.py"),
+            "dest_path": str(tmp_path / "new.py"),
+        })()
+    )
+
+    batch = handler.take_settled_batch(debounce_seconds=0.0)
+    assert {path.name for path in batch} == {"old.py", "new.py"}
+
+
+def test_rebuild_refreshes_evidence_and_skips_the_slow_checks(tmp_path):
+    """Vulnerability, license and history checks are network- and
+    history-bound, take seconds to minutes, and do not change because a
+    function body was edited."""
+    repo = _git_repo(tmp_path)
+    (repo / "app.py").write_text("def f():\n    return 1\n\ndef added_later():\n    return 2\n")
+
+    with patch("aletheore.evidence.scan_repository", wraps=None) as scan:
+        scan.return_value = {"repository": {"modules": []}}
+        with patch("aletheore.evidence.write_evidence"):
+            rebuild(repo, lambda _message: None)
+
+    assert scan.call_args.kwargs == {
+        "check_vulnerabilities": False,
+        "check_licenses": False,
+        "scan_git_history": False,
+    }
+
+
+def test_rebuild_does_not_build_a_first_index_unasked(tmp_path):
+    """Building a first index embeds every chunk - it needs a provider and
+    real time. Starting that because someone edited a file would surprise."""
+    repo = _git_repo(tmp_path)
+
+    with patch("aletheore.search_index.build_index") as build:
+        rebuild(repo, lambda _message: None)
+
+    build.assert_not_called()
+
+
+def test_rebuild_refreshes_an_index_that_already_exists(tmp_path):
+    repo = _git_repo(tmp_path)
+    (repo / ".aletheore" / "index.lancedb").mkdir(parents=True)
+
+    with patch("aletheore.search_index.build_index", return_value=7) as build:
+        messages: list[str] = []
+        rebuild(repo, messages.append)
+
+    build.assert_called_once()
+    assert "index updated (7 chunks)" in messages
+
+
+def test_an_unreachable_embedder_does_not_end_the_watch(tmp_path):
+    """Evidence is already current, which is most of the value, and the next
+    edit retries."""
+    repo = _git_repo(tmp_path)
+    (repo / ".aletheore" / "index.lancedb").mkdir(parents=True)
+
+    with patch("aletheore.search_index.build_index", side_effect=RuntimeError("ollama down")):
+        messages: list[str] = []
+        rebuild(repo, messages.append)
+
+    assert any("index not updated" in message for message in messages)
+    assert any("evidence updated" in message for message in messages)
+
+
+def test_watch_rebuilds_on_a_real_edit_and_does_not_retrigger_itself(tmp_path):
+    """The end-to-end property that matters: a rebuild writes into
+    .aletheore/, and those writes must not start another rebuild."""
+    repo = _git_repo(tmp_path)
+    messages: list[str] = []
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=watch, args=(repo, messages.append),
+        kwargs={"debounce_seconds": 0.3, "stop": stop}, daemon=True,
+    )
+    thread.start()
+    time.sleep(1.0)
+
+    (repo / "app.py").write_text("def f():\n    return 2\n\ndef brand_new():\n    return 3\n")
+    time.sleep(4.0)
+    settled = len(messages)
+    time.sleep(3.0)
+
+    stop.set()
+    thread.join(timeout=6)
+
+    assert any("evidence updated" in message for message in messages)
+    assert len(messages) == settled, f"watcher retriggered on its own writes: {messages[settled:]}"
+
+
+def test_a_failing_scan_does_not_end_the_session(tmp_path):
+    """A half-written file or a syntax error mid-keystroke should not end a
+    session that the next save would fix."""
+    repo = _git_repo(tmp_path)
+    messages: list[str] = []
+    stop = threading.Event()
+
+    with patch("aletheore.evidence.scan_repository", side_effect=RuntimeError("bad parse")):
+        thread = threading.Thread(
+            target=watch, args=(repo, messages.append),
+            kwargs={"debounce_seconds": 0.3, "stop": stop}, daemon=True,
+        )
+        thread.start()
+        time.sleep(0.8)
+        (repo / "app.py").write_text("def broken(:\n")
+        time.sleep(3.0)
+        alive = thread.is_alive()
+        stop.set()
+        thread.join(timeout=6)
+
+    assert alive, "watch exited on a failed rebuild"
+    assert any("rebuild failed" in message for message in messages)


### PR DESCRIPTION
> **Stacked on #208**, which it depends on: without incremental indexing every rebuild re-embeds the whole repository, and a watch loop that costs 50 seconds per save is not usable. Merge #208 first and this retargets cleanly. It does *not* depend on #209.

A scan is only true at the moment it ran. Between scans, `query`, the MCP server an agent is driving, and the dashboard are all answering from a repository that has since moved.

```
$ aletheore watch .
23:58:50 watching /path/to/repo - Ctrl-C to stop
23:58:55 1 file(s) changed (app.py)
23:58:56 evidence updated
```

## Why watchdog rather than polling

Measured before taking the dependency:

```
walk + stat, 644 files:  841 ms
```

A two-second poll would burn **~40% of a core continuously** on a laptop already running an editor and a compiler — worse on a monorepo. FSEvents/inotify make idle cost essentially zero, and cost scales with edits rather than repository size.

## Three things this has to get right

**It must not retrigger itself.** A rebuild writes `air.json`, `air.toon`, `scan-cache.json`, a history snapshot and the LanceDB index into `.aletheore/`. Without excluding that directory, the rebuild's own output starts another rebuild — a loop that never settles and burns a core until killed. Tested end-to-end: after a real edit and rebuild, **zero further events during a 3-second idle**.

**Bursts collapse into one rebuild.** One save is one event; format-on-save across a package, a branch checkout, or a rebase is hundreds within a second. 50 events → 1 rebuild, tested.

**Failures don't end the session.** A half-written file fails a scan; an unreachable Ollama fails an index. Both are reported and the loop continues, because the next save is usually the fix.

## Deliberate scope choices

- **Slow checks skipped.** Vulnerability, license and git-history scanning are network- and history-bound, take seconds to minutes, and don't change because a function body was edited. A full `aletheore scan` still runs them.
- **No first index built unasked.** Refreshing an existing index is cheap (#208); *building* one embeds every chunk and needs a provider. Starting that because someone edited a file would surprise.

## One regression worth flagging

Every aletheore and watchdog import in `watch.py` is function-local. `cli.py` needs `DEBOUNCE_SECONDS` at module scope for a typer default, and `search_index` pulls in lancedb/pyarrow/pandas — a module-level import here dragged that whole stack into `aletheore --help`. `test_cli.py` already guards this and caught it.

Removing the `FileSystemEventHandler` base class to achieve that then broke event delivery entirely — watchdog dispatches through `dispatch()`, not `on_any_event()`, so a plain object is accepted by `schedule()` and never called. There's now an explicit adapter built inside `watch()`, and a comment saying why it isn't duck-typed.

## Testing

**1114 passing**, lint at baseline. 18 new tests: `.aletheore` exclusion across five path shapes, debounce collapsing, move events recording both ends, slow-check skipping, first-index restraint, embedder failure, end-to-end rebuild, and the no-self-retrigger property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)