### PR TITLE
fix: stop trusting Paddle custom_data.installation_id as an authorization claim

### DIFF
--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -35,6 +35,12 @@ OAUTH_STATE_COOKIE_NAME = "oauth_state"
 OAUTH_STATE_TTL = timedelta(minutes=10)
 NEXT_COOKIE_NAME = "aletheore_oauth_next"
 
+# How long a signed checkout token is good for - see sign_checkout_installation_id.
+# Long enough to sit on the /subscribe page and complete a Paddle Checkout
+# overlay; short enough that a leaked token (a shared screenshot, a proxy
+# log) isn't a standing bearer credential for someone else's installation.
+CHECKOUT_TOKEN_TTL = timedelta(minutes=30)
+
 # GitHub's own OAuth flow already gates against credential brute-forcing
 # (there's no password here to guess), but neither /auth/login nor
 # /auth/callback had any rate limiting at all - the latter makes two real
@@ -228,6 +234,37 @@ def unsign_oauth_state(signed: str, secret: str) -> str | None:
             max_age=int(OAUTH_STATE_TTL.total_seconds()),
         )
     except BadSignature:
+        return None
+
+
+def sign_checkout_installation_id(installation_id: int, secret: str) -> str:
+    """Binds a Paddle checkout's custom_data to one installation without
+    trusting the browser to name it.
+
+    The subscribe page renders one token per installation the current
+    session was already verified to administer
+    (_administered_installation_ids_for_session_or_401); the raw integer
+    never reaches the client. Paddle's webhook only ever proves "Paddle
+    sent this event", never "the payer was authorized to name this
+    installation" - a plain custom_data.installation_id lets anyone open
+    Paddle.Checkout.open() from the browser console with any id and have
+    the webhook act on it unconditionally. A distinct salt from
+    sign_oauth_state's, so a token minted for one purpose can't be replayed
+    against the other even though both derive from the same SESSION_SECRET.
+    """
+    return URLSafeTimedSerializer(_signing_secret(secret), salt="checkout-installation-id").dumps(
+        str(installation_id)
+    )
+
+
+def unsign_checkout_installation_id(signed: str, secret: str) -> int | None:
+    try:
+        value = URLSafeTimedSerializer(_signing_secret(secret), salt="checkout-installation-id").loads(
+            signed,
+            max_age=int(CHECKOUT_TOKEN_TTL.total_seconds()),
+        )
+        return int(value)
+    except (BadSignature, ValueError, TypeError):
         return None
 
 

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app_server.admin import _administered_installation_ids_for_session_or_401
-from app_server.auth import SESSION_COOKIE_NAME, get_current_session
+from app_server.auth import SESSION_COOKIE_NAME, get_current_session, sign_checkout_installation_id
 from app_server.config import get_settings
 from app_server.db import list_installations_for_ids
 from app_server.github_install import github_app_install_url
@@ -2215,11 +2215,28 @@ def _subscribe_install_prompt_page(plan: str, next_path: str) -> str:
 
 
 def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]) -> str:
+    settings = get_settings()
+    # Signed here, not the raw installation_id: the browser fully controls
+    # what Paddle.Checkout.open() actually sends (devtools can call it
+    # directly with any custom_data), and the webhook has no other way to
+    # know the payer was authorized to name this installation - see
+    # sign_checkout_installation_id. Minted once per installation this
+    # session was already verified to administer
+    # (_administered_installation_ids_for_session_or_401, in the caller),
+    # so a token can only ever exist for an installation this user
+    # legitimately administers.
+    tokens = {
+        installation["installation_id"]: sign_checkout_installation_id(
+            installation["installation_id"], settings.session_secret
+        )
+        for installation in installations
+    }
+
     pw_customer_id: str | None = None
     if len(installations) == 1:
         installation = installations[0]
         pw_customer_id = installation.get("paddle_customer_id")
