### PR TITLE
feat: switch production embedding cache from Ollama+nomic to jina-embed

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -24,6 +24,9 @@ jobs:
           - image: scan-worker
             dockerfile: github-app/Dockerfile.scan-worker
             tag: aletheore-scan-worker:ci
+          - image: jina-embed
+            dockerfile: github-app/Dockerfile.jina-embed
+            tag: aletheore-jina-embed:ci
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -70,6 +73,9 @@ jobs:
           - image: scan-worker
             dockerfile: github-app/Dockerfile.scan-worker
             tag: aletheore-scan-worker:ci
+          - image: jina-embed
+            dockerfile: github-app/Dockerfile.jina-embed
+            tag: aletheore-jina-embed:ci
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,19 @@
+# CVE-2026-4372 and CVE-2026-5241 (transformers, jina-embed image only):
+# both are fixed only in transformers>=5.3.0/5.5.0. Verified empirically
+# that transformers v5 breaks jina-embeddings-v2-base-code's vendored
+# remote code beyond a single importable function (find_pruneable_heads_
+# and_indices can be shimmed back in, but a v5 config attribute-access
+# change then fails deeper inside modeling_bert.py's JinaBertSelfAttention
+# init - fixing that would mean forking and maintaining someone else's
+# HuggingFace model code). Pinned to transformers==4.48.0 instead, which
+# closes the other 3 transformers CVEs this same scan found (all fixed at
+# 4.48.0) and is the newest version confirmed compatible.
+#
+# Accepted for jina-embed specifically because both CVEs concern loading
+# untrusted/attacker-supplied model files at runtime: this image only
+# ever loads one fixed model (jinaai/jina-embeddings-v2-base-code), baked
+# into the image at build time from HuggingFace's own hosted weights, and
+# takes no model input from any caller at runtime - there is no code path
+# for a caller to supply a different model to load.
+CVE-2026-4372
+CVE-2026-5241

--- a/github-app/Dockerfile.jina-embed
+++ b/github-app/Dockerfile.jina-embed
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY github-app/requirements-jina-embed.txt .
 # CPU-only torch wheel - these hosts have no GPU, and the default PyPI
 # wheel pulls CUDA libraries that roughly double image size for nothing.
-RUN pip install --no-cache-dir torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu \
+RUN pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu \
     && pip install --no-cache-dir -r requirements-jina-embed.txt \
     # torch's CPU wheel pulls setuptools 78.1.0, which carries CVE-2025-47273
     # (path traversal) - fixed in 78.1.1. Upgraded explicitly since torch

--- a/github-app/Dockerfile.jina-embed
+++ b/github-app/Dockerfile.jina-embed
@@ -6,7 +6,11 @@ COPY github-app/requirements-jina-embed.txt .
 # CPU-only torch wheel - these hosts have no GPU, and the default PyPI
 # wheel pulls CUDA libraries that roughly double image size for nothing.
 RUN pip install --no-cache-dir torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir -r requirements-jina-embed.txt
+    && pip install --no-cache-dir -r requirements-jina-embed.txt \
+    # torch's CPU wheel pulls setuptools 78.1.0, which carries CVE-2025-47273
+    # (path traversal) - fixed in 78.1.1. Upgraded explicitly since torch
+    # itself doesn't pin a fixed floor.
+    && pip install --no-cache-dir --upgrade "setuptools>=78.1.1"
 
 COPY github-app/jina_embed ./jina_embed
 

--- a/github-app/Dockerfile.jina-embed
+++ b/github-app/Dockerfile.jina-embed
@@ -1,0 +1,32 @@
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+
+WORKDIR /app
+
+COPY github-app/requirements-jina-embed.txt .
+# CPU-only torch wheel - these hosts have no GPU, and the default PyPI
+# wheel pulls CUDA libraries that roughly double image size for nothing.
+RUN pip install --no-cache-dir torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir -r requirements-jina-embed.txt
+
+COPY github-app/jina_embed ./jina_embed
+
+# HF_HOME set before the download below so the cache lands under /app,
+# where the aletheore user (whose $HOME is /app) can actually read it -
+# the default ~/.cache/huggingface would be under /root, invisible to a
+# non-root user with a different $HOME, silently forcing a re-download
+# on every cold start despite the weights already being baked in.
+ENV HF_HOME=/app/.cache/huggingface
+
+# Bake the model weights into the image at build time rather than
+# downloading on first request - a cold start that also needs a ~300MB
+# HuggingFace download is a worse failure mode (timeout, no retry budget)
+# than a slower image build.
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('jinaai/jina-embeddings-v2-base-code', trust_remote_code=True, device='cpu')"
+
+RUN groupadd --system aletheore \
+    && useradd --system --gid aletheore --home-dir /app --no-create-home aletheore \
+    && chown -R aletheore:aletheore /app
+USER aletheore
+
+EXPOSE 80
+CMD ["uvicorn", "jina_embed.server:app", "--host", "0.0.0.0", "--port", "80"]

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -79,7 +79,7 @@ services:
         required: false
     environment:
       - GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app-key.pem
