### PR TITLE
feat: warn when spend approaches its cap, soften spend-cap messages

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -1,9 +1,13 @@
 import json
+import logging
 from datetime import datetime
 
 import asyncpg
 
 from app_server.evidence_limits import check_evidence_size
+from app_server.llm_cost import WARN_FRACTION_OF_CAP, crossed_spend_warning_threshold
+
+logger = logging.getLogger(__name__)
 
 
 async def create_pool(dsn: str) -> asyncpg.Pool:
@@ -524,17 +528,39 @@ async def get_llm_spend_this_month(pool: asyncpg.Pool, installation_id: int) -> 
     return float(row["total_cost_usd"]) if row else 0.0
 
 
-async def record_llm_spend(pool: asyncpg.Pool, installation_id: int, cost_usd: float) -> None:
-    await pool.execute(
+async def record_llm_spend(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    cost_usd: float,
+    monthly_cap: float | None = None,
+) -> None:
+    """monthly_cap: when given, logs a one-time warning if this call is the
+    one that pushes the installation's spend this month past
+    WARN_FRACTION_OF_CAP of it - see llm_cost.crossed_spend_warning_threshold.
+    Omit it (as existing callers that predate this did) to skip the check
+    entirely; it has no effect on what gets recorded."""
+    row = await pool.fetchrow(
         """
         INSERT INTO llm_spend (installation_id, month, total_cost_usd)
         VALUES ($1, date_trunc('month', now())::date, $2)
         ON CONFLICT (installation_id, month) DO UPDATE
         SET total_cost_usd = llm_spend.total_cost_usd + EXCLUDED.total_cost_usd
+        RETURNING total_cost_usd
         """,
         installation_id,
         cost_usd,
     )
+    if monthly_cap is not None and row is not None:
+        new_total = float(row["total_cost_usd"])
+        previous_total = new_total - cost_usd
+        if crossed_spend_warning_threshold(previous_total, new_total, monthly_cap):
+            logger.warning(
+                "llm spend crossed %.0f%% of monthly cap: installation=%s $%.2f of $%.2f",
+                WARN_FRACTION_OF_CAP * 100,
+                installation_id,
+                new_total,
+                monthly_cap,
+            )
 
 
 async def get_flash_review_count_this_month(pool: asyncpg.Pool, installation_id: int) -> int:

--- a/github-app/app_server/embeddings_api.py
+++ b/github-app/app_server/embeddings_api.py
@@ -138,7 +138,9 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
             status_code=402,
             detail=(
                 f"monthly spend cap reached for this installation (${monthly_cap:.2f}) - "
-                "hosted embeddings are paused until it resets"
+                "hosted embeddings resume next month, or contact support@aletheore.com to "
+                "raise the limit sooner. 'aletheore index' with a local Ollama or your own "
+                "OPENAI_API_KEY works right now and is free, with no cap"
             ),
         )
 
@@ -166,7 +168,12 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
     # Billed on the provider's own token count rather than a local estimate,
     # so the recorded spend matches the invoice.
     prompt_tokens = response.usage.prompt_tokens if response.usage else 0
