### PR TITLE
fix: replace nomic-embed-text-v1.5 with all-MiniLM-L6-v2 in TEI

### DIFF
--- a/github-app/Dockerfile.tei
+++ b/github-app/Dockerfile.tei
@@ -1,10 +1,11 @@
-# Self-hosted nomic-embed-text-v1.5, replacing Ollama: same model, TEI's
-# dynamic batching gives real concurrent-request throughput instead of
-# Ollama's general-purpose LLM runtime. The model is downloaded and its
-# config.json patched at BUILD time (see tei/download_and_patch.py) - a
-# fresh deploy never depends on HuggingFace being reachable and never pays
-# the parse-fail-then-fallback cost this exact model triggers on a stock
-# TEI image.
+# Self-hosted all-MiniLM-L6-v2 (replacing Ollama, and before that
+# nomic-embed-text-v1.5 - nomic OOM-killed repeatedly on the real
+# production host even at a 4GB cgroup limit; see tei/download_and_patch.py
+# for the dmesg evidence). TEI's dynamic batching gives real
+# concurrent-request throughput instead of Ollama's general-purpose LLM
+# runtime. The model is downloaded at BUILD time (see
+# tei/download_and_patch.py) - a fresh deploy never depends on HuggingFace
+# being reachable at container start.
 
 FROM python:3.12-slim AS model
 COPY github-app/tei/download_and_patch.py /tmp/download_and_patch.py

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -323,13 +323,16 @@ services:
     # redis above.
     security_opt:
       - "no-new-privileges:true"
-    cpus: "2.0"
-    # Measured directly against the running production container: 2g
-    # OOM-killed it 9 times during warmup before it ever reached Ready,
-    # even natively (no emulation) - warmup briefly needs real headroom
-    # above the model's own steady-state footprint. Host has 15GB with
-    # ~14GB free, so this costs nothing the rest of the stack needs.
-    mem_limit: 4g
+    cpus: "1.0"
+    # Was nomic-embed-text-v1.5 at mem_limit 4g; that OOM-killed repeatedly
+    # in production even at 4g (dmesg: every kill landed at anon-rss
+    # ~4184-4185MB, right at the 4GB boundary, so the limit was censoring
+    # the real peak, not measuring it - the "sufficient at 4g" claim was
+    # never actually verified). Replaced with all-MiniLM-L6-v2 (22M params,
+    # 384-dim, ~90MB weights - see tei/download_and_patch.py). This value
+    # is set from a local `docker stats` warmup measurement with no limit
+    # imposed, plus margin - not a guess repeated a third time.
+    mem_limit: 1g
 
   caddy:
     image: caddy:2-alpine

--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -1,34 +1,26 @@
-"""TEI (self-hosted nomic-embed-text-v1.5) embedding client for
-evidence-packet similarity caching. Was Ollama; replaced for real
-concurrent-request throughput (see Dockerfile.tei)."""
+"""TEI (self-hosted all-MiniLM-L6-v2) embedding client for evidence-packet
+similarity caching. Was Ollama, then nomic-embed-text-v1.5 (which
+repeatedly OOM-killed in production - see Dockerfile.tei); replaced with
+this much smaller model for real reliability on a resource-constrained
+host (see tei/download_and_patch.py)."""
 
 import logging
 import os
 
 import httpx
 
-EMBEDDING_MODEL = "nomic-embed-text-v1.5"
+EMBEDDING_MODEL = "all-MiniLM-L6-v2"
 
-# The model's own real, hard-trained context is 2048 tokens (confirmed
-# directly against the running Ollama server this replaced:
-# `nomic-bert.context_length = 2048`; requesting more there got silently
-# clamped with a warning). TEI's own self-reported max_input_length is NOT
-# trustworthy for this number - it comes from a legacy config field
-# (n_positions=8192) that Dockerfile.tei's build-time patch removes
-# specifically because it doesn't reflect the model's real trained limit.
-# The char-based truncation below is the real safety margin, independent
-# of whatever TEI reports.
-#
-# Empirically calibrated against the real running model with text shaped
-# like actual evidence packets (file paths, symbol names, short identifiers
-# - not plain prose, and not a pathological single repeated character
-# either): 6600 chars succeeded, 6990 failed. 5000 chars keeps a real
-# margin below that boundary for token-density variance in different
-# packets and the container being busier under real concurrent load than
-# this manual test. A truncated embedding is still useful for similarity
+# The model's own real, hard-trained context is 256 tokens
+# (sentence_bert_config.json's max_seq_length on the HF repo) - much
+# shorter than nomic's 2048, the trade this smaller/more-reliable model
+# makes. TEI's auto_truncate=true means it silently truncates past this
+# rather than erroring, so the char-based truncation below is a courtesy
+# (avoid sending obviously-wasted bytes over the wire), not the only line
+# of defense. A truncated embedding is still useful for similarity
 # matching; the exact text match isn't needed, and a cache hit is always
 # re-verified against current evidence regardless of how it was found.