-      - OLLAMA_BASE_URL=http://ollama:11434
+      - JINA_EMBED_BASE_URL=http://jina-embed:80
       - ALETHEORE_REPO_CHECKOUT_ROOT=/data/aletheore-repo-checkouts
       - ALETHEORE_APP_HEALTH_URL=http://app-server:8000/healthz
       - ALETHEORE_BACKUP_DIR=/app/backups
@@ -104,8 +104,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      ollama:
-        condition: service_started
+      jina-embed:
+        condition: service_healthy
     cpus: "1.0"
     mem_limit: 1g
     # See app-server's identical block above for the reasoning. Higher
@@ -147,7 +147,7 @@ services:
         required: false
     environment:
       - GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app-key.pem
-      - OLLAMA_BASE_URL=http://ollama:11434
+      - JINA_EMBED_BASE_URL=http://jina-embed:80
       - ALETHEORE_REPO_CHECKOUT_ROOT=/data/aletheore-repo-checkouts
       - ALETHEORE_APP_HEALTH_URL=http://app-server:8000/healthz
       - ALETHEORE_BACKUP_DIR=/app/backups
@@ -162,8 +162,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      ollama:
-        condition: service_started
+      jina-embed:
+        condition: service_healthy
     cpus: "1.0"
     mem_limit: 1g
     security_opt:
@@ -179,7 +179,7 @@ services:
   # transactional email, behind it. Same image as scan-worker since
   # run_health_check_sweep_job's failure-alert enrichment needs the same
   # GitHub App credentials and LLM keys; RESEND_API_KEY comes from the
-  # same env_file. No Ollama or persistent repo-checkout volume since
+  # same env_file. No jina-embed or persistent repo-checkout volume since
   # neither health checks nor email sends do embeddings or local git work.
   health-worker:
     build:
@@ -362,32 +362,41 @@ services:
     security_opt:
       - "no-new-privileges:true"
 
-  ollama:
-    image: ollama/ollama:latest
+  # Replaced Ollama+nomic-embed-text here (see PR history) after a real,
+  # corrected 6-language retrieval benchmark showed jina-embeddings-v2-
+  # base-code beating nomic on every metric (75.0/93.1/95.8% vs
+  # 73.6/87.5/91.7% top-1/3/5 pooled) while bge-m3 actually underperformed
+  # nomic - jina was the only code-specific model tested, which tracks.
+  # Model weights are baked into the image at build time (see
+  # Dockerfile.jina-embed), so no persistent volume is needed here the way
+  # Ollama needed one for its pulled model - a fresh container already has
+  # the weights.
+  jina-embed:
+    build:
+      context: ..
+      dockerfile: github-app/Dockerfile.jina-embed
     restart: unless-stopped
-    # Internal-only (11434, never published to the host) - same reasoning
-    # as redis above.
+    # Internal-only (port 80, never published to the host) - same
+    # reasoning as redis above.
     security_opt:
       - "no-new-privileges:true"
