### PR TITLE
fix: raise TEI memory limit after real production OOM kills

### DIFF
--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -324,7 +324,12 @@ services:
     security_opt:
       - "no-new-privileges:true"
     cpus: "2.0"
-    mem_limit: 2g
+    # Measured directly against the running production container: 2g
+    # OOM-killed it 9 times during warmup before it ever reached Ready,
+    # even natively (no emulation) - warmup briefly needs real headroom
+    # above the model's own steady-state footprint. Host has 15GB with
+    # ~14GB free, so this costs nothing the rest of the stack needs.
+    mem_limit: 4g
 
   caddy:
     image: caddy:2-alpine


### PR DESCRIPTION
## Summary
PR #238 shipped `tei` with `mem_limit: 2g` (matching Ollama's old allocation). Deployed to production and watched it live: OOM-killed 9 times in a row during warmup, never reached Ready. Confirmed via `docker inspect --format '{{.State.OOMKilled}}'` → `true`, `RestartCount=9`. Not an emulation artifact — this was native x86_64 on the real host.

## Fix
Raise `mem_limit` to `4g`. Host has 15GB total, ~14GB free before this change, so there's ample headroom.

## Impact while this was broken
Non-critical: `embedding_client.embed_text()` degrades to `None` on connection failure by design (evidence-packet similarity cache, not a hard dependency) — this was a silent cache-miss, not a service outage. Stopped the crash-looping container on the server (`docker compose stop tei`) while this fix goes through CI.

## Test plan
- [x] `docker compose config -q` validates
- [ ] Deploy and confirm TEI reaches Ready without OOM (next step after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)