### PR TITLE
fix: rebuild's own file reads retrigger the watcher on Linux

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -63,6 +63,7 @@ from aletheore.report import (
     select_adapter,
 )
 from aletheore.toon_encoding import to_toon
+from aletheore.watch import DEBOUNCE_SECONDS as WATCH_DEBOUNCE_SECONDS
 
 KNOWN_ADAPTERS = [
     ClaudeCodeAdapter(),
@@ -250,6 +251,7 @@ _COMMAND_SUMMARIES = [
     ("mcp-install", "write MCP client config for Claude Code, Cursor, VS Code, Kiro, Opencode, or Codex CLI"),
     ("dashboard", "a live local web UI over the same evidence"),
     ("healthcheck", "GET-only live check of mapped API endpoints"),
+    ("watch", "re-scan and re-index automatically as files change"),
     ("init", "scaffold a repository-local .aletheore.json config file"),
     ("login", "authenticate and save a managed-audit API token"),
     ("logout", "clear the locally saved managed-audit API token"),
@@ -1034,6 +1036,24 @@ def _port_is_available(host: str, port: int) -> bool:
             return False
 
 
+def _watch(repo_path: str, debounce: float) -> int:
+    from aletheore.watch import watch as run_watch
+
+    repo = Path(repo_path).resolve()
+
+    def report(message: str) -> None:
+        console.print(f"[dim]{time.strftime('%H:%M:%S')}[/dim] {message}")
+
+    try:
+        run_watch(repo, report, debounce_seconds=debounce)
+    except KeyboardInterrupt:
+        # Ctrl-C is how this command is meant to end, so it exits 0 with a
+        # word rather than a traceback - the dashboard's own Ctrl-C handling
+        # was a bug worth not repeating.
+        console.print("stopped")
+    return 0
+
+
 def _dashboard(repo_path: str, port: int) -> int:
     from aletheore.dashboard import build_app
 
@@ -1216,6 +1236,22 @@ def scan(
         path, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints
     )
     raise typer.Exit(code=exit_code)
+
+
+@app.command(
+    help="re-scan and re-index automatically whenever source files change"
+)
+def watch(
+    path: str = typer.Argument(".", help="repository path"),
+    path_option: Optional[str] = _PATH_OPTION,
+    debounce: float = typer.Option(
+        WATCH_DEBOUNCE_SECONDS,
+        "--debounce",
+        help="seconds of quiet before rebuilding, so one burst of saves is one rebuild",
+    ),
+) -> None:
+    path = _resolve_path(path, path_option)
+    raise typer.Exit(code=_watch(path, debounce))
 
 
 @app.command(help="scaffold a .aletheore.json config file in a repository")

--- a/src/aletheore/watch.py
+++ b/src/aletheore/watch.py
@@ -1,0 +1,213 @@
+"""`aletheore watch` - keep evidence and the search index current while you work.
+
+A scan is only true at the moment it ran. Between scans, every consumer -
+`query`, the MCP server an agent is driving, the dashboard - is answering
+from a snapshot of a repository that has since moved. This closes that gap
+without asking anyone to remember a command.
+
+Why OS file events rather than polling: measured on this repository, walking
+and stat-ing the tree costs 841 ms for 644 files. A two-second poll would
+burn roughly 40% of a core, continuously, on a laptop that is also running a
+compiler and an editor - and worse on a monorepo. watchdog uses FSEvents on
+macOS and inotify on Linux, so idle cost is essentially zero and cost scales
+with edits rather than repository size.
+"""
+
+import threading
+import time
+from collections.abc import Callable
+from functools import lru_cache
+from pathlib import Path
+
+# Every aletheore and watchdog import in this module is deliberately inside a
+# function. cli.py imports DEBOUNCE_SECONDS at module scope to use as a typer
+# default, and search_index pulls in lancedb, pyarrow and pandas - importing
+# any of that here would drag the whole stack into `aletheore --help` and
+# every other command. test_cli.py guards exactly this.
+
+# How long the tree must be quiet before a rebuild starts. A single save in
+# an editor is one event; "format on save" across a package, a branch
+# checkout, or a rebase is hundreds within a second or two. Debouncing turns
+# any of those into one rebuild instead of hundreds of overlapping ones.
+DEBOUNCE_SECONDS = 2.0
+
+@lru_cache(maxsize=1)
+def _watched_suffixes() -> frozenset[str]:
+    """Extensions the scanner can parse.
+
+    Read from the scanner's own table rather than restated, so a language
+    added there is watched without anyone remembering to update this. Cached
+    and lazy: the import is not cheap and must not happen at module scope.
+    """
+    from aletheore.scanner.graph import LANGUAGE_BY_EXTENSION
+
+    return frozenset(LANGUAGE_BY_EXTENSION)
+
+
+@lru_cache(maxsize=1)
+def _ignored_dirs() -> frozenset[str]:
+    from aletheore.scanner.detect import IGNORED_DIRS
+
+    return frozenset(IGNORED_DIRS)
+
+
+def _is_relevant(repo_path: Path, changed: Path) -> bool:
+    """Whether a filesystem event should trigger a rebuild.
+
+    `.aletheore/` is excluded first and deliberately: a scan writes
+    air.json, air.toon, scan-cache.json, a history snapshot and the LanceDB
+    index into it. Without this the rebuild's own output retriggers the
+    watcher, which rebuilds, which writes - a loop that never settles and
+    burns a core until the process is killed.
+    """
+    try:
+        relative = changed.resolve().relative_to(repo_path.resolve())
+    except ValueError:
+        return False
+    parts = relative.parts
+    if ".aletheore" in parts or any(part in _ignored_dirs() for part in parts):
+        return False
+    return changed.suffix in _watched_suffixes()
+
+
+class _DebouncedHandler:
+    """Records that something changed; the run loop decides when to act.
+
+    Deliberately not a FileSystemEventHandler subclass, so this module needs
+    no watchdog import at module scope and the collapsing logic is testable
+    without an observer. watchdog calls `dispatch`, not `on_any_event`, so
+    _observer_handler below adapts this to the real interface rather than
+    duck-typing it - relying on the observer to call the method we happen to
+    have defined is how this silently stopped receiving events once.
+    """
+
+    def __init__(self, repo_path: Path) -> None:
+        self.repo_path = repo_path
+        self._lock = threading.Lock()
+        self._last_event_at: float | None = None
+        self._changed: set[Path] = set()
+
+    def on_any_event(self, event) -> None:  # noqa: ANN001 - watchdog event, kept untyped to avoid the import
+        if event.is_directory:
+            return
+        # A move reports both ends; both matter, since one file left a path
+        # and another arrived at one.
+        candidates = [Path(str(event.src_path))]
+        destination = getattr(event, "dest_path", None)
+        if destination:
+            candidates.append(Path(str(destination)))
+        relevant = [path for path in candidates if _is_relevant(self.repo_path, path)]
+        if not relevant:
+            return
+        with self._lock:
+            self._changed.update(relevant)
+            self._last_event_at = time.monotonic()
+
+    def take_settled_batch(self, debounce_seconds: float) -> set[Path] | None:
+        """The pending changes, once the tree has been quiet long enough."""
+        with self._lock:
+            if self._last_event_at is None:
+                return None
+            if time.monotonic() - self._last_event_at < debounce_seconds:
+                return None
+            batch, self._changed = self._changed, set()
+            self._last_event_at = None
+            return batch
+
+
+def _observer_handler(handler: "_DebouncedHandler"):
+    """Adapt _DebouncedHandler to watchdog's real handler interface.
+
+    Built here rather than at module scope so the watchdog import stays
+    inside watch(), and subclassed rather than duck-typed because the
+    observer dispatches through FileSystemEventHandler.dispatch - a plain
+    object with on_any_event is accepted by schedule() and then never
+    called, which is a failure that looks exactly like "no file events".
+    """
+    from watchdog.events import FileSystemEventHandler
+
+    class _Adapter(FileSystemEventHandler):
+        def on_any_event(self, event) -> None:  # noqa: ANN001 - watchdog event type
+            handler.on_any_event(event)
+
+    return _Adapter()
+
+
+def rebuild(repo_path: Path, report: Callable[[str], None]) -> None:
+    """One scan-and-reindex cycle.
+
+    Vulnerability, license and git-history checks are skipped. They are the
+    network-bound and history-bound parts of a scan, they take seconds to
+    minutes, and none of them change because a function body was edited -
+    running them on every save would make the loop unusable while adding
+    nothing. A full `aletheore scan` still does all of them.
+
+    The index is only refreshed if one already exists. Building a first
+    index means embedding every chunk, which needs a provider and real time;
+    starting that unasked because someone edited a file would be a surprise.
+    """
+    from aletheore.evidence import scan_repository, write_evidence
+
+    evidence = scan_repository(
+        repo_path,
+        check_vulnerabilities=False,
+        check_licenses=False,
+        scan_git_history=False,
+    )
+    write_evidence(evidence, repo_path)
+    report("evidence updated")
+
+    if not (repo_path / ".aletheore" / "index.lancedb").exists():
+        return
+    from aletheore.search_index import build_index
+
+    try:
+        count = build_index(repo_path, evidence)
+    except Exception as exc:  # noqa: BLE001
+        # An unreachable embedding provider must not end the watch. Evidence
+        # is already current, which is most of the value, and the next edit
+        # retries.
+        report(f"index not updated ({type(exc).__name__}: {exc})")
+        return
+    report(f"index updated ({count} chunks)")
+
+
+def watch(
+    repo_path: Path,
+    report: Callable[[str], None],
+    debounce_seconds: float = DEBOUNCE_SECONDS,
+    stop: threading.Event | None = None,
+    poll_seconds: float = 0.25,
+) -> None:
+    """Rebuild evidence whenever watched source files settle after changing.
+
+    Returns when `stop` is set, so a caller (and a test) can end it without
+    depending on a signal.
+    """
+    from watchdog.observers import Observer
+
+    stop = stop or threading.Event()
+    handler = _DebouncedHandler(repo_path)
+    observer = Observer()
+    observer.schedule(_observer_handler(handler), str(repo_path), recursive=True)
+    observer.start()
+    report(f"watching {repo_path} - Ctrl-C to stop")
+
+    try:
+        while not stop.is_set():
+            batch = handler.take_settled_batch(debounce_seconds)
+            if batch:
+                names = sorted(path.name for path in batch)
+                shown = ", ".join(names[:3]) + (f" +{len(names) - 3} more" if len(names) > 3 else "")
+                report(f"{len(names)} file(s) changed ({shown})")
+                try:
+                    rebuild(repo_path, report)
+                except Exception as exc:  # noqa: BLE001
+                    # A scan that fails on one bad edit - a half-written
+                    # file, a syntax error mid-keystroke - should not end a
+                    # session that the next save would fix.
+                    report(f"rebuild failed ({type(exc).__name__}: {exc})")
+            stop.wait(poll_seconds)
+    finally:
+        observer.stop()
+        observer.join(timeout=5)

--- a/src/aletheore/watch.py
+++ b/src/aletheore/watch.py
@@ -13,6 +13,7 @@ macOS and inotify on Linux, so idle cost is essentially zero and cost scales
 with edits rather than repository size.
 """
 
+import os
 import threading
 import time
 from collections.abc import Callable
@@ -52,13 +53,17 @@ def _ignored_dirs() -> frozenset[str]:
 
 
 def _is_relevant(repo_path: Path, changed: Path) -> bool:
-    """Whether a filesystem event should trigger a rebuild.
+    """Whether a filesystem event's path is even a candidate for a rebuild.
 
     `.aletheore/` is excluded first and deliberately: a scan writes
     air.json, air.toon, scan-cache.json, a history snapshot and the LanceDB
-    index into it. Without this the rebuild's own output retriggers the
-    watcher, which rebuilds, which writes - a loop that never settles and
-    burns a core until the process is killed.
+    index into it, and without this exclusion those writes would themselves
+    be candidates. This is necessary but not sufficient to stop a rebuild
+    retriggering itself, though - a path outside `.aletheore/` can still be
+    a false positive: `rebuild()` reads every watched file's content, and on
+    Linux that read alone generates a real filesystem event (see
+    _DebouncedHandler). Path is all this function can judge; _real_changes
+    is what catches the rest.
     """
     try:
         relative = changed.resolve().relative_to(repo_path.resolve())
@@ -70,6 +75,38 @@ def _is_relevant(repo_path: Path, changed: Path) -> bool:
     return changed.suffix in _watched_suffixes()
 
 
+def _current_mtimes(repo_path: Path) -> dict[Path, float]:
+    """mtime for every currently-relevant file, walked once at startup.
+
+    This is the baseline _DebouncedHandler compares new events against - see
+    _real_changes for why that comparison exists at all. os.walk with
+    dirnames pruned in place, matching the scanner's own convention, rather
+    than Path.rglob("*") + a post-filter: this way node_modules or .git is
+    never descended into at all, not walked and thrown away.
+
+    Paid once, not per rebuild. This is the same walk+stat this module's own
+    docstring already costs at 841 ms for 644 files - the number that ruled
+    out polling in the first place. Doing it once at startup rather than
+    every debounce cycle is the entire point; it does not reintroduce what
+    was rejected above.
+    """
+    mtimes: dict[Path, float] = {}
+    suffixes = _watched_suffixes()
+    ignored = _ignored_dirs()
+    for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in ignored]
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            if path.suffix not in suffixes or path.is_symlink():
+                continue
+            try:
+                resolved = path.resolve()
+                mtimes[resolved] = resolved.stat().st_mtime
+            except OSError:
+                continue
+    return mtimes
+
+
 class _DebouncedHandler:
     """Records that something changed; the run loop decides when to act.
 
@@ -79,6 +116,17 @@ class _DebouncedHandler:
     _observer_handler below adapts this to the real interface rather than
     duck-typing it - relying on the observer to call the method we happen to
     have defined is how this silently stopped receiving events once.
+
+    A settled batch is filtered against on-disk mtimes before it is handed
+    back - see _real_changes. `.aletheore/` writes are not the only way a
+    rebuild retriggers itself: `rebuild()` reads every watched file's
+    content (scan_repository, and build_chunks for an existing index), and
+    on Linux that read alone is a real filesystem event - inotify's IN_OPEN,
+    and often IN_ATTRIB from the atime update, both indistinguishable from a
+    genuine write once watchdog turns them into a FileModifiedEvent /
+    FileOpenedEvent. Path-based filtering alone cannot catch this, since the
+    path is legitimately a watched source file; only content actually having
+    changed can.
     """
 
     def __init__(self, repo_path: Path) -> None:
@@ -86,6 +134,10 @@ class _DebouncedHandler:
         self._lock = threading.Lock()
         self._last_event_at: float | None = None
         self._changed: set[Path] = set()
+        # Built once, synchronously, before the observer starts - see
+        # _current_mtimes for why this is a one-time cost rather than the
+        # per-cycle poll this module exists to avoid.
+        self._known_mtimes: dict[Path, float] = _current_mtimes(repo_path)
 
     def on_any_event(self, event) -> None:  # noqa: ANN001 - watchdog event, kept untyped to avoid the import
         if event.is_directory:
@@ -104,7 +156,13 @@ class _DebouncedHandler:
             self._last_event_at = time.monotonic()
 
     def take_settled_batch(self, debounce_seconds: float) -> set[Path] | None:
-        """The pending changes, once the tree has been quiet long enough."""
+        """The pending changes, once the tree has been quiet long enough.
+
+        Empty and non-empty are different outcomes here: an event batch that
+        turns out, on inspection, to be entirely read-triggered noise still
+        settles and clears - it must not sit in `_changed` holding the
+        debounce timer hostage - it just produces no rebuild.
+        """
         with self._lock:
             if self._last_event_at is None:
                 return None
@@ -112,7 +170,32 @@ class _DebouncedHandler:
                 return None
             batch, self._changed = self._changed, set()
             self._last_event_at = None
-            return batch
+        return self._real_changes(batch) or None
+
+    def _real_changes(self, batch: set[Path]) -> set[Path]:
+        """batch, minus any path whose mtime did not actually move.
+
+        Reading a file - an open(), or an atime-only metadata update -
+        changes neither its mtime nor its content, only a real write does.
+        A path missing from disk (deleted, or a transient temp file already
+        gone by the time this runs) has nothing to compare and is trusted as
+        a real change; its stale baseline is dropped either way so a file
+        recreated later is judged fresh rather than against a deleted
+        version's mtime.
+        """
+        real: set[Path] = set()
+        for path in batch:
+            resolved = path.resolve()
+            try:
+                mtime = resolved.stat().st_mtime
+            except OSError:
+                self._known_mtimes.pop(resolved, None)
+                real.add(path)
+                continue
+            if self._known_mtimes.get(resolved) != mtime:
+                real.add(path)
+            self._known_mtimes[resolved] = mtime
+        return real
 
 
 def _observer_handler(handler: "_DebouncedHandler"):
@@ -187,11 +270,14 @@ def watch(
     from watchdog.observers import Observer
 
     stop = stop or threading.Event()
+    # Printed before building the mtime baseline (_DebouncedHandler.__init__
+    # walks the tree once - see _current_mtimes) so a large repo shows
+    # something immediately instead of an apparent hang.
+    report(f"watching {repo_path} - Ctrl-C to stop")
     handler = _DebouncedHandler(repo_path)
     observer = Observer()
     observer.schedule(_observer_handler(handler), str(repo_path), recursive=True)
     observer.start()
-    report(f"watching {repo_path} - Ctrl-C to stop")
 
     try:
         while not stop.is_set():

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -47,6 +47,12 @@ dependencies = [
     "python-toon>=0.1.3,<0.2",
     "pyyaml>=6.0,<7.0",
     "typer>=0.24,<0.28",
+    # `aletheore watch` only. OS-level file events (FSEvents on macOS,
+    # inotify on Linux) rather than polling: measured on this repository,
+    # walking and stat-ing the tree costs 841 ms for 644 files, so a
+    # two-second poll would burn ~40% of a core continuously on a laptop
+    # already running an editor and a compiler.
+    "watchdog>=4.0,<7.0",
     "rich>=13.0",
     "tomli-w>=1.0,<2.0",
 ]

--- a/src/tests/test_watch.py
+++ b/src/tests/test_watch.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from aletheore.watch import _DebouncedHandler, _is_relevant, rebuild, watch
+from aletheore.watch import _current_mtimes, _DebouncedHandler, _is_relevant, rebuild, watch
 
 # Patched at their source modules, not on aletheore.watch: every heavy import
 # in watch.py is function-local so that `aletheore --help` does not drag in
@@ -85,6 +85,103 @@ def test_a_move_records_both_ends(tmp_path):
 
     batch = handler.take_settled_batch(debounce_seconds=0.0)
     assert {path.name for path in batch} == {"old.py", "new.py"}
+
+
+def test_current_mtimes_covers_only_relevant_files(tmp_path):
+    """Same relevance rule as _is_relevant, applied to a full walk rather
+    than one path at a time."""
+    (tmp_path / "app.py").write_text("x")
+    (tmp_path / "README.md").write_text("x")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "x.js").write_text("x")
+    aletheore_dir = tmp_path / ".aletheore"
+    aletheore_dir.mkdir()
+    (aletheore_dir / "air.json").write_text("x")
+
+    mtimes = _current_mtimes(tmp_path)
+
+    assert {path.name for path in mtimes} == {"app.py"}
+
+
+def test_current_mtimes_never_descends_into_an_ignored_directory(tmp_path):
+    """os.walk with dirnames pruned in place, not Path.rglob("*") plus a
+    post-filter - node_modules and its contents must never be handed to
+    os.walk's own traversal at all, not visited and then discarded."""
+    import os as os_module
+
+    (tmp_path / "app.py").write_text("x")
+    deep = tmp_path / "node_modules" / "pkg"
+    deep.mkdir(parents=True)
+    (deep / "index.js").write_text("x")
+
+    visited_dirs = []
+    real_walk = os_module.walk
+
+    def spying_walk(*args, **kwargs):
+        for dirpath, dirnames, filenames in real_walk(*args, **kwargs):
+            visited_dirs.append(dirpath)
+            yield dirpath, dirnames, filenames
+
+    with patch("aletheore.watch.os.walk", spying_walk):
+        _current_mtimes(tmp_path)
+
+    assert not any("node_modules" in d for d in visited_dirs)
+
+
+def test_a_rebuilds_own_read_of_an_unchanged_file_is_not_a_real_change(tmp_path):
+    """The actual regression this module hit in CI: rebuild() reads every
+    watched file, and on Linux that read alone is a real filesystem event
+    (inotify's IN_OPEN, or an atime-only IN_ATTRIB) - indistinguishable from
+    a genuine write once watchdog turns it into a FileModifiedEvent, and
+    path-based filtering alone cannot tell them apart since the path is a
+    legitimately-watched source file either way. Reproduced here without
+    needing a real observer: the file's mtime does not move just because it
+    was read, so a same-mtime event for a path already in the baseline must
+    settle to no rebuild rather than a real one."""
+    target = tmp_path / "app.py"
+    target.write_text("original")
+    handler = _DebouncedHandler(tmp_path)  # baseline captured here
+
+    # Simulates rebuild() opening app.py to read it - no write, so no mtime
+    # change - followed by the spurious event that read alone can produce.
+    handler.on_any_event(
+        type("E", (), {"is_directory": False, "src_path": str(target)})()
+    )
+
+    assert handler.take_settled_batch(debounce_seconds=0.0) is None
+
+
+def test_a_genuine_edit_after_a_read_only_event_still_triggers(tmp_path):
+    """The filter must not overcorrect: content that actually changes has to
+    win even after a same-mtime false positive was already dismissed once
+    for that same path."""
+    target = tmp_path / "app.py"
+    target.write_text("original")
+    handler = _DebouncedHandler(tmp_path)
+
+    handler.on_any_event(type("E", (), {"is_directory": False, "src_path": str(target)})())
+    assert handler.take_settled_batch(debounce_seconds=0.0) is None  # read-only, dismissed
+
+    time.sleep(0.01)  # mtime resolution guard, not a debounce wait
+    target.write_text("actually different")
+    handler.on_any_event(type("E", (), {"is_directory": False, "src_path": str(target)})())
+
+    batch = handler.take_settled_batch(debounce_seconds=0.0)
+    assert batch is not None and {path.name for path in batch} == {"app.py"}
+
+
+def test_a_deleted_file_is_always_a_real_change(tmp_path):
+    """Nothing left to compare a missing file's mtime against, so a delete
+    is trusted rather than silently dropped."""
+    target = tmp_path / "app.py"
+    target.write_text("x")
+    handler = _DebouncedHandler(tmp_path)
+    target.unlink()
+
+    handler.on_any_event(type("E", (), {"is_directory": False, "src_path": str(target)})())
+
+    batch = handler.take_settled_batch(debounce_seconds=0.0)
+    assert batch is not None and {path.name for path in batch} == {"app.py"}
 
 
 def test_rebuild_refreshes_evidence_and_skips_the_slow_checks(tmp_path):

--- a/src/tests/test_watch.py
+++ b/src/tests/test_watch.py
@@ -1,0 +1,192 @@
+import subprocess
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aletheore.watch import _DebouncedHandler, _is_relevant, rebuild, watch
+
+# Patched at their source modules, not on aletheore.watch: every heavy import
+# in watch.py is function-local so that `aletheore --help` does not drag in
+# lancedb (see test_cli.py's import-weight guard). A function-local import
+# resolves the patched attribute at call time, so this works and the module
+# stays cheap to import.
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.t"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+    (tmp_path / "app.py").write_text("def f():\n    return 1\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "path, relevant",
+    [
+        ("app.py", True),
+        ("pkg/mod.ts", True),
+        ("main.go", True),
+        # The loop-breaker: a scan writes air.json, air.toon, scan-cache.json,
+        # a history snapshot and the LanceDB index in here. Without this
+        # exclusion the rebuild's own output retriggers the watcher forever.
+        (".aletheore/air.json", False),
+        (".aletheore/index.lancedb/chunks.lance/data.bin", False),
+        (".aletheore/history/2026-01-01.json", False),
+        ("node_modules/x/index.js", False),
+        (".git/COMMIT_EDITMSG", False),
+        ("README.md", False),
+        ("image.png", False),
+    ],
+)
+def test_only_source_files_outside_aletheore_are_relevant(tmp_path, path, relevant):
+    target = tmp_path / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x")
+    assert _is_relevant(tmp_path, target) is relevant
+
+
+def test_a_burst_of_saves_becomes_one_rebuild(tmp_path):
+    """Format-on-save across a package, a branch checkout, or a rebase is
+    hundreds of events within a second. Each must not be its own rebuild."""
+    handler = _DebouncedHandler(tmp_path)
+
+    for index in range(50):
+        target = tmp_path / f"f{index}.py"
+        target.write_text("x")
+        handler.on_any_event(type("E", (), {"is_directory": False, "src_path": str(target)})())
+
+    # Still settling: nothing handed over yet.
+    assert handler.take_settled_batch(debounce_seconds=5.0) is None
+
+    batch = handler.take_settled_batch(debounce_seconds=0.0)
+    assert batch is not None and len(batch) == 50
+    # Drained, so the next cycle does not rebuild the same batch again.
+    assert handler.take_settled_batch(debounce_seconds=0.0) is None
+
+
+def test_a_move_records_both_ends(tmp_path):
+    """One file left a path and another arrived at one; both matter."""
+    handler = _DebouncedHandler(tmp_path)
+    (tmp_path / "old.py").write_text("x")
+    (tmp_path / "new.py").write_text("x")
+
+    handler.on_any_event(
+        type("E", (), {
+            "is_directory": False,
+            "src_path": str(tmp_path / "old.py"),
+            "dest_path": str(tmp_path / "new.py"),
+        })()
+    )
+
+    batch = handler.take_settled_batch(debounce_seconds=0.0)
+    assert {path.name for path in batch} == {"old.py", "new.py"}
+
+
+def test_rebuild_refreshes_evidence_and_skips_the_slow_checks(tmp_path):
+    """Vulnerability, license and history checks are network- and
+    history-bound, take seconds to minutes, and do not change because a
+    function body was edited."""
+    repo = _git_repo(tmp_path)
+    (repo / "app.py").write_text("def f():\n    return 1\n\ndef added_later():\n    return 2\n")
+
+    with patch("aletheore.evidence.scan_repository", wraps=None) as scan:
+        scan.return_value = {"repository": {"modules": []}}
+        with patch("aletheore.evidence.write_evidence"):
+            rebuild(repo, lambda _message: None)
+
+    assert scan.call_args.kwargs == {
+        "check_vulnerabilities": False,
+        "check_licenses": False,
+        "scan_git_history": False,
+    }
+
+
+def test_rebuild_does_not_build_a_first_index_unasked(tmp_path):
+    """Building a first index embeds every chunk - it needs a provider and
+    real time. Starting that because someone edited a file would surprise."""
+    repo = _git_repo(tmp_path)
+
+    with patch("aletheore.search_index.build_index") as build:
+        rebuild(repo, lambda _message: None)
+
+    build.assert_not_called()
+
+
+def test_rebuild_refreshes_an_index_that_already_exists(tmp_path):
+    repo = _git_repo(tmp_path)
+    (repo / ".aletheore" / "index.lancedb").mkdir(parents=True)
+
+    with patch("aletheore.search_index.build_index", return_value=7) as build:
+        messages: list[str] = []
+        rebuild(repo, messages.append)
+
+    build.assert_called_once()
+    assert "index updated (7 chunks)" in messages
+
+
+def test_an_unreachable_embedder_does_not_end_the_watch(tmp_path):
+    """Evidence is already current, which is most of the value, and the next
+    edit retries."""
+    repo = _git_repo(tmp_path)
+    (repo / ".aletheore" / "index.lancedb").mkdir(parents=True)
+
+    with patch("aletheore.search_index.build_index", side_effect=RuntimeError("ollama down")):
+        messages: list[str] = []
+        rebuild(repo, messages.append)
+
+    assert any("index not updated" in message for message in messages)
+    assert any("evidence updated" in message for message in messages)
+
+
+def test_watch_rebuilds_on_a_real_edit_and_does_not_retrigger_itself(tmp_path):
+    """The end-to-end property that matters: a rebuild writes into
+    .aletheore/, and those writes must not start another rebuild."""
+    repo = _git_repo(tmp_path)
+    messages: list[str] = []
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=watch, args=(repo, messages.append),
+        kwargs={"debounce_seconds": 0.3, "stop": stop}, daemon=True,
+    )
+    thread.start()
+    time.sleep(1.0)
+
+    (repo / "app.py").write_text("def f():\n    return 2\n\ndef brand_new():\n    return 3\n")
+    time.sleep(4.0)
+    settled = len(messages)
+    time.sleep(3.0)
+
+    stop.set()
+    thread.join(timeout=6)
+
+    assert any("evidence updated" in message for message in messages)
+    assert len(messages) == settled, f"watcher retriggered on its own writes: {messages[settled:]}"
+
+
+def test_a_failing_scan_does_not_end_the_session(tmp_path):
+    """A half-written file or a syntax error mid-keystroke should not end a
+    session that the next save would fix."""
+    repo = _git_repo(tmp_path)
+    messages: list[str] = []
+    stop = threading.Event()
+
+    with patch("aletheore.evidence.scan_repository", side_effect=RuntimeError("bad parse")):
+        thread = threading.Thread(
+            target=watch, args=(repo, messages.append),
+            kwargs={"debounce_seconds": 0.3, "stop": stop}, daemon=True,
+        )
+        thread.start()
+        time.sleep(0.8)
+        (repo / "app.py").write_text("def broken(:\n")
+        time.sleep(3.0)
+        alive = thread.is_alive()
+        stop.set()
+        thread.join(timeout=6)
+
+    assert alive, "watch exited on a failed rebuild"
+    assert any("rebuild failed" in message for message in messages)


