### PR TITLE
chore: bump jina-embed mem_limit from 1500m to 2500m

### DIFF
--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -396,7 +396,11 @@ services:
       # a busy host doesn't get flagged unhealthy before it's had a chance.
       start_period: 60s
     cpus: "1.0"
-    mem_limit: 1500m
+    # Bumped from 1500m: was already sitting at 84% of that cap after a
+    # single warm-up request (model-load baseline, not a leak), leaving
+    # almost no headroom for concurrent traffic before the cgroup OOM-kills
+    # it. Host has 12GB+ free, so this is cheap insurance.
+    mem_limit: 2500m
 
   caddy:
     image: caddy:2-alpine


### PR DESCRIPTION
## Summary
- Prod host RAM audit found jina-embed at 1.23GB/1.465GB (84%) used after a single warm-up request - model-load baseline, not a leak, but too little headroom before a concurrent-traffic OOM-kill
- Host has 12GB+ RAM free, so raising the cap is cheap insurance

## Test plan
- [x] CI (no functional code change, config only)
- [ ] Redeploy on prod, confirm container comes up healthy under the new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)