-MAX_EMBEDDING_CHARS = 5000
+MAX_EMBEDDING_CHARS = 1000
 
 logger = logging.getLogger(__name__)
 

--- a/github-app/tei/download_and_patch.py
+++ b/github-app/tei/download_and_patch.py
@@ -1,30 +1,32 @@
-"""Bakes nomic-embed-text-v1.5 into the TEI image at build time, patched.
+"""Bakes sentence-transformers/all-MiniLM-L6-v2 into the TEI image at build
+time.
 
-The model's config.json carries both GPT-2-style legacy field names (n_embd,
-n_head, n_inner, n_layer, n_positions) and their canonical BERT-style
-equivalents (hidden_size, num_attention_heads, intermediate_size,
-num_hidden_layers, max_position_embeddings) - same values, dual naming, a
-known pattern for NomicBert's GPT/BERT-compatible config. TEI's backend-init
-code flattens both into one struct and re-serializes it internally; with
-both spellings present this emits `hidden_size` twice and the ONNX loading
-path throws "duplicate field `hidden_size`" and falls back to a slower,
-more constrained path. n_positions=8192 also isn't a true duplicate value
-of max_position_embeddings=2048, and TEI reports IT (not 2048) as
-max_input_length - the model was only ever trained on 2048 tokens, so
-trusting that reported ceiling would silently produce degraded embeddings
-for longer input. All five legacy fields are dropped below; nothing here
-was needed for correctness, only for parsing and for TEI's own self-report.
+Replaced nomic-embed-text-v1.5 after it repeatedly OOM-killed on the real
+production host: dmesg showed every kill landing at anon-rss ~4184-4185MB,
+right at the 4GB cgroup boundary, to within 1MB every single time - the
+process was still climbing when killed, so no cgroup limit we tried was
+actually measuring its peak, only censoring it. MiniLM is a 22M-param,
+6-layer, 384-dim model (~90MB ONNX weights) built for exactly this
+resource-constrained use case; this component is a similarity CACHE for
+evidence packets, not the core relevance signal (see embedding_client.py -
+it already degrades to `None`/cache-miss on any failure), so the much
+smaller embedding space is a good trade for actually fitting on this host.
+
+Unlike nomic's NomicBert config, MiniLM's config.json is a plain
+single-named BERT config (hidden_size, num_attention_heads, etc, no GPT-2
+alias fields) - the LEGACY_ALIAS_KEYS removal below is a no-op for this
+model. Left in as a harmless safety net rather than deleted, in case we
+swap models again.
 
 Downloading and patching at build time, not at container startup, means a
-fresh deploy never depends on HuggingFace's availability and never repeats
-the parse-fail-then-slow-fallback dance in prod.
+fresh deploy never depends on HuggingFace's availability.
 """
 
 import json
 import urllib.request
 from pathlib import Path
 
-REPO = "nomic-ai/nomic-embed-text-v1.5"
+REPO = "sentence-transformers/all-MiniLM-L6-v2"
 REVISION = "main"
 OUT_DIR = Path("/model")
 


### PR DESCRIPTION
## Summary
- PR #239 raised TEI's `mem_limit` 2g -> 4g but that did **not** fix production OOM kills. `dmesg` on the real host showed every kill landing at `anon-rss ~4184-4185MB`, right at the 4GB boundary, to within 1MB every time — the process was still growing when killed, so the limit was censoring the true peak, not measuring it.
- Swapped `nomic-embed-text-v1.5` (137M params, 768-dim, 2048-token context) for `all-MiniLM-L6-v2` (22M params, 384-dim, 256-token context). This is a similarity **cache** for evidence packets only (already degrades to a miss on any failure — see `embedding_client.py`), so the smaller embedding space is a fair trade for something that actually fits this 4-vCPU/15GB host.
- `mem_limit` dropped `4g -> 1g` based on a real local measurement (steady-state ~230-260MB), not another guess.

## Verified locally
- Built the image, ran the container, reached `Ready` in ~1.3s.
- `/embed` returns real 384-dim vectors.
- Confirmed TEI silently truncates over-length input (`auto_truncate=true`) rather than erroring — up to 5000 chars tested, all succeeded — so `MAX_EMBEDDING_CHARS` is a client-side courtesy, not a safety boundary.
- `pytest tests/test_embedding_client.py` — 8/8 pass unchanged (no hardcoded dimension assumptions).

## Test plan
- [x] Local Docker build + run, `/embed` functional test
- [x] Unit tests pass
- [ ] CI green
- [ ] Deploy to prod, watch `docker stats` through warmup, confirm no OOM
- [ ] Re-run `embed_text()` against the live service from `scan-worker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)