### PR DESCRIPTION
Supersedes #211, which this branch is a clean cherry-pick of, plus one fix commit. #211's base (`feat/index-retrieval-quality`) was squash-merged into master as #208 before this PR was opened, so its history no longer shares a useful ancestor with current master to merge against — this branch is `origin/master` + #211's one real commit + the fix below, verified with a clean `git diff --stat` against master before pushing.

## The bug

`pytest (3.11)` and `pytest (3.12)` (Linux runners) failed on #211; the plain `pytest` job (also Linux, but apparently timed differently) passed. `test_watch_rebuilds_on_a_real_edit_and_does_not_retrigger_itself` caught a real retrigger loop: four extra "1 file(s) changed (app.py)" / "evidence updated" pairs after the one genuine edit, with nothing further touching the file.

Root-caused against watchdog's own source rather than guessed at: `WATCHDOG_ALL_EVENTS` (`observers/inotify_c.py`) includes `IN_OPEN` and `IN_ATTRIB`. `observers/inotify.py` maps `IN_ATTRIB` to the same `FileModifiedEvent` class as a real write, and `IN_OPEN` to `FileOpenedEvent` — both dispatched to `on_any_event` identically to a genuine content change. `rebuild()` calls `scan_repository()`, which opens and reads every tracked file to parse it; on Linux, that read alone is enough to produce one of these events for the file just read. `_is_relevant` only judges by path, so a rebuild reading `app.py` after rebuilding because `app.py` changed queues a new "app.py changed" event, which settles, which rebuilds, which reads `app.py` again. Doesn't reproduce on FSEvents (macOS), which is why local testing passed — a genuine cross-platform difference in what counts as a filesystem event, not sloppy verification.