-    # Tried OLLAMA_CONTEXT_LENGTH=8192 here first, assuming nomic-embed-text
-    # supports an 8192-token context - it doesn't, not on the GGUF this
-    # pulls: confirmed directly against the running server that the model's
-    # own trained context is a hard 2048, and requesting more just logged
-    # "requested context size too large for model" and got silently
-    # clamped back down. The real fix is keeping input within that limit
-    # (see MAX_EMBEDDING_CHARS in scan_worker/embedding_client.py), not a
-    # server setting that can't raise a ceiling the model itself doesn't have.
-    volumes:
-      - aletheore_ollama_data:/root/.ollama
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        ollama serve &
-        sleep 3
-        ollama pull nomic-embed-text
-        wait
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:80/healthz', timeout=3)",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      # Model load happens at import time, before uvicorn starts accepting
+      # connections at all - generous start_period so a slow cold start on
+      # a busy host doesn't get flagged unhealthy before it's had a chance.
+      start_period: 60s
     cpus: "1.0"
-    mem_limit: 1g
+    mem_limit: 1500m
 
   caddy:
     image: caddy:2-alpine
@@ -429,12 +438,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # No published port, no privileged-port binding - safe for the same
-    # reason as redis/ollama above.
+    # reason as redis/jina-embed above.
     security_opt:
       - "no-new-privileges:true"
 
 volumes:
   aletheore_postgres_data:
-  aletheore_ollama_data:
   aletheore_caddy_data:
   aletheore_caddy_config:

--- a/github-app/jina_embed/server.py
+++ b/github-app/jina_embed/server.py
@@ -1,0 +1,47 @@
+"""Internal-only embedding service backed by jinaai/jina-embeddings-v2-base-code.
+
+Replaces Ollama+nomic-embed-text as the embedder behind scan_worker's
+evidence-packet and flash-review similarity caches - see
+docs/superpowers/specs (jina vs nomic vs bge-m3 retrieval benchmark) for
+why: real, corrected benchmark numbers across 6 languages showed jina
+beating nomic on every metric (75.0/93.1/95.8% vs 73.6/87.5/91.7% top-1/3/5),
+with bge-m3 actually worse than nomic.
+
+CPU-only in production (no MPS/CUDA on these hosts) - fine here because
+callers send one text per request, not the large batches a full index
+build sends; a single ~5000-char embed is fast enough on CPU that the
+batching/leak concerns from local benchmarking don't apply.
+"""
+import logging
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sentence_transformers import SentenceTransformer
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+
+logger.info("Loading jinaai/jina-embeddings-v2-base-code...")
+_model = SentenceTransformer("jinaai/jina-embeddings-v2-base-code", trust_remote_code=True, device="cpu")
+logger.info("Model loaded, dim=%d", _model.get_sentence_embedding_dimension())
+
+
+class EmbedRequest(BaseModel):
+    text: str
+
+
+class EmbedResponse(BaseModel):
+    embedding: list[float]
+
+
+@app.post("/embed", response_model=EmbedResponse)
+def embed(req: EmbedRequest) -> EmbedResponse:
+    vector = _model.encode(req.text, normalize_embeddings=True).tolist()
+    return EmbedResponse(embedding=vector)
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok"}

