### PR TITLE
fix: hosted embeddings rate limit shared across repos on one token

### DIFF
--- a/github-app/app_server/embeddings_api.py
+++ b/github-app/app_server/embeddings_api.py
@@ -57,16 +57,33 @@ MAX_TEXTS_PER_REQUEST = 256
 # than a limit real usage approaches.
 MAX_CHARS_PER_TEXT = 8_000
 
-# Generous, because a legitimate first index of a large repository is a
-# burst: ~1,500 chunks at 200 per request is 8 calls, and a monorepo several
-# times that. The spend cap is the real cost control; this only stops a
-# caller from turning one token into unbounded upstream volume.
-RATE_LIMIT_REQUESTS = 400
+# Keyed per (installation, repo_id) below, not just installation - see the
+# repo_id field. `aletheore watch`'s 2-second debounce means one repo alone
+# can theoretically send up to 1,800 requests/hour (one settled batch every
+# debounce interval); real editing sessions land far below that, but the
+# ceiling has to clear it with room, not just the common case. Generous
+# beyond that too, because a legitimate first index of a large repository
+# is a burst: ~1,500 chunks at 200 per request is 8 calls, and a monorepo
+# several times that. The spend cap is the real cost control; this only
+# stops a caller from turning one token into unbounded upstream volume.
+RATE_LIMIT_REQUESTS = 2000
 RATE_LIMIT_WINDOW_SECONDS = 3600
+
+# Bucket key length, not a content limit: repo_id is a 16-char hex prefix of
+# a sha256 (see aletheore.search_index._repo_id) client-side, but the field
+# is caller-supplied and unauthenticated-in-meaning - it only ever affects
+# which rate-limit counter a request lands in, never authorization or
+# billing, so nothing worse than a wasted Redis key results from an odd
+# value. Bounded anyway against a pathological string bloating a key.
+MAX_REPO_ID_LENGTH = 128
 
 
 class EmbeddingsRequest(BaseModel):
     texts: list[str] = Field(min_length=1, max_length=MAX_TEXTS_PER_REQUEST)
+    # Optional so an older CLI that predates this field still works - it
+    # just shares the coarser, installation-only bucket every caller used
+    # to share (see the fallback in create_embeddings below).
+    repo_id: str | None = Field(default=None, max_length=MAX_REPO_ID_LENGTH)
 
 
 async def _authenticated_installation(request: Request) -> dict:
@@ -104,10 +121,23 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
                 detail=f"each text must be at most {MAX_CHARS_PER_TEXT} characters",
             )
 
+    # Per-repo when the caller sends one (see EmbeddingsRequest.repo_id):
+    # `aletheore watch` running against several repos on one token would
+    # otherwise share a single counter, and one repo's rebase-heavy burst
+    # could starve the others' embeddings on the same installation. Falls
+    # back to the old installation-only bucket for a caller that doesn't
+    # send it, rather than treating a missing repo_id as its own bucket -
+    # an empty-string "no repo" bucket would just recreate the shared-budget
+    # problem for every caller that omits the field.
+    rate_limit_key = (
+        f"ratelimit:embeddings:{installation_id}:{body.repo_id}"
+        if body.repo_id
+        else f"ratelimit:embeddings:{installation_id}"
+    )
     try:
         rate_limited = is_rate_limited(
             get_redis_client(),
-            f"ratelimit:embeddings:{installation_id}",
+            rate_limit_key,
             RATE_LIMIT_REQUESTS,
             RATE_LIMIT_WINDOW_SECONDS,
         )

--- a/github-app/tests/test_embeddings_api.py
+++ b/github-app/tests/test_embeddings_api.py
@@ -27,11 +27,14 @@ async def _installation_with_token(pool, installation_id: int, plan: str, token:
     )
 
 
-async def _post(pool, token: str | None, texts: list[str]):
+async def _post(pool, token: str | None, texts: list[str], repo_id: str | None = None):
     app.state.db_pool = pool
     headers = {"Authorization": f"Bearer {token}"} if token else {}
+    body = {"texts": texts}
+    if repo_id is not None:
+        body["repo_id"] = repo_id
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        return await client.post("/v1/embeddings", json={"texts": texts}, headers=headers)
+        return await client.post("/v1/embeddings", json=body, headers=headers)
 
 
 @pytest.mark.asyncio