-        continue_attrs = f'data-installation-id="{installation["installation_id"]}"'
+        continue_attrs = f'data-installation-token="{tokens[installation["installation_id"]]}"'
         body = f"""
         <h1>Subscribe to {escape(_plan_display_name(plan))}</h1>
         <p>{escape(installation["account_login"])} is currently on {escape(_plan_display_name(installation["plan"]))}.</p>
@@ -2230,7 +2247,7 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
         options = "\n".join(
             (
                 '<label class="claim-option">'
-                f'<input type="radio" name="installation_id" value="{installation["installation_id"]}"'
+                f'<input type="radio" name="installation_token" value="{tokens[installation["installation_id"]]}"'
                 f'{" checked" if index == 0 else ""}> '
                 f'{escape(installation["account_login"])} '
                 f'(currently {escape(_plan_display_name(installation["plan"]))})'
@@ -2246,7 +2263,6 @@ def _subscribe_checkout_page(plan: str, price_id: str, installations: list[dict]
         <p><a href="/dashboard">Cancel</a></p>
         """
 
-    settings = get_settings()
     # pwCustomer (Paddle Retain) only makes sense for a known, already-Paddle
     # customer - only wireable here when there's exactly one installation to
     # check out for, since Paddle.Initialize() runs once for the whole page,
