### PR TITLE
feat: add per-repo checkout lock and scale scan-worker to two replicas

### DIFF
--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -118,6 +118,60 @@ services:
       - ALL
     pids_limit: 1024
 
+  # Second replica of scan-worker, consuming the same "scans" queue. RQ's
+  # own job dequeue is already safe for multiple workers (atomic claim via
+  # Redis) - the one thing that WASN'T safe for two replicas was
+  # _ensure_persistent_checkout's unlocked use of the shared
+  # ./repo-checkouts bind mount (two replicas racing `git checkout -f`/
+  # `git clean -fdx` on the same working tree, or racing the live-token
+  # `git remote set-url` around it). repo_checkout_lock (scan_worker/db.py)
+  # closes that: same-repo jobs across replicas now serialize via a
+  # Postgres advisory lock instead of racing, while different repos (the
+  # actual point of a second replica) genuinely run in parallel. Otherwise
+  # identical to scan-worker above - keep both blocks in sync.
+  scan-worker-2:
+    build:
+      context: ..
+      dockerfile: github-app/Dockerfile.scan-worker
+    restart: unless-stopped
+    labels:
+      - autoheal=true
+    healthcheck:
+      test: ["CMD-SHELL", "find /tmp/heartbeat -mmin -2 | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      - GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app-key.pem
+      - OLLAMA_BASE_URL=http://ollama:11434
+      - ALETHEORE_REPO_CHECKOUT_ROOT=/data/aletheore-repo-checkouts
+      - ALETHEORE_APP_HEALTH_URL=http://app-server:8000/healthz
+      - ALETHEORE_BACKUP_DIR=/app/backups
+    volumes:
+      - ./app-private-key.pem:/run/secrets/github-app-key.pem:ro
+      - ./repo-checkouts:/data/aletheore-repo-checkouts
+      - ./backups:/app/backups:ro
+    tmpfs:
+      - /tmp:size=1g,mode=1777
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      ollama:
+        condition: service_started
+    cpus: "1.0"
+    mem_limit: 1g
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    pids_limit: 1024
+
   # Consumes the "health" and "email" queues (see scan_worker/scheduler.py
   # and health_worker.py) - a dedicated worker so a long-running AI job on
   # scan-worker's "scans" queue (Flash review, AIRview, managed audit) can

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 # reserved for the session-scoped spend lock. The installation id is key 2.
 SCAN_SLOT_LOCK_NAMESPACE = 1
 SPEND_LOCK_NAMESPACE = 2
+# Namespace 3 is reserved for the per-repo checkout lock (see
+# repo_checkout_lock) - key 2 is hashtext(installation_id:repo_full_name)
+# rather than a bare int, since the resource being protected is a
+# composite (installation, repo) pair, not a single id.
+REPO_CHECKOUT_LOCK_NAMESPACE = 3
 ADVISORY_LOCK_TIMEOUT = "5s"
 
 
@@ -328,6 +333,45 @@ def installation_spend_lock(dsn: str, installation_id: int):
             cur.execute(
                 "SELECT pg_advisory_unlock(%s, %s)",
                 (SPEND_LOCK_NAMESPACE, installation_id),
+            )
+        conn.close()
+
+
+@contextmanager
+def repo_checkout_lock(dsn: str, installation_id: int, repo_full_name: str):
+    """Serializes concurrent scan-worker replicas' use of one repo's
+    persistent, reused-across-scans checkout (see _ensure_persistent_checkout
+    in jobs.py), which has no filesystem-level locking of its own: two
+    replicas racing `git checkout -f`/`git clean -fdx` against the same
+    working tree can corrupt it, and racing `git remote set-url` (which
+    briefly writes a live access token into .git/config, then resets it
+    back) can leave one replica's fetch using the other's credentials or
+    a URL with no credentials at all.
+
+    Deliberately blocking (no lock_timeout, unlike the quick check-then-write
+    locks above) - a second job for the same repo should wait its turn and
+    still run once the first finishes, not fail fast and drop a real PR
+    scan or push reconciliation. A crashed holder releases automatically:
+    Postgres advisory locks are tied to the session/connection, which
+    always closes (killed or not) before the lock could leak. Different
+    repos, and different installations, are completely unaffected and run
+    in true parallel across replicas - this only narrows the pre-existing
+    single-worker-wide serialization down to "same repo only".
+    """
+    key = f"{installation_id}:{repo_full_name}"
+    conn = psycopg.connect(dsn, autocommit=True)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_advisory_lock(%s, hashtext(%s))",
+                (REPO_CHECKOUT_LOCK_NAMESPACE, key),
+            )
+        yield
+    finally:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_advisory_unlock(%s, hashtext(%s))",
+                (REPO_CHECKOUT_LOCK_NAMESPACE, key),
             )
         conn.close()
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -95,6 +95,7 @@ from scan_worker.db import (
     record_llm_spend,
     record_sent_email,
     record_wiki_catchup_swept,
+    repo_checkout_lock,
     set_docs_build_status,
     set_last_reviewed_sha,
     set_wiki_build_status,
@@ -812,40 +813,50 @@ def run_pr_scan_job(
         clone_url = _clone_url(repo_full_name, token)
         base_dir = job_dir / "base"
         _clone_ref(clone_url, base_sha, base_dir)
-        head_dir = _prepare_head_checkout(clone_url, head_sha, installation_id, repo_full_name, job_dir / "head")
 
-        try:
-            previous_sha = CodeGraphStore(
-                settings.database_url, installation_id, repo_full_name
-            ).load_last_synced_sha(GRAPH_BRANCH)
-        except Exception:  # noqa: BLE001
-            previous_sha = None
-        unchanged_scan_cache_path = _build_unchanged_scan_cache(
-            installation_id, repo_full_name, head_dir, previous_sha, head_sha,
-            job_dir / "unchanged-scan-cache.json",
-        )
+        # Locked for the whole checkout-through-git-graph-sync span, not just
+        # the checkout call: _ensure_persistent_checkout has no filesystem
+        # locking of its own (see repo_checkout_lock's docstring), and
+        # _sync_persistent_git_graph also runs git commands against head_dir.
+        # A second scan-worker replica racing this same repo needs to wait
+        # for the whole thing, not just the initial checkout.
+        with repo_checkout_lock(settings.database_url, installation_id, repo_full_name):
+            head_dir = _prepare_head_checkout(
+                clone_url, head_sha, installation_id, repo_full_name, job_dir / "head"
+            )
 
-        base_evidence_path = _run_scan(base_dir)
-        head_evidence_path = _run_scan(head_dir, unchanged_scan_cache_path=unchanged_scan_cache_path)
-        old = json.loads(base_evidence_path.read_text())
-        new = json.loads(head_evidence_path.read_text())
-        diff = compute_diff(old, new, full=False)
-        dismissed = get_dismissed_identity_keys(settings.database_url, installation_id, repo_full_name)
-        # history_secrets shares the same (path, pattern, match_preview) identity
-        # space as secrets - accepted_secrets (.aletheore.json) already treats them
-        # as one baseline (secrets.py's _baseline_keys is shared by find_secrets and
-        # find_secrets_in_history), so a "secret" dismissal filters both here too.
-        diff["secrets"]["new"] = filter_dismissed(diff["secrets"]["new"], "secret", dismissed["secret"])
-        diff["history_secrets"]["new"] = filter_dismissed(
-            diff["history_secrets"]["new"], "secret", dismissed["secret"]
-        )
-        diff["vulnerabilities"]["new"] = filter_dismissed(
-            diff["vulnerabilities"]["new"], "vulnerability", dismissed["vulnerability"]
-        )
+            try:
+                previous_sha = CodeGraphStore(
+                    settings.database_url, installation_id, repo_full_name
+                ).load_last_synced_sha(GRAPH_BRANCH)
+            except Exception:  # noqa: BLE001
+                previous_sha = None
+            unchanged_scan_cache_path = _build_unchanged_scan_cache(
+                installation_id, repo_full_name, head_dir, previous_sha, head_sha,
+                job_dir / "unchanged-scan-cache.json",
+            )
 
-        client = get_github_api_client()
-        upsert_pr_comment(client, token, repo_full_name, pr_number, format_diff_comment(diff))
-        new = _sync_persistent_git_graph(installation_id, repo_full_name, head_dir, new)
+            base_evidence_path = _run_scan(base_dir)
+            head_evidence_path = _run_scan(head_dir, unchanged_scan_cache_path=unchanged_scan_cache_path)
+            old = json.loads(base_evidence_path.read_text())
+            new = json.loads(head_evidence_path.read_text())
+            diff = compute_diff(old, new, full=False)
+            dismissed = get_dismissed_identity_keys(settings.database_url, installation_id, repo_full_name)
+            # history_secrets shares the same (path, pattern, match_preview) identity
+            # space as secrets - accepted_secrets (.aletheore.json) already treats them
+            # as one baseline (secrets.py's _baseline_keys is shared by find_secrets and
+            # find_secrets_in_history), so a "secret" dismissal filters both here too.
+            diff["secrets"]["new"] = filter_dismissed(diff["secrets"]["new"], "secret", dismissed["secret"])
+            diff["history_secrets"]["new"] = filter_dismissed(
+                diff["history_secrets"]["new"], "secret", dismissed["secret"]
+            )
+            diff["vulnerabilities"]["new"] = filter_dismissed(
+                diff["vulnerabilities"]["new"], "vulnerability", dismissed["vulnerability"]
+            )
+
+            client = get_github_api_client()
+            upsert_pr_comment(client, token, repo_full_name, pr_number, format_diff_comment(diff))
+            new = _sync_persistent_git_graph(installation_id, repo_full_name, head_dir, new)
         _sync_code_graph(installation_id, repo_full_name, head_sha, new)
         _insert_history(installation_id, repo_full_name, new)
 
@@ -1021,11 +1032,17 @@ def run_push_scan_job(
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
         token = _token_sync(installation_id, app_jwt)
         clone_url = _clone_url(repo_full_name, token)
-        repo_dir = _prepare_head_checkout(clone_url, head_sha, installation_id, repo_full_name, job_dir / "repo")
 
-        evidence_path = _run_scan(repo_dir)
-        evidence = json.loads(evidence_path.read_text())
-        evidence = _sync_persistent_git_graph(installation_id, repo_full_name, repo_dir, evidence)
+        # See run_pr_scan_job's identical lock for why this spans checkout
+        # through git-graph-sync rather than just the checkout call.
+        with repo_checkout_lock(settings.database_url, installation_id, repo_full_name):
+            repo_dir = _prepare_head_checkout(
+                clone_url, head_sha, installation_id, repo_full_name, job_dir / "repo"
+            )
+
+            evidence_path = _run_scan(repo_dir)
+            evidence = json.loads(evidence_path.read_text())
+            evidence = _sync_persistent_git_graph(installation_id, repo_full_name, repo_dir, evidence)
         _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
         _insert_history(installation_id, repo_full_name, evidence)
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -19,6 +19,18 @@ def _noop_spend_lock(*args, **kwargs):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _noop_repo_checkout_lock(monkeypatch):
+    # repo_checkout_lock (see scan_worker/db.py) opens a real psycopg
+    # connection to settings.database_url - most tests here run against a
+    # fake DSN (or no DSN at all), which would hang or fail slowly rather
+    # than exercising the actual lock. The lock's own correctness has its
+    # own real-Postgres tests in test_scan_worker_db.py; this file only
+    # needs run_pr_scan_job/run_push_scan_job's wiring around it to be a
+    # no-op, autoused so none of the 30+ existing tests need touching.
+    monkeypatch.setattr("scan_worker.jobs.repo_checkout_lock", _noop_spend_lock)
+
+
 def _patch_no_spend_cap(monkeypatch) -> None:
     """AIRview/Docs build jobs now gate on the same installation monthly
     LLM spend cap managed audits and flash review already used - real

--- a/github-app/tests/test_pr_scan_e2e.py
+++ b/github-app/tests/test_pr_scan_e2e.py
@@ -1,8 +1,14 @@
 import asyncio
+from contextlib import contextmanager
 
 from rq import Queue
 
 from app_server.webhooks.pull_request import handle_pull_request_event
+
+
+@contextmanager
+def _noop_repo_checkout_lock(*args, **kwargs):
+    yield
 
 
 def test_pull_request_webhook_to_pr_comment_end_to_end(
@@ -37,6 +43,10 @@ def test_pull_request_webhook_to_pr_comment_end_to_end(
     monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._maybe_create_check_run", lambda *a, **k: None)
+    # repo_checkout_lock opens a real psycopg connection to
+    # settings.database_url - the fake "postgresql://unused" DSN set above
+    # would hang or fail slowly rather than exercising the actual lock.
+    monkeypatch.setattr("scan_worker.jobs.repo_checkout_lock", _noop_repo_checkout_lock)
 
     payload = {
         "action": "opened",

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -30,6 +30,8 @@ from scan_worker.db import (
     insert_endpoint_health,
     insert_repo_history,
     installation_spend_lock,
+    repo_checkout_lock,
+    REPO_CHECKOUT_LOCK_NAMESPACE,
     SCAN_SLOT_LOCK_NAMESPACE,
     SPEND_LOCK_NAMESPACE,
     list_health_check_targets_all,
@@ -731,6 +733,68 @@ async def test_installation_spend_lock_releases_after_context_exits(pool):
             acquired = cur.fetchone()[0]
             cur.execute("SELECT pg_advisory_unlock(%s, %s)", (SPEND_LOCK_NAMESPACE, 301))
     assert acquired is True
+
+
+@pytest.mark.asyncio
+async def test_repo_checkout_lock_blocks_concurrent_acquisition_for_same_repo(pool):
+    import psycopg
+
+    with repo_checkout_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+        with psycopg.connect(TEST_DATABASE_URL, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_try_advisory_lock(%s, hashtext(%s))",
+                    (REPO_CHECKOUT_LOCK_NAMESPACE, "301:a/repo1"),
+                )
+                acquired = cur.fetchone()[0]
+        assert acquired is False
+
+
+@pytest.mark.asyncio
+async def test_repo_checkout_lock_releases_after_context_exits(pool):
+    import psycopg
+
+    with repo_checkout_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+        pass
+
+    with psycopg.connect(TEST_DATABASE_URL, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_try_advisory_lock(%s, hashtext(%s))",
+                (REPO_CHECKOUT_LOCK_NAMESPACE, "301:a/repo1"),
+            )
+            acquired = cur.fetchone()[0]
+            cur.execute(
+                "SELECT pg_advisory_unlock(%s, hashtext(%s))",
+                (REPO_CHECKOUT_LOCK_NAMESPACE, "301:a/repo1"),
+            )
+    assert acquired is True
+
+
+@pytest.mark.asyncio
+async def test_repo_checkout_lock_does_not_block_a_different_repo(pool):
+    import psycopg
+
+    with repo_checkout_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+        with psycopg.connect(TEST_DATABASE_URL, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_try_advisory_lock(%s, hashtext(%s))",
+                    (REPO_CHECKOUT_LOCK_NAMESPACE, "301:a/repo2"),
+                )
+                acquired = cur.fetchone()[0]
+                cur.execute(
+                    "SELECT pg_advisory_unlock(%s, hashtext(%s))",
+                    (REPO_CHECKOUT_LOCK_NAMESPACE, "301:a/repo2"),
+                )
+    assert acquired is True
+
+
+@pytest.mark.asyncio
+async def test_repo_checkout_lock_does_not_collide_with_spend_lock(pool):
+    with installation_spend_lock(TEST_DATABASE_URL, 301):
+        with repo_checkout_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+            pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `scan-worker` runs exactly one RQ worker process today, so every scan job - regardless of repo - queues and runs strictly serially. Two people scanning different repos at the same time genuinely wait on each other.
- Scaling to a second replica is the fix, but `_ensure_persistent_checkout` has no filesystem-level locking: two replicas racing a job for the *same* repo would race `git checkout -f`/`git clean -fdx` against the same shared working tree, and race the live-token `git remote set-url` cycle around it.
- Adds `repo_checkout_lock` (Postgres advisory lock, new namespace 3, keyed per `installation_id:repo_full_name`) wrapping the checkout-through-git-graph-sync span in both `run_pr_scan_job` and `run_push_scan_job`. Different repos now run genuinely in parallel across the two replicas; same-repo jobs still safely serialize instead of racing.
- Adds a second `scan-worker-2` service to `docker-compose.yml`, identical to `scan-worker`, sharing the same `./repo-checkouts` bind mount (now safe thanks to the lock).

## Resource note
CPU limits now sum to 5.5 (`app-server` 1.0 + `scan-worker` 1.0 + `scan-worker-2` 1.0 + `health-worker` 0.5 + `demo-scan-worker` 1.0 + `demo-sandbox-runner` 1.0) against 4 physical cores on the production host. Docker's `cpus:` is a soft CFS quota, not a hard reservation, and these rarely peak simultaneously - flagging it rather than hiding it.

## Test plan
- [x] 4 new tests for `repo_checkout_lock` against a real Postgres (blocks same-repo, releases cleanly, doesn't block a different repo, doesn't collide with the existing spend lock)
- [x] Full `tests/` suite: 1123 passed, 8 skipped
- [x] `tests/test_jobs.py`: 146 passed
- [x] `docker compose config -q` valid
- [ ] CI green
- [ ] Deploy to prod, confirm both `scan-worker` replicas come up healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)