@@ -163,3 +166,53 @@ async def test_the_only_row_written_is_the_spend_row(pool):
     after = {t: await pool.fetchval(f"SELECT count(*) FROM {t}") for t in tables}  # noqa: S608
     grew = {t for t in tables if after[t] != before[t]}
     assert grew == {"llm_spend"}, f"unexpected writes to {grew - {'llm_spend'}}"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_key_includes_repo_id_when_given(pool):
+    """`aletheore watch` running against several repos on one token would
+    otherwise share a single request budget - the key has to actually carry
+    the repo, not just accept the field and ignore it."""
+    await _installation_with_token(pool, 9009, "air", "repo-token")
+
+    with patch("app_server.embeddings_api.OpenAI", return_value=_fake_openai()), \
+         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}), \
+         patch("app_server.embeddings_api.is_rate_limited", return_value=False) as rl:
+        await _post(pool, "repo-token", ["x"], repo_id="repo-abc")
+
+    assert rl.call_args.args[1] == "ratelimit:embeddings:9009:repo-abc"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_key_falls_back_to_installation_only_without_repo_id(pool):
+    """An older CLI that predates repo_id must keep working exactly as
+    before - the coarser, shared-per-installation bucket every caller used
+    to get."""
+    await _installation_with_token(pool, 9010, "air", "norepo-token")
+
+    with patch("app_server.embeddings_api.OpenAI", return_value=_fake_openai()), \
+         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}), \
+         patch("app_server.embeddings_api.is_rate_limited", return_value=False) as rl:
+        await _post(pool, "norepo-token", ["x"])
+
+    assert rl.call_args.args[1] == "ratelimit:embeddings:9010"
+
+
+@pytest.mark.asyncio
+async def test_one_repo_being_rate_limited_does_not_block_another_repo_on_the_same_token(pool):
+    """The actual point of per-repo keying: one repo's rebase-heavy burst
+    hitting its own limit must not starve a second repo watched on the same
+    installation token."""
+    await _installation_with_token(pool, 9011, "air", "multi-repo-token")
+
+    def fake_rate_limited(redis_conn, key, limit, window):  # noqa: ANN001
+        return "repo-a" in key
+
+    with patch("app_server.embeddings_api.OpenAI", return_value=_fake_openai()), \
+         patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}), \
+         patch("app_server.embeddings_api.is_rate_limited", side_effect=fake_rate_limited):
+        blocked = await _post(pool, "multi-repo-token", ["x"], repo_id="repo-a")
+        allowed = await _post(pool, "multi-repo-token", ["x"], repo_id="repo-b")
+
+    assert blocked.status_code == 429
+    assert allowed.status_code == 200

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -222,11 +222,26 @@ class HostedEmbeddingUnavailableError(Exception):
     """
 
 
+def _repo_id(repo_path: Path) -> str:
+    """Stable, opaque identifier for a repository, derived from its resolved
+    local path.
+
+    Lets the hosted embeddings rate limit key on (installation, repo)
+    instead of only installation: `aletheore watch` running against several
+    repos on one token would otherwise share a single request budget, and
+    one repo's rebase-heavy burst could starve the others. Never the raw
+    path - just a bucket the server can count requests against without
+    learning anything about the caller's filesystem.
+    """
+    return hashlib.sha256(str(repo_path.resolve()).encode("utf-8")).hexdigest()[:16]
+
+
 def embed_texts_hosted(
     texts: list[str],
     token: str,
     api_base_url: str = DEFAULT_API_BASE_URL,
     http_client: httpx.Client | None = None,
+    repo_id: str | None = None,
 ) -> list[list[float]]:
     """Embed via Aletheore's endpoint using a saved API token.
 
