### PR TITLE
fix: dependency-scan blind spots, secret-pattern gaps, and FastAPI prefix loss

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -56,8 +56,102 @@ def _string_literal_text(node: Node, source: bytes) -> str:
     return raw.strip("'\"")
 
 
-def _extract_flask_fastapi_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
+def _collect_fastapi_include_prefixes(root: Node, source: bytes) -> dict[str, list[str]]:
+    prefixes: dict[str, list[str]] = {}
+    for n in _walk_tree(root):
+        if n.type != "call":
+            continue
+        function = n.child_by_field_name("function")
+        args = n.child_by_field_name("arguments")
+        if function is None or args is None or function.type != "attribute":
+            continue
+        name = function.child_by_field_name("attribute")
+        if name is None or source[name.start_byte:name.end_byte].decode() != "include_router":
+            continue
+        positional = [arg for arg in args.named_children if arg.type != "keyword_argument"]
+        if not positional or positional[0].type != "identifier":
+            continue
+        prefix_arg = next(
+            (arg for arg in args.named_children if arg.type == "keyword_argument"
+             and source[arg.child_by_field_name("name").start_byte:arg.child_by_field_name("name").end_byte].decode() == "prefix"),
+            None,
+        )
+        if prefix_arg is None:
+            continue
+        value = prefix_arg.child_by_field_name("value")
+        if value is None or value.type != "string":
+            continue
+        router = source[positional[0].start_byte:positional[0].end_byte].decode()
+        prefixes.setdefault(router, []).append(_string_literal_text(value, source))
+    return prefixes
+
+
+def _walk_tree(root: Node):
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        yield node
+        stack.extend(reversed(node.children))
+
+
+def _extract_flask_fastapi_routes(
+    root: Node,
+    source: bytes,
+    rel_path: str,
+    external_router_mount_prefixes: dict[str, list[str]] | None = None,
+) -> list[dict]:
     entries: list[dict] = []
+
+    def literal(node: Node | None) -> str | None:
+        if node is None or node.type != "string":
+            return None
+        return _string_literal_text(node, source)
+
+    def join_prefix(prefix: str, path: str) -> str:
+        if not prefix:
+            return path
+        if not path:
+            return prefix
+        return f"/{prefix.strip('/')}/{path.strip('/')}" if path != "/" else f"/{prefix.strip('/')}/"
+
+    router_prefixes: dict[str, str] = {}
+    router_mount_prefixes: dict[str, list[str]] = {
+        name: list(prefixes)
+        for name, prefixes in (external_router_mount_prefixes or {}).items()
+    }
+
+    def collect_static_prefixes(n: Node) -> None:
+        # include_router(...) prefixes are deliberately NOT collected here even
+        # when the call happens to live in this same file - map_api_endpoints's
+        # cross-file pre-pass (_collect_fastapi_include_prefixes) already scans
+        # every .py file, this one included, and hands the result in via
+        # external_router_mount_prefixes. Collecting it again here double-counted
+        # the prefix for any router mounted in the same file it's defined in
+        # (e.g. router = APIRouter(...); ...; app.include_router(router, prefix=...)
+        # all in one module) - confirmed via a real map_api_endpoints() run:
+        # "/internal" was applied twice, producing .../internal/internal/....
+        if n.type == "call":
+            function = n.child_by_field_name("function")
+            args = n.child_by_field_name("arguments")
+            if function is not None and args is not None:
+                function_text = source[function.start_byte:function.end_byte].decode()
+                if function.type == "identifier" and function_text == "APIRouter":
+                    parent = n.parent
+                    if parent is not None and parent.type == "assignment":
+                        left = parent.child_by_field_name("left")
+                        if left is not None and left.type == "identifier":
+                            prefix_arg = next(
+                                (arg for arg in args.named_children if arg.type == "keyword_argument"
+                                 and source[arg.child_by_field_name("name").start_byte:arg.child_by_field_name("name").end_byte].decode() == "prefix"),
+                                None,
+                            )
+                            prefix = literal(prefix_arg.child_by_field_name("value")) if prefix_arg else None
+                            if prefix is not None:
+                                router_prefixes[source[left.start_byte:left.end_byte].decode()] = prefix
+        for child in n.children:
+            collect_static_prefixes(child)
+
+    collect_static_prefixes(root)
 
     def walk(n: Node) -> None:
         if n.type == "decorated_definition":
@@ -89,6 +183,17 @@ def _extract_flask_fastapi_routes(root: Node, source: bytes, rel_path: str) -> l
                 if path_node is None:
                     continue
                 path = _string_literal_text(path_node, source)
