### PR TITLE
fix: make the public-status opt-in genuinely per-repo instead of account-wide

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -41,6 +41,7 @@ from app_server.db import (
     get_latest_evidence,
     get_llm_spend_this_month,
     get_max_tokens,
+    get_public_status_enabled,
     is_installation_member,
     list_api_tokens,
     list_health_check_targets,
@@ -410,6 +411,7 @@ async def admin_page(org: str, repo: str, request: Request):
     llm_spend_month_to_date = await get_llm_spend_this_month(pool, installation_id)
     flash_reviews_month_to_date = await get_flash_review_count_this_month(pool, installation_id)
     llm_spend_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
+    public_status_enabled = await get_public_status_enabled(pool, installation_id, repo_full_name)
     return {
         "installation": installation,
         "tokens": tokens,
@@ -419,6 +421,7 @@ async def admin_page(org: str, repo: str, request: Request):
         "health_targets": health_targets,
         "health_target_limit": health_target_limit,
         "public_status_url": f"/v1/health/{org}/{repo}",
+        "public_status_enabled": public_status_enabled,
         "branch_protection_disclosure": BRANCH_PROTECTION_DISCLOSURE,
         # llm_spend and flash_review_monthly_count are already tracked
         # internally for the hard spend cap (scan_worker/jobs.py) - this is
@@ -828,7 +831,7 @@ async def set_public_status_route(org: str, repo: str, request: Request, body: S
     only way to turn it on."""
     installation = await _require_admin_installation(request, org, repo)
     pool = request.app.state.db_pool
-    await set_public_status_enabled(pool, installation["installation_id"], body.enabled)
+    await set_public_status_enabled(pool, installation["installation_id"], f"{org}/{repo}", body.enabled)
     session = await get_current_session(request)
     await record_admin_action(
         pool, installation["installation_id"], session["github_login"], "public_status_setting_changed",

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -26,6 +26,7 @@ from app_server.db import (
     get_installation,
     get_installation_by_account_login,
     get_latest_evidence,
+    get_public_status_enabled,
     get_recent_endpoint_health,
     get_recent_history,
     get_wiki_build_status,
@@ -535,7 +536,9 @@ async def get_public_health(org: str, repo: str, request: Request, response: Res
     # distinct status, so this doesn't itself disclose whether the repo
     # has simply never opted in vs never been scanned.
     installation = await get_installation_by_account_login(request.app.state.db_pool, org)
-    if installation is None or not installation["public_status_enabled"]:
+    if installation is None or not await get_public_status_enabled(
+        request.app.state.db_pool, installation["installation_id"], repo_full_name
+    ):
         raise HTTPException(
             status_code=404,
             detail="no health data for this repo",

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -32,7 +32,7 @@ async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | N
         """
         SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
                health_check_base_url, health_check_latency_threshold_ms,
-               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled, public_status_enabled
+               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
         FROM installations
         WHERE installation_id = $1
         """,
@@ -49,7 +49,7 @@ async def get_installation_by_account_login(pool: asyncpg.Pool, account_login: s
         """
         SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
                health_check_base_url, health_check_latency_threshold_ms,
-               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled, public_status_enabled
+               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
         FROM installations
         WHERE account_login = $1
         """,
@@ -110,17 +110,38 @@ async def delete_installation(pool: asyncpg.Pool, installation_id: int) -> None:
     await pool.execute("DELETE FROM installations WHERE installation_id = $1", installation_id)
 
 
-async def set_public_status_enabled(pool: asyncpg.Pool, installation_id: int, enabled: bool) -> None:
-    """Opts an installation's repos into (or out of) the public,
-    unauthenticated /v1/health/{org}/{repo} status API. Off by default
-    (see migration 043) - endpoint paths, reachability, and latency
-    derived from a customer's private repository must never be exposed
-    without an explicit choice to do so."""
+async def set_public_status_enabled(
+    pool: asyncpg.Pool, installation_id: int, repo_full_name: str, enabled: bool
+) -> None:
+    """Opts one specific repo into (or out of) the public, unauthenticated
+    /v1/health/{org}/{repo} status API. Off by default (see migration 043),
+    and scoped per repo (see migration 047) - endpoint paths, reachability,
+    and latency derived from a customer's private repository must never be
+    exposed without an explicit, repo-specific choice to do so. This must
+    stay per-repo: the admin route that calls this is repo-scoped
+    (/admin/{org}/{repo}/public-status), and an account-wide flag here
+    would silently expose every other repo in the installation the moment
+    one repo opted in (see F21)."""
     await pool.execute(
-        "UPDATE installations SET public_status_enabled = $2, updated_at = now() WHERE installation_id = $1",
+        """
+        INSERT INTO repo_public_status (installation_id, repo_full_name, enabled, updated_at)
+        VALUES ($1, $2, $3, now())
+        ON CONFLICT (installation_id, repo_full_name)
+        DO UPDATE SET enabled = EXCLUDED.enabled, updated_at = now()
+        """,
         installation_id,
+        repo_full_name,
         enabled,
     )
+
+
+async def get_public_status_enabled(pool: asyncpg.Pool, installation_id: int, repo_full_name: str) -> bool:
+    enabled = await pool.fetchval(
+        "SELECT enabled FROM repo_public_status WHERE installation_id = $1 AND repo_full_name = $2",
+        installation_id,
+        repo_full_name,
+    )
+    return bool(enabled)
 
 
 async def set_llm_suggestions_enabled(

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1110,7 +1110,7 @@ async function loadTargets() {{
 
   const origin = window.location.origin;
   const statusUrl = origin + data.public_status_url;
-  const publicStatusEnabled = data.installation.public_status_enabled === true;
+  const publicStatusEnabled = data.public_status_enabled === true;
   statusApiBody.innerHTML =
     '<label style="display:flex;align-items:center;gap:7px;font-size:12.5px;">' +
     '<input type="checkbox" id="public-status-toggle"' +

--- a/github-app/migrations/047_public_status_per_repo.sql
+++ b/github-app/migrations/047_public_status_per_repo.sql
@@ -1,0 +1,43 @@
+-- F21: /admin/{org}/{repo}/public-status is a repo-scoped route (its
+-- audit-log entry even records repo_full_name), but the flag it wrote was
+-- installations.public_status_enabled - a single account-wide column. The
+-- unauthenticated GET /v1/health/{org}/{repo} read side only checked that
+-- column, never the requested repo, so opting in one public repo silently
+-- exposed endpoint paths, reachability, and latency for every other repo
+-- in the account, including private ones.
+--
+-- Fix: make the opt-in genuinely per-repo.
+CREATE TABLE IF NOT EXISTS repo_public_status (
+    installation_id BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name  TEXT NOT NULL,
+    enabled         BOOLEAN NOT NULL DEFAULT false,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (installation_id, repo_full_name)
+);
+
+-- Backfill from admin_action_log rather than defaulting every previously
+-- account-wide-enabled installation to "on for all repos" (which would
+-- just re-create the leak in migrated form) or "off for everyone" (which
+-- would silently break a status page a customer already published). The
+-- log already recorded which specific repo each toggle was for - take the
+-- most recent action per (installation, repo) pair and keep only the ones
+-- whose latest state was "enabled". An installation with no matching log
+-- row (e.g. seeded outside the admin route) gets nothing backfilled and
+-- stays off, consistent with "off by default" from migration 043.
+INSERT INTO repo_public_status (installation_id, repo_full_name, enabled, updated_at)
+SELECT installation_id, repo_full_name, enabled, updated_at
+FROM (
+    SELECT DISTINCT ON (installation_id, detail->>'repo_full_name')
+        installation_id,
+        detail->>'repo_full_name' AS repo_full_name,
+        (detail->>'enabled')::boolean AS enabled,
+        created_at AS updated_at
+    FROM admin_action_log
+    WHERE action = 'public_status_setting_changed'
+      AND detail->>'repo_full_name' IS NOT NULL
+    ORDER BY installation_id, detail->>'repo_full_name', created_at DESC
+) latest
+WHERE enabled = true
+ON CONFLICT (installation_id, repo_full_name) DO NOTHING;
+
+ALTER TABLE installations DROP COLUMN IF EXISTS public_status_enabled;

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -485,7 +485,19 @@ async def test_set_public_status_route_toggles_the_flag(pool, monkeypatch):
         dashboard_response = await client.get("/admin/octocat/hello-world")
     assert on_response.status_code == 200
     assert on_response.json()["public_status_enabled"] is True
-    assert dashboard_response.json()["installation"]["public_status_enabled"] is True
+    assert dashboard_response.json()["public_status_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_public_status_route_does_not_leak_to_other_repos(pool, monkeypatch):
+    # F21: this route is repo-scoped in its URL and docstring, but used to
+    # write an account-wide column - enabling it on one repo silently
+    # exposed every other repo in the account, including private ones.
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        await client.put("/admin/octocat/hello-world/public-status", json={"enabled": True})
+        other_repo_settings = await client.get("/admin/octocat/internal-billing")
+    assert other_repo_settings.json()["public_status_enabled"] is False
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -671,7 +671,7 @@ async def test_undismiss_finding_route_removes_it(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_public_health_returns_latest_per_endpoint(pool):
     await upsert_installation(pool, 500, "octocat")
-    await set_public_status_enabled(pool, 500, True)
+    await set_public_status_enabled(pool, 500, "octocat/hello-world", True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -717,7 +717,7 @@ async def test_public_health_returns_latest_per_endpoint(pool):
 @pytest.mark.asyncio
 async def test_public_health_uptime_pct_excludes_checks_older_than_7_days(pool):
     await upsert_installation(pool, 507, "octocat")
-    await set_public_status_enabled(pool, 507, True)
+    await set_public_status_enabled(pool, 507, "octocat/hello-world", True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -749,7 +749,7 @@ async def test_public_health_excludes_endpoints_not_checked_recently(pool):
     # sweep has stopped checking it, and this public API shouldn't keep
     # reporting it as "up" forever off one ancient row.
     await upsert_installation(pool, 508, "octocat")
-    await set_public_status_enabled(pool, 508, True)
+    await set_public_status_enabled(pool, 508, "octocat/hello-world", True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -777,7 +777,7 @@ async def test_public_health_rate_limits_after_threshold(pool, monkeypatch, redi
     from app_server import dashboard
 
     await upsert_installation(pool, 508, "octocat")
-    await set_public_status_enabled(pool, 508, True)
+    await set_public_status_enabled(pool, 508, "octocat/hello-world", True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -810,7 +810,7 @@ async def test_public_health_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis
     from app_server import dashboard
 
     await upsert_installation(pool, 509, "octocat")
-    await set_public_status_enabled(pool, 509, True)
+    await set_public_status_enabled(pool, 509, "octocat/hello-world", True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -844,7 +844,7 @@ async def test_public_health_rate_limit_is_keyed_per_ip(pool, monkeypatch, redis
 @pytest.mark.asyncio
 async def test_public_health_fails_open_when_redis_is_unreachable(pool, monkeypatch):
     await upsert_installation(pool, 510, "octocat")
-    await set_public_status_enabled(pool, 510, True)
+    await set_public_status_enabled(pool, 510, "octocat/hello-world", True)
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -903,6 +903,33 @@ async def test_public_health_404s_when_not_opted_in(pool):
 
 
 @pytest.mark.asyncio
+async def test_public_health_opt_in_does_not_leak_other_repos_in_the_account(pool):
+    # F21: public_status_enabled used to be a column on installations, so
+    # opting in one repo silently exposed every other repo's endpoint
+    # health under the same account, private repos included.
+    await upsert_installation(pool, 513, "octocat")
+    await set_public_status_enabled(pool, 513, "octocat/public-api", True)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable)
+            VALUES (513, 'octocat/internal-billing', 'GET', '/api/invoices', true)
+            """
+        )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        opted_in_repo = await client.get("/v1/health/octocat/public-api")
+        other_repo = await client.get("/v1/health/octocat/internal-billing")
+
+    assert opted_in_repo.status_code == 404  # no endpoint_health rows for it, but opted in
+    assert other_repo.status_code == 404
+    assert other_repo.json()["detail"] == "no health data for this repo"
+
+
+@pytest.mark.asyncio
 async def test_public_health_opting_in_then_out_toggles_visibility(pool):
     await upsert_installation(pool, 512, "octocat")
     async with pool.acquire() as conn:
@@ -918,9 +945,9 @@ async def test_public_health_opting_in_then_out_toggles_visibility(pool):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         before = await client.get("/v1/health/octocat/hello-world")
-        await set_public_status_enabled(pool, 512, True)
+        await set_public_status_enabled(pool, 512, "octocat/hello-world", True)
         during = await client.get("/v1/health/octocat/hello-world")
-        await set_public_status_enabled(pool, 512, False)
+        await set_public_status_enabled(pool, 512, "octocat/hello-world", False)
         after = await client.get("/v1/health/octocat/hello-world")
 
     assert before.status_code == 404


### PR DESCRIPTION
## Summary

`PUT /admin/{org}/{repo}/public-status` is a repo-scoped route in URL, docstring, and its own audit-log entry - but it wrote `installations.public_status_enabled`, a single account-wide column. The unauthenticated `GET /v1/health/{org}/{repo}` read side only checked that column and never re-checked the requested repo. Consequence: an admin enabling public status on `acme/public-api` silently exposed endpoint paths, reachability, and latency for **every other repo in the account**, including private ones - `acme/internal-billing` included, with no additional action from the admin.

## Fix

- New `repo_public_status (installation_id, repo_full_name) -> enabled` table (migration 047), replacing the account-wide column.
- `set_public_status_enabled` / new `get_public_status_enabled` in `db.py` now take `repo_full_name` and read/write this table.
- `admin.py`'s route and `dashboard.py`'s public read path both key off the specific repo now.
- `frontend.py`'s settings toggle already presented this as per-repo in its copy ("Make **this repo's** endpoint status publicly readable") - only the backend storage was wrong, so no UI copy changes were needed, just wiring the checkbox state to the new per-repo field.
- **Backfill**: rather than defaulting every previously-opted-in installation to "on for every repo" (re-creates the leak) or "off for everyone" (silently breaks an already-published status page), the migration recovers real per-repo intent from `admin_action_log`, which already recorded which specific repo each toggle was for. Takes the latest state per (installation, repo) pair; installations with no matching log row get nothing backfilled and stay off, consistent with "off by default" from migration 043.
- Dropped `installations.public_status_enabled` in the same migration - no other code referenced it after the read/write paths moved.

## Test plan
- [x] New regression test proving cross-repo isolation on the write path (`test_set_public_status_route_does_not_leak_to_other_repos`)
- [x] New regression test proving cross-repo isolation on the public read endpoint (`test_public_health_opt_in_does_not_leak_other_repos_in_the_account`)
- [x] Updated all existing public-status tests (`test_admin.py`, `test_dashboard.py`) for the new per-repo signature
- [x] Full `github-app/tests/` suite: 1196 passed, 8 skipped, no regressions