### PR TITLE
fix: widen expired-session test's margin against DB clock skew

### DIFF
--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -35,7 +35,13 @@ async def test_signin_page_is_not_cacheable(pool):
 async def test_get_session_returns_none_for_expired_session(pool):
     monkeypatch_secret = "test-session-secret"
     encrypted = encrypt_access_token("gho_realtoken", monkeypatch_secret)
-    already_expired = datetime.now(timezone.utc) - timedelta(seconds=1)
+    # get_session compares expires_at against the DB server's own now(), not
+    # the test runner's clock - a 1-second margin flakes under any real
+    # clock skew between the two (observed locally against a Docker
+    # Postgres container). 5 minutes is well past any skew worth worrying
+    # about while still clearly testing "already expired", not "expires
+    # soon".
+    already_expired = datetime.now(timezone.utc) - timedelta(minutes=5)
     await create_session(pool, "sess-expired", 42, "octocat", encrypted, already_expired)
 
     assert await get_session(pool, "sess-expired") is None


### PR DESCRIPTION
## Summary

\`test_get_session_returns_none_for_expired_session\` created a session expiring 1 second in the past and immediately asserted \`get_session\` returned \`None\`. \`get_session\`'s query compares \`expires_at\` against the Postgres server's own \`now()\`, not the test runner's clock, so a 1-second margin flakes under any real skew between the two. Observed locally: passed 3/3 in isolation, failed once inside a ~7-minute full-suite run against a local Docker Postgres container.

Not a bug in \`auth.py\` or \`db.py\` — CI's own \`pytest\` job (a fresh container per run) never failed this test. Test-only fix: widened the margin to 5 minutes, well past any clock skew worth worrying about while still clearly testing "already expired" rather than "expires soon".

## Test plan
- [x] \`tests/test_auth.py\`: 34 passed