### PR TITLE
feat: replace Ollama with self-hosted TEI for evidence-packet embedding cache

### DIFF
--- a/github-app/Dockerfile.tei
+++ b/github-app/Dockerfile.tei
@@ -1,0 +1,16 @@
+# Self-hosted nomic-embed-text-v1.5, replacing Ollama: same model, TEI's
+# dynamic batching gives real concurrent-request throughput instead of
+# Ollama's general-purpose LLM runtime. The model is downloaded and its
+# config.json patched at BUILD time (see tei/download_and_patch.py) - a
+# fresh deploy never depends on HuggingFace being reachable and never pays
+# the parse-fail-then-fallback cost this exact model triggers on a stock
+# TEI image.
+
+FROM python:3.12-slim AS model
+COPY github-app/tei/download_and_patch.py /tmp/download_and_patch.py
+RUN python3 /tmp/download_and_patch.py
+
+FROM ghcr.io/huggingface/text-embeddings-inference:cpu-latest
+COPY --from=model /model /model
+ENTRYPOINT ["text-embeddings-router"]
+CMD ["--model-id", "/model", "--port", "80"]

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -79,7 +79,7 @@ services:
         required: false
     environment:
       - GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app-key.pem
-      - OLLAMA_BASE_URL=http://ollama:11434
+      - TEI_BASE_URL=http://tei:80
       - ALETHEORE_REPO_CHECKOUT_ROOT=/data/aletheore-repo-checkouts
       - ALETHEORE_APP_HEALTH_URL=http://app-server:8000/healthz
       - ALETHEORE_BACKUP_DIR=/app/backups
@@ -104,7 +104,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      ollama:
+      tei:
         condition: service_started
     cpus: "1.0"
     mem_limit: 1g
@@ -308,32 +308,23 @@ services:
     security_opt:
       - "no-new-privileges:true"
 
-  ollama:
-    image: ollama/ollama:latest
+  # Self-hosted nomic-embed-text-v1.5 via HuggingFace's Text Embeddings
+  # Inference, replacing Ollama - same model, real dynamic batching for
+  # concurrent embedding requests instead of a general-purpose LLM runtime.
+  # Model is downloaded and its config.json patched at BUILD time, not
+  # here (see Dockerfile.tei and tei/download_and_patch.py) - no network
+  # dependency or slow fallback path at container start.
+  tei:
+    build:
+      context: ..
+      dockerfile: github-app/Dockerfile.tei
     restart: unless-stopped
-    # Internal-only (11434, never published to the host) - same reasoning
-    # as redis above.
+    # Internal-only (80, never published to the host) - same reasoning as
+    # redis above.
     security_opt:
       - "no-new-privileges:true"
-    # Tried OLLAMA_CONTEXT_LENGTH=8192 here first, assuming nomic-embed-text
-    # supports an 8192-token context - it doesn't, not on the GGUF this
-    # pulls: confirmed directly against the running server that the model's
-    # own trained context is a hard 2048, and requesting more just logged
-    # "requested context size too large for model" and got silently
-    # clamped back down. The real fix is keeping input within that limit
-    # (see MAX_EMBEDDING_CHARS in scan_worker/embedding_client.py), not a
-    # server setting that can't raise a ceiling the model itself doesn't have.
-    volumes:
-      - aletheore_ollama_data:/root/.ollama
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        ollama serve &
-        sleep 3
-        ollama pull nomic-embed-text
-        wait
-    cpus: "1.0"
-    mem_limit: 1g
+    cpus: "2.0"
+    mem_limit: 2g
 
   caddy:
     image: caddy:2-alpine
@@ -381,6 +372,5 @@ services:
 
 volumes:
   aletheore_postgres_data:
-  aletheore_ollama_data:
   aletheore_caddy_data:
   aletheore_caddy_config:

--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -1,70 +1,65 @@
-"""Ollama embedding client for evidence-packet similarity caching."""
+"""TEI (self-hosted nomic-embed-text-v1.5) embedding client for
+evidence-packet similarity caching. Was Ollama; replaced for real
+concurrent-request throughput (see Dockerfile.tei)."""
 
 import logging
 import os
 
 import httpx
 
-EMBEDDING_MODEL = "nomic-embed-text"
+EMBEDDING_MODEL = "nomic-embed-text-v1.5"
 