--- a/github-app/migrations/049_purge_cache_for_embedder_switch.sql
+++ b/github-app/migrations/049_purge_cache_for_embedder_switch.sql
@@ -1,0 +1,12 @@
+-- Switching the embedder from Ollama+nomic-embed-text to jina-embeddings-
+-- v2-base-code (see scan_worker/embedding_client.py). Both happen to be
+-- 768-dim, so old nomic vectors would pass the array-length check in
+-- packet_cache.py's cosine similarity and get compared against new jina
+-- query vectors - meaningless since they're different embedding spaces.
+-- Downstream re-validation (see live_wiki.py's _validate_written_output)
+-- would likely catch any resulting false match before it's served, but
+-- there's no reason to spend cycles on lookups that are doomed by
+-- construction. Both caches self-heal from here: a fresh row is written
+-- on every miss.
+TRUNCATE evidence_packet_cache;
+TRUNCATE flash_review_cache;

--- a/github-app/requirements-jina-embed.txt
+++ b/github-app/requirements-jina-embed.txt
@@ -1,6 +1,6 @@
-fastapi==0.115.6
+fastapi==0.141.1
 uvicorn==0.34.0
 sentence-transformers==3.3.1
-transformers==4.46.3
+transformers==4.48.0
 einops==0.8.0
-torch==2.5.1
+torch==2.6.0

--- a/github-app/requirements-jina-embed.txt
+++ b/github-app/requirements-jina-embed.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.6
+uvicorn==0.34.0
+sentence-transformers==3.3.1
+transformers==4.46.3
+einops==0.8.0
+torch==2.5.1

--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -1,39 +1,31 @@
-"""Ollama embedding client for evidence-packet similarity caching."""
+"""jina-embed client for evidence-packet and flash-review similarity caching.
+
+Replaced Ollama+nomic-embed-text after a real, corrected 6-language
+retrieval benchmark showed jina-embeddings-v2-base-code beating nomic on
+every metric (75.0/93.1/95.8% vs 73.6/87.5/91.7% top-1/3/5 pooled), while
+bge-m3 actually underperformed nomic. See jina_embed/server.py, which
+serves this model behind a plain /embed endpoint.
+"""
 
 import logging
 import os
 
 import httpx
 
-EMBEDDING_MODEL = "nomic-embed-text"
-
-# The pulled nomic-embed-text GGUF's own metadata caps it at a real,
-# hard 2048-token training context (confirmed directly against the running
-# server: `nomic-bert.context_length = 2048`, and requesting num_ctx=8192
-# just produced "requested context size too large for model" and got
-# silently clamped back to 2048 - the model was never going to accept more,
-# regardless of server or per-request settings). Every real embedding call
-# failed until input was kept under this real limit; the cache had a 0%
-# hit rate for the 38 hours it ran before this was caught.
-EMBEDDING_NUM_CTX = 2048
-
-# Empirically calibrated against the real running model with text shaped
-# like actual evidence packets (file paths, symbol names, short identifiers
-# - not plain prose, and not a pathological single repeated character
-# either): 6600 chars succeeded, 6990 failed. 5000 chars keeps a real
-# margin below that boundary for token-density variance in different
-# packets and the single-CPU container being busier under real concurrent
-# load than this manual test. A truncated embedding is still useful for
-# similarity matching; the exact text match isn't needed, and a cache hit
-# is always re-verified against current evidence regardless of how it was
-# found.
+# jina-embeddings-v2-base-code supports an 8192-token context (vs nomic's
+# hard 2048), but this cap is kept conservative rather than re-tuned
+# against the new model's real limit: it was already comfortably safe for
+# real evidence-packet sizes under nomic, and a truncated embedding is
+# still useful for similarity matching - the exact text match isn't
+# needed, and a cache hit is always re-verified against current evidence
+# regardless of how it was found.
 MAX_EMBEDDING_CHARS = 5000
 
 logger = logging.getLogger(__name__)
 
 
 def _client(base_url: str | None = None) -> httpx.Client:
-    return httpx.Client(base_url=base_url or os.environ.get("OLLAMA_BASE_URL", "http://ollama:11434"))
+    return httpx.Client(base_url=base_url or os.environ.get("JINA_EMBED_BASE_URL", "http://jina-embed:80"))
 
 
 def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 10.0) -> list[float] | None:
@@ -47,12 +39,8 @@ def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 
     try:
         with _client(base_url) as client:
             response = client.post(
-                "/api/embeddings",
-                json={
-                    "model": EMBEDDING_MODEL,
-                    "prompt": text,
-                    "options": {"num_ctx": EMBEDDING_NUM_CTX},
-                },
+                "/embed",
+                json={"text": text},
                 timeout=timeout_seconds,
             )
             response.raise_for_status()

--- a/github-app/tests/test_embedding_client.py
+++ b/github-app/tests/test_embedding_client.py
@@ -7,12 +7,12 @@ from scan_worker.embedding_client import MAX_EMBEDDING_CHARS, embed_text
 
 def test_embed_text_returns_vector_on_success(monkeypatch):
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/api/embeddings"
+        assert request.url.path == "/embed"
         return httpx.Response(200, json={"embedding": [0.1, 0.2, 0.3]})
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
     )
 
     result = embed_text("some evidence text")
@@ -20,12 +20,7 @@ def test_embed_text_returns_vector_on_success(monkeypatch):
     assert result == [0.1, 0.2, 0.3]
 
 
-def test_embed_text_sends_the_models_real_context_window(monkeypatch):
-    # Confirmed directly against the running production model: the pulled
-    # nomic-embed-text GGUF has a hard 2048-token trained context (not 8192,
-    # which was a first, wrong assumption - requesting more just got
-    # silently clamped by Ollama with a warning). Sending it explicitly
-    # keeps this self-documenting even though it now matches the default.
+def test_embed_text_sends_the_text_field(monkeypatch):
     seen = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -34,34 +29,34 @@ def test_embed_text_sends_the_models_real_context_window(monkeypatch):
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
     )
 
     embed_text("some evidence text")
 