-    await record_llm_spend(pool, installation_id, cost_for_usage(EMBEDDING_MODEL, prompt_tokens, 0))
+    await record_llm_spend(
+        pool,
+        installation_id,
+        cost_for_usage(EMBEDDING_MODEL, prompt_tokens, 0),
+        monthly_cap=monthly_cap,
+    )
 
     return {
         "model": EMBEDDING_MODEL,

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -88,3 +88,27 @@ def base_cap_for_plan(plan: str) -> float:
 
 def monthly_cap_for_installation(base_cap_usd: float, extra_seats: int) -> float:
     return base_cap_usd + EXTRA_SEAT_LLM_CAP_USD * extra_seats
+
+
+# The cap itself is a worst-case abuse ceiling, not a target - see
+# CAP_FRACTION_OF_PRICE. This is a much lower bar: a signal that real usage
+# is starting to approach that ceiling, worth a log line so someone notices
+# before an installation actually hits it, not proof of a problem on its own.
+WARN_FRACTION_OF_CAP = 0.3
+
+
+def crossed_spend_warning_threshold(
+    previous_total_usd: float, new_total_usd: float, monthly_cap_usd: float
+) -> bool:
+    """Whether this specific increment is the one that pushed spend past
+    WARN_FRACTION_OF_CAP of the cap.
+
+    Edge-triggered on the previous/new pair rather than just checking
+    new_total_usd, so record_llm_spend logs once per crossing instead of on
+    every call for the rest of the month once an installation is over the
+    threshold.
+    """
+    if monthly_cap_usd <= 0:
+        return False
+    threshold = WARN_FRACTION_OF_CAP * monthly_cap_usd
+    return previous_total_usd < threshold <= new_total_usd

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -1,8 +1,12 @@
 import json
+import logging
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
 from app_server.evidence_limits import check_evidence_size
+from app_server.llm_cost import WARN_FRACTION_OF_CAP, crossed_spend_warning_threshold
+
+logger = logging.getLogger(__name__)
 
 
 def insert_repo_history(
@@ -181,7 +185,14 @@ def get_llm_spend_this_month(dsn: str, installation_id: int) -> float:
             return float(row[0]) if row else 0.0
 
 
-def record_llm_spend(dsn: str, installation_id: int, cost_usd: float) -> None:
+def record_llm_spend(
+    dsn: str, installation_id: int, cost_usd: float, monthly_cap: float | None = None
+) -> None:
+    """monthly_cap: when given, logs a one-time warning if this call is the
+    one that pushes the installation's spend this month past
+    WARN_FRACTION_OF_CAP of it - see llm_cost.crossed_spend_warning_threshold.
+    Omit it (as existing callers that predate this did) to skip the check
+    entirely; it has no effect on what gets recorded."""
     import psycopg
 
     with psycopg.connect(dsn) as conn:
@@ -192,10 +203,24 @@ def record_llm_spend(dsn: str, installation_id: int, cost_usd: float) -> None:
                 VALUES (%s, date_trunc('month', now())::date, %s)
                 ON CONFLICT (installation_id, month) DO UPDATE
                 SET total_cost_usd = llm_spend.total_cost_usd + EXCLUDED.total_cost_usd
+                RETURNING total_cost_usd
                 """,
                 (installation_id, cost_usd),
             )
+            row = cur.fetchone()
         conn.commit()
+
+    if monthly_cap is not None and row is not None:
+        new_total = float(row[0])
+        previous_total = new_total - cost_usd
+        if crossed_spend_warning_threshold(previous_total, new_total, monthly_cap):
+            logger.warning(
+                "llm spend crossed %.0f%% of monthly cap: installation=%s $%.2f of $%.2f",
+                WARN_FRACTION_OF_CAP * 100,
+                installation_id,
+                new_total,
+                monthly_cap,
+            )
 
 
 def get_flash_review_count_this_month(dsn: str, installation_id: int) -> int:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1167,7 +1167,7 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                     body = (
                         f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
                         f"Monthly spend cap reached for this installation (${monthly_cap:.2f}). "
-                        "Try again next month, or contact support to increase your limit."
+                        "Resumes next month, or email support@aletheore.com to raise the limit sooner."
                     )
                 else:
                     spend_accumulator = {"total": 0.0, "model": model_for_plan(plan)}
@@ -1184,7 +1184,10 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                         include_llm_suggestions=include_suggestions,
                     )
                     record_llm_spend(
-                        settings.database_url, installation_id, spend_accumulator["total"]
+                        settings.database_url,
+                        installation_id,
+                        spend_accumulator["total"],
+                        monthly_cap=monthly_cap,
                     )
                     verification_token = _sign_and_persist_audit_report(
                         settings,
@@ -1270,7 +1273,12 @@ def run_managed_audit_api_job(
                 plan=plan,
                 include_llm_suggestions=include_suggestions,
             )
-            record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
+            record_llm_spend(
+                settings.database_url,
+                installation_id,
+                spend_accumulator["total"],
+                monthly_cap=monthly_cap,
+            )
             verification_token = _sign_and_persist_audit_report(
                 settings,
                 installation_id,
@@ -1320,7 +1328,7 @@ def run_flash_review_job(
 
         try:
             _run_flash_review(
-                settings, installation_id, repo_full_name, pr_number, base_sha, head_sha
+                settings, installation_id, repo_full_name, pr_number, base_sha, head_sha, monthly_cap
             )
         except Exception as exc:  # noqa: BLE001
             try:
@@ -1338,6 +1346,7 @@ def _run_flash_review(
     pr_number: int,
     base_sha: str,
     head_sha: str,
+    monthly_cap: float,
 ) -> None:
     app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
     token = _token_sync(installation_id, app_jwt)
@@ -1425,7 +1434,9 @@ def _run_flash_review(
                 file_contents=file_contents,
                 on_grounding_result=_on_grounding_result,
             )
-    record_llm_spend(settings.database_url, installation_id, spend_accumulator["total"])
+    record_llm_spend(
+        settings.database_url, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap
+    )
     increment_flash_review_count(settings.database_url, installation_id)
 
     proposed = grounding_result.get("proposed", 0)
@@ -2399,7 +2410,7 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
                 model_used=model_used,
                 fetch_line_count=fetch_line_count,
             )
-            record_llm_spend(dsn, installation_id, spend_accumulator["total"])
+            record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
             _store_wiki_generation(
                 dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
                 fetch_line_count=fetch_line_count,
@@ -2531,7 +2542,7 @@ def _maybe_update_live_wiki(
                 model_used=update_model,
                 fetch_line_count=fetch_line_count,
             )
-            record_llm_spend(dsn, installation_id, spend_accumulator["total"])
+            record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
             _store_wiki_generation(
                 dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
                 fetch_line_count=fetch_line_count,
@@ -2802,7 +2813,7 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         succeeded, last_error = _run_docs_build_for_modules(
             dsn, installation_id, repo_full_name, modules, writing_adapter, client, token, None
         )
-        record_llm_spend(dsn, installation_id, spend_accumulator["total"])
+        record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
     if succeeded == 0 and last_error is not None:
         # Every module in this run failed - genuinely nothing new landed,
         # unlike a partial run where some succeeded and persisted already.
@@ -2941,7 +2952,7 @@ def _maybe_update_live_docs(
         succeeded, last_error = _run_docs_build_for_modules(
             dsn, installation_id, repo_full_name, changed_modules, writing_adapter, client, token, head_sha
         )
-        record_llm_spend(dsn, installation_id, spend_accumulator["total"])
+        record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
     if succeeded == 0 and last_error is not None:
         set_docs_build_status(dsn, installation_id, repo_full_name, "failed", last_error)
         return

--- a/github-app/tests/test_db.py
+++ b/github-app/tests/test_db.py
@@ -196,6 +196,29 @@ async def test_record_llm_spend_is_independent_per_installation(pool):
 
 
 @pytest.mark.asyncio
+async def test_record_llm_spend_without_monthly_cap_never_warns(pool, caplog):
+    """Existing callers that predate the cap-warning parameter must keep
+    working unchanged - omitting monthly_cap skips the check entirely."""
+    await upsert_installation(pool, 500, "octocat")
+    with caplog.at_level("WARNING"):
+        await record_llm_spend(pool, 500, 10.00)
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_record_llm_spend_warns_once_when_crossing_the_threshold(pool, caplog):
+    await upsert_installation(pool, 500, "octocat")
+    with caplog.at_level("WARNING"):
+        await record_llm_spend(pool, 500, 2.00, monthly_cap=15.00)  # under 30% ($4.50)
+        await record_llm_spend(pool, 500, 5.00, monthly_cap=15.00)  # $7 total - crosses it
+        await record_llm_spend(pool, 500, 1.00, monthly_cap=15.00)  # already over - no refire
+
+    warnings = [r for r in caplog.records if "installation=500" in r.message]
+    assert len(warnings) == 1
+    assert "30%" in warnings[0].message
+
+
+@pytest.mark.asyncio
 async def test_get_extra_seats_defaults_to_zero(pool):
     await upsert_installation(pool, 500, "octocat")
     assert await get_extra_seats(pool, 500) == 0

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1409,7 +1409,8 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     )
     recorded_spend = []
     monkeypatch.setattr(
-        "scan_worker.jobs.record_llm_spend", lambda dsn, iid, cost: recorded_spend.append(cost)
+        "scan_worker.jobs.record_llm_spend",
+        lambda dsn, iid, cost, **kwargs: recorded_spend.append(cost),
     )
     monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
     set_sha_calls = []

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -3,7 +3,14 @@ from datetime import date
 import pytest
 
 from app_server import llm_cost
-from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation, stale_models
+from app_server.llm_cost import (
+    WARN_FRACTION_OF_CAP,
+    base_cap_for_plan,
+    cost_for_usage,
+    crossed_spend_warning_threshold,
+    monthly_cap_for_installation,
+    stale_models,
+)
 
 
 def test_cost_for_usage_deepseek_v4_pro():
@@ -94,3 +101,31 @@ def test_cost_for_usage_does_not_warn_for_freshly_verified_model(monkeypatch, ca
         cost_for_usage("deepseek-v4-flash", 1000, 1000)
 
     assert caplog.records == []
+
+
+def test_crossed_spend_warning_threshold_fires_on_the_crossing_increment():
+    """A $10 increment against a $15 cap crosses the 30% ($4.50) threshold
+    partway through - previous total ($2) was under it, new total ($12) is
+    over."""
+    assert crossed_spend_warning_threshold(2.0, 12.0, 15.0) is True
+
+
+def test_crossed_spend_warning_threshold_does_not_fire_while_still_under():
+    assert crossed_spend_warning_threshold(1.0, 2.0, 15.0) is False
+
+
+def test_crossed_spend_warning_threshold_does_not_refire_once_already_over():
+    """Edge-triggered: an installation already past the threshold must not
+    log again on every subsequent call for the rest of the month."""
+    assert crossed_spend_warning_threshold(10.0, 11.0, 15.0) is False
+
+
+def test_crossed_spend_warning_threshold_fires_exactly_at_the_boundary():
+    threshold = WARN_FRACTION_OF_CAP * 15.0
+    assert crossed_spend_warning_threshold(threshold - 0.01, threshold, 15.0) is True
+
+
+def test_crossed_spend_warning_threshold_never_fires_for_a_zero_cap():
+    """A zero cap means no plan matched (base_cap_for_plan's default) - not
+    a real installation to warn about."""
+    assert crossed_spend_warning_threshold(0.0, 100.0, 0.0) is False

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -619,6 +619,27 @@ async def test_record_llm_spend_accumulates_sync(pool):
 
 
 @pytest.mark.asyncio
+async def test_record_llm_spend_sync_without_monthly_cap_never_warns(pool, caplog):
+    await _insert_installation(pool, 301, "a")
+    with caplog.at_level("WARNING"):
+        record_llm_spend(TEST_DATABASE_URL, 301, 10.00)
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_record_llm_spend_sync_warns_once_when_crossing_the_threshold(pool, caplog):
+    await _insert_installation(pool, 301, "a")
+    with caplog.at_level("WARNING"):
+        record_llm_spend(TEST_DATABASE_URL, 301, 2.00, monthly_cap=15.00)  # under 30% ($4.50)
+        record_llm_spend(TEST_DATABASE_URL, 301, 5.00, monthly_cap=15.00)  # $7 total - crosses it
+        record_llm_spend(TEST_DATABASE_URL, 301, 1.00, monthly_cap=15.00)  # already over
+
+    warnings = [r for r in caplog.records if "installation=301" in r.message]
+    assert len(warnings) == 1
+    assert "30%" in warnings[0].message
+
+
+@pytest.mark.asyncio
 async def test_get_extra_seats_sync_defaults_to_zero(pool):
     await _insert_installation(pool, 301, "a")
     assert get_extra_seats(TEST_DATABASE_URL, 301) == 0


### PR DESCRIPTION
## Summary
- Adds a one-time warning log (`llm spend crossed 30% of monthly cap...`) when an installation's recorded spend crosses `WARN_FRACTION_OF_CAP` (0.3) of its monthly cap — the cap itself is a worst-case abuse ceiling per its own comments, not a metering target, so this is the missing early signal.
- `record_llm_spend` (both async/sync) now returns the new total via the existing `INSERT ... RETURNING` (no extra query) and takes an optional `monthly_cap` param; edge-triggered so it logs once per crossing, not on every call after.
- All 8 call sites (managed audit x2, flash review, live wiki x2, live docs x2, hosted embeddings) now pass their already-computed `monthly_cap` through.
- Softened the hosted-embeddings 402 and the managed-audit chat comment to name the free, uncapped fallback and support@aletheore.com instead of reading as a dead end.

## Test plan
- [x] New unit tests for `crossed_spend_warning_threshold` (edge/boundary/no-refire/zero-cap cases)
- [x] New integration tests for both `record_llm_spend` variants against a real test Postgres (warns once on crossing, never warns without `monthly_cap`)
- [x] Full github-app suite: 1181 passed, 8 skipped (pre-existing skips, unrelated)