-# The pulled nomic-embed-text GGUF's own metadata caps it at a real,
-# hard 2048-token training context (confirmed directly against the running
-# server: `nomic-bert.context_length = 2048`, and requesting num_ctx=8192
-# just produced "requested context size too large for model" and got
-# silently clamped back to 2048 - the model was never going to accept more,
-# regardless of server or per-request settings). Every real embedding call
-# failed until input was kept under this real limit; the cache had a 0%
-# hit rate for the 38 hours it ran before this was caught.
-EMBEDDING_NUM_CTX = 2048
-
+# The model's own real, hard-trained context is 2048 tokens (confirmed
+# directly against the running Ollama server this replaced:
+# `nomic-bert.context_length = 2048`; requesting more there got silently
+# clamped with a warning). TEI's own self-reported max_input_length is NOT
+# trustworthy for this number - it comes from a legacy config field
+# (n_positions=8192) that Dockerfile.tei's build-time patch removes
+# specifically because it doesn't reflect the model's real trained limit.
+# The char-based truncation below is the real safety margin, independent
+# of whatever TEI reports.
+#
 # Empirically calibrated against the real running model with text shaped
 # like actual evidence packets (file paths, symbol names, short identifiers
 # - not plain prose, and not a pathological single repeated character
 # either): 6600 chars succeeded, 6990 failed. 5000 chars keeps a real
 # margin below that boundary for token-density variance in different
-# packets and the single-CPU container being busier under real concurrent
-# load than this manual test. A truncated embedding is still useful for
-# similarity matching; the exact text match isn't needed, and a cache hit
-# is always re-verified against current evidence regardless of how it was
-# found.
+# packets and the container being busier under real concurrent load than
+# this manual test. A truncated embedding is still useful for similarity
+# matching; the exact text match isn't needed, and a cache hit is always
+# re-verified against current evidence regardless of how it was found.
 MAX_EMBEDDING_CHARS = 5000
 
 logger = logging.getLogger(__name__)
 
 
 def _client(base_url: str | None = None) -> httpx.Client:
-    return httpx.Client(base_url=base_url or os.environ.get("OLLAMA_BASE_URL", "http://ollama:11434"))
+    return httpx.Client(base_url=base_url or os.environ.get("TEI_BASE_URL", "http://tei:80"))
 
 
 def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 10.0) -> list[float] | None:
     # A 7000-char prompt (above the truncation budget below) measured 3.6s
-    # against the real server - 5.0 left too little margin under real
-    # concurrent load on a single-CPU container; this is a degrade-to-miss
-    # timeout, not a build-blocking one, so erring toward more patience
-    # costs nothing but a slightly slower cache lookup.
+    # against the real Ollama server this replaced - 5.0 left too little
+    # margin under real concurrent load; this is a degrade-to-miss timeout,
+    # not a build-blocking one, so erring toward more patience costs
+    # nothing but a slightly slower cache lookup.
     if len(text) > MAX_EMBEDDING_CHARS:
         text = text[:MAX_EMBEDDING_CHARS]
     try:
         with _client(base_url) as client:
-            response = client.post(
-                "/api/embeddings",
-                json={
-                    "model": EMBEDDING_MODEL,
-                    "prompt": text,
-                    "options": {"num_ctx": EMBEDDING_NUM_CTX},
-                },
-                timeout=timeout_seconds,
-            )
+            response = client.post("/embed", json={"inputs": text}, timeout=timeout_seconds)
             response.raise_for_status()
             data = response.json()
     except (httpx.HTTPError, ValueError) as exc:
         logger.warning("embedding call failed (%s); treating cache as unavailable", type(exc).__name__)
         return None
 
-    embedding = data.get("embedding")
-    if not isinstance(embedding, list) or not embedding:
+    # TEI's /embed returns a list of embeddings, one per input text - a
+    # single-item batch here since embed_text sends exactly one string.
+    if not isinstance(data, list) or not data or not isinstance(data[0], list) or not data[0]:
         logger.warning("embedding response missing embedding array; treating cache as unavailable")
         return None
+    embedding = data[0]
     if not all(isinstance(value, int | float) for value in embedding):
         logger.warning("embedding response contains non-numeric values; treating cache as unavailable")
         return None