-    assert seen["body"]["options"] == {"num_ctx": 2048}
+    assert seen["body"] == {"text": "some evidence text"}
 
 
 def test_embed_text_truncates_oversized_input(monkeypatch):
     # A real production packet hit 52k+ tokens - nowhere close to fitting
-    # the model's real 2048-token context. Truncating keeps the call from
-    # failing outright; the exact text match isn't needed for similarity
-    # matching, and any cache hit found this way is still re-verified
-    # against current evidence before being served.
+    # the model's real context. Truncating keeps the call from failing
+    # outright; the exact text match isn't needed for similarity matching,
+    # and any cache hit found this way is still re-verified against
+    # current evidence before being served.
     seen = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
-        seen["prompt"] = json.loads(request.content)["prompt"]
+        seen["text"] = json.loads(request.content)["text"]
         return httpx.Response(200, json={"embedding": [0.1]})
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
     )
 
     embed_text("x" * (MAX_EMBEDDING_CHARS + 5000))
 
-    assert len(seen["prompt"]) == MAX_EMBEDDING_CHARS
+    assert len(seen["text"]) == MAX_EMBEDDING_CHARS
 
 
 def test_embed_text_uses_explicit_base_url(monkeypatch):
@@ -76,8 +71,8 @@ def test_embed_text_uses_explicit_base_url(monkeypatch):
         lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url=base_url),
     )
 
-    assert embed_text("some evidence text", base_url="http://custom-ollama:11434") == [0.1]
-    assert seen["url"].startswith("http://custom-ollama:11434/")
+    assert embed_text("some evidence text", base_url="http://custom-jina-embed:9999") == [0.1]
+    assert seen["url"].startswith("http://custom-jina-embed:9999/")
 
 
 def test_embed_text_returns_none_on_connection_error(monkeypatch):
@@ -86,7 +81,7 @@ def test_embed_text_returns_none_on_connection_error(monkeypatch):
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
     )
 
     assert embed_text("some evidence text") is None
@@ -98,7 +93,7 @@ def test_embed_text_returns_none_on_timeout(monkeypatch):
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
     )
 
     assert embed_text("some evidence text") is None
@@ -110,7 +105,7 @@ def test_embed_text_returns_none_on_malformed_response(monkeypatch):
 
     monkeypatch.setattr(
         "scan_worker.embedding_client._client",
-        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://ollama:11434"),
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
     )
 
     assert embed_text("some evidence text") is None


### PR DESCRIPTION
## Summary
- Real, corrected 6-language retrieval benchmark showed `jina-embeddings-v2-base-code` beating `nomic-embed-text` on every metric (75.0/93.1/95.8% vs 73.6/87.5/91.7% top-1/3/5 pooled, n=72). `bge-m3` actually underperformed nomic (66.7/84.7/94.4%).
- Scoped to production infrastructure only (the evidence-packet + flash-review similarity caches in `scan_worker`) — not the open-source CLI's local default, since Ollama can't serve jina and self-hosting users would lose working search without a separate service.
- New `jina-embed` Docker service replaces `ollama` in `docker-compose.yml`. CPU-only, weights baked into the image at build time (verified: cold start needs no HuggingFace download).
- `embedding_client.py` now calls a simple `/embed` endpoint instead of Ollama's `/api/embeddings` shape.
- Migration `049` purges both cache tables — nomic and jina happen to share the 768-dim array shape, so old rows would otherwise silently get compared against incompatible new vectors (existing downstream re-validation would likely catch a false match, but no reason to spend cycles on doomed lookups).

## Test plan
- [x] Full `github-app` test suite: 1276 passed, 8 skipped (`test_embedding_client.py`, `test_packet_cache.py`, `test_flash_review_cache.py` all updated/passing)
- [x] `docker build -f github-app/Dockerfile.jina-embed` succeeds
- [x] Ran the built image locally: `/healthz` returns ok, `/embed` returns real 768-dim vectors, no runtime download triggered
- [ ] CI green
- [ ] Deploy + verify against live production traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)