@@ -2259,11 +2275,11 @@ Paddle.Environment.set("{settings.paddle_environment}");
 Paddle.Initialize({{ token: "{settings.paddle_client_token}"{pw_customer_config} }});
 document.getElementById("continue-checkout").addEventListener("click", (event) => {{
   const btn = event.currentTarget;
-  const selected = document.querySelector('input[name="installation_id"]:checked');
-  const installationId = selected ? selected.value : btn.dataset.installationId;
+  const selected = document.querySelector('input[name="installation_token"]:checked');
+  const installationToken = selected ? selected.value : btn.dataset.installationToken;
   Paddle.Checkout.open({{
     items: [{{ priceId: "{price_id}", quantity: 1 }}],
-    customData: {{ installation_id: installationId }},
+    customData: {{ installation_token: installationToken }},
     settings: {{
       displayMode: "overlay",
       variant: "one-page",

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -5,6 +5,7 @@ from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from fastapi import APIRouter, Request, Response
 
 from app_server.affiliates import get_affiliate_by_discount_id, get_referral, record_commission, record_referral
+from app_server.auth import unsign_checkout_installation_id
 from app_server.config import get_settings
 from app_server.db import (
     add_paddle_ids_to_installation,
@@ -59,15 +60,23 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         return
 
     data = payload.get("data") or {}
-    installation_id_raw = (data.get("custom_data") or {}).get("installation_id")
-    installation_id = None
-    if installation_id_raw is not None:
-        try:
-            installation_id = int(installation_id_raw)
-        except (TypeError, ValueError):
-            installation_id = None
+    # Signed, not a raw integer: custom_data is set by the browser calling
+    # Paddle.Checkout.open(), which nothing stops from being called directly
+    # with any custom_data - the Paddle signature on this webhook proves
+    # only "Paddle sent this event", never "the payer was authorized to
+    # name this installation". unsign_checkout_installation_id verifies the
+    # token was minted server-side, for this exact installation, to a
+    # session that was already checked against
+    # _administered_installation_ids_for_session_or_401 - see
+    # sign_checkout_installation_id and frontend.py's checkout page.
+    installation_token = (data.get("custom_data") or {}).get("installation_token")
+    installation_id = (
+        unsign_checkout_installation_id(installation_token, get_settings().session_secret)
+        if installation_token
+        else None
+    )
     if installation_id is None:
-        logger.warning("%s missing installation_id in custom_data", event_type)
+        logger.warning("%s missing or invalid installation_token in custom_data", event_type)
         return
 
     items = data.get("items") or []
@@ -93,6 +102,22 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
 
     previous = await get_installation(pool, installation_id)
     previous_plan = previous["plan"] if previous is not None else "free"
+
+    # Defense in depth beyond the signed token above: once an installation
+    # has a Paddle customer on file, only that same customer's events may
+    # mutate it. Never blocks the first subscription.created for a fresh
+    # installation (nothing stored yet to mismatch against), but closes the
+    # billing-portal-hijack path even if a future change ever reintroduced
+    # a spoofable identifier into custom_data.
+    previous_customer_id = previous.get("paddle_customer_id") if previous is not None else None
+    event_customer_id = data.get("customer_id")
+    if previous_customer_id and event_customer_id and previous_customer_id != event_customer_id:
+        logger.warning(
+            "%s customer_id mismatch for installation=%s - ignoring",
+            event_type,
+            installation_id,
+        )
+        return
 
     await set_installation_plan(pool, installation_id, plan)
     if "id" in data and "customer_id" in data:
@@ -194,14 +219,19 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
     string - matches the "15% of everything Paddle actually collects"
     scope decision for both a discounted first month and every undiscounted
     month after it, without special-casing either.
+
+    installation_id comes from the same signed custom_data.installation_token
+    as the subscription handlers above, for the same reason: an unsigned,
+    caller-supplied installation_id here would let anyone checking out for
+    themselves name a different, referred installation and misattribute the
+    resulting commission to that installation's affiliate.
     """
-    installation_id_raw = (data.get("custom_data") or {}).get("installation_id")
-    installation_id = None
-    if installation_id_raw is not None:
-        try:
-            installation_id = int(installation_id_raw)
-        except (TypeError, ValueError):
-            installation_id = None
+    installation_token = (data.get("custom_data") or {}).get("installation_token")
+    installation_id = (
+        unsign_checkout_installation_id(installation_token, get_settings().session_secret)
+        if installation_token
+        else None
+    )
     if installation_id is None:
         return
 

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -8,7 +8,10 @@ from app_server.auth import (
     encrypt_access_token,
     get_current_session,
     refresh_github_access_token,
+    sign_checkout_installation_id,
+    sign_oauth_state,
     sign_session_id,
+    unsign_checkout_installation_id,
     unsign_session_id,
     _derive_key,
     _fernet_key,
@@ -678,3 +681,39 @@ async def test_login_fails_open_when_redis_is_unreachable(pool, monkeypatch):
         response = await client.get("/auth/login", follow_redirects=False)
 
     assert response.status_code == 307
+
+
+def test_checkout_installation_id_round_trips():
+    signed = sign_checkout_installation_id(12345, "a-secret")
+    assert unsign_checkout_installation_id(signed, "a-secret") == 12345
+
+
+def test_checkout_installation_id_rejects_tampering():
+    signed = sign_checkout_installation_id(12345, "a-secret")
+    # Flipped mid-string, not the trailing character: base64's own padding
+    # bits can leave the last character of a token free to change without
+    # altering the decoded bytes at all, which would make this assert
+    # nothing.
+    middle = len(signed) // 2
+    flipped = "x" if signed[middle] != "x" else "y"
+    tampered = signed[:middle] + flipped + signed[middle + 1 :]
+    assert unsign_checkout_installation_id(tampered, "a-secret") is None
+
+
+def test_checkout_installation_id_rejects_the_wrong_secret():
+    signed = sign_checkout_installation_id(12345, "a-secret")
+    assert unsign_checkout_installation_id(signed, "a-different-secret") is None
+
+
+def test_checkout_installation_id_rejects_garbage():
+    assert unsign_checkout_installation_id("not-a-real-token", "a-secret") is None
+
+
+def test_checkout_installation_id_and_oauth_state_do_not_cross_purposes():
+    """Both derive from the same secret via _signing_secret, but a distinct
+    salt per purpose means a token minted for one can't be replayed against
+    the other - an oauth_state token must not decode as an installation id,
+    even though it's a validly-signed itsdangerous payload from this same
+    server."""
+    oauth_token = sign_oauth_state("some-state-value", "a-secret")
+    assert unsign_checkout_installation_id(oauth_token, "a-secret") is None

--- a/github-app/tests/test_frontend_subscribe.py
+++ b/github-app/tests/test_frontend_subscribe.py
@@ -1,10 +1,11 @@
+import re
 from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app_server.auth import encrypt_access_token, sign_session_id
+from app_server.auth import encrypt_access_token, sign_session_id, unsign_checkout_installation_id
 from app_server.db import add_paddle_ids_to_installation, create_session, upsert_installation
 from app_server.main import app
 
@@ -122,9 +123,17 @@ async def test_one_installation_shows_checkout_with_current_plan(pool, monkeypat
     assert response.status_code == 200
     assert "acme" in response.text
     assert "currently on Aletheore Community" in response.text
-    assert 'data-installation-id="2001"' in response.text
+    # A signed token, not the raw installation_id - the browser must never
+    # be handed something Paddle.Checkout.open() could forward for a
+    # different installation. Decoding it is what proves it's actually
+    # usable, not just present-and-opaque.
+    assert 'data-installation-id="2001"' not in response.text
+    match = re.search(r'data-installation-token="([^"]+)"', response.text)
+    assert match is not None
+    assert unsign_checkout_installation_id(match.group(1), "test-session-secret") == 2001
     assert "pri_01kyhevc8bkcghfpwjymz16y2h" in response.text  # air monthly price id
     assert "customData" in response.text
+    assert "installation_token" in response.text
     assert "successUrl" in response.text and "dashboard" in response.text
     assert 'href="/dashboard"' in response.text
     assert "pwCustomer" not in response.text
@@ -153,8 +162,13 @@ async def test_multiple_installations_shows_selection(pool, monkeypatch):
     async with client:
         response = await client.get("/subscribe?plan=air&interval=year")
     assert response.status_code == 200
-    assert 'value="2002"' in response.text
-    assert 'value="2003"' in response.text
+    # Radio values are signed tokens, not raw installation ids - same
+    # reasoning as the single-installation case above.
+    assert 'value="2002"' not in response.text
+    assert 'value="2003"' not in response.text
+    tokens = re.findall(r'name="installation_token" value="([^"]+)"', response.text)
+    decoded = {unsign_checkout_installation_id(token, "test-session-secret") for token in tokens}
+    assert decoded == {2002, 2003}
     assert "acme" in response.text
     assert "beta-corp" in response.text
     assert "pri_01kyhevc9xn6z2nghmy8057jvp" in response.text  # air yearly price id

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -12,6 +12,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app_server import paddle_ip_allowlist
 from app_server.affiliates import create_affiliate, get_referral, list_affiliates_with_totals, record_referral
+from app_server.auth import sign_checkout_installation_id
 from app_server.db import (
     add_installation_member,
     claim_webhook_delivery,
@@ -25,6 +26,11 @@ from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
 from app_server.webhooks.paddle import handle_paddle_webhook_event
 
 WEBHOOK_SECRET = "pdl_ntfset_test_secret"
+# Matches conftest.py's SESSION_SECRET default - the webhook handler
+# verifies custom_data.installation_token against this same secret via
+# get_settings().session_secret, so a test-built token has to be signed
+# with it to pass.
+SESSION_SECRET = "test-session-secret"
 
 
 def _sign(raw_body: bytes, secret: str = WEBHOOK_SECRET) -> str:
@@ -32,6 +38,10 @@ def _sign(raw_body: bytes, secret: str = WEBHOOK_SECRET) -> str:
     signed_payload = f"{ts}:{raw_body.decode()}"
     digest = hmac.new(secret.encode(), signed_payload.encode(), hashlib.sha256).hexdigest()
     return f"ts={ts};h1={digest}"
+
+
+def _installation_token(installation_id: int) -> str:
+    return sign_checkout_installation_id(installation_id, SESSION_SECRET)
 
 
 def _subscription_created_payload(
@@ -47,7 +57,7 @@ def _subscription_created_payload(
             "id": "sub_test_123",
             "customer_id": "ctm_test_456",
             "status": "active",
-            "custom_data": {"installation_id": str(installation_id)},
+            "custom_data": {"installation_token": _installation_token(installation_id)},
             "items": [{"price": {"id": price_id}}],
         },
     }
@@ -71,7 +81,7 @@ def _transaction_completed_payload(
         "event_type": "transaction.completed",
         "data": {
             "id": transaction_id,
-            "custom_data": {"installation_id": str(installation_id)},
+            "custom_data": {"installation_token": _installation_token(installation_id)},
             "details": {"totals": {"total": total_cents}},
             "billed_at": "2026-08-10T12:00:00Z",
         },
@@ -92,7 +102,7 @@ def _subscription_event_payload(
             "id": "sub_test_123",
             "customer_id": "ctm_test_456",
             "status": status,
-            "custom_data": {"installation_id": str(installation_id)},
+            "custom_data": {"installation_token": _installation_token(installation_id)},
             "items": [{"price": {"id": price_id}}] if price_id else [],
         },
     }
@@ -251,11 +261,99 @@ async def test_missing_installation_id_returns_200_but_writes_nothing(pool, monk
     monkeypatch.setenv("PADDLE_WEBHOOK_SECRET", WEBHOOK_SECRET)
     app.state.db_pool = pool
     payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 104)
-    del payload["data"]["custom_data"]["installation_id"]
+    del payload["data"]["custom_data"]["installation_token"]
     body = json.dumps(payload).encode()
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/webhooks/paddle", content=body, headers={"paddle-signature": _sign(body)})
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_raw_unsigned_installation_id_is_rejected_not_trusted(pool):
+    """The actual vulnerability this closes: custom_data is set by the
+    browser calling Paddle.Checkout.open(), which nothing stops from being
+    called directly with any value - a raw installation_id, spoofing a
+    victim's id, must not be trusted just because it looks like a valid
+    integer. Only a signed installation_token, minted server-side for a
+    session that was already verified to administer that installation, may
+    name one."""
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (950, 'victim-org', 'air')"
+    )
+    payload = _subscription_event_payload(
+        "subscription.canceled", "canceled", 950, event_id="evt_spoofed"
+    )
+    # Simulates an attacker calling Paddle.Checkout.open() from the browser
+    # console with a raw custom_data.installation_id naming a victim's
+    # installation - the exact shape this codebase used to accept.
+    payload["data"]["custom_data"] = {"installation_id": "950"}
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    installation = await get_installation(pool, 950)
+    assert installation["plan"] == "air", "a spoofed raw installation_id must not downgrade a real customer"
+
+
+@pytest.mark.asyncio
+async def test_a_tampered_installation_token_is_rejected(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (951, 'victim-org2', 'air')"
+    )
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 951, event_id="evt_tampered")
+    # A token minted for a different installation, spliced onto this
+    # event - must not be accepted for 951 just because it's a
+    # well-formed, validly-signed token for *something*.
+    payload["data"]["custom_data"]["installation_token"] = _installation_token(952)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    installation = await get_installation(pool, 951)
+    assert installation["plan"] == "air"
+
+
+@pytest.mark.asyncio
+async def test_a_forged_installation_token_is_rejected(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (953, 'victim-org3', 'air')"
+    )
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 953, event_id="evt_forged")
+    real_token = payload["data"]["custom_data"]["installation_token"]
+    # Flipped mid-string, not the trailing character: base64's own padding
+    # bits can leave the last character of a token free to change without
+    # altering the decoded bytes at all, which would make this test pass
+    # for the wrong reason (or flake, since the token itself is timestamp-
+    # dependent and different on every run).
+    middle = len(real_token) // 2
+    flipped_char = "x" if real_token[middle] != "x" else "y"
+    payload["data"]["custom_data"]["installation_token"] = (
+        real_token[:middle] + flipped_char + real_token[middle + 1 :]
+    )
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    installation = await get_installation(pool, 953)
+    assert installation["plan"] == "air"
+
+
+@pytest.mark.asyncio
+async def test_customer_id_mismatch_is_rejected_even_with_a_valid_token(pool):
+    """Defense in depth beyond the signed token: once an installation has a
+    real Paddle customer on file, an event claiming a different customer_id
+    must not mutate it, even if it somehow carried a validly-signed token -
+    this is what closes the billing-portal-hijack path if a future change
+    ever reintroduced a spoofable identifier into custom_data."""
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, paddle_customer_id) "
+        "VALUES (954, 'victim-org4', 'air', 'ctm_real_customer')"
+    )
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 954, event_id="evt_mismatch")
+    payload["data"]["customer_id"] = "ctm_attacker_customer"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    installation = await get_installation(pool, 954)
+    assert installation["plan"] == "air"
+    assert installation["paddle_customer_id"] == "ctm_real_customer"
 
 
 @pytest.mark.asyncio
@@ -400,7 +498,7 @@ async def test_subscription_updated_reconciles_extra_seats_from_items(pool):
             "id": "sub_test_123",
             "customer_id": "ctm_test_456",
             "status": "active",
-            "custom_data": {"installation_id": "305"},
+            "custom_data": {"installation_token": _installation_token(305)},
             "items": [
                 {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
                 {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 3},
@@ -864,7 +962,7 @@ async def test_repeated_transaction_completed_delivery_does_not_double_commissio
 @pytest.mark.asyncio
 async def test_transaction_completed_missing_installation_id_does_not_error(pool):
     payload = _transaction_completed_payload(913, "2699")
-    del payload["data"]["custom_data"]["installation_id"]
+    del payload["data"]["custom_data"]["installation_token"]
 
     # Must not raise.
     await handle_paddle_webhook_event(payload, pool, "redis://unused")


### PR DESCRIPTION
## Summary

Paddle's webhook signature proves only that Paddle sent the event — never that the payer was authorized to name the installation. `custom_data` is set client-side via `Paddle.Checkout.open()`, and nothing prevents that call from being made directly from a browser console with an arbitrary `installation_id`. Two handlers trusted this raw value verbatim:

- The subscription-event webhook handler (`webhooks/paddle.py`) — lets an attacker attach a subscription/plan change to any installation they can guess the id of (billing-portal/plan hijack).
- `_handle_transaction_completed` — the same trust bug misattributes affiliate commissions to an attacker-chosen installation.

## Fix

- `auth.py`: new `sign_checkout_installation_id` / `unsign_checkout_installation_id`, reusing the existing itsdangerous HKDF-subkey signing pattern already used for `oauth-state` and `session-id` tokens (`salt="checkout-installation-id"`, 30-minute TTL).
- `frontend.py`: `/subscribe` now mints one signed token per already-authorized installation and hands the browser `installation_token` (opaque, signed) instead of a raw `installation_id`.
- `webhooks/paddle.py`: both handlers now decode and verify `custom_data.installation_token` instead of trusting `custom_data.installation_id`. Also added a defense-in-depth check — an existing installation's stored `paddle_customer_id` must match the event's `customer_id` when one is already on file — as a second independent barrier against the billing-portal-hijack impact specifically.

Chose the signed-token approach over the audit's alternative (server-side Paddle transaction creation) because it reuses an already-proven, already-tested pattern in this codebase rather than introducing new, unverified Paddle API integration risk into a live billing path.

## Test plan
- [x] Added regression tests: raw/unsigned id rejected, tampered token rejected, forged token rejected, customer_id mismatch rejected even with a valid token (`test_webhooks_paddle.py`)
- [x] Added round-trip/tamper/wrong-secret/cross-purpose unit tests for the new sign/unsign functions (`test_auth.py`)
- [x] Updated `test_frontend_subscribe.py` to assert the old raw-id attributes are gone and that the new signed tokens decode correctly
- [x] Full `github-app/tests/` suite: 1193 passed, 8 skipped, no regressions