+                router_object = func.child_by_field_name("object")
+                router_name = (
+                    source[router_object.start_byte:router_object.end_byte].decode()
+                    if router_object is not None and router_object.type == "identifier"
+                    else None
+                )
+                prefixes = ([] if router_name is None else router_mount_prefixes.get(router_name, []))
+                if router_name is not None and router_name in router_prefixes:
+                    prefixes.insert(0, router_prefixes[router_name])
+                for prefix in prefixes:
+                    path = join_prefix(prefix, path)
                 line = decorator.start_point[0] + 1
 
                 if attribute_name == "route":
@@ -1092,6 +1197,15 @@ def map_api_endpoints(
         parser.language = lang
         parsers[name] = parser
 
+    cross_file_router_mounts: dict[str, list[str]] = {}
+    for path in _iter_source_files(repo_path, ignored_paths):
+        if path.suffix != ".py":
+            continue
+        source = path.read_bytes()
+        tree = parsers["py"].parse(source)
+        for router, prefixes in _collect_fastapi_include_prefixes(tree.root_node, source).items():
+            cross_file_router_mounts.setdefault(router, []).extend(prefixes)
+
     for path in _iter_source_files(repo_path, ignored_paths):
         rel_path = _rel(repo_path, path)
 
@@ -1104,7 +1218,11 @@ def map_api_endpoints(
         if suffix == ".py":
             source = path.read_bytes()
             tree = parsers["py"].parse(source)
-            endpoints.extend(_extract_flask_fastapi_routes(tree.root_node, source, rel_path))
+            endpoints.extend(
+                _extract_flask_fastapi_routes(
+                    tree.root_node, source, rel_path, cross_file_router_mounts
+                )
+            )
             if path.name == "urls.py":
                 endpoints.extend(_extract_django_routes(tree.root_node, source, rel_path))
         elif suffix in (".js", ".jsx"):

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -623,6 +623,12 @@ def _extract_javascript(node: Node, source: bytes) -> tuple[list[str], list[dict
     functions: list[dict] = []
     classes: list[dict] = []
 
+    def string_literal(n: Node | None) -> str | None:
+        if n is None or n.type != "string":
+            return None
+        raw = source[n.start_byte:n.end_byte].decode()
+        return raw[1:-1] if len(raw) >= 2 and raw[0] in "'\"" else None
+
     def walk(root: Node):
         # Iterative, not recursive - see _extract_python's walk for why.
         stack = [root]
@@ -633,15 +639,33 @@ def _extract_javascript(node: Node, source: bytes) -> tuple[list[str], list[dict
                 if source_node is not None:
                     raw = source[source_node.start_byte:source_node.end_byte].decode()
                     imports.append(raw.strip("'\""))
+            elif n.type == "export_statement":
+                # Re-export barrels ("export { x } from './x'", "export * from
+                # './x'") get their own export_statement node type with a
+                # "source" field - a walk that only matches import_statement
+                # never sees them, so a file only ever referenced through one
+                # is invisible to imported_by/dead-code despite being live.
+                specifier = string_literal(n.child_by_field_name("source"))
+                if specifier is not None:
+                    imports.append(specifier)
             elif n.type == "call_expression":
-                # CommonJS `require('./x')`. Handling only ESM `import` left the
-                # dependency graph of every CommonJS codebase completely empty -
-                # measured on expressjs/express: 141 modules, 0 resolved imports,
-                # so community detection saw no edges and emitted one cluster per
-                # file. CommonJS is still most of npm, so this is not a legacy
-                # edge case.
+                # CommonJS `require('./x')` and dynamic `import('./x')`. Handling
+                # only ESM `import` left the dependency graph of every CommonJS
+                # codebase completely empty - measured on expressjs/express: 141
+                # modules, 0 resolved imports, so community detection saw no
+                # edges and emitted one cluster per file. CommonJS is still most
+                # of npm, so this is not a legacy edge case. Dynamic import()'s
+                # callee is its own "import" node type (not an identifier), same
+                # tree-sitter shape as the "import" keyword in a static
+                # import_statement.
                 fn = n.child_by_field_name("function")
-                if fn is not None and source[fn.start_byte:fn.end_byte] == b"require":
+                is_require = (
+                    fn is not None
+                    and fn.type == "identifier"
+                    and source[fn.start_byte:fn.end_byte] == b"require"
+                )
+                is_dynamic_import = fn is not None and fn.type == "import"
+                if is_require or is_dynamic_import:
                     args = n.child_by_field_name("arguments")
                     if args is not None:
                         for arg in args.named_children:

--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -66,15 +66,18 @@ _LOW_ENTROPY_THRESHOLD = 3.0
 # overlaps the real value, meaning a naive redact(group(0)) leaks trailing characters of the
 # actual secret. Group 2 isolates just the captured value.
 SECRET_PATTERNS = [
-    ("aws_access_key_id", re.compile(r"AKIA[0-9A-Z]{16}"), 0),
-    ("github_token", re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"), 0),
+    ("aws_access_key_id", re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{16}"), 0),
+    ("github_token", re.compile(r"(?:gh[pousr]_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{20,})"), 0),
     ("stripe_key", re.compile(r"(sk|pk)_(live|test)_[A-Za-z0-9]{16,}"), 0),
     ("private_key_header", re.compile(r"-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----"), 0),
     ("slack_token", re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), 0),
     ("google_api_key", re.compile(r"AIza[0-9A-Za-z_-]{35}"), 0),
     (
         "generic_credential_assignment",
-        re.compile(r"(?i)\b(PASSWORD|SECRET|API_KEY)\s*[:=]\s*['\"]([A-Za-z0-9+/=_-]{16,})['\"]"),
+        re.compile(
+            r"(?i)(?:^|[\s_-])(PASSWORD|SECRET|API_KEY)\s*[:=]\s*"
+            r"['\"]?([A-Za-z0-9+/=_-]{16,})['\"]?(?=\s|$|[,#;)])"
+        ),
         2,
     ),
 ]
@@ -208,8 +211,7 @@ def find_secrets(repo_path: Path, baseline: list[dict] | None = None) -> dict:
         rel_path = path.relative_to(repo_path).as_posix()
         for line_no, line in enumerate(text.splitlines(), start=1):
             for pattern_name, pattern, value_group in SECRET_PATTERNS:
-                match = pattern.search(line)
-                if match:
+                for match in pattern.finditer(line):
                     value = match.group(value_group)
                     match_preview = _redact(value, f"{rel_path}:{pattern_name}")
                     findings.append(
@@ -306,8 +308,7 @@ def find_secrets_in_history(
 
             content = line[1:]
             for pattern_name, pattern, value_group in SECRET_PATTERNS:
-                match = pattern.search(content)
-                if match:
+                for match in pattern.finditer(content):
                     value = match.group(value_group)
                     match_preview = _redact(value, f"{current_file}:{pattern_name}")
                     findings.append(

--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -40,14 +40,21 @@ def _clean_range_version(version: str) -> str | None:
 
 
 def _parse_pep508_dependency(dependency: str) -> tuple[str, str, str] | None:
+    has_marker = ";" in dependency
     dependency = dependency.split(";", 1)[0].strip()
-    match = re.match(
-        r"^([A-Za-z0-9_.-]+)(?:\[[^\]]+\])?\s*(==|>=)\s*([0-9][^,\s]*)$",
-        dependency,
-    )
-    if not match:
+    name_match = re.match(r"^([A-Za-z0-9_.-]+)(?:\[[^\]]+\])?", dependency)
+    if not name_match:
         return None
-    return (match.group(1).lower().replace("_", "-"), match.group(3), "PyPI")
+    name = name_match.group(1).lower().replace("_", "-")
+    specifiers = dependency[name_match.end():]
+    version_match = re.search(r"(?:==|>=|~=)\s*([0-9][^,\s]*)", specifiers)
+    # A lower bound is the most useful stable approximation for a range. Keep
+    # unpinned declarations too: downstream checks can query the package as a
+    # whole instead of silently pretending the dependency was absent.
+    if version_match is None and has_marker:
+        return None
+    version = version_match.group(1) if version_match else "*"
+    return (name, version, "PyPI")
 
 
 def _parse_python_dependency_value(name: str, value: object) -> tuple[str, str, str] | None:
@@ -431,7 +438,10 @@ def _parse_nuget_pins(repo_path: Path) -> list[tuple[str, str, str]]:
 
 def _query_batch(pins: list[tuple[str, str, str]], timeout: int) -> list[dict]:
     queries = [
-        {"package": {"name": name, "ecosystem": ecosystem}, "version": version}
+        {
+            "package": {"name": name, "ecosystem": ecosystem},
+            **({} if version == "*" else {"version": version}),
+        }
         for name, version, ecosystem in pins
     ]
     body = json.dumps({"queries": queries}).encode("utf-8")

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -132,6 +132,58 @@ def test_extract_fastapi_verb_decorator_labeled_ambiguous():
     ]
 
 
+def test_extract_fastapi_composes_router_and_include_prefixes():
+    # include_router(...) prefixes are supplied via external_router_mount_prefixes
+    # here, not written inline - _extract_flask_fastapi_routes no longer collects
+    # them from its own source, since map_api_endpoints's cross-file pre-pass is
+    # now the single source of truth for that (see test below for why: collecting
+    # it both ways double-counted the prefix whenever include_router happened to
+    # be in the same file as the router it mounts).
+    root, source = parse_python(
+        'router = APIRouter(prefix="/api/v1/users")\n'
+        '@router.get("/{user_id}")\n'
+        'def get_user(user_id: int):\n    pass\n'
+    )
+
+    entries = _extract_flask_fastapi_routes(
+        root, source, "app/api.py", {"router": ["/internal"]}
+    )
+
+    assert entries[0]["method"] == "GET"
+    assert entries[0]["path"] == "/internal/api/v1/users/{user_id}"
+    assert entries[0]["unresolved"] is False
+
+
+def test_map_api_endpoints_composes_fastapi_prefix_from_another_file(tmp_path):
+    (tmp_path / "users.py").write_text(
+        'router = APIRouter(prefix="/users")\n'
+        '@router.get("/{user_id}")\n'
+        'def get_user(user_id: int):\n    pass\n'
+    )
+    (tmp_path / "main.py").write_text(
+        'app.include_router(router, prefix="/api/v1")\n'
+    )
+
+    result = map_api_endpoints(tmp_path)
+
+    route = next(endpoint for endpoint in result["endpoints"] if endpoint["file"] == "users.py")
+    assert route["path"] == "/api/v1/users/{user_id}"
+
+
+def test_map_api_endpoints_does_not_double_count_a_same_file_include_router_prefix(tmp_path):
+    (tmp_path / "api.py").write_text(
+        'router = APIRouter(prefix="/api/v1/users")\n'
+        '@router.get("/{user_id}")\n'
+        'def get_user(user_id: int):\n    pass\n'
+        'app.include_router(router, prefix="/internal")\n'
+    )
+
+    result = map_api_endpoints(tmp_path)
+
+    route = next(endpoint for endpoint in result["endpoints"] if endpoint["file"] == "api.py")
+    assert route["path"] == "/internal/api/v1/users/{user_id}"
+
+
 def test_extract_flask_fastapi_ignores_non_route_decorators():
     root, source = parse_python("@staticmethod\ndef helper():\n    pass\n")
 

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -226,6 +226,29 @@ def test_build_module_graph_extracts_javascript_imports(tmp_path):
     assert unparseable == []
 
 
+def test_build_module_graph_extracts_commonjs_reexports_and_dynamic_imports(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "foo.js").write_text("export const foo = 1;\n")
+    (repo / "baz.js").write_text("export const baz = 2;\n")
+    (repo / "qux.js").write_text("export const qux = 3;\n")
+    (repo / "consumer.js").write_text(
+        "const foo = require('./foo');\n"
+        "export { baz } from './baz';\n"
+        "export * from './qux';\n"
+        "async function load() { return import('./foo'); }\n"
+    )
+
+    modules, dependency_graph, unparseable = build_module_graph(repo)
+    consumer = next(module for module in modules if module["path"] == "consumer.js")
+
+    assert consumer["imports"] == ["foo.js", "baz.js", "qux.js", "foo.js"]
+    assert ["consumer.js", "foo.js"] in dependency_graph["edges"]
+    assert ["consumer.js", "baz.js"] in dependency_graph["edges"]
+    assert ["consumer.js", "qux.js"] in dependency_graph["edges"]
+    assert unparseable == []
+
+
 def test_javascript_extracts_jsdoc_comment(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -108,6 +108,33 @@ def test_find_secrets_detects_github_token_and_private_key_header(tmp_path):
     assert "private_key_header" in patterns_found
 
 
+def test_find_secrets_detects_unquoted_generic_credentials_and_multiple_matches(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env").write_text(
+        "DB_PASSWORD=Tr0ub4dor4NoSpecialChars\n"
+        "export API_KEY=abcdefghijklmnopqrstuvwx1234\n"
+        "password: mysecretvalue1234567890\n"
+        "old_key=AKIA1234567890ABCDEF new_key=AKIAABCDEFGHIJKLMNOP\n"
+    )
+
+    findings = find_secrets(repo)["findings"]
+
+    assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 3
+    assert sum(f["pattern"] == "aws_access_key_id" for f in findings) == 2
+
+
+def test_find_secrets_detects_fine_grained_github_and_sts_aws_tokens(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "tokens.txt").write_text(
+        "github_pat_1234567890abcdefghijkl\nASIA1234567890ABCDEF\n"
+    )
+
+    patterns = {finding["pattern"] for finding in find_secrets(repo)["findings"]}
+    assert patterns == {"github_token", "aws_access_key_id"}
+
+
 def test_find_secrets_ignores_ignored_dirs_and_binary_extensions(tmp_path):
     repo = tmp_path / "repo"
     (repo / "node_modules" / "pkg").mkdir(parents=True)

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -437,6 +437,27 @@ def test_parse_pip_pins_reads_pep621_pyproject_dependencies(tmp_path):
     assert not any(pin[0] == "tzdata" for pin in pins)
 
 
+def test_parse_pip_pins_keeps_compound_compatible_and_unpinned_pep508_dependencies(tmp_path):
+    from aletheore.vulnerabilities import _parse_pip_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "[project]\n"
+        "dependencies = [\n"
+        '  "tree-sitter>=0.24.0,<0.25.0",\n'
+        '  "openai~=1.0.0",\n'
+        '  "rich",\n'
+        "]\n"
+    )
+
+    pins = _parse_pip_pins(repo)
+
+    assert ("tree-sitter", "0.24.0", "PyPI") in pins
+    assert ("openai", "1.0.0", "PyPI") in pins
+    assert ("rich", "*", "PyPI") in pins
+
+
 def test_parse_pip_pins_reads_poetry_dependencies(tmp_path):
     from aletheore.vulnerabilities import _parse_pip_pins
 


### PR DESCRIPTION
## Summary

Four independently-verified bugs found auditing `dead_code.py`'s dependency chain (`vulnerabilities.py`, `scanner/graph.py`) and `secrets.py`/`endpoints.py`. Codex implemented the initial fixes for all four (across two rounds); this PR also fixes one regression the second round introduced (same-file prefix double-counting in `endpoints.py`) and resolves a merge conflict against master's own independent CommonJS `require()` fix in `scanner/graph.py`.

- **`_parse_pep508_dependency`** silently dropped any dependency using a compound PEP 440 range (`>=X,<Y`), the `~=` operator, or no version at all — confirmed on this repo's own `pyproject.toml`, where 15 of 17 real runtime dependencies were invisible to CVE scanning, license checking, and unused-dependency detection alike (all three share this one parser). OSV queries for unpinned/wildcard dependencies now omit the version field rather than silently excluding them entirely.
- **`_extract_javascript`** only matched ES `import` statements. CommonJS `require()`, re-export barrels (`export ... from`/`export * from`), and dynamic `import()` were all invisible to the dependency graph — false "dead code" positives and blind spots in `imported_by` for any file only reached through one of those forms. (Master had independently picked up its own `require()`-only fix in the meantime; merged the two so `require()`, dynamic `import()`, and re-export barrels are all covered without duplicating detection logic.)
- **`generic_credential_assignment`** required the value be quoted, missing the most common real-world shape: unquoted `.env`/docker-compose/shell-export/YAML assignments. Also added `ASIA` (STS session token) and `github_pat_` (fine-grained PAT) coverage, and switched line scans from `search()` to `finditer()` so multiple matches of the same pattern on one line aren't silently dropped after the first.
- **`_extract_flask_fastapi_routes`** never composed `APIRouter(prefix=...)` or `include_router(..., prefix=...)` into the extracted path — FastAPI's standard multi-file "Bigger Applications" layout produced systematically wrong, prefix-less paths with no signal anything was missing. `map_api_endpoints` now does a cross-file pre-pass to resolve `include_router` prefixes declared in a different file than the router they mount.

## Fixed during review, before merge

The cross-file prefix fix initially double-counted a router's prefix whenever `include_router(...)` happened to live in the *same* file as the router it mounts (the pre-existing same-file collection and the new cross-file pre-pass both found and applied it, e.g. `/internal/internal/api/v1/...`). Removed the now-redundant same-file collection since the pre-pass already covers every file, including the one being parsed — verified via the real `map_api_endpoints()` entrypoint, with a new regression test (`test_map_api_endpoints_does_not_double_count_a_same_file_include_router_prefix`).

## Test plan

- [x] 1198/1198 tests pass (full `src/` suite)
- [x] `git diff --check` clean
- [x] Each fix independently reproduced and verified against the actual failing input before/after (not inferred from the diff)