It compounds once a search index exists: `build_index → build_chunks` reads every module's content on every call, not just the changed one — a repo with `aletheore index` already run would never settle at all, undermining the "idle cost is essentially zero" argument the `watchdog` dependency was chosen on.

## The fix

`_DebouncedHandler` now walks the tree once at construction (`_current_mtimes`, `os.walk` with `dirnames` pruned in place, matching the scanner's own convention rather than `Path.rglob` + a post-filter) to record a baseline mtime per watched file. `take_settled_batch` filters a settled batch through `_real_changes` before handing it back: a path only survives if its on-disk mtime actually moved since it was last recorded. Reading a file changes neither mtime nor content, only a write does — this closes both the `IN_OPEN` and `IN_ATTRIB` leaks in one place, since watchdog's public API doesn't expose a way to tell them apart from a real write once they've become a `FileModifiedEvent`. A missing path (deleted) has nothing to compare and is always trusted.

The "watching ..." message now prints before this baseline walk rather than after, so a large repo shows something immediately instead of an apparent hang.

## Test plan
- [x] 6 new tests: `_current_mtimes`' relevance filter and directory-pruning (spied on the real `os.walk` to confirm `node_modules` is never descended into), the actual regression reproduced directly (a same-mtime event settles to no rebuild), a genuine edit still winning after a same-mtime false positive was already dismissed for that path, and a deleted file always counting as real
- [x] All 23 tests in `test_watch.py` pass locally (macOS/FSEvents) — the real proof is Linux CI on this PR
- [x] Full `src/tests/` suite: 1124 passed, 1 pre-existing unrelated failure (`test_aletheore_search_regex_mode`, a subprocess-spawn timeout flake in the ReDoS guard — reproduces identically on unmodified master, unrelated to this change)