### PR TITLE
perf: run AIRview subsystem and file-page writing calls concurrently

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -6,6 +6,7 @@ import os
 import secrets
 import shutil
 import subprocess
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -2915,9 +2916,16 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
             return
 
         spend_accumulator = {"total": 0.0}
+        spend_lock = threading.Lock()
 
         def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            spend_accumulator["total"] += cost_for_usage(model_used, prompt_tokens, completion_tokens)
+            # live_wiki.generate_subsystems/generate_file_pages now run their
+            # per-item writing calls on a bounded thread pool, so this fires
+            # from multiple worker threads concurrently - += on a shared dict
+            # value is a read-modify-write race without the lock.
+            cost = cost_for_usage(model_used, prompt_tokens, completion_tokens)
+            with spend_lock:
+                spend_accumulator["total"] += cost
 
         try:
             naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
@@ -3048,9 +3056,15 @@ def _maybe_update_live_wiki(
 
         update_model = resolve_model(live_wiki.UPDATE_MODEL)
         spend_accumulator = {"total": 0.0}
+        spend_lock = threading.Lock()
 
         def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            spend_accumulator["total"] += cost_for_usage(update_model, prompt_tokens, completion_tokens)
+            # See matching comment in run_live_wiki_full_build_job: generation
+            # now runs on a bounded thread pool, so this callback is no
+            # longer single-threaded.
+            cost = cost_for_usage(update_model, prompt_tokens, completion_tokens)
+            with spend_lock:
+                spend_accumulator["total"] += cost
 
         try:
             naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)

--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -21,7 +21,8 @@ import json
 import logging
 import re
 import statistics
-from typing import Callable
+from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
+from typing import Callable, TypeVar
 
 from aletheore.citation_verifier import verify_citations
 from aletheore.evidence_packet import build_evidence_packet
@@ -36,6 +37,48 @@ UPDATE_MODEL = "deepseek-v4-flash"
 # only ever happens on a citation failure, which is rare, so this does not
 # meaningfully move per-push AIRview cost.
 SUBSYSTEM_WRITE_ATTEMPTS = 2