--- a/github-app/tei/download_and_patch.py
+++ b/github-app/tei/download_and_patch.py
@@ -1,0 +1,67 @@
+"""Bakes nomic-embed-text-v1.5 into the TEI image at build time, patched.
+
+The model's config.json carries both GPT-2-style legacy field names (n_embd,
+n_head, n_inner, n_layer, n_positions) and their canonical BERT-style
+equivalents (hidden_size, num_attention_heads, intermediate_size,
+num_hidden_layers, max_position_embeddings) - same values, dual naming, a
+known pattern for NomicBert's GPT/BERT-compatible config. TEI's backend-init
+code flattens both into one struct and re-serializes it internally; with
+both spellings present this emits `hidden_size` twice and the ONNX loading
+path throws "duplicate field `hidden_size`" and falls back to a slower,
+more constrained path. n_positions=8192 also isn't a true duplicate value
+of max_position_embeddings=2048, and TEI reports IT (not 2048) as
+max_input_length - the model was only ever trained on 2048 tokens, so
+trusting that reported ceiling would silently produce degraded embeddings
+for longer input. All five legacy fields are dropped below; nothing here
+was needed for correctness, only for parsing and for TEI's own self-report.
+
+Downloading and patching at build time, not at container startup, means a
+fresh deploy never depends on HuggingFace's availability and never repeats
+the parse-fail-then-slow-fallback dance in prod.
+"""
+
+import json
+import urllib.request
+from pathlib import Path
+
+REPO = "nomic-ai/nomic-embed-text-v1.5"
+REVISION = "main"
+OUT_DIR = Path("/model")
+
+FILES = [
+    "config.json",
+    "1_Pooling/config.json",
+    "sentence_bert_config.json",
+    "config_sentence_transformers.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "modules.json",
+    "onnx/model.onnx",
+]
+
+LEGACY_ALIAS_KEYS = ("n_embd", "n_head", "n_inner", "n_layer", "n_positions")
+
+
+def fetch(relpath: str) -> bytes:
+    url = f"https://huggingface.co/{REPO}/resolve/{REVISION}/{relpath}"
+    with urllib.request.urlopen(url, timeout=120) as response:
+        return response.read()
+
+
+def main() -> None:
+    for relpath in FILES:
+        dest = OUT_DIR / relpath
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        data = fetch(relpath)
+        dest.write_bytes(data)
+        print(f"downloaded {relpath} ({len(data)} bytes)")
+
+    config_path = OUT_DIR / "config.json"
+    config = json.loads(config_path.read_text())
+    removed = [k for k in LEGACY_ALIAS_KEYS if config.pop(k, None) is not None]
+    config_path.write_text(json.dumps(config, indent=2))
+    print(f"patched config.json, removed: {removed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/github-app/tests/test_embedding_client.py
+++ b/github-app/tests/test_embedding_client.py
@@ -7,12 +7,12 @@ from scan_worker.embedding_client import MAX_EMBEDDING_CHARS, embed_text
 
 def test_embed_text_returns_vector_on_success(monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/api/embeddings"
-        return httpx.Response(200, json={"embedding": [0.1, 0.2, 0.3]})
+        assert request.url.path == "/embed"
+        return httpx.Response(200, json=[[0.1, 0.2, 0.3]])
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://tei:80"),
     )
 
     result = embed_text("some evidence text")
@@ -20,26 +20,21 @@ def test_embed_text_returns_vector_on_success(monkeypatch):
     assert result == [0.1, 0.2, 0.3]
 
 
-def test_embed_text_sends_the_models_real_context_window(monkeypatch):
-    # Confirmed directly against the running production model: the pulled
-    # nomic-embed-text GGUF has a hard 2048-token trained context (not 8192,
-    # which was a first, wrong assumption - requesting more just got
-    # silently clamped by Ollama with a warning). Sending it explicitly
-    # keeps this self-documenting even though it now matches the default.
+def test_embed_text_sends_inputs_as_a_single_string(monkeypatch):
     seen = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen["body"] = json.loads(request.content)
-        return httpx.Response(200, json={"embedding": [0.1]})
+        return httpx.Response(200, json=[[0.1]])
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://tei:80"),
     )
 
     embed_text("some evidence text")
 
-    assert seen["body"]["options"] == {"num_ctx": 2048}
+    assert seen["body"] == {"inputs": "some evidence text"}
 
 
 def test_embed_text_truncates_oversized_input(monkeypatch):
@@ -51,17 +46,17 @@ def test_embed_text_truncates_oversized_input(monkeypatch):
     seen = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
-        seen["prompt"] = json.loads(request.content)["prompt"]
-        return httpx.Response(200, json={"embedding": [0.1]})
+        seen["inputs"] = json.loads(request.content)["inputs"]
+        return httpx.Response(200, json=[[0.1]])
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://tei:80"),
     )
 
     embed_text("x" * (MAX_EMBEDDING_CHARS + 5000))
 