@@ -237,10 +252,13 @@ def embed_texts_hosted(
     changes mid-session is honoured without the CLI knowing anything.
     """
     client = http_client or httpx.Client(base_url=api_base_url, timeout=120.0)
+    body: dict = {"texts": texts}
+    if repo_id:
+        body["repo_id"] = repo_id
     try:
         response = client.post(
             HOSTED_EMBEDDING_PATH,
-            json={"texts": texts},
+            json=body,
             headers={"Authorization": f"Bearer {token}"},
         )
     except httpx.HTTPError as exc:
@@ -340,7 +358,9 @@ def _escape_sql_literal(value: str) -> str:
 EMBED_BATCH_SIZE = 200
 
 
-def _embed_in_batches(texts: list[str], batch_size: int = EMBED_BATCH_SIZE) -> list[list[float]]:
+def _embed_in_batches(
+    texts: list[str], batch_size: int = EMBED_BATCH_SIZE, repo_id: str | None = None
+) -> list[list[float]]:
     """Embed everything, preferring Aletheore's endpoint when entitled.
 
     Hosted first, then local, and never the reverse: someone paying for
@@ -353,6 +373,9 @@ def _embed_in_batches(texts: list[str], batch_size: int = EMBED_BATCH_SIZE) -> l
     hosted failure partway through is raised rather than worked around. A
     half-built index that errors is recoverable; one built from two models
     is not.
+
+    repo_id: forwarded to embed_texts_hosted so the hosted rate limit can be
+    keyed per repo rather than per installation - see _repo_id.
     """
     token = get_api_key(
         "ALETHEORE_API_TOKEN", "aletheore-managed-audit", prompt_fn=lambda _: ""
@@ -364,7 +387,7 @@ def _embed_in_batches(texts: list[str], batch_size: int = EMBED_BATCH_SIZE) -> l
         batch = texts[start : start + batch_size]
         if use_hosted:
             try:
-                vectors.extend(embed_texts_hosted(batch, token))
+                vectors.extend(embed_texts_hosted(batch, token, repo_id=repo_id))
                 continue
             except HostedEmbeddingUnavailableError as exc:
                 if vectors:
@@ -436,7 +459,8 @@ def build_index(repo_path: Path, evidence: dict) -> int:
     index_path = _index_path(repo_path)
     reusable = _reusable_vectors(index_path)
     stale = [chunk for chunk in chunks if chunk["chunk_hash"] not in reusable]
-    fresh_vectors = _embed_in_batches([chunk["text"] for chunk in stale])
+    repo = _repo_id(repo_path)
+    fresh_vectors = _embed_in_batches([chunk["text"] for chunk in stale], repo_id=repo)
 
     # Vectors from two different embedding models cannot share an index -
     # nomic-embed-text returns 768 dimensions and text-embedding-3-small
@@ -471,13 +495,13 @@ def build_index(repo_path: Path, evidence: dict) -> int:
         current_dimension = (
             len(fresh_vectors[0])
             if fresh_vectors
-            else len(_embed_in_batches([chunks[0]["text"]])[0])
+            else len(_embed_in_batches([chunks[0]["text"]], repo_id=repo)[0])
         )
         reused_dimensions = {len(vector) for vector in reusable.values()}
         if reused_dimensions != {current_dimension}:
             reusable = {}
             stale = chunks
-            fresh_vectors = _embed_in_batches([chunk["text"] for chunk in stale])
+            fresh_vectors = _embed_in_batches([chunk["text"] for chunk in stale], repo_id=repo)
 
     fresh = dict(zip((chunk["chunk_hash"] for chunk in stale), fresh_vectors))
     rows = [

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -12,11 +12,13 @@ from aletheore.search_index import (
     _embed_in_batches,
     _escape_sql_literal,
     _fts_candidates,
+    _repo_id,
     _reusable_vectors,
     _rrf_fuse,
     build_chunks,
     build_index,
     embed_texts,
+    embed_texts_hosted,
     open_index,
     search_index,
 )
@@ -658,6 +660,77 @@ def _hosted_response(status: int, payload: dict | None = None):
     response.reason_phrase = "Error"
     response.text = str(payload)
     return response
+
+
+def test_repo_id_is_stable_for_the_same_path(tmp_path):
+    """Same repo, same value every time - it's the key the hosted rate
+    limit buckets requests by, not a random tag."""
+    assert _repo_id(tmp_path) == _repo_id(tmp_path)
+
+
+def test_repo_id_differs_between_repos(tmp_path):
+    other = tmp_path / "other"
+    other.mkdir()
+    assert _repo_id(tmp_path) != _repo_id(other)
+
+
+def test_repo_id_never_contains_the_raw_path(tmp_path):
+    """A bucket key, not a filesystem disclosure - the server should learn
+    nothing about the caller's directory layout from it."""
+    assert str(tmp_path) not in _repo_id(tmp_path)
+    assert tmp_path.name not in _repo_id(tmp_path)
+
+
+def test_embed_texts_hosted_includes_repo_id_when_given():
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.1] * 1536]})
+
+    embed_texts_hosted(["chunk"], "tok", http_client=http, repo_id="abc123")
+
+    assert http.post.call_args.kwargs["json"]["repo_id"] == "abc123"
+
+
+def test_embed_texts_hosted_omits_repo_id_when_not_given():
+    """No repo_id, no key in the body - an older server that doesn't know
+    the field yet should see exactly the request it always saw."""
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.1] * 1536]})
+
+    embed_texts_hosted(["chunk"], "tok", http_client=http)
+
+    assert "repo_id" not in http.post.call_args.kwargs["json"]
+
+
+def test_embed_in_batches_forwards_repo_id_to_every_hosted_batch():
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.1] * 1536]})
+
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http):
+        _embed_in_batches(["a", "b"], batch_size=1, repo_id="repo-xyz")
+
+    assert http.post.call_count == 2
+    assert all(
+        call.kwargs["json"]["repo_id"] == "repo-xyz" for call in http.post.call_args_list
+    )
+
+
+def test_build_index_sends_the_repos_own_repo_id_to_hosted_embeddings(tmp_path):
+    """End-to-end wiring check: build_index computes repo_id from the path
+    it was given and it has to actually reach the wire, not just exist as a
+    parameter nothing calls."""
+    (tmp_path / "app.py").write_text("def greet():\n    return 'hi'\n")
+    evidence = _evidence_with_module(
+        "app.py", [{"name": "greet", "start_line": 1, "end_line": 2}]
+    )
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.1] * 1536]})
+
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http):
+        build_index(tmp_path, evidence)
+
+    assert http.post.call_args.kwargs["json"]["repo_id"] == _repo_id(tmp_path)
 
 
 def test_hosted_embeddings_are_preferred_when_a_token_exists():


