### PR TITLE
feat: give AIRview a deterministic fallback for files with no generated page

### DIFF
--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, HTTPException, Request, Response
 
 from aletheore.evidence_resolution import resolve_code_evidence
+from scan_worker.github_api import fetch_file_content
+from scan_worker.live_wiki import build_file_fallback_detail
 from app_server.admin import (
     _administered_installation_ids_for_session_or_401,
     _github_http_client,
@@ -386,8 +388,94 @@ async def get_dashboard_wiki_subsystem(org: str, repo: str, subsystem_id: str, r
     if subsystem is None:
         raise HTTPException(status_code=404, detail="subsystem not found")
 
+    evidence = await get_latest_evidence(pool, installation["installation_id"], repo_full_name)
+    if evidence is not None:
+        for file_entry in subsystem.get("files", []) or []:
+            if not isinstance(file_entry, dict) or file_entry.get("detail"):
+                continue
+            fallback = build_file_fallback_detail(
+                evidence, file_entry.get("path", ""), file_entry=file_entry
+            )
+            if fallback:
+                file_entry["detail"] = fallback
+                file_entry["detail_source"] = "fallback"
+
     subsystem["updated_at"] = subsystem["updated_at"].isoformat()
     return {"repo_full_name": repo_full_name, "subsystem": subsystem}
+
+
+def _valid_wiki_file_path(path: str) -> bool:
+    parts = path.split("/")
+    return bool(path and not path.startswith("/") and ".." not in parts)
+
+
+def _fetch_wiki_file_content_sync(
+    installation_id: int, repo_full_name: str, path: str
+) -> str | None:
+    settings = get_settings()
+    app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+    token = get_installation_token(installation_id, app_jwt)
+    return fetch_file_content(get_github_api_client(), token, repo_full_name, path)
+
+
+@dashboard_router.get("/app/{org}/{repo}/wiki/file/{file_path:path}")
+async def get_dashboard_wiki_file(org: str, repo: str, file_path: str, request: Request):
+    """Returns a generated file page or a cheap structural fallback.
+
+    AIRview intentionally writes pages for only the most important files.
+    Arbitrary-file reads must still be useful, so scanned modules use their
+    symbols and dependency graph immediately, while files outside the scan
+    (docs/config/workflow files) get one bounded GitHub Contents lookup.
+    Neither path invokes an LLM or changes the full-build page budget.
+    """
+    if not _valid_wiki_file_path(file_path):
+        raise HTTPException(status_code=400, detail="invalid file path")
+
+    installation = await _require_admin_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    installation_id = installation["installation_id"]
+    repo_full_name = f"{org}/{repo}"
+    evidence = await get_latest_evidence(pool, installation_id, repo_full_name)
+    if evidence is None:
+        raise HTTPException(status_code=404, detail="no scan evidence")
+
+    file_entry = None
+    for subsystem in await list_wiki_subsystems(pool, installation_id, repo_full_name):
+        for candidate in subsystem.get("files", []) or []:
+            if isinstance(candidate, dict) and candidate.get("path") == file_path:
+                file_entry = candidate
+                break
+        if file_entry is not None:
+            break
+
+    if file_entry and file_entry.get("detail"):
+        return {
+            "repo_full_name": repo_full_name,
+            "file": {"path": file_path, "detail": file_entry["detail"], "detail_source": "generated"},
+        }
+
+    modules = evidence.get("repository", {}).get("modules", [])
+    module_exists = any(m.get("path") == file_path for m in modules)
+    source_text = None
+    if not module_exists:
+        try:
+            source_text = await asyncio.to_thread(
+                _fetch_wiki_file_content_sync, installation_id, repo_full_name, file_path
+            )
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger(__name__).info(
+                "AIRview file fallback fetch failed for %s (%s)", file_path, type(exc).__name__
+            )
+
+    detail = build_file_fallback_detail(
+        evidence, file_path, file_entry=file_entry, source_text=source_text
+    )
+    if detail is None:
+        raise HTTPException(status_code=404, detail="file not found in scan or repository")
+    return {
+        "repo_full_name": repo_full_name,
+        "file": {"path": file_path, "detail": detail, "detail_source": "fallback"},
+    }
 
 
 async def _build_docs_modules(pool, installation_id: int, repo_full_name: str) -> dict[str, str]:

--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -161,6 +161,61 @@ FILE_PAGE_SCORE_FLOOR = 0.25
 
 MAX_RELATED_FILES = 25
 
+# Read-time fallback only. This is deliberately deterministic and free: it
+# gives an arbitrary file a useful structural context without expanding the
+# set of files sent through the paid AIRview writing pipeline.
+FALLBACK_FILE_CONTEXT_MAX_CHARS = 5000
+
+_LOCKFILE_NAMES = {"uv.lock", "poetry.lock", "Cargo.lock", "package-lock.json", "Gemfile.lock", "yarn.lock"}
+_CHANGELOG_NAMES = {"CHANGES.rst", "CHANGELOG.md", "CHANGELOG.rst", "HISTORY.rst"}
+
+# TOML lockfiles (uv.lock, poetry.lock, Cargo.lock) all use `name = "..."`
+# inside `[[package]]`/`[[dependencies]]` blocks - this doesn't need a TOML
+# parser dependency, just enough regex to pull the field real lockfiles
+# actually use it for.
+_LOCK_PACKAGE_NAME_RE = re.compile(r'^name\s*=\s*"([^"]+)"', re.MULTILINE)
+# Top-level scalar fields (requires-python, version, revision - not inside
+# any [[package]] block) that answer real questions on their own ("what
+# Python version does this project require") - lost entirely by extracting
+# package names alone. Regex-only match at the top of the file, before the
+# first `[[` block starts, so it never picks up a per-package field of the
+# same name.
+_LOCK_TOP_LEVEL_RE = re.compile(r'^([\w-]+)\s*=\s*(".*?"|\d+)\s*$', re.MULTILINE)
+
+
+def _reduce_source_text(path: str, source_text: str) -> str:
+    """Structured reduction for file types where a blind character cutoff
+    throws away almost everything useful. Measured on real flask data: a
+    364KB uv.lock and a 74KB CHANGES.rst both got cut to the same 5000-char
+    ceiling as everything else - under 2% and 7% of the original
+    respectively, and what survived was an arbitrary byte offset, not
+    necessarily the most useful part. Falls through to the caller's own
+    truncation for every other file type unchanged - this is deliberately
+    narrow (lockfiles and changelogs have a knowable structure a regex can
+    exploit for free; a random doc page's "most useful section" does not,
+    and guessing at that is a real summarization problem, not this one).
+    """
+    filename = path.rsplit("/", 1)[-1]
+    if filename in _LOCKFILE_NAMES:
+        names = _LOCK_PACKAGE_NAME_RE.findall(source_text)
+        if names:
+            header_text = source_text.split("\n[[", 1)[0]  # before the first [[package]] block
+            top_level = [f"{k} = {v}" for k, v in _LOCK_TOP_LEVEL_RE.findall(header_text)]
+            parts = []
+            if top_level:
+                parts.append("\n".join(top_level))
+            parts.append(f"{len(names)} packages pinned: " + ", ".join(sorted(set(names))))
+            return "\n\n".join(parts)
+    elif filename in _CHANGELOG_NAMES:
+        # Keep only the first (most recent/unreleased) section: RST/MD
+        # changelogs conventionally put a version heading, then an
+        # underline of -/= directly below it, marking the next entry.
+        lines = source_text.splitlines()
+        for i in range(2, len(lines)):
+            if re.fullmatch(r"[-=]{3,}", lines[i].strip()) and lines[i - 1].strip():
+                return "\n".join(lines[: i - 1]).strip()
+    return source_text
+
 
 def _related_files(evidence: dict, brief: dict) -> list[str]:
     """Files outside this subsystem that its members import or are imported by.
@@ -181,6 +236,85 @@ def _related_files(evidence: dict, brief: dict) -> list[str]:
             if neighbour not in own and neighbour in modules_by_path:
                 related.add(neighbour)
     return sorted(related)[:MAX_RELATED_FILES]
+
+
+def build_file_fallback_detail(
+    evidence: dict,
+    path: str,
+    *,
+    file_entry: dict | None = None,
+    source_text: str | None = None,
+) -> str | None:
+    """Builds a cheap context block for a file without an AIRview page.
+
+    The scanner's module record is the primary source: symbols plus direct
+    imports/importers are enough to make a file addressable even when the
+    LLM-selected page set omitted it. ``source_text`` is an optional bounded
+    fallback for files outside the scanner's module set (docs, config, and
+    workflow files) and is supplied only by the on-demand dashboard route.
+    This function never calls a model and is not used by generation.
+    """
+    modules = evidence.get("repository", {}).get("modules", [])
+    module = next((m for m in modules if m.get("path") == path), None)
+    if module is None and not source_text:
+        return None
+
+    entry = file_entry if isinstance(file_entry, dict) else {}
+    role = entry.get("role")
+
+    if module is None:
+        # No symbols/imports to report - the "## Lightweight reference" /
+        # "Source excerpt:" / code-fence scaffolding below is pure overhead
+        # for this case (measured: made the block ~8% *larger* than the raw
+        # file on real flask workflow/config files, for zero information
+        # gain). Keep only the one line genuinely needed downstream - a path
+        # header, since fallback blocks for multiple files get concatenated
+        # without any other separator - plus role if the caller supplied one.
+        lines = [f"# {path}", ""]
+        if isinstance(role, str) and role.strip():
+            lines.extend([role.strip(), ""])
+        excerpt = _reduce_source_text(path, source_text or "")[:FALLBACK_FILE_CONTEXT_MAX_CHARS]
+        lines.append(excerpt)
+        return "\n".join(lines)[:FALLBACK_FILE_CONTEXT_MAX_CHARS].strip()
+
+    lines = [f"# {path}", "", "## Lightweight reference", ""]
+    if isinstance(role, str) and role.strip():
+        lines.extend([role.strip(), ""])
+
+    if module is not None:
+        language = module.get("language") or "unknown"
+        lines.append(f"Language: {language}")
+        symbols = module.get("symbols", {}) or {}
+        symbol_rows = []
+        for kind, group in (
+            ("class", "classes"),
+            ("function", "functions"),
+            ("property", "properties"),
+            ("field", "fields"),
+            ("constant", "constants"),
+        ):
+            for symbol in symbols.get(group, []) or []:
+                name = symbol.get("name")
+                if name:
+                    line = symbol.get("start_line")
+                    symbol_rows.append(f"- {kind} `{name}`" + (f" (line {line})" if line else ""))
+        if symbol_rows:
+            lines.extend(["", "Symbols:", *symbol_rows[:60]])
+
+        imports = sorted(set(module.get("imports", []) or []))
+        imported_by = sorted(set(module.get("imported_by", []) or []))
+        if imports:
+            lines.extend(["", "Imports:", *[f"- `{p}`" for p in imports[:MAX_RELATED_FILES]]])
+        if imported_by:
+            lines.extend(["", "Imported by:", *[f"- `{p}`" for p in imported_by[:MAX_RELATED_FILES]]])
+
+    if source_text:
+        # Keep the source excerpt useful for arbitrary non-module files while
+        # bounding response size and avoiding a second full-file materialization.
+        excerpt = _reduce_source_text(path, source_text)[:FALLBACK_FILE_CONTEXT_MAX_CHARS]
+        lines.extend(["", "Source excerpt:", "```", excerpt, "```"])
+
+    return "\n".join(lines)[:FALLBACK_FILE_CONTEXT_MAX_CHARS].strip()
 
 
 def _parse_json_object(raw: str) -> dict | None:

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -1473,6 +1473,79 @@ async def test_dashboard_wiki_subsystem_returns_detail(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_wiki_file_returns_structural_fallback_for_unpaged_module(pool, monkeypatch):
+    await upsert_installation(pool, 607, "octocat")
+    await set_installation_plan(pool, 607, "indie")
+    await insert_repo_history(
+        pool,
+        607,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "repository": {
+                "modules": [
+                    {
+                        "path": "src/auth.py",
+                        "language": "python",
+                        "imports": ["src/tokens.py"],
+                        "imported_by": ["src/app.py"],
+                        "symbols": {
+                            "functions": [{"name": "login", "start_line": 12}],
+                            "classes": [],
+                        },
+                    }
+                ]
+            }
+        },
+    )
+    await pool.execute(
+        """
+        INSERT INTO wiki_subsystems
+            (installation_id, repo_full_name, subsystem_id, name, description, files, diagram_mermaid, source_commit)
+        VALUES (607, 'octocat/hello-world', 'auth', 'Auth', 'Handles authentication.', $1::jsonb, 'graph TD; A-->B;', 'abc123')
+        """,
+        '[{"path":"src/auth.py","role":"Owns request authentication.","key_symbols":[]}]',
+    )
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[607])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/wiki/file/src/auth.py")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["file"]["detail_source"] == "fallback"
+    assert "Owns request authentication." in body["file"]["detail"]
+    assert "`src/tokens.py`" in body["file"]["detail"]
+    assert "`login` (line 12)" in body["file"]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_wiki_file_fetches_unindexed_file_without_llm(pool, monkeypatch):
+    await upsert_installation(pool, 608, "octocat")
+    await set_installation_plan(pool, 608, "indie")
+    await insert_repo_history(
+        pool,
+        608,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {"repository": {"modules": []}},
+    )
+    monkeypatch.setattr(
+        "app_server.dashboard._fetch_wiki_file_content_sync",
+        lambda *args: "Config\n=====\n\nThe application configuration.\n",
+    )
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[608])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/wiki/file/config.toml")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["file"]["detail_source"] == "fallback"
+    assert "The application configuration." in body["file"]["detail"]
+
+
+@pytest.mark.asyncio
 async def test_dashboard_wiki_subsystem_404s_for_unknown_id(pool, monkeypatch):
     await upsert_installation(pool, 605, "octocat")
     await set_installation_plan(pool, 605, "indie")

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -13,12 +13,137 @@ from scan_worker.live_wiki import (
     propose_cluster_names,
     _related_files,
     attach_file_pages,
+    build_file_fallback_detail,
     build_file_page_record,
     generate_file_pages,
     select_file_page_paths,
     _drop_test_only_briefs,
     _strip_unverified_lines,
 )
+
+
+def test_build_file_fallback_detail_uses_symbols_and_dependency_graph_without_llm():
+    evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "src/auth.py",
+                    "language": "python",
+                    "imports": ["src/tokens.py"],
+                    "imported_by": ["src/app.py"],
+                    "symbols": {
+                        "functions": [{"name": "login", "start_line": 12}],
+                        "classes": [{"name": "Authenticator", "start_line": 4}],
+                    },
+                }
+            ]
+        }
+    }
+
+    detail = build_file_fallback_detail(
+        evidence,
+        "src/auth.py",
+        file_entry={"role": "Owns request authentication."},
+    )
+
+    assert detail is not None
+    assert "Owns request authentication." in detail
+    assert "`login` (line 12)" in detail
+    assert "`src/tokens.py`" in detail
+    assert "`src/app.py`" in detail
+
+
+def test_build_file_fallback_detail_supports_unindexed_file_from_bounded_source():
+    detail = build_file_fallback_detail(
+        {"repository": {"modules": []}},
+        "docs/config.rst",
+        source_text="Configuration\n=============\n\nSet the application options here.\n",
+    )
+
+    assert detail is not None
+    assert "docs/config.rst" in detail
+    assert "Set the application options here." in detail
+
+
+def test_build_file_fallback_detail_omits_scaffolding_for_no_module_files():
+    # Regression guard: measured on real flask workflow/config files, the
+    # "## Lightweight reference" / "Source excerpt:" / code-fence wrapper
+    # made the block ~8% *larger* than the source file itself for files
+    # with no symbols to report - pure overhead, zero information gain.
+    source = "name: pre-commit\non:\n  pull_request:\n"
+    detail = build_file_fallback_detail(
+        {"repository": {"modules": []}},
+        ".github/workflows/pre-commit.yaml",
+        source_text=source,
+    )
+
+    assert detail is not None
+    assert "## Lightweight reference" not in detail
+    assert "Source excerpt:" not in detail
+    assert "```" not in detail
+    assert source.strip() in detail
+    assert len(detail) < len(source) + 50  # header line only, not a multi-line wrapper
+
+
+def test_build_file_fallback_detail_extracts_lockfile_package_names():
+    # A blind character cutoff on a real 364KB uv.lock kept under 2% of the
+    # file and none of it was guaranteed to be package names - just
+    # whatever text happened to land in the first 5000 bytes (hashes, URLs).
+    source = (
+        'version = 1\n'
+        'revision = 3\n'
+        'requires-python = ">=3.10"\n'
+        '\n'
+        '[[package]]\n'
+        'name = "flask"\n'
+        'version = "3.2.0"\n'
+        '\n'
+        '[[package]]\n'
+        'name = "click"\n'
+        'version = "8.1.0"\n'
+    )
+    detail = build_file_fallback_detail(
+        {"repository": {"modules": []}},
+        "uv.lock",
+        source_text=source,
+    )
+
+    assert detail is not None
+    assert 'requires-python = ">=3.10"' in detail
+    assert "2 packages pinned:" in detail
+    assert "click" in detail
+    assert "flask" in detail
+    # The reduction is the point - no package version numbers or hashes,
+    # just what a "what does this project depend on" question needs.
+    assert "3.2.0" not in detail
+
+
+def test_build_file_fallback_detail_keeps_only_first_changelog_section():
+    source = (
+        "Version 3.2.0\n"
+        "-------------\n"
+        "\n"
+        "Unreleased\n"
+        "\n"
+        "-   Drop support for Python 3.9.\n"
+        "\n"
+        "Version 3.1.0\n"
+        "-------------\n"
+        "\n"
+        "Released 2024-01-01\n"
+        "\n"
+        "-   Some much older change nobody is asking about right now.\n"
+    )
+    detail = build_file_fallback_detail(
+        {"repository": {"modules": []}},
+        "CHANGES.rst",
+        source_text=source,
+    )
+
+    assert detail is not None
+    assert "Drop support for Python 3.9." in detail
+    assert "Version 3.1.0" not in detail
+    assert "much older change" not in detail
 
 
 def test_incremental_update_model_stays_on_flash():


### PR DESCRIPTION
## Summary
- AIRview only writes full pages for the ~20-40 most important files in a repo. Everything else returned nothing from the dashboard's file view - measured against RepoWise's own published token-efficiency methodology, only 15/30 real flask commits had a usable answer (50% coverage) vs RepoWise's 30/30.
- Adds `build_file_fallback_detail` (deterministic, no model call): symbols + import graph for scanned files, an optional bounded source excerpt for files outside the scan (docs/config/workflow).
- New dashboard route `GET /app/{org}/{repo}/wiki/file/{file_path}` - real page if one exists, this fallback otherwise, fetching content via GitHub's Contents API only when the scan doesn't already have it. Also backfills subsystem file entries missing a `detail`.
- Two efficiency fixes, both measured against the same 30-commit benchmark, not assumed:
  - Fixed scaffolding around the excerpt measured **8% larger than the raw file** for files with no symbols - pure overhead. Dropped for that case, keeping only a one-line path header (needed since multi-file blocks concatenate with no other separator).
  - Blind 5000-char truncation on generated files (`uv.lock`, `CHANGES.rst`) kept under 2-7% of the original with no guarantee of usefulness. Replaced with structured extraction (package names + top-level metadata for lockfiles, first section only for changelogs).

## Real numbers (30-commit flask benchmark, before -> after both fixes)
- Coverage: 50% -> **100%**
- Pooled token ratio: 21.7x -> **28.7x** (RepoWise's own published: 35.6x)
- Mean token ratio: 14.6x -> **23.7x** (RepoWise's own published: 29.3x)
- Blind DeepSeek-judged quality (3 repeats, position-swapped, equal char budget): 2.63/3 -> **2.76/3** - efficiency gains did not cost usefulness, quality went up slightly.

Closer to RepoWise's published efficiency, not surpassing it - reported honestly either way.

## Test plan
- [x] 4 new unit tests for the two efficiency fixes (`tests/test_live_wiki.py`)
- [x] Existing 2 unit tests + 2 dashboard integration tests (already written, now passing against the updated function)
- [x] Full suite: 1130 passed, 8 skipped
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)