-    assert len(seen["prompt"]) == MAX_EMBEDDING_CHARS
+    assert len(seen["inputs"]) == MAX_EMBEDDING_CHARS
 
 
 def test_embed_text_uses_explicit_base_url(monkeypatch):
@@ -69,15 +64,15 @@ def test_embed_text_uses_explicit_base_url(monkeypatch):
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen["url"] = str(request.url)
-        return httpx.Response(200, json={"embedding": [0.1]})
+        return httpx.Response(200, json=[[0.1]])
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
         lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url=base_url),
     )
 
-    assert embed_text("some evidence text", base_url="http://custom-ollama:11434") == [0.1]
-    assert seen["url"].startswith("http://custom-ollama:11434/")
+    assert embed_text("some evidence text", base_url="http://custom-tei:80") == [0.1]
+    assert seen["url"].startswith("http://custom-tei/")
 
 
 def test_embed_text_returns_none_on_connection_error(monkeypatch):
@@ -86,7 +81,7 @@ def test_embed_text_returns_none_on_connection_error(monkeypatch):
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://tei:80"),
     )
 
     assert embed_text("some evidence text") is None
@@ -98,7 +93,7 @@ def test_embed_text_returns_none_on_timeout(monkeypatch):
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://tei:80"),
     )
 
     assert embed_text("some evidence text") is None
@@ -110,7 +105,19 @@ def test_embed_text_returns_none_on_malformed_response(monkeypatch):
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://tei:80"),
+    )
+
+    assert embed_text("some evidence text") is None
+
+
+def test_embed_text_returns_none_on_empty_batch(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    monkeypatch.setattr(
+        "scan_worker.embedding_client._client",
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://tei:80"),
     )
 
     assert embed_text("some evidence text") is None


### PR DESCRIPTION
## Summary
- Replaces the `ollama` docker-compose service with `tei` (HuggingFace Text Embeddings Inference), serving the same `nomic-embed-text-v1.5` model.
- Motivation: real dynamic batching for concurrent embedding requests instead of Ollama's general-purpose LLM runtime.
- Model is downloaded and its `config.json` patched at **build time** (`Dockerfile.tei` + `tei/download_and_patch.py`), so a fresh deploy has no HuggingFace runtime dependency.

## Why the config.json patch
The model's config carries duplicate GPT-2/BERT-style field pairs (`n_embd`/`hidden_size`, `n_head`/`num_attention_heads`, `n_inner`/`intermediate_size`, `n_layer`/`num_hidden_layers`, `n_positions`/`max_position_embeddings`). TEI's ONNX loading path chokes on this with `Failed to parse config.json: duplicate field 'hidden_size'` and falls back to a slower, batch-size-4-constrained path. `n_positions=8192` also isn't a true duplicate of `max_position_embeddings=2048` — the model was only ever trained on 2048 tokens, so it shouldn't be trusted as the real input ceiling either way. All five are stripped at build time.

## Verified before this PR
- TEI-served embeddings vs Ollama-served embeddings on the exact same 32-question Flask + 15-question gin benchmark corpora: **0/47 questions differ in top-5 ranked files** — byte-identical retrieval, not just matching aggregate percentages.
- TEI's OpenAI-compatible `/v1/embeddings` and native `/embed` endpoints both confirmed working against the patched, locally-baked image.
- `embedding_client.py` rewritten for TEI's `/embed` shape (was Ollama's native `/api/embeddings`); `MAX_EMBEDDING_CHARS` client-side truncation is unchanged and remains the real safety margin against the model's real 2048-token context.

## Resources (production host: 4 vCPU / 15GB RAM, x86_64, currently ~1.1GB used)
- `tei`: `cpus: 2.0`, `mem_limit: 2g` (was `ollama`: 1.0 / 1g) — headroom for concurrent load, well within what the host has free alongside the existing stack (~3GB combined explicit limits today).

## Test plan
- [x] `pytest tests/test_embedding_client.py` — 8 passed (rewritten for TEI's response shape)
- [x] Full `github-app` suite — 688 passed, 585 skipped, 3 pre-existing Redis-connectivity failures unrelated to this change (no local Redis)
- [x] `docker compose config -q` validates
- [x] `docker build -f github-app/Dockerfile.tei .` builds clean, confirmed patch removes all 5 legacy keys
- [x] Ran the built image locally (x86_64 emulated): loads from the baked-in local path with zero network calls, serves correct 768-dim embeddings via both `/embed` and `/v1/embeddings`
- [ ] Deploy to production and verify against the real service (next step after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)