### PR DESCRIPTION
## Summary

`aletheore watch`'s 2-second debounce means one repo alone can send up to 1,800 requests/hour in theory to `/v1/embeddings`, against a 400/hour cap sized for manual `aletheore index` runs (~8 requests each) before watch existed. Worse, the limit is keyed on `installation_id` alone, so `watch` running against several repos on one token shares that single budget — one repo's rebase-heavy burst could starve the others' hosted embeddings mid-session, silently degrading them to the local fallback.

Two changes together, since either alone is incomplete: raising the number alone doesn't fix N repos each staying under a per-repo ceiling but summing past a shared one; per-repo keying alone doesn't raise the ceiling for the ordinary single-repo case.

- `search_index._repo_id(repo_path)`: a stable, opaque identifier (truncated sha256 of the resolved path), threaded through `_embed_in_batches` → `embed_texts_hosted` → the request body. Never the raw path — a bucket key only.
- `EmbeddingsRequest` gains an optional `repo_id`. `create_embeddings` keys the rate limit on `ratelimit:embeddings:{installation_id}:{repo_id}` when given, falling back to the old installation-only key otherwise — an older CLI keeps working unchanged rather than landing in its own accidental "no repo" bucket.
- `RATE_LIMIT_REQUESTS` 400 → 2000/hour: clears the single-repo 1,800/hour theoretical ceiling with room. The spend cap is unchanged and remains the real cost control; this only bounds request volume per token.

## Test plan
- [x] 11 new tests across both sides: `repo_id` stability/uniqueness/never-contains-the-raw-path, `embed_texts_hosted`/`_embed_in_batches` actually forward it, `build_index`'s own `repo_id` reaches the wire end to end, the rate-limit key includes/omits it correctly, and — the actual point of the change — one repo hitting its own limit no longer blocks a second repo on the same token
- [x] `src/tests/test_search_index.py`: 42 passed
- [x] `github-app/tests/test_embeddings_api.py`: 13 passed
- [x] Full `src/tests/`: 1109 passed