### PR TITLE
fix: affiliate payout report multiplied commissions by referral count

### DIFF
--- a/github-app/app_server/affiliates.py
+++ b/github-app/app_server/affiliates.py
@@ -77,8 +77,18 @@ async def record_commission(
 async def list_affiliates_with_totals(pool: asyncpg.Pool) -> list[dict]:
     """One row per affiliate for the admin report page: how many
     installations they've referred, and total commission accrued vs. paid
-    so far. LEFT JOINs so an affiliate with no referrals/commissions yet
-    still shows up with zeroes rather than being dropped."""
+    so far.
+
+    Each total is a scalar subquery, not a JOIN, deliberately: joining
+    affiliate_referrals and affiliate_commissions onto affiliates in one
+    query is a cartesian product between the two (R referrals x C
+    commissions for one affiliate = R*C rows), and while
+    COUNT(DISTINCT r.installation_id) survives that fan-out, SUM(amount_usd)
+    does not - every commission was summed once per referral. Reproduced:
+    an affiliate with 3 referrals and $30 of real commissions reported
+    $90.00 owed. A single referral (R=1) hides it completely, which is
+    exactly what a one-referral manual check would show as correct.
+    """
     rows = await pool.fetch(
         """
         SELECT
@@ -86,13 +96,18 @@ async def list_affiliates_with_totals(pool: asyncpg.Pool) -> list[dict]:
             a.code,
             a.name,
             a.created_at,
-            COUNT(DISTINCT r.installation_id) AS referral_count,
-            COALESCE(SUM(c.amount_usd) FILTER (WHERE NOT c.paid), 0) AS total_owed_usd,
-            COALESCE(SUM(c.amount_usd) FILTER (WHERE c.paid), 0) AS total_paid_usd
+            (SELECT COUNT(*) FROM affiliate_referrals r WHERE r.affiliate_id = a.id) AS referral_count,
+            COALESCE(
+                (SELECT SUM(amount_usd) FROM affiliate_commissions c
+                 WHERE c.affiliate_id = a.id AND NOT c.paid),
+                0
+            ) AS total_owed_usd,
+            COALESCE(
+                (SELECT SUM(amount_usd) FROM affiliate_commissions c
+                 WHERE c.affiliate_id = a.id AND c.paid),
+                0
+            ) AS total_paid_usd
         FROM affiliates a
-        LEFT JOIN affiliate_referrals r ON r.affiliate_id = a.id
-        LEFT JOIN affiliate_commissions c ON c.affiliate_id = a.id
-        GROUP BY a.id, a.code, a.name, a.created_at
         ORDER BY a.created_at
         """
     )

--- a/github-app/tests/test_affiliates.py
+++ b/github-app/tests/test_affiliates.py
@@ -156,3 +156,32 @@ async def test_mark_commissions_paid_does_not_touch_other_affiliates(pool):
     assert totals[affiliate_a["id"]]["total_paid_usd"] == Decimal("3.00")
     assert totals[affiliate_b["id"]]["total_owed_usd"] == Decimal("7.00")
     assert totals[affiliate_b["id"]]["total_paid_usd"] == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_totals_are_not_multiplied_by_referral_count(pool):
+    """Regression for a real bug: joining affiliate_referrals and
+    affiliate_commissions onto affiliates in one query is a cartesian
+    product between the two (R referrals x C commissions = R*C rows), so a
+    plain SUM(amount_usd) counted every commission once per referral
+    instead of once. The multiplier is exactly the referral count, which is
+    why a fixture with one referral - test_mark_commissions_paid_moves_owed_to_paid
+    above, R=1 - cannot catch it: the multiplication factor is 1 either
+    way. This needs at least two referrals and at least one commission to
+    expose it. Reproduced before the fix: 3 referrals + $30 of real
+    commissions reported $90.00 owed."""
+    affiliate = await create_affiliate(pool, "VERA10", "dsc_vera", "Vera")
+    await upsert_installation(pool, 910, "acme")
+    await upsert_installation(pool, 911, "beta")
+    await upsert_installation(pool, 912, "gamma")
+    await record_referral(pool, 910, affiliate["id"])
+    await record_referral(pool, 911, affiliate["id"])
+    await record_referral(pool, 912, affiliate["id"])
+    now = datetime.now(timezone.utc)
+    await record_commission(pool, affiliate["id"], 910, "txn_e", Decimal("10.00"), now)
+    await record_commission(pool, affiliate["id"], 911, "txn_f", Decimal("20.00"), now)
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+
+    assert totals[affiliate["id"]]["referral_count"] == 3
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("30.00")


### PR DESCRIPTION
## Summary

\`list_affiliates_with_totals\` (\`app_server/affiliates.py\`) joined \`affiliate_referrals\` and \`affiliate_commissions\` onto \`affiliates\` in one query — a cartesian product between the two independent one-to-many relationships (R referrals × C commissions for one affiliate = R×C rows). \`COUNT(DISTINCT r.installation_id)\` survives that fan-out; a plain \`SUM(amount_usd)\` does not, so every commission was summed once per referral instead of once.

Verified directly against the test database before fixing: one affiliate, 3 referrals, $30.00 of real unpaid commissions → the existing query reported **$90.00 owed** (exactly 3×, the multiplier being the affiliate's referral count).

\`GET /admin/affiliates\` is the report an admin pays an affiliate from, and \`POST /admin/affiliates/{id}/mark-paid\` then flips those exact commission rows to \`paid=true\` — so this was an unrecoverable overpayment on any affiliate with more than one referral, growing worse as the referral program succeeds. Confirmed the existing test suite's fixtures are all single-referral (R=1), where the multiplication factor is 1 either way — which is exactly why it shipped and passed the 2026-08-11 end-to-end checkout verification.

## Fix

Replaced both JOINs with independent scalar subqueries per total, so referral count and each commission sum are computed directly against \`affiliate_commissions\`/\`affiliate_referrals\` rather than a joined row set. Same output shape (same column names), so \`admin.py\`'s consumer needs no change.

## Test plan
- [x] New regression test: 3 referrals + 2 commissions (the minimum shape that exposes the bug) — confirms both \`referral_count\` and \`total_owed_usd\` are correct
- [x] \`tests/test_affiliates.py\`: 13 passed
- [x] \`tests/test_admin_affiliates.py\` + \`tests/test_webhooks_paddle.py\`: 53 passed