+
+# Subsystem and file-page writing calls are independent - no subsystem's
+# prose depends on another's, and file pages don't depend on each other
+# (only on the subsystem names, which are already resolved by the time this
+# runs). Each one is a synchronous, network-bound LLM call, so a full build
+# paid full round-trip latency per item in strict sequence: measured at
+# ~20-30 min for a single medium repo (~40 file pages + a dozen subsystems).
+# A small thread pool overlaps that latency instead of serializing it.
+# Kept modest rather than "as many as there are items": callers' on_usage/
+# before_llm_call/cache_lookup/cache_write closures may not be written to
+# tolerate unbounded concurrent invocation, and this is a single tenant's
+# build sharing one API key, not a place to maximize provider QPS.
+MAX_GENERATION_WORKERS = 6
+
+_T = TypeVar("_T")
+
+
+def _run_concurrently(thunks: list[Callable[[], _T]], max_workers: int = MAX_GENERATION_WORKERS) -> list[_T]:
+    """Runs each zero-arg callable in a bounded thread pool, in order.
+
+    Results are returned in the same order as `thunks`, regardless of
+    completion order - callers that zip results back against their inputs
+    do not need to track indices themselves. On the first exception, the
+    remaining not-yet-started work is cancelled and that exception is
+    re-raised once every already-started thunk has finished - matching the
+    prior fully-serial behavior, where one failure aborted the whole build
+    without silently continuing to spend budget on the rest.
+    """
+    if not thunks:
+        return []
+    if len(thunks) == 1:
+        return [thunks[0]()]
+
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(thunks))) as pool:
+        futures = [pool.submit(thunk) for thunk in thunks]
+        done, not_done = wait(futures, return_when=FIRST_EXCEPTION)
+        first_exception = next((f.exception() for f in done if f.exception() is not None), None)
+        if first_exception is not None:
+            for f in not_done:
+                f.cancel()
+            raise first_exception
+        return [f.result() for f in futures]
 
 SUBSYSTEM_DESCRIPTION_UNAVAILABLE = (
     "_Description withheld: the generated summary for this subsystem cited code that "
@@ -583,26 +626,28 @@ def generate_subsystems(
     names = propose_cluster_names(briefs, naming_adapter)
     clusters_by_id = {c["id"]: c for c in evidence.get("architecture", {}).get("clusters", [])}
 
-    records = []
-    for brief in briefs:
-        cid = brief["cluster_id"]
-        cluster = clusters_by_id.get(cid)
-        if cluster is None:
-            continue
-        record = build_subsystem_record(
+    def _thunk(brief: dict, cluster: dict) -> Callable[[], dict]:
+        return lambda: build_subsystem_record(
             evidence,
             cluster,
             brief,
-            names[cid],
+            names[brief["cluster_id"]],
             writing_adapter,
             cache_lookup=cache_lookup,
             cache_write=cache_write,
             model_used=model_used,
             fetch_line_count=fetch_line_count,
         )
-        if record is not None:
-            records.append(record)
-    return records
+
+    thunks = []
+    for brief in briefs:
+        cluster = clusters_by_id.get(brief["cluster_id"])
+        if cluster is None:
+            continue
+        thunks.append(_thunk(brief, cluster))
+
+    records = _run_concurrently(thunks)
+    return [r for r in records if r is not None]
 
 
 def select_file_page_paths(
@@ -772,17 +817,19 @@ def generate_file_pages(
     targets = paths if paths is not None else select_file_page_paths(evidence, max_files=max_files)
     subsystem_by_path = subsystem_by_path or {}
 
-    pages: dict[str, str] = {}
-    for path in targets:
-        detail = build_file_page_record(
+    def _thunk(path: str) -> Callable[[], str | None]:
+        return lambda: build_file_page_record(
             evidence,
             path,
             writing_adapter,
             subsystem_name=subsystem_by_path.get(path, ""),
             fetch_line_count=fetch_line_count,
         )
-        if detail:
-            pages[path] = detail
+
+    details = _run_concurrently([_thunk(path) for path in targets])
+    pages: dict[str, str] = {
+        path: detail for path, detail in zip(targets, details) if detail
+    }
     logger.info("AIRview generated %d/%d file pages", len(pages), len(targets))
     return pages
 

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -1,6 +1,10 @@
 import json
 import logging
+import threading
+import time
 from unittest.mock import MagicMock
+
+import pytest
 
 from scan_worker.live_wiki import (
     AIRVIEW_PROMPT_VERSION,
@@ -18,6 +22,7 @@ from scan_worker.live_wiki import (
     generate_file_pages,
     select_file_page_paths,
     _drop_test_only_briefs,
+    _run_concurrently,
     _strip_unverified_lines,
 )
 
@@ -570,6 +575,82 @@ def test_generate_subsystems_incremental_filters_to_given_clusters():
     naming_adapter.simple_completion.assert_not_called()
 
 
+def _two_cluster_evidence() -> dict:
+    return {
+        "repository": {
+            "modules": [
+                {"path": "auth/login.py", "language": "python", "imports": [],
+                 "symbols": {"functions": [{"name": "do_login", "start_line": 10, "end_line": 20}], "classes": []}},
+                {"path": "billing/charge.py", "language": "python", "imports": [],
+                 "symbols": {"functions": [{"name": "do_charge", "start_line": 1, "end_line": 9}], "classes": []}},
+            ],
+            "dependency_graph": {"nodes": [], "edges": []},
+        },
+        "architecture": {
+            "clusters": [
+                {"id": 0, "modules": ["auth/login.py"], "internal_edges": 0},
+                {"id": 1, "modules": ["billing/charge.py"], "internal_edges": 0},
+            ]
+        },
+    }
+
+
+def test_generate_subsystems_preserves_cluster_order_under_concurrency():
+    # Cluster 0's write is the slow one, so a naive implementation that just
+    # ran things concurrently and appended results in completion order would
+    # put cluster 1 first - order must come from the input, not the race.
+    evidence = _two_cluster_evidence()
+    naming_adapter = _adapter(json.dumps({"0": "Auth", "1": "Billing"}))
+
+    def _respond(_system_prompt, user_prompt, cwd):
+        payload = json.loads(user_prompt)
+        if payload["name"] == "Auth":
+            time.sleep(0.15)
+        return json.dumps({"description": f"{payload['name']} stuff.", "files": []})
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _respond
+
+    records = generate_subsystems(evidence, naming_adapter, writing_adapter)
+
+    assert [r["name"] for r in records] == ["Auth", "Billing"]
+
+
+def test_generate_subsystems_overlaps_writing_calls_instead_of_serializing():
+    # Real regression this guards: before bounding concurrency, a full build
+    # paid full LLM round-trip latency per subsystem in strict sequence,
+    # measured at ~20-30 min total for one medium repo. Two 150ms calls
+    # finishing in well under their combined 300ms proves they overlapped.
+    evidence = _two_cluster_evidence()
+    naming_adapter = _adapter(json.dumps({"0": "Auth", "1": "Billing"}))
+
+    def _slow_response(_system_prompt, user_prompt, cwd):
+        time.sleep(0.15)
+        return json.dumps({"description": "stuff.", "files": []})
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _slow_response
+
+    started = time.monotonic()
+    generate_subsystems(evidence, naming_adapter, writing_adapter)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.28
+
+
+def test_generate_subsystems_propagates_a_write_failure_instead_of_swallowing_it():
+    # Matches the prior fully-serial behavior: one subsystem's LLM call
+    # raising aborted the whole build rather than silently continuing to
+    # spend budget on the rest. Concurrency must not change that contract.
+    evidence = _two_cluster_evidence()
+    naming_adapter = _adapter(json.dumps({"0": "Auth", "1": "Billing"}))
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = RuntimeError("model call failed")
+
+    with pytest.raises(RuntimeError, match="model call failed"):
+        generate_subsystems(evidence, naming_adapter, writing_adapter)
+
+
 def test_generate_overview_happy_path():
     evidence = make_evidence()
     subsystem_records = [{"subsystem_id": "0", "name": "Authentication", "description": "Handles login."}]
@@ -706,6 +787,87 @@ def test_generate_file_pages_keys_pages_by_path():
         make_evidence(), _adapter(json.dumps({"detail": detail})), paths=["auth/login.py"]
     )
     assert pages == {"auth/login.py": detail}
+
+
+def test_generate_file_pages_overlaps_writing_calls_instead_of_serializing():
+    # Same regression as generate_subsystems: up to DEFAULT_MAX_FILE_PAGES
+    # (40) file pages were written one full LLM round-trip at a time.
+    evidence = _two_cluster_evidence()
+
+    def _slow_response(_system_prompt, user_prompt, cwd):
+        time.sleep(0.15)
+        payload = json.loads(user_prompt)
+        return json.dumps({"detail": f"## Overview\nSee {payload['path']}:1."})
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _slow_response
+
+    started = time.monotonic()
+    pages = generate_file_pages(
+        evidence, writing_adapter, paths=["auth/login.py", "billing/charge.py"]
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.28
+    assert set(pages) == {"auth/login.py", "billing/charge.py"}
+
+
+def test_generate_file_pages_keeps_path_to_detail_mapping_correct_under_concurrency():
+    # A naive zip(targets, completion_order) would cross-wire pages across
+    # files whenever a later file's call happens to finish first.
+    evidence = _two_cluster_evidence()
+
+    def _respond(_system_prompt, user_prompt, cwd):
+        payload = json.loads(user_prompt)
+        if payload["path"] == "auth/login.py":
+            time.sleep(0.1)
+        return json.dumps({"detail": f"## Overview\nSee {payload['path']}:1."})
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _respond
+
+    pages = generate_file_pages(
+        evidence, writing_adapter, paths=["auth/login.py", "billing/charge.py"]
+    )
+
+    assert pages["auth/login.py"] == "## Overview\nSee auth/login.py:1."
+    assert pages["billing/charge.py"] == "## Overview\nSee billing/charge.py:1."
+
+
+def test_run_concurrently_preserves_input_order_regardless_of_completion_order():
+    def _slow():
+        time.sleep(0.1)
+        return "slow"
+
+    results = _run_concurrently([_slow, lambda: "fast"])
+
+    assert results == ["slow", "fast"]
+
+
+def test_run_concurrently_reraises_the_first_exception():
+    def _boom():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        _run_concurrently([_boom, lambda: "unaffected"])
+
+
+def test_run_concurrently_handles_empty_and_singleton_input():
+    assert _run_concurrently([]) == []
+    assert _run_concurrently([lambda: "only"]) == ["only"]
+
+
+def test_run_concurrently_actually_uses_multiple_threads():
+    # Guards against a regression to a fake pool that just calls thunks
+    # inline - two thunks that block on each other's start can only both
+    # finish if they truly ran on separate threads.
+    barrier = threading.Barrier(2, timeout=2)
+
+    def _wait_for_both():
+        barrier.wait()
+        return "ok"
+
+    assert _run_concurrently([_wait_for_both, _wait_for_both]) == ["ok", "ok"]
 
 
 def test_attach_file_pages_leaves_files_without_a_page_untouched():


### PR DESCRIPTION
## Summary
- `generate_subsystems` and `generate_file_pages` (`github-app/scan_worker/live_wiki.py`) wrote their items one blocking LLM call at a time - measured at ~20-30 min for a single medium repo's full build (~40 file pages + a dozen subsystems)
- This is the real production path (`run_live_wiki_full_build_job`, triggered on free-to-paid upgrade and on push), not just a benchmark artifact - it ties up an RQ worker slot for the whole build every time
- None of these calls depend on each other (subsystems are independent; file pages only depend on subsystem naming, already resolved by then), so a bounded thread pool (6 workers) overlaps the latency instead of serializing it
- Also fixes a thread-safety gap the change introduces: `jobs.py`'s `on_usage` spend-accumulator closures did `total += cost` against a plain dict - a lost-update race once the underlying calls run on multiple threads. Both call sites (full build + incremental update) now guard the increment with a lock

## Behavior preserved
- **Ordering**: results always come back in input order, regardless of completion order
- **Fail-fast**: one write failing still aborts the whole build (matches the prior serial contract - no silently continuing to spend budget on the rest after a real error)

## Real-world verification
Ran both stages against flask's already-built evidence with real DeepSeek calls (not mocked):
```
flask: 12 clusters, 23 planned file pages
generate_subsystems: 281.9s for 5 subsystems written (of 12 clusters)
generate_file_pages: 404.0s for 21/23 pages
TOTAL: 686.0s (11.4 min) | tokens in=87567 out=337967
```
5/12 clusters is correct (7 are test-only, dropped by `_drop_test_only_briefs`). 21/23 pages is correct (2 didn't pass citation verification - same salvage behavior as before). Compares against a separate serial run on the same corpus that was still in stage 2 alone past the 28-minute mark.

## Test plan
- [x] All existing tests pass unchanged (60/60 `test_live_wiki.py`, 145/145 + 1 skip `test_jobs.py`)
- [x] 9 new tests: order preservation under out-of-order completion, real wall-clock overlap (two 150ms calls finish in <280ms), fail-fast exception propagation, and a `threading.Barrier` test that only passes with genuine multi-threading
- [x] Real DeepSeek run against flask's evidence (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)