### PR TITLE
fix: MCP server bug fixes and gap-closing (consent, dimension guard, 3 new tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ PHP, C, C++, and C#**.
   against your own repo — see [`src/README.md`](src/README.md) for why it isn't wired into CI.
 - **`aletheore query`** / **`aletheore diff`** — answer a targeted question or compare two
   scans from existing evidence, no re-scan or LLM call needed.
-- **`aletheore mcp`** — a stdio MCP server exposing 27 tools by default (28 with
+- **`aletheore mcp`** — a stdio MCP server exposing 30 tools by default (31 with
   `ALETHEORE_MCP_ALLOW=external` enabled) (module/symbol/dependency lookups,
   ownership, clusters, dead code, hotspots, full-text and semantic search, scan and index
   triggers) so a coding agent can query your repo's structure directly instead of shelling out

--- a/docs/superpowers/plans/2026-08-15-mcp-server-fixes-and-gaps.md
+++ b/docs/superpowers/plans/2026-08-15-mcp-server-fixes-and-gaps.md
@@ -1,0 +1,1354 @@
+# MCP Server Fixes and Gap-Closing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix five real bugs found in a live audit of Aletheore's MCP server (`src/aletheore/mcp_server.py`) and close three of the audit's identified capability gaps, then prove the whole server works end-to-end against this repo's own evidence.
+
+**Architecture:** No new subsystems. Every task is a small, targeted change inside the existing MCP server / query / search-index modules, following patterns that already exist in each file (the effect-class consent system in `mcp_server.py`, the version-checked evidence loader in `evidence.py`, the query-function registry in `query.py`). Three brand-new read-only tools are added using the exact same `_register_*_tool` + `QUERY_FUNCTIONS`-style pattern already used by the 26 existing tools.
+
+**Tech Stack:** Python 3.11+, `mcp>=2.0,<3.0` (`MCPServer`), `lancedb`, `pytest` + `pytest-asyncio`.
+
+**Spec:** No separate spec doc — this plan is grounded directly in a live code audit performed in-conversation (file:line citations throughout) plus direct verification against this repo's own `.aletheore/air.json`. Out of scope, explicitly deferred: hosted MCP resurrection (a full abandoned branch, `codex/aletheore-hosted-mcp`, exists for that separately) and any PR-level MCP tools. Do not touch either in this plan.
+
+## Global Constraints
+
+- Every new/changed MCP tool must keep the existing TOON-encoding convention (`_toon_result`) — never return raw JSON.
+- Every new tool that only reads `.aletheore/air.json` is read-only (`READ_ONLY_ANNOTATIONS`) and registers unconditionally (no effect gating) — this matches all 23 existing read-only tools.
+- Never add a bare `json.loads` on an evidence or snapshot file anywhere in `mcp_server.py` — always route through `load_evidence_file` (already imported at `mcp_server.py:18`) so version/schema errors surface clearly instead of as a raw `KeyError` three calls later.
+- Test fixtures: use `make_repo_with_evidence(tmp_path)` from `src/tests/test_mcp_server.py` (or `tests.air_fixtures.minimal_air_evidence()` directly, matching `test_mcp_consent.py`'s pattern) — do not hand-roll evidence dicts missing required AIR schema keys.
+- Tool call tests use the pattern already established at `test_mcp_server.py:317-330`: `@pytest.mark.asyncio async def test_x(tmp_path): repo = make_repo_with_evidence(tmp_path); server = build_server(repo); result = await server.call_tool("tool_name", {...}); assert tool_result_body(result) == {"result": expected}`.
+- Run tests with: `cd src && python3 -m pytest tests/test_mcp_server.py tests/test_mcp_consent.py tests/test_query.py tests/test_search_index.py -v` (adjust the exact interpreter/venv the environment actually has `mcp`/`lancedb` installed under — check with `python3 -c "import mcp, lancedb"` first; if that fails, find the project's real venv before running any test step).
+
+---
+
+### Task 1: Gate hosted-embedding upload behind explicit consent
+
+**Files:**
+- Modify: `src/aletheore/search_index.py:734-775` (`_embed_in_batches`), `:814-820` (`_embed_stale_by_hash`), `:823-887` (`build_index`)
+- Modify: `src/aletheore/mcp_server.py:488-509` (`_register_index_tool`), `:630-641` (call site in `build_server`)
+- Test: `src/tests/test_search_index.py`, `src/tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: existing `get_api_key`, `embed_texts_hosted`, `embed_texts` (unchanged signatures).
+- Produces: `_embed_in_batches(texts, batch_size=EMBED_BATCH_SIZE, repo_id=None, allow_hosted=True)`, `_embed_stale_by_hash(stale, repo_id=None, allow_hosted=True)`, `build_index(repo_path, evidence, allow_hosted=True)` — all three gain one new keyword-only-in-practice `bool` parameter, default `True` (preserves current CLI behavior exactly). `_register_index_tool(mcp_instance, repo_path, effects)` gains a third positional parameter.
+
+**Why:** `_embed_in_batches` (`search_index.py:753-756`) silently uses Aletheore's hosted embedding endpoint whenever `ALETHEORE_API_TOKEN` resolves — with **no** TTY/consent check. Contrast `embed_texts`'s OpenAI fallback (`search_index.py:682-695`), which explicitly refuses on a non-interactive session (`sys.stdin.isatty()`) and prompts on a real terminal. Every MCP tool call is non-interactive by definition, so `aletheore_index` called via MCP by a logged-in user silently ships this repo's source chunks to `app.aletheore.com` — directly contradicting `src/README.md:527-532`'s claim and `test_mcp_consent.py`'s own docstring (`:165-191`) that MCP "cannot send code to OpenAI." The codebase already has the right mechanism for exactly this class of decision — `mcp_server.py`'s `EFFECT_EXTERNAL` ("transmits repository evidence to a third-party service", `mcp_server.py:220-232`) — this task wires the hosted-embedding path into it instead of inventing a new consent flow.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# src/tests/test_search_index.py — add near the existing _embed_in_batches tests
+# (around test_no_token_means_no_hosted_call_at_all, ~line 1271)
+
+def test_allow_hosted_false_skips_hosted_call_even_with_a_token(capsys):
+    http = MagicMock()
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http), \
+         patch("aletheore.search_index.embed_texts", side_effect=lambda t: [[0.0] * 768] * len(t)):
+        vectors = _embed_in_batches(["chunk"], allow_hosted=False)
+
+    http.post.assert_not_called()
+    assert len(vectors[0]) == 768
+    assert "not permitted in this context" in capsys.readouterr().err
+
+
+def test_allow_hosted_true_is_the_default_and_preserves_existing_behavior():
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.1] * 1536]})
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http):
+        vectors = _embed_in_batches(["chunk"])  # no allow_hosted kwarg at all
+
+    http.post.assert_called_once()
+    assert len(vectors[0]) == 1536
+```
+
+```python
+# src/tests/test_mcp_server.py — add near test_aletheore_index_tool_builds_the_search_index (~line 371)
+
+@pytest.mark.asyncio
+async def test_aletheore_index_tool_forbids_hosted_embeddings_by_default(tmp_path):
+    # Default MCP posture is EFFECT_WRITE + EFFECT_NETWORK only (mcp_server.py's
+    # _DEFAULT_ALLOWED_EFFECTS) - EFFECT_EXTERNAL is off, so a logged-in user's
+    # code must not silently reach the hosted embedding endpoint through MCP.
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)  # default effects, no `allow=` override
+
+    with patch("aletheore.search_index.build_index", return_value=3) as mock_build_index:
+        await server.call_tool("aletheore_index", {})
+
+    _, kwargs = mock_build_index.call_args
+    assert kwargs["allow_hosted"] is False
+
+
+@pytest.mark.asyncio
+async def test_aletheore_index_tool_permits_hosted_embeddings_when_external_is_allowed(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo, allow=frozenset({"write", "network", "external"}))
+
+    with patch("aletheore.search_index.build_index", return_value=3) as mock_build_index:
+        await server.call_tool("aletheore_index", {})
+
+    _, kwargs = mock_build_index.call_args
+    assert kwargs["allow_hosted"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd src && python3 -m pytest tests/test_search_index.py::test_allow_hosted_false_skips_hosted_call_even_with_a_token tests/test_search_index.py::test_allow_hosted_true_is_the_default_and_preserves_existing_behavior tests/test_mcp_server.py::test_aletheore_index_tool_forbids_hosted_embeddings_by_default tests/test_mcp_server.py::test_aletheore_index_tool_permits_hosted_embeddings_when_external_is_allowed -v`
+Expected: FAIL — `_embed_in_batches() got an unexpected keyword argument 'allow_hosted'` and `mock_build_index.call_args` has no `allow_hosted` kwarg.
+
+- [ ] **Step 3: Implement in `search_index.py`**
+
+Replace `_embed_in_batches` (currently `search_index.py:734-775`):
+
+```python
+def _embed_in_batches(
+    texts: list[str],
+    batch_size: int = EMBED_BATCH_SIZE,
+    repo_id: str | None = None,
+    allow_hosted: bool = True,
+) -> list[list[float]]:
+    """Embed everything, preferring Aletheore's endpoint when entitled.
+
+    Hosted first, then local, and never the reverse: someone paying for
+    hosted embeddings should not silently have their code sent to their own
+    OpenAI account instead.
+
+    The fallback is only allowed before the first batch succeeds. After that,
+    switching providers mid-run would mix 1536-dimension vectors with 768-
+    dimension ones in a single index, which LanceDB rejects outright - so a
+    hosted failure partway through is raised rather than worked around. A
+    half-built index that errors is recoverable; one built from two models
+    is not.
+
+    repo_id: forwarded to embed_texts_hosted so the hosted rate limit can be
+    keyed per repo rather than per installation - see _repo_id.
+
+    allow_hosted: the caller's consent to transmit this repository's code to
+    Aletheore's hosted embedding endpoint. Defaults to True to preserve the
+    CLI's existing interactive behavior. MCP's aletheore_index tool passes
+    False unless the operator has explicitly permitted EFFECT_EXTERNAL (see
+    mcp_server.py's consent model) - MCP tool calls are always
+    non-interactive, so there is no equivalent of embed_texts's isatty()
+    prompt available to ask for consent in the moment.
+    """
+    token = get_api_key(
+        "ALETHEORE_API_TOKEN", "aletheore-managed-audit", prompt_fn=lambda _: ""
+    )
+    use_hosted = bool(token) and allow_hosted
+    if token and not allow_hosted:
+        print(
+            "aletheore: hosted embeddings available but not permitted in this "
+            "context; using local provider",
+            file=sys.stderr,
+        )
+    vectors: list[list[float]] = []
+
+    for start in range(0, len(texts), batch_size):
+        batch = texts[start : start + batch_size]
+        if use_hosted:
+            try:
+                vectors.extend(embed_texts_hosted(batch, token, repo_id=repo_id))
+                continue
+            except HostedEmbeddingUnavailableError as exc:
+                if vectors:
+                    raise
+                # Nothing embedded yet, so falling back costs no consistency.
+                # Printed rather than swallowed: a 402 means the plan
+                # changed, which the user needs to see.
+                print(f"aletheore: hosted embeddings unavailable ({exc}); using local provider")
+                use_hosted = False
+        vectors.extend(embed_texts(batch))
+
+    return vectors
+```
+
+Update `_embed_stale_by_hash` (currently `search_index.py:814-820`):
+
+```python
+def _embed_stale_by_hash(
+    stale: list[dict], repo_id: str | None = None, allow_hosted: bool = True
+) -> dict[str, list[float]]:
+    stale_by_hash = {chunk["chunk_hash"]: chunk["text"] for chunk in stale}
+    stale_hashes = list(stale_by_hash)
+    fresh_vectors = _embed_in_batches(
+        [stale_by_hash[chunk_hash] for chunk_hash in stale_hashes],
+        repo_id=repo_id,
+        allow_hosted=allow_hosted,
+    )
+    return dict(zip(stale_hashes, fresh_vectors))
+```
+
+In `build_index` (currently `search_index.py:823-887`), change the signature and thread the flag through both call sites of `_embed_stale_by_hash` / `_embed_in_batches`:
+
+```python
+def build_index(repo_path: Path, evidence: dict, allow_hosted: bool = True) -> int:
+    chunks = build_chunks(evidence, repo_path)
+    if not chunks:
+        return 0
+
+    for chunk in chunks:
+        chunk["chunk_hash"] = _chunk_hash(chunk["text"])
+
+    index_path = _index_path(repo_path)
+    reusable = _reusable_vectors(index_path)
+    stale = [chunk for chunk in chunks if chunk["chunk_hash"] not in reusable]
+    repo = _repo_id(repo_path)
+    fresh = _embed_stale_by_hash(stale, repo_id=repo, allow_hosted=allow_hosted)
+    fresh_vectors = list(fresh.values())
+
+    if reusable:
+        current_dimension = (
+            len(fresh_vectors[0])
+            if fresh_vectors
+            else len(_embed_in_batches([chunks[0]["text"]], repo_id=repo, allow_hosted=allow_hosted)[0])
+        )
+        reused_dimensions = {len(vector) for vector in reusable.values()}
+        if reused_dimensions != {current_dimension}:
+            reusable = {}
+            stale = chunks
+            fresh = _embed_stale_by_hash(stale, repo_id=repo, allow_hosted=allow_hosted)
+
+    rows = [
+        {**chunk, "vector": reusable.get(chunk["chunk_hash"]) or fresh[chunk["chunk_hash"]]}
+        for chunk in chunks
+    ]
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    db = lancedb.connect(str(index_path))
+    table = db.create_table(TABLE_NAME, data=rows, mode="overwrite")
+    try:
+        table.create_index("text", config=FTS(), replace=True)
+    except Exception:  # noqa: BLE001 - any backend failure degrades, never fails the build
+        pass
+    return len(rows)
+```
+
+(Leave every comment already in `build_index` in place — only the signature and the two `_embed_stale_by_hash`/`_embed_in_batches` call sites change.)
+
+- [ ] **Step 4: Implement in `mcp_server.py`**
+
+Change `_register_index_tool` (currently `mcp_server.py:488-509`):
+
+```python
+def _register_index_tool(mcp_instance: MCPServer, repo_path: Path, effects: frozenset[str]) -> None:
+    @mcp_instance.tool(
+        name="aletheore_index",
+        # Writes the vector index and sends code chunks to the embedding
+        # provider - Aletheore's hosted endpoint if entitled and permitted,
+        # else local Ollama, else OpenAI on fallback.
+        annotations=ToolAnnotations(
+            readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
+        ),
+    )
+    def aletheore_index() -> str:
+        """Build the semantic search index for this repo's evidence, required
+        before aletheore_search_codebase or aletheore_answer can be used.
+        Embeds via Aletheore's hosted endpoint if this session has permission
+        to transmit evidence externally and a token is available, else a
+        local Ollama instance, falling back to OpenAI if that's unavailable
+        too."""
+        from aletheore.search_index import build_index
+
+        evidence = read_evidence(repo_path)
+        try:
+            count = build_index(repo_path, evidence, allow_hosted=EFFECT_EXTERNAL in effects)
+        except Exception as exc:  # noqa: BLE001
+            return _toon_result({"error": str(exc)})
+        return _toon_result({"indexed_chunks": count})
+```
+
+Update the call site in `build_server` (currently `mcp_server.py:634-635`):
+
+```python
+    if permitted("aletheore_index"):
+        _register_index_tool(mcp_instance, repo_path, effects)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd src && python3 -m pytest tests/test_search_index.py tests/test_mcp_server.py tests/test_mcp_consent.py -v`
+Expected: PASS — including all pre-existing tests in these three files (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aletheore/search_index.py src/aletheore/mcp_server.py src/tests/test_search_index.py src/tests/test_mcp_server.py
+git commit -m "fix: gate hosted-embedding upload behind EFFECT_EXTERNAL consent
+
+aletheore_index called via MCP silently shipped this repo's source chunks
+to Aletheore's hosted embedding endpoint whenever a saved token existed -
+no TTY/consent check, unlike the OpenAI-fallback path which explicitly
+refuses on a non-interactive session. Wires the hosted-embedding decision
+into the existing EFFECT_EXTERNAL consent class instead of inventing a new
+gate, so it's off by default under MCP and matches what the README/tests
+already claim."
+```
+
+---
+
+### Task 2: Guard against a dimension mismatch on the search side
+
+**Files:**
+- Modify: `src/aletheore/search_index.py:36-37` (near `IndexNotFoundError`), `:1096-1103` (`search_index`)
+- Modify: `src/aletheore/mcp_server.py:37` (import), `:517-535` (`_register_search_codebase_tool`)
+- Test: `src/tests/test_search_index.py`, `src/tests/test_mcp_server.py`
+
+**Interfaces:**
+- Produces: `class IndexDimensionMismatchError(Exception)` in `search_index.py`, raised by `search_index()`.
+- Consumes/re-exports: `mcp_server.py` imports it alongside the existing `IndexNotFoundError, search_index` at line 37.
+
+**Why:** `build_index` has careful dimension-drift handling (`search_index.py:848-886`, comment explains the exact reproduction: "index with Ollama, lose Ollama, and the next build crashed on the fallback rather than degrading"). `search_index()` (`search_index.py:1096-1103`) has none: it always embeds the query with the pure-local `embed_texts`, with no check against the table's actual stored vector width. An index built via the hosted path (1536-dim, `text-embedding-3-small`) searched with a 768-dim local query vector currently either crashes inside LanceDB with an opaque error or (worse) silently ranks nonsense, for exactly the paying users hosted embeddings exist for. `src/tests/test_search_index.py:1202-1260` covers the build side only — no existing test covers search-after-hosted-build.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/tests/test_search_index.py — add near the other IndexNotFoundError-adjacent tests
+
+def test_search_index_raises_a_clear_error_on_dimension_mismatch(tmp_path):
+    """An index built with 1536-dim hosted vectors, searched with a 768-dim
+    local query vector, must fail with an actionable message - not an
+    opaque LanceDB internal error and not silently wrong rankings."""
+    from aletheore.search_index import (
+        IndexDimensionMismatchError,
+        TABLE_NAME,
+        _index_path,
+        search_index,
+    )
+    import lancedb
+
+    repo = tmp_path
+    index_path = _index_path(repo)
+    index_path.parent.mkdir(parents=True)
+    db = lancedb.connect(str(index_path))
+    db.create_table(
+        TABLE_NAME,
+        data=[
+            {
+                "module_path": "a.py",
+                "symbol_name": "foo",
+                "start_line": 1,
+                "end_line": 2,
+                "language": "python",
+                "imports": [],
+                "text": "def foo(): pass",
+                "chunk_hash": "abc",
+                "vector": [0.1] * 1536,
+            }
+        ],
+    )
+
+    with patch("aletheore.search_index.embed_texts", return_value=[[0.0] * 768]):
+        with pytest.raises(IndexDimensionMismatchError, match="1536.*768|768.*1536"):
+            search_index(repo, "where is foo")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd src && python3 -m pytest tests/test_search_index.py::test_search_index_raises_a_clear_error_on_dimension_mismatch -v`
+Expected: FAIL — `ImportError: cannot import name 'IndexDimensionMismatchError'`.
+
+- [ ] **Step 3: Implement**
+
+Add the exception next to the existing ones in `search_index.py` (near line 36-37):
+
+```python
+class IndexNotFoundError(Exception):
+    pass
+
+
+class IndexDimensionMismatchError(Exception):
+    pass
+```
+
+Update `search_index()` (currently `search_index.py:1096-1103`):
+
+```python
+def search_index(
+    repo_path: Path, query_text: str, k: int = 10, language: str | None = None
+) -> list[dict]:
+    if language is None:
+        # The question may name its own language - see _detect_query_language.
+        language = _detect_query_language(query_text)
+    table = open_index(repo_path)
+    query_vector = embed_texts([query_text])[0]
+
+    # The index and the query must come from the same embedding model - see
+    # build_index's dimension-drift handling for the mechanism that keeps
+    # the index internally consistent. This is the mirror check for the
+    # query itself: the available provider can differ between when the
+    # index was built and when it's searched (e.g. a hosted token was
+    # revoked, or Ollama came up where it wasn't before), and a raw
+    # dimension mismatch otherwise surfaces as an opaque LanceDB error deep
+    # inside table.search() rather than a message telling the user what to
+    # do about it.
+    table_dimension = table.schema.field("vector").type.list_size
+    if len(query_vector) != table_dimension:
+        raise IndexDimensionMismatchError(
+            f"the index at {_index_path(repo_path)} holds {table_dimension}-dimension "
+            f"vectors but the query embedded to {len(query_vector)} dimensions with the "
+            f"embedding provider available right now - re-run 'aletheore index {repo_path}' "
+            "to rebuild the index with the current provider"
+        )
+
+    # Over-fetch, then thin by file: the chunks displaced by the per-file cap
+    # have to be replaced by something, and that something is only available
+    # if the search returned more than k to begin with.
+    limit = k * _OVERFETCH_FACTOR
+    vector_query = table.search(query_vector).limit(limit)
+    if language:
+        vector_query = vector_query.where(f"language = '{_escape_sql_literal(language)}'")
+    candidates = _rrf_fuse(
+        vector_query.to_list(), _fts_candidates(table, query_text, limit, language)
+    )
+
+    per_file: dict[str, int] = {}
+    raw_results = []
+    for candidate in candidates:
+        path = candidate["module_path"]
+        if per_file.get(path, 0) >= MAX_CHUNKS_PER_FILE:
+            continue
+        per_file[path] = per_file.get(path, 0) + 1
+        raw_results.append(candidate)
+        if len(raw_results) == k:
+            break
+    return [
+        {
+            "module_path": result["module_path"],
+            "symbol_name": result["symbol_name"],
+            "start_line": result["start_line"],
+            "end_line": result["end_line"],
+            "language": result["language"],
+            "imports": result.get("imports") or [],
+            "text": result["text"],
+            "score": result.get("_distance"),
+        }
+        for result in raw_results
+    ]
+```
+
+In `mcp_server.py`, update the import at line 37:
+
+```python
+from aletheore.search_index import IndexDimensionMismatchError, IndexNotFoundError, search_index
+```
+
+Update `_register_search_codebase_tool` (currently `mcp_server.py:517-535`) to handle the new error:
+
+```python
+    def aletheore_search_codebase(query: str, k: int = 10, language: str | None = None) -> str:
+        """Hybrid search (meaning + exact identifiers) over the repository's
+        indexed code. language: optional filter, e.g. 'python', 'typescript' -
+        use it on a polyglot repo when the question is about one stack, since
+        an unfiltered search ranks every language's chunks against each other.
+        Names must match evidence's own repository.languages values."""
+        try:
+            return _toon_result(search_index(repo_path, query, k=k, language=language))
+        except IndexNotFoundError:
+            return _toon_result(_NO_INDEX_ERROR)
+        except IndexDimensionMismatchError as exc:
+            return _toon_result({"error": str(exc)})
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd src && python3 -m pytest tests/test_search_index.py::test_search_index_raises_a_clear_error_on_dimension_mismatch -v`
+Expected: PASS
+
+- [ ] **Step 5: Add the MCP-level test**
+
+```python
+# src/tests/test_mcp_server.py — add near test_aletheore_search_codebase_returns_friendly_error_when_index_not_built
+
+@pytest.mark.asyncio
+async def test_aletheore_search_codebase_returns_friendly_error_on_dimension_mismatch(tmp_path):
+    from aletheore.mcp_server import IndexDimensionMismatchError
+
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    with patch(
+        "aletheore.mcp_server.search_index",
+        side_effect=IndexDimensionMismatchError("the index at ... holds 1536-dimension vectors ..."),
+    ):
+        result = await server.call_tool("aletheore_search_codebase", {"query": "where is foo"})
+
+    assert "1536-dimension" in tool_result_body(result)["result"]["error"]
+```
+
+- [ ] **Step 6: Run the full file and verify it passes**
+
+Run: `cd src && python3 -m pytest tests/test_search_index.py tests/test_mcp_server.py -v`
+Expected: PASS, no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/aletheore/search_index.py src/aletheore/mcp_server.py src/tests/test_search_index.py src/tests/test_mcp_server.py
+git commit -m "fix: raise a clear error instead of corrupting/crashing on index dimension mismatch
+
+build_index already handles the embedding-provider-changed-underneath-it
+case; search_index had no equivalent guard, so a hosted-built (1536-dim)
+index searched after the provider changed either crashed inside LanceDB
+with an opaque error or silently ranked garbage against a 768-dim local
+query vector. Same class of bug the build-side comment at search_index.py
+already documents reproducing, just on the other half of the code path."
+```
+
+---
+
+### Task 3: Fix `aletheore_changes` bypassing the version-compatibility check
+
+**Files:**
+- Modify: `src/aletheore/mcp_server.py:303-315` (`_register_changes_tool`)
+- Test: `src/tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `load_evidence_file` (already imported at `mcp_server.py:18`), `IncompatibleEvidenceVersionError`, `MalformedEvidenceError` (already imported at `mcp_server.py:16-17`).
+
+**Why:** Every other evidence reader in this file routes through `load_evidence_file`, which checks `aletheore_version` compatibility before returning (see `read_evidence`'s own comment, `mcp_server.py:67-75`, explaining exactly why: "a truncated or hand-edited air.json with a *compatible* version used to pass straight through here and only surface as a raw KeyError deep inside whichever tool first touched the missing/wrong field"). `_register_changes_tool` (`mcp_server.py:303-315`) is the one exception — it reads snapshot files with a bare `json.loads`, so a stale or incompatible snapshot produces a raw, unhelpful exception (or a `KeyError` inside `compute_diff`) instead of the same clear, actionable error every other tool gives.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/tests/test_mcp_server.py — add near the other test_read_evidence_rejects_* tests
+
+@pytest.mark.asyncio
+async def test_aletheore_changes_returns_clear_error_for_incompatible_snapshot(tmp_path):
+    from aletheore.history import save_snapshot
+    from tests.air_fixtures import minimal_air_evidence
+
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    evidence = minimal_air_evidence()
+    save_snapshot(evidence, repo)  # first snapshot, compatible version
+
+    bad = minimal_air_evidence()
+    bad["aletheore_version"] = "0.0.1-does-not-exist"
+    save_snapshot(bad, repo)  # second snapshot, incompatible
+
+    result = await server.call_tool("aletheore_changes", {})
+
+    body = tool_result_body(result)["result"]
+    assert "error" in body
+    assert "0.0.1-does-not-exist" in body["error"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py::test_aletheore_changes_returns_clear_error_for_incompatible_snapshot -v`
+Expected: FAIL — either an uncaught `IncompatibleEvidenceVersionError` propagating out of the tool call, or a `KeyError`/assertion failure because the current code returns `{"message": ...}` shaped output for a bare-JSON success case instead of an `"error"` key.
+
+- [ ] **Step 3: Implement**
+
+Replace `_register_changes_tool` (currently `mcp_server.py:303-315`):
+
+```python
+def _register_changes_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_changes", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_changes(full: bool = False) -> str:
+        """What changed between the two most recent scans of this repo."""
+        snapshots = list_snapshots(repo_path)
+        if len(snapshots) < 2:
+            return _toon_result({"message": "no prior snapshot to compare against"})
+        try:
+            old = load_evidence_file(snapshots[-2])
+            new = load_evidence_file(snapshots[-1])
+        except json.JSONDecodeError:
+            return _toon_result({"message": f"most recent snapshot is unreadable ({snapshots[-2]})"})
+        except (IncompatibleEvidenceVersionError, MalformedEvidenceError) as exc:
+            return _toon_result({"error": str(exc)})
+        return _toon_result(compute_diff(old, new, full=full))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py::test_aletheore_changes_returns_clear_error_for_incompatible_snapshot -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full file to check for regressions**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py -v -k changes`
+Expected: PASS, including any pre-existing `aletheore_changes` tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aletheore/mcp_server.py src/tests/test_mcp_server.py
+git commit -m "fix: route aletheore_changes through the version-checking evidence loader
+
+Every other evidence reader in this file uses load_evidence_file, which
+refuses an incompatible aletheore_version with a clear, actionable error.
+aletheore_changes read snapshot files with a bare json.loads instead, so a
+stale snapshot surfaced as a raw exception or a KeyError inside
+compute_diff rather than the same clear message every other tool gives."
+```
+
+---
+
+### Task 4: Make `aletheore_search` respect the repo's ignore patterns
+
+**Files:**
+- Modify: `src/aletheore/mcp_server.py:36` (import), `:158-185` (`_search_files`)
+- Test: `src/tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `load_repo_config` (new import from `aletheore.repo_config`), whose return dict has an `"ignored_paths"` key (confirmed usage pattern at `src/aletheore/secrets.py:201-204`).
+
+**Why:** The real scanner (`secrets.py:201-204`) calls `iter_all_files(repo_path, load_repo_config(repo_path)["ignored_paths"])` — `.aletheore.yml`'s `ignored_paths` config is honored everywhere else. `_search_files` (`mcp_server.py:158-185`) calls `iter_all_files(repo_path)` with no second argument (`mcp_server.py:166`) — `iter_all_files` already accepts an optional `ignored_paths` parameter (`secrets.py:86`), it's just never passed here. Anything a repo owner has explicitly configured to be ignored (generated code, vendored bundles, large data fixtures) is currently searched anyway by `aletheore_search`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/tests/test_mcp_server.py — add near the search tests
+
+@pytest.mark.asyncio
+async def test_aletheore_search_respects_repo_config_ignored_paths(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    (repo / "vendor").mkdir()
+    (repo / "vendor" / "bundle.js").write_text("needle in a vendored file")
+    (repo / "real.py").write_text("needle in a real file")
+    (repo / ".aletheore.yml").write_text("ignored_paths:\n  - vendor/**\n")
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_search", {"pattern": "needle"})
+
+    matches = tool_result_body(result)["result"]["matches"]
+    matched_paths = {m["path"] for m in matches}
+    assert "real.py" in matched_paths
+    assert "vendor/bundle.js" not in matched_paths
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py::test_aletheore_search_respects_repo_config_ignored_paths -v`
+Expected: FAIL — `vendor/bundle.js` is in `matched_paths`.
+
+- [ ] **Step 3: Implement**
+
+Add the import in `mcp_server.py` near line 36:
+
+```python
+from aletheore.repo_config import load_repo_config
+from aletheore.secrets import iter_all_files
+```
+
+Update `_search_files` (currently `mcp_server.py:158-185`):
+
+```python
+def _search_files(repo_path: Path, pattern: str, regex: bool, path_glob: str | None) -> dict:
+    """The actual search. Literal (non-regex) mode has no backtracking risk
+    and is called directly in-process; regex mode is only ever called
+    through _run_search in a subprocess (see _SEARCH_TIMEOUT_SECONDS)."""
+    compiled = re.compile(pattern) if regex else None
+    matches: list[dict] = []
+    truncated = False
+    ignored_paths = load_repo_config(repo_path)["ignored_paths"]
+
+    for path in iter_all_files(repo_path, ignored_paths):
+        rel_path = path.relative_to(repo_path).as_posix()
+        if path_glob is not None and not PurePath(rel_path).match(path_glob):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            found = compiled.search(line) is not None if compiled else pattern in line
+            if found:
+                if len(matches) >= _SEARCH_MATCH_CAP:
+                    truncated = True
+                    break
+                matches.append({"path": rel_path, "line": line_no, "text": line})
+        if truncated:
+            break
+
+    return {"matches": matches, "truncated": truncated}
+```
+
+(This single change covers both the literal in-process path and the regex subprocess path — both call `_search_files`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py::test_aletheore_search_respects_repo_config_ignored_paths -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full file to check for regressions**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py -v -k search`
+Expected: PASS, including the existing search timeout/regex/truncation tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aletheore/mcp_server.py src/tests/test_mcp_server.py
+git commit -m "fix: make aletheore_search respect .aletheore.yml's ignored_paths
+
+The real scanner (secrets.py) and every file-walk site already honor
+repo-configured ignore patterns; aletheore_search called iter_all_files
+with no ignored_paths argument even though the function already accepts
+one, so vendored/generated files a repo owner explicitly excluded were
+searched anyway."
+```
+
+---
+
+### Task 5: Add `aletheore_list` — list modules, clusters, and branches by name
+
+**Files:**
+- Modify: `src/aletheore/query.py` (add three functions)
+- Modify: `src/aletheore/mcp_server.py` (add one new tool registration)
+- Test: `src/tests/test_query.py`, `src/tests/test_mcp_server.py`
+
+**Interfaces:**
+- Produces (in `query.py`): `list_modules(evidence: dict) -> list[str]`, `list_clusters(evidence: dict) -> list[dict]`, `list_branches(evidence: dict) -> list[str]`.
+- Produces (in `mcp_server.py`): tool `aletheore_list(kind: str) -> str`, `kind` one of `"modules"`, `"clusters"`, `"branches"`.
+
+**Why:** 8 of the 16 dynamic query tools (`aletheore_imports`, `_imported_by`, `_symbols`, `_secrets`, `_cluster` need a file path; `_branch` needs a branch name) require an exact name "as it appears in evidence" — but no tool returns the list of valid names. An agent must bootstrap from `aletheore_search` or the raw filesystem before most of the toolset is usable. Confirmed against this repo's own evidence (`.aletheore/air.json`): `repository.modules[].path`, `architecture.clusters[].id`/`.modules`, `git.branches[].name` are the exact real shapes.
+
+One tool with a `kind` parameter, not three separate tools — avoids repeating the `imports`/`imported_by`/`cluster` redundancy already flagged in the audit (three tool-list slots for what `aletheore_neighborhood` already returns in one call).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# src/tests/test_query.py — add at the end of the file
+
+def test_list_modules_returns_every_module_path():
+    from aletheore.query import list_modules
+
+    evidence = {"repository": {"modules": [{"path": "a.py"}, {"path": "b.py"}]}}
+    assert list_modules(evidence) == ["a.py", "b.py"]
+
+
+def test_list_clusters_returns_id_and_module_count():
+    from aletheore.query import list_clusters
+
+    evidence = {
+        "architecture": {
+            "clusters": [
+                {"id": 0, "modules": ["a.py", "b.py"], "internal_edges": 1},
+                {"id": 1, "modules": ["c.py"], "internal_edges": 0},
+            ]
+        }
+    }
+    assert list_clusters(evidence) == [
+        {"id": 0, "module_count": 2},
+        {"id": 1, "module_count": 1},
+    ]
+
+
+def test_list_branches_returns_every_branch_name():
+    from aletheore.query import list_branches
+
+    evidence = {"git": {"branches": [{"name": "main"}, {"name": "dev"}]}}
+    assert list_branches(evidence) == ["main", "dev"]
+```
+
+```python
+# src/tests/test_mcp_server.py — add near test_aletheore_imports_tool_returns_correct_result
+
+@pytest.mark.asyncio
+async def test_aletheore_list_modules(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_list", {"kind": "modules"})
+
+    assert tool_result_body(result) == {"result": ["a.py", "b.py"]}
+
+
+@pytest.mark.asyncio
+async def test_aletheore_list_unknown_kind_returns_an_error(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_list", {"kind": "nonsense"})
+
+    assert "error" in tool_result_body(result)["result"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd src && python3 -m pytest tests/test_query.py -k list_ tests/test_mcp_server.py -k aletheore_list -v`
+Expected: FAIL — `ImportError` / `ToolError: unknown tool "aletheore_list"`.
+
+- [ ] **Step 3: Implement in `query.py`**
+
+Add near the end of `query.py`, before `QUERY_FUNCTIONS`:
+
+```python
+def list_modules(evidence: dict) -> list[str]:
+    return [module["path"] for module in evidence["repository"]["modules"]]
+
+
+def list_clusters(evidence: dict) -> list[dict]:
+    return [
+        {"id": cluster["id"], "module_count": len(cluster["modules"])}
+        for cluster in evidence["architecture"]["clusters"]
+    ]
+
+
+def list_branches(evidence: dict) -> list[str]:
+    return [branch["name"] for branch in evidence["git"]["branches"]]
+```
+
+- [ ] **Step 4: Implement in `mcp_server.py`**
+
+Add the import at the top, alongside the existing `query` import (`mcp_server.py:25-35`):
+
+```python
+from aletheore.query import (
+    ModuleNotFoundInEvidenceError,
+    QUERY_FUNCTIONS,
+    find_code_evidence_for_dependency,
+    find_code_evidence_for_endpoint,
+    find_code_evidence_for_symbol,
+    find_cluster,
+    find_imported_by,
+    find_imports,
+    find_symbol_source,
+    list_branches,
+    list_clusters,
+    list_modules,
+)
+```
+
+Add a new registration function, next to `_register_neighborhood_tool`:
+
+```python
+_LIST_KIND_TO_FUNCTION = {
+    "modules": list_modules,
+    "clusters": list_clusters,
+    "branches": list_branches,
+}
+
+
+def _register_list_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_list", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_list(kind: str) -> str:
+        """Lists the valid names/identifiers for one evidence collection, so
+        other tools' exact-match `target` arguments can be filled in
+        correctly. kind: one of 'modules' (file paths, for aletheore_imports/
+        _imported_by/_symbols/_secrets/_cluster/_neighborhood/_symbol_source's
+        module argument), 'clusters' (architecture cluster ids), or
+        'branches' (git branch names, for aletheore_branch)."""
+        func = _LIST_KIND_TO_FUNCTION.get(kind)
+        if func is None:
+            return _toon_result(
+                {"error": f"unknown kind {kind!r} - expected one of {sorted(_LIST_KIND_TO_FUNCTION)}"}
+            )
+        evidence = read_evidence(repo_path)
+        return _toon_result(func(evidence))
+```
+
+Register it in `build_server` next to `_register_neighborhood_tool` (currently `mcp_server.py:615-620`):
+
+```python
+    _register_query_wrapper_tools(mcp_instance, repo_path)
+    _register_changes_tool(mcp_instance, repo_path)
+    _register_neighborhood_tool(mcp_instance, repo_path)
+    _register_list_tool(mcp_instance, repo_path)
+    _register_search_tool(mcp_instance, repo_path)
+    _register_symbol_source_tool(mcp_instance, repo_path)
+    _register_code_evidence_tools(mcp_instance, repo_path)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd src && python3 -m pytest tests/test_query.py -k list_ tests/test_mcp_server.py -k aletheore_list -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aletheore/query.py src/aletheore/mcp_server.py src/tests/test_query.py src/tests/test_mcp_server.py
+git commit -m "feat: add aletheore_list MCP tool for modules/clusters/branches
+
+8 of the 16 dynamic query tools require an exact name 'as it appears in
+evidence', but nothing returned the list of valid names - an agent had to
+bootstrap from aletheore_search or the raw filesystem before most of the
+toolset was usable. One tool with a kind parameter rather than three
+separate ones, to avoid repeating the existing imports/imported_by/cluster
+redundancy that aletheore_neighborhood already solves."
+```
+
+---
+
+### Task 6: Add `aletheore_overview` — the "what is this repo?" tool
+
+**Files:**
+- Modify: `src/aletheore/query.py` (add one function)
+- Modify: `src/aletheore/mcp_server.py` (add one new tool registration)
+- Test: `src/tests/test_query.py`, `src/tests/test_mcp_server.py`
+
+**Interfaces:**
+- Produces (in `query.py`): `find_repo_overview(evidence: dict) -> dict`.
+- Produces (in `mcp_server.py`): tool `aletheore_overview() -> str`, no arguments.
+
+**Why:** `repository.languages`, `.frameworks`, `.monorepo`, `.dependency_graph`, `git.commit_cadence`, `.repo_age_days`, `.total_commits`, and `architecture.cross_cluster_edges` are all real evidence fields (confirmed directly against this repo's own `.aletheore/air.json`) reachable by **no** existing tool. "What is this repo?" is the first question any agent asks, and today answering it means calling several of the wrong-shaped tools or none at all. The full `dependency_graph` (nodes+edges) and full `cross_cluster_edges` list can be large for a big repo, so this returns counts for those rather than the raw graph, consistent with the file's existing TOON-cost-consciousness (see the `_toon_result` comment at `mcp_server.py:81-87`) — an agent that wants the full graph already has `aletheore_neighborhood`/`aletheore_cluster` for that.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/tests/test_query.py — add at the end of the file
+
+def test_find_repo_overview_summarizes_the_real_evidence_shape():
+    from aletheore.query import find_repo_overview
+
+    evidence = {
+        "repository": {
+            "languages": [{"name": "python", "file_count": 271, "loc": 65970}],
+            "frameworks": [{"name": "fastapi"}],
+            "monorepo": {"detected": False, "workspaces": []},
+            "dependency_graph": {"nodes": ["a.py", "b.py"], "edges": [["a.py", "b.py"]]},
+            "modules": [{"path": "a.py"}, {"path": "b.py"}],
+        },
+        "architecture": {
+            "clusters": [{"id": 0, "modules": ["a.py"], "internal_edges": 0}],
+            "cross_cluster_edges": [["a.py", "b.py"]],
+        },
+        "git": {
+            "repo_age_days": 400,
+            "total_commits": 1200,
+            "commit_cadence": {"weekly_counts": [10, 20], "trend": "increasing"},
+            "branches": [{"name": "main"}, {"name": "dev"}],
+        },
+    }
+
+    overview = find_repo_overview(evidence)
+
+    assert overview == {
+        "languages": [{"name": "python", "file_count": 271, "loc": 65970}],
+        "frameworks": [{"name": "fastapi"}],
+        "monorepo": {"detected": False, "workspaces": []},
+        "dependency_graph_summary": {"node_count": 2, "edge_count": 1},
+        "module_count": 2,
+        "cluster_count": 1,
+        "cross_cluster_edge_count": 1,
+        "git": {
+            "repo_age_days": 400,
+            "total_commits": 1200,
+            "commit_cadence": {"weekly_counts": [10, 20], "trend": "increasing"},
+            "branch_count": 2,
+        },
+    }
+```
+
+```python
+# src/tests/test_mcp_server.py — add near test_aletheore_imports_tool_returns_correct_result
+
+@pytest.mark.asyncio
+async def test_aletheore_overview_returns_repo_summary(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_overview", {})
+
+    body = tool_result_body(result)["result"]
+    assert body["module_count"] == 2
+    assert "languages" in body
+    assert "git" in body
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd src && python3 -m pytest tests/test_query.py -k overview tests/test_mcp_server.py -k overview -v`
+Expected: FAIL — `ImportError` / `ToolError: unknown tool "aletheore_overview"`.
+
+- [ ] **Step 3: Implement in `query.py`**
+
+Add near the other `find_*` functions (grouping doesn't matter, but keep it near `list_modules`/`list_clusters`/`list_branches` added in Task 5):
+
+```python
+def find_repo_overview(evidence: dict) -> dict:
+    repo = evidence["repository"]
+    git = evidence["git"]
+    arch = evidence["architecture"]
+    dependency_graph = repo["dependency_graph"]
+    return {
+        "languages": repo["languages"],
+        "frameworks": repo["frameworks"],
+        "monorepo": repo["monorepo"],
+        "dependency_graph_summary": {
+            "node_count": len(dependency_graph["nodes"]),
+            "edge_count": len(dependency_graph["edges"]),
+        },
+        "module_count": len(repo["modules"]),
+        "cluster_count": len(arch["clusters"]),
+        "cross_cluster_edge_count": len(arch["cross_cluster_edges"]),
+        "git": {
+            "repo_age_days": git["repo_age_days"],
+            "total_commits": git["total_commits"],
+            "commit_cadence": git["commit_cadence"],
+            "branch_count": len(git["branches"]),
+        },
+    }
+```
+
+- [ ] **Step 4: Implement in `mcp_server.py`**
+
+Add the import alongside the Task 5 additions:
+
+```python
+from aletheore.query import (
+    ModuleNotFoundInEvidenceError,
+    QUERY_FUNCTIONS,
+    find_code_evidence_for_dependency,
+    find_code_evidence_for_endpoint,
+    find_code_evidence_for_symbol,
+    find_cluster,
+    find_imported_by,
+    find_imports,
+    find_repo_overview,
+    find_symbol_source,
+    list_branches,
+    list_clusters,
+    list_modules,
+)
+```
+
+Add a registration function next to `_register_list_tool`:
+
+```python
+def _register_overview_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_overview", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_overview() -> str:
+        """A repo-level summary: languages, frameworks, monorepo structure,
+        dependency-graph size, module/cluster counts, and git age/commit
+        cadence/branch count. The starting point for 'what is this repo?' -
+        call this before anything else on an unfamiliar repository."""
+        evidence = read_evidence(repo_path)
+        return _toon_result(find_repo_overview(evidence))
+```
+
+Register it in `build_server`, next to `_register_list_tool`:
+
+```python
+    _register_query_wrapper_tools(mcp_instance, repo_path)
+    _register_changes_tool(mcp_instance, repo_path)
+    _register_neighborhood_tool(mcp_instance, repo_path)
+    _register_list_tool(mcp_instance, repo_path)
+    _register_overview_tool(mcp_instance, repo_path)
+    _register_search_tool(mcp_instance, repo_path)
+    _register_symbol_source_tool(mcp_instance, repo_path)
+    _register_code_evidence_tools(mcp_instance, repo_path)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd src && python3 -m pytest tests/test_query.py -k overview tests/test_mcp_server.py -k overview -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/aletheore/query.py src/aletheore/mcp_server.py src/tests/test_query.py src/tests/test_mcp_server.py
+git commit -m "feat: add aletheore_overview MCP tool - the 'what is this repo?' answer
+
+repository.languages/.frameworks/.monorepo/.dependency_graph and
+git.commit_cadence/.repo_age_days/.total_commits sit in evidence but were
+reachable by no tool - the first question any agent asks about an
+unfamiliar repo had no single call to answer it. Returns summarized
+counts for the dependency graph and cross-cluster edges rather than the
+raw graph, matching the file's existing TOON-cost-consciousness -
+aletheore_neighborhood/_cluster already cover the full-detail case."
+```
+
+---
+
+### Task 7: Expose citation verification as `aletheore_verify_citations`
+
+**Files:**
+- Modify: `src/aletheore/mcp_server.py` (add one new tool registration)
+- Test: `src/tests/test_mcp_server.py`
+
+**Interfaces:**
+- Consumes: `verify_citations` and `local_line_count_fetcher` from `aletheore.citation_verifier` (`citation_verifier.py:105`, `:169`).
+- Produces: tool `aletheore_verify_citations(report_text: str) -> str`.
+
+**Why:** `aletheore verify` (CLI, `cli.py:865-895`) checks a report's `file:line` citations against real evidence and real file line counts — arguably the product's most differentiated capability, and precisely what an agent writing a grounded report from these same MCP tools would want before presenting it. Not exposed via MCP at all. Takes `report_text` directly (a string) rather than a file path: an MCP-calling agent already has the report text in its own context and has no reason to round-trip it through disk first, unlike the CLI's `_verify` which is driven by a human pointing at an existing file.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# src/tests/test_mcp_server.py — add near test_aletheore_symbol_source_returns_exact_source
+
+@pytest.mark.asyncio
+async def test_aletheore_verify_citations_reports_verified_and_unverified(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    (repo / "a.py").write_text("def foo():\n    pass\n")
+    server = build_server(repo)
+
+    report = "See `a.py:1` for the real one and `nonexistent.py:5` for the fake one."
+    result = await server.call_tool("aletheore_verify_citations", {"report_text": report})
+
+    body = tool_result_body(result)["result"]
+    assert body["total_citations"] == 2
+    assert len(body["verified"]) == 1
+    assert len(body["unverified"]) == 1
+    assert body["unverified"][0]["file"] == "nonexistent.py"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py::test_aletheore_verify_citations_reports_verified_and_unverified -v`
+Expected: FAIL — `ToolError: unknown tool "aletheore_verify_citations"`.
+
+- [ ] **Step 3: Implement**
+
+Add a registration function in `mcp_server.py`, next to `_register_symbol_source_tool`:
+
+```python
+def _register_verify_citations_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_verify_citations", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_verify_citations(report_text: str) -> str:
+        """Checks every `file:line` citation in report_text against this
+        repo's real evidence and real file line counts. Call this on any
+        report you write before presenting it - a citation naming a file
+        that isn't in evidence, or a line beyond the file's real length, is
+        flagged as unverified rather than trusted."""
+        from aletheore.citation_verifier import local_line_count_fetcher, verify_citations
+
+        evidence = read_evidence(repo_path)
+        result = verify_citations(
+            report_text, evidence, fetch_line_count=local_line_count_fetcher(repo_path)
+        )
+        return _toon_result(result)
+```
+
+Register it in `build_server`, next to `_register_symbol_source_tool` (currently `mcp_server.py:619`):
+
+```python
+    _register_symbol_source_tool(mcp_instance, repo_path)
+    _register_verify_citations_tool(mcp_instance, repo_path)
+    _register_code_evidence_tools(mcp_instance, repo_path)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py::test_aletheore_verify_citations_reports_verified_and_unverified -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/aletheore/mcp_server.py src/tests/test_mcp_server.py
+git commit -m "feat: add aletheore_verify_citations MCP tool
+
+aletheore verify (CLI) checks a report's file:line citations against real
+evidence and real file line counts - arguably the product's most
+differentiated capability, and exactly what an agent writing a grounded
+report from these same MCP tools would want before presenting it. Takes
+report_text directly rather than a file path, since an MCP-calling agent
+already has the text in context."
+```
+
+---
+
+### Task 8: Update the tool-inventory tests for the three new tools
+
+**Files:**
+- Modify: `src/tests/test_mcp_server.py:220-263` (`test_build_server_registers_expected_tools`)
+- Modify: `src/tests/test_mcp_consent.py` (any hardcoded default-tool-count assertions)
+
+**Interfaces:**
+- Consumes: nothing new — this task only updates assertions to match the tool set Tasks 1-7 produced.
+
+**Why:** `test_build_server_registers_expected_tools` (`test_mcp_server.py:262`) asserts `len(names) == 28` — the pre-existing full inventory. After Tasks 5-7 add `aletheore_list`, `aletheore_overview`, `aletheore_verify_citations` (all unconditionally-registered read-only tools), the full inventory (with every effect allowed) becomes 31. `test_mcp_consent.py` may have its own count-based assertions for the *default* posture (previously 27; now 30, since the three new tools are all read-only and register unconditionally regardless of `ALETHEORE_MCP_ALLOW`).
+
+- [ ] **Step 1: Update the full-inventory test**
+
+In `test_mcp_server.py`, update `test_build_server_registers_expected_tools` (currently ending at line 262-263):
+
+```python
+    expected = {
+        "aletheore_imports",
+        "aletheore_imported_by",
+        "aletheore_symbols",
+        "aletheore_branch",
+        "aletheore_ownership",
+        "aletheore_secrets",
+        "aletheore_vulnerabilities",
+        "aletheore_licenses",
+        "aletheore_endpoints",
+        "aletheore_cluster",
+        "aletheore_layer_violations",
+        "aletheore_dead_code",
+        "aletheore_hotspots",
+        "aletheore_database",
+        "aletheore_infrastructure",
+        "aletheore_environment_variables",
+        "aletheore_changes",
+        "aletheore_neighborhood",
+        "aletheore_list",
+        "aletheore_overview",
+        "aletheore_verify_citations",
+        "aletheore_search",
+        "aletheore_symbol_source",
+        "aletheore_scan",
+        "aletheore_healthcheck",
+        "aletheore_index",
+        "aletheore_search_codebase",
+        "aletheore_managed_audit",
+        "aletheore_find_evidence_for_endpoint",
+        "aletheore_find_evidence_for_symbol",
+        "aletheore_find_evidence_for_dependency",
+    }
+    assert expected.issubset(names)
+    assert len(names) == 31
+    assert "aletheore_answer" not in names
+```
+
+- [ ] **Step 2: Run it, find every other hardcoded count**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py::test_build_server_registers_expected_tools -v`
+Expected: FAIL first (still says 28), then search the whole consent-test file for any other now-stale count:
+
+Run: `grep -n "len(names)\|== 27\|== 28\|_DEFAULT" tests/test_mcp_consent.py`
+
+For each match found, update the expected count the same way: add 3 for every posture that includes the default read-only tool set (every posture does, since `aletheore_list`/`_overview`/`_verify_citations` register unconditionally like the other 20 always-on read-only tools — they are never in `TOOL_REQUIRED_EFFECTS` and never behind `permitted(...)`).
+
+- [ ] **Step 3: Run the full test suite to verify no other count is stale**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py tests/test_mcp_consent.py -v`
+Expected: PASS, zero failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tests/test_mcp_server.py src/tests/test_mcp_consent.py
+git commit -m "test: update tool-inventory counts for aletheore_list/_overview/_verify_citations
+
+Three new always-on read-only tools shift every hardcoded tool-count
+assertion up by 3."
+```
+
+---
+
+### Task 9: Fix the website doc inconsistency, then verify the whole server end-to-end
+
+**Files:**
+- Modify: `website/developers.html:152-183`
+- No test file — this task's verification is a real, live invocation of the built server, not a pytest run.
+
+**Why (doc fix):** `website/developers.html:183` says "28 tools are always available" and lists `aletheore_managed_audit` (line 178) with no gated marker — both wrong. `aletheore_managed_audit` requires `EFFECT_EXTERNAL` (`mcp_server.py:595`), off by default, exactly like `aletheore_answer` which the page already marks with an `optional` class and a title tooltip. `README.md` and `website/llms.txt` already state the correct default count. After Task 5-7, the default-posture count is also higher than what any doc currently says.
+
+**Why (end-to-end verification):** This whole plan started because 26 of 27 tools were confirmed dead on this exact machine (`air.json` written by `aletheore_version='0.2.0'`, incompatible with the current build). Every fix above was verified only by mocked unit tests. Before calling this done, run the real server against this repo's real, freshly-regenerated evidence and call a representative sample of tools for real — including the three brand-new ones and the two tools this plan changed the error paths of.
+
+- [ ] **Step 1: Fix `website/developers.html`**
+
+Replace lines 152-181 (the `<span>` list) by inserting the three new tool names in the same style as the existing list, and mark `aletheore_managed_audit` as gated to match `aletheore_answer*`'s existing pattern:
+
+```html
+        <div class="mcp-tool-list">
+          <span>aletheore_scan</span>
+          <span>aletheore_imports</span>
+          <span>aletheore_imported_by</span>
+          <span>aletheore_symbols</span>
+          <span>aletheore_branch</span>
+          <span>aletheore_ownership</span>
+          <span>aletheore_secrets</span>
+          <span>aletheore_vulnerabilities</span>
+          <span>aletheore_licenses</span>
+          <span>aletheore_endpoints</span>
+          <span>aletheore_cluster</span>
+          <span>aletheore_layer_violations</span>
+          <span>aletheore_dead_code</span>
+          <span>aletheore_hotspots</span>
+          <span>aletheore_database</span>
+          <span>aletheore_infrastructure</span>
+          <span>aletheore_environment_variables</span>
+          <span>aletheore_changes</span>
+          <span>aletheore_neighborhood</span>
+          <span>aletheore_list</span>
+          <span>aletheore_overview</span>
+          <span>aletheore_verify_citations</span>
+          <span>aletheore_search</span>
+          <span>aletheore_symbol_source</span>
+          <span>aletheore_find_evidence_for_endpoint</span>
+          <span>aletheore_find_evidence_for_symbol</span>
+          <span>aletheore_find_evidence_for_dependency</span>
+          <span>aletheore_healthcheck</span>
+          <span>aletheore_index</span>
+          <span>aletheore_search_codebase</span>
+          <span class="optional" title="Only registered when the MCP server is started with --agent">aletheore_answer*</span>
+          <span class="optional" title="Requires ALETHEORE_MCP_ALLOW to include 'external' - off by default">aletheore_managed_audit*</span>
+        </div>
+        <p class="mcp-tool-note">30 tools are available by default. <code>aletheore_answer</code>* is registered only when the server is started with <code>--agent</code>; <code>aletheore_managed_audit</code>* requires explicit consent to transmit evidence externally (<code>ALETHEORE_MCP_ALLOW=...,external</code>) and is off by default.</p>
+```
+
+- [ ] **Step 2: Check `README.md` and `website/llms.txt` for the same stale counts**
+
+Run: `grep -n "27\|28\b" README.md website/llms.txt 2>/dev/null`
+
+For any hit describing the MCP tool count, update it to match: 30 tools by default (23 original read-only + 3 new read-only + `aletheore_scan`/`_healthcheck`/`_index`/`_search_codebase` = the same effectful set as before, all still on by default), 31 with `external` allowed, 32 with `--agent` too.
+
+- [ ] **Step 3: Real end-to-end verification — regenerate evidence and hand-invoke the server**
+
+```bash
+cd /path/to/this/worktree
+python3 -m pip install -e src   # if not already installed in this environment
+python3 -m aletheore.cli scan .   # or: aletheore scan . — regenerates .aletheore/air.json at the current schema version
+```
+
+Expected: completes without error; `.aletheore/air.json`'s `aletheore_version` now matches the current build (check with `python3 -c "import json; print(json.load(open('.aletheore/air.json'))['aletheore_version'])"` against `src/aletheore/evidence.py`'s `EVIDENCE_VERSION`).
+
+Then, from a Python REPL or a throwaway script in this worktree, build the server directly and call a representative sample of tools for real — not mocked:
+
+```python
+import asyncio
+from pathlib import Path
+from aletheore.mcp_server import build_server
+
+async def main():
+    server = build_server(Path("."), allow=frozenset({"write", "network", "external"}))
+    tools = await server.list_tools()
+    print(f"{len(tools)} tools registered")
+    assert len(tools) == 31  # or 32 if --agent-equivalent answer_adapter is also passed
+
+    for name, args in [
+        ("aletheore_overview", {}),
+        ("aletheore_list", {"kind": "modules"}),
+        ("aletheore_changes", {}),
+        ("aletheore_search", {"pattern": "def build_server"}),
+        ("aletheore_verify_citations", {"report_text": "See `src/aletheore/mcp_server.py:1` for the top of the file."}),
+    ]:
+        result = await server.call_tool(name, args)
+        print(f"--- {name} ---")
+        print(result.content[0].text[:500])
+
+asyncio.run(main())
+```
+
+Expected: every call returns real, non-error TOON output (`aletheore_overview` shows this repo's actual language/module counts; `aletheore_list` with `kind=modules` returns real file paths from this repo; `aletheore_search` finds the real `build_server` definition; `aletheore_verify_citations` reports the citation verified since `mcp_server.py` line 1 is real). None of these being possible on this exact machine before Task 9 (everything failed with the version-incompatibility error) is the actual proof this plan is done, not just that the mocked unit tests pass.
+
+- [ ] **Step 4: Run the complete test suite one final time**
+
+Run: `cd src && python3 -m pytest tests/test_mcp_server.py tests/test_mcp_consent.py tests/test_query.py tests/test_search_index.py -v`
+Expected: PASS, zero failures, zero skips beyond any pre-existing ones unrelated to this plan.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/developers.html README.md website/llms.txt
+git commit -m "docs: fix stale MCP tool count and missing gated-marker for managed_audit
+
+website/developers.html said '28 tools are always available' and listed
+aletheore_managed_audit with no gated indicator, though it requires
+explicit external-transmission consent and is off by default - same
+treatment aletheore_answer already gets. Also brings the count current
+after Tasks 5-7 added three new default-on tools."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** All 5 bugs (consent gap, dimension mismatch, changes version-check, search ignored_paths, doc inconsistency) → Tasks 1-4, 9. All 3 gaps (list, overview, verify) → Tasks 5-7. Task 8 keeps the test suite internally consistent after 5-7. Task 9's Step 3 is the actual "retest it" the user asked for — real invocation, not just mocks, specifically because the live-broken-tools discovery is what started this plan.
+
+**Placeholder scan:** No TBD/TODO. Every step has real code, real file:line grounding verified directly against this repo's current source (not the audit transcript alone — re-read live during plan-writing), and real assertions.
+
+**Type consistency:** `allow_hosted: bool` threads unchanged through `_embed_in_batches` → `_embed_stale_by_hash` → `build_index` → `_register_index_tool`. `IndexDimensionMismatchError` is defined once (Task 2) and imported once (`mcp_server.py`), never redefined. `find_repo_overview`/`list_modules`/`list_clusters`/`list_branches` signatures in Tasks 5-6 match exactly what Task 5/6's registration functions call them with (`func(evidence)`, no extra args).

--- a/src/README.md
+++ b/src/README.md
@@ -441,9 +441,10 @@ Starts a stdio MCP server scoped to one repository, so a coding agent can query 
 directly instead of shelling out via Bash or re-reading files on every lookup. Every tool
 result is [TOON](https://toonformat.dev)-encoded rather than plain JSON — the calling agent's
 own token budget is what actually pays for reading these results, and evidence's shape (almost
-entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 27 tools
-by default — see [Tool permissions](#tool-permissions) for the 28th — plus one optional answer
-tool when started with `--agent`:
+entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 26 tools in
+a read-only posture, 30 by default, and 31 with every effect permitted — see
+[Tool permissions](#tool-permissions) for what gates the rest — plus one optional answer tool
+when started with `--agent`:
 
 - The 16 query kinds above as tools, each named `aletheore_<kind>` with underscores in place of
   hyphens (`aletheore_imports`, `aletheore_imported_by`, `aletheore_symbols`, `aletheore_branch`,
@@ -453,12 +454,21 @@ tool when started with `--agent`:
   `aletheore_environment_variables`) — each tool's own description states what `target` expects
   (a file path, a branch name, or that the tool takes no target at all).
 - `aletheore_changes(full=False)` — what changed between the two most recent scans.
+- `aletheore_overview()` — a repo-level summary: languages, frameworks, monorepo structure,
+  dependency-graph size, module/cluster counts, and git age/commit cadence/branch count. The
+  starting point for "what is this repo?" — call this before anything else on an unfamiliar
+  repository.
+- `aletheore_list(kind)` — the valid names/identifiers for one evidence collection (`modules`,
+  `clusters`, or `branches`), so another tool's exact-match `target` argument can be filled in
+  correctly.
 - `aletheore_neighborhood(target)` — a module's imports, dependents, and cluster in one call,
   instead of three round-trips.
 - `aletheore_search(pattern, regex=False, path_glob=None)` — literal or regex full-text search
   over tracked source files, capped at 200 matches.
 - `aletheore_symbol_source(module, symbol)` — exact source text for one named function/class,
   with resolved line bounds.
+- `aletheore_verify_citations(report_text)` — checks every `file:line` citation in a report
+  against this repo's real evidence and real file line counts, same check as `aletheore verify`.
 - `aletheore_find_evidence_for_endpoint(method, path)`, `aletheore_find_evidence_for_symbol(symbol)`,
   `aletheore_find_evidence_for_dependency(dependency)` — resolve an endpoint/symbol/dependency to
   full source evidence: file, line, owner, commit, and (for endpoints) live-health risk.
@@ -523,12 +533,20 @@ are withheld, the server prints one line to stderr naming them and the variable 
 `aletheore_answer` reaches an LLM provider but is not gated, because it is registered only when
 you pass `aletheore mcp --agent` — that flag is already the consent step.
 
-`aletheore_index` and `aletheore_search_codebase` embed through a local Ollama instance and can
-fall back to OpenAI, which is why they might look like they belong under `external`. They don't:
-that fallback requires an interactive confirmation and is refused outright when stdin isn't a
-TTY, and an MCP server is always spawned with piped stdio. From MCP these tools reach Ollama on
-localhost or fail — they cannot send code to OpenAI. If Ollama isn't running, expect an
-"embedding provider unavailable" error rather than a silent upload.
+`aletheore_search_codebase` (and the query side of `aletheore_answer`) always embeds through a
+local Ollama instance and can fall back to OpenAI, which is why it might look like it belongs
+under `external`. It doesn't: that fallback requires an interactive confirmation and is refused
+outright when stdin isn't a TTY, and an MCP server is always spawned with piped stdio. From MCP
+this tool reaches Ollama on localhost or fails — it cannot send code to OpenAI. If Ollama isn't
+running, expect an "embedding provider unavailable" error rather than a silent upload.
+
+`aletheore_index` embeds the same way by default, but it has a second path `aletheore_search_codebase`
+doesn't: when `external` is permitted, it prefers Aletheore's own hosted embedding endpoint over
+the local instance, uploading this repository's code chunks there instead of embedding on your
+machine. With `external` withheld (the default posture), `aletheore_index` never reaches that
+hosted endpoint either — it falls through to the local Ollama/OpenAI-fallback path above, for the
+same reason `aletheore_managed_audit` doesn't upload evidence without being asked. Set
+`ALETHEORE_MCP_ALLOW=write,network,external` to opt in.
 
 ### `aletheore mcp-install [path]`
 

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -710,11 +710,18 @@ def _query(
         if target is None:
             print("error: query type 'search-codebase' requires a natural-language query")
             return 1
-        from aletheore.search_index import IndexNotFoundError, search_index
+        from aletheore.search_index import (
+            IndexDimensionMismatchError,
+            IndexNotFoundError,
+            search_index,
+        )
 
         try:
             result = search_index(Path(repo_path).resolve(), target, k=k, language=language)
         except IndexNotFoundError as exc:
+            console.print(f"[bold red]error:[/bold red] {exc}")
+            return 1
+        except IndexDimensionMismatchError as exc:
             console.print(f"[bold red]error:[/bold red] {exc}")
             return 1
         print(to_toon({"result": result}))
@@ -740,11 +747,14 @@ def _query(
                 console.print("Cancelled - no data was sent.")
                 return 0
         from aletheore.answer import answer_question
-        from aletheore.search_index import IndexNotFoundError
+        from aletheore.search_index import IndexDimensionMismatchError, IndexNotFoundError
 
         try:
             result = answer_question(Path(repo_path).resolve(), target, adapter, k=k)
         except IndexNotFoundError as exc:
+            console.print(f"[bold red]error:[/bold red] {exc}")
+            return 1
+        except IndexDimensionMismatchError as exc:
             console.print(f"[bold red]error:[/bold red] {exc}")
             return 1
         print(to_toon({"result": result}))

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -33,6 +33,7 @@ from aletheore.query import (
     find_imports,
     find_symbol_source,
 )
+from aletheore.repo_config import load_repo_config
 from aletheore.secrets import iter_all_files
 from aletheore.search_index import IndexDimensionMismatchError, IndexNotFoundError, search_index
 from aletheore.toon_encoding import to_toon
@@ -162,8 +163,9 @@ def _search_files(repo_path: Path, pattern: str, regex: bool, path_glob: str | N
     compiled = re.compile(pattern) if regex else None
     matches: list[dict] = []
     truncated = False
+    ignored_paths = load_repo_config(repo_path)["ignored_paths"]
 
-    for path in iter_all_files(repo_path):
+    for path in iter_all_files(repo_path, ignored_paths):
         rel_path = path.relative_to(repo_path).as_posix()
         if path_glob is not None and not PurePath(rel_path).match(path_glob):
             continue

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -308,10 +308,12 @@ def _register_changes_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
         if len(snapshots) < 2:
             return _toon_result({"message": "no prior snapshot to compare against"})
         try:
-            old = json.loads(snapshots[-2].read_text())
+            old = load_evidence_file(snapshots[-2])
+            new = load_evidence_file(snapshots[-1])
         except json.JSONDecodeError:
             return _toon_result({"message": f"most recent snapshot is unreadable ({snapshots[-2]})"})
-        new = json.loads(snapshots[-1].read_text())
+        except (IncompatibleEvidenceVersionError, MalformedEvidenceError) as exc:
+            return _toon_result({"error": str(exc)})
         return _toon_result(compute_diff(old, new, full=full))
 
 

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -32,6 +32,9 @@ from aletheore.query import (
     find_imported_by,
     find_imports,
     find_symbol_source,
+    list_branches,
+    list_clusters,
+    list_modules,
 )
 from aletheore.repo_config import load_repo_config
 from aletheore.secrets import iter_all_files
@@ -340,6 +343,31 @@ def _register_neighborhood_tool(mcp_instance: MCPServer, repo_path: Path) -> Non
         )
 
 
+_LIST_KIND_TO_FUNCTION = {
+    "modules": list_modules,
+    "clusters": list_clusters,
+    "branches": list_branches,
+}
+
+
+def _register_list_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_list", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_list(kind: str) -> str:
+        """Lists the valid names/identifiers for one evidence collection, so
+        other tools' exact-match `target` arguments can be filled in
+        correctly. kind: one of 'modules' (file paths, for aletheore_imports/
+        _imported_by/_symbols/_secrets/_cluster/_neighborhood/_symbol_source's
+        module argument), 'clusters' (architecture cluster ids), or
+        'branches' (git branch names, for aletheore_branch)."""
+        func = _LIST_KIND_TO_FUNCTION.get(kind)
+        if func is None:
+            return _toon_result(
+                {"error": f"unknown kind {kind!r} - expected one of {sorted(_LIST_KIND_TO_FUNCTION)}"}
+            )
+        evidence = read_evidence(repo_path)
+        return _toon_result(func(evidence))
+
+
 def _register_search_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
     @mcp_instance.tool(name="aletheore_search", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_search(pattern: str, regex: bool = False, path_glob: str | None = None) -> str:
@@ -624,6 +652,7 @@ def build_server(
     _register_query_wrapper_tools(mcp_instance, repo_path)
     _register_changes_tool(mcp_instance, repo_path)
     _register_neighborhood_tool(mcp_instance, repo_path)
+    _register_list_tool(mcp_instance, repo_path)
     _register_search_tool(mcp_instance, repo_path)
     _register_symbol_source_tool(mcp_instance, repo_path)
     _register_code_evidence_tools(mcp_instance, repo_path)

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -426,6 +426,23 @@ def _register_symbol_source_tool(mcp_instance: MCPServer, repo_path: Path) -> No
         return _toon_result(find_symbol_source(evidence, repo_path, module, symbol))
 
 
+def _register_verify_citations_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_verify_citations", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_verify_citations(report_text: str) -> str:
+        """Checks every `file:line` citation in report_text against this
+        repo's real evidence and real file line counts. Call this on any
+        report you write before presenting it - a citation naming a file
+        that isn't in evidence, or a line beyond the file's real length, is
+        flagged as unverified rather than trusted."""
+        from aletheore.citation_verifier import local_line_count_fetcher, verify_citations
+
+        evidence = read_evidence(repo_path)
+        result = verify_citations(
+            report_text, evidence, fetch_line_count=local_line_count_fetcher(repo_path)
+        )
+        return _toon_result(result)
+
+
 def _register_code_evidence_tools(mcp_instance: MCPServer, repo_path: Path) -> None:
     @mcp_instance.tool(name="aletheore_find_evidence_for_endpoint", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_find_evidence_for_endpoint(method: str, path: str) -> str:
@@ -668,6 +685,7 @@ def build_server(
     _register_overview_tool(mcp_instance, repo_path)
     _register_search_tool(mcp_instance, repo_path)
     _register_symbol_source_tool(mcp_instance, repo_path)
+    _register_verify_citations_tool(mcp_instance, repo_path)
     _register_code_evidence_tools(mcp_instance, repo_path)
 
     withheld: list[str] = []

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -34,7 +34,7 @@ from aletheore.query import (
     find_symbol_source,
 )
 from aletheore.secrets import iter_all_files
-from aletheore.search_index import IndexNotFoundError, search_index
+from aletheore.search_index import IndexDimensionMismatchError, IndexNotFoundError, search_index
 from aletheore.toon_encoding import to_toon
 
 
@@ -536,6 +536,8 @@ def _register_search_codebase_tool(mcp_instance: MCPServer, repo_path: Path) -> 
             return _toon_result(search_index(repo_path, query, k=k, language=language))
         except IndexNotFoundError:
             return _toon_result(_NO_INDEX_ERROR)
+        except IndexDimensionMismatchError as exc:
+            return _toon_result({"error": str(exc)})
 
 
 def _register_answer_tool(

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -31,6 +31,7 @@ from aletheore.query import (
     find_cluster,
     find_imported_by,
     find_imports,
+    find_repo_overview,
     find_symbol_source,
     list_branches,
     list_clusters,
@@ -368,6 +369,17 @@ def _register_list_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
         return _toon_result(func(evidence))
 
 
+def _register_overview_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_overview", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_overview() -> str:
+        """A repo-level summary: languages, frameworks, monorepo structure,
+        dependency-graph size, module/cluster counts, and git age/commit
+        cadence/branch count. The starting point for 'what is this repo?' -
+        call this before anything else on an unfamiliar repository."""
+        evidence = read_evidence(repo_path)
+        return _toon_result(find_repo_overview(evidence))
+
+
 def _register_search_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
     @mcp_instance.tool(name="aletheore_search", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_search(pattern: str, regex: bool = False, path_glob: str | None = None) -> str:
@@ -653,6 +665,7 @@ def build_server(
     _register_changes_tool(mcp_instance, repo_path)
     _register_neighborhood_tool(mcp_instance, repo_path)
     _register_list_tool(mcp_instance, repo_path)
+    _register_overview_tool(mcp_instance, repo_path)
     _register_search_tool(mcp_instance, repo_path)
     _register_symbol_source_tool(mcp_instance, repo_path)
     _register_code_evidence_tools(mcp_instance, repo_path)

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -617,6 +617,8 @@ def _register_answer_tool(
             return _toon_result(answer_question(repo_path, question, answer_adapter, k=k))
         except IndexNotFoundError:
             return _toon_result(_NO_INDEX_ERROR)
+        except IndexDimensionMismatchError as exc:
+            return _toon_result({"error": str(exc)})
 
 
 def _register_managed_audit_tool(mcp_instance: MCPServer, repo_path: Path) -> None:

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -485,25 +485,28 @@ def _register_healthcheck_tool(mcp_instance: MCPServer, repo_path: Path) -> None
         return _toon_result(result)
 
 
-def _register_index_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+def _register_index_tool(mcp_instance: MCPServer, repo_path: Path, effects: frozenset[str]) -> None:
     @mcp_instance.tool(
         name="aletheore_index",
         # Writes the vector index and sends code chunks to the embedding
-        # provider - local Ollama when it is up, OpenAI on fallback.
+        # provider - Aletheore's hosted endpoint if entitled and permitted,
+        # else local Ollama, else OpenAI on fallback.
         annotations=ToolAnnotations(
             readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
         ),
     )
     def aletheore_index() -> str:
-        """Build the semantic search index this repo's evidence, required
+        """Build the semantic search index for this repo's evidence, required
         before aletheore_search_codebase or aletheore_answer can be used.
-        Embeds via a local Ollama instance, falling back to OpenAI if
-        unavailable."""
+        Embeds via Aletheore's hosted endpoint if this session has permission
+        to transmit evidence externally and a token is available, else a
+        local Ollama instance, falling back to OpenAI if that's unavailable
+        too."""
         from aletheore.search_index import build_index
 
         evidence = read_evidence(repo_path)
         try:
-            count = build_index(repo_path, evidence)
+            count = build_index(repo_path, evidence, allow_hosted=EFFECT_EXTERNAL in effects)
         except Exception as exc:  # noqa: BLE001
             return _toon_result({"error": str(exc)})
         return _toon_result({"indexed_chunks": count})
@@ -632,7 +635,7 @@ def build_server(
     if permitted("aletheore_healthcheck"):
         _register_healthcheck_tool(mcp_instance, repo_path)
     if permitted("aletheore_index"):
-        _register_index_tool(mcp_instance, repo_path)
+        _register_index_tool(mcp_instance, repo_path, effects)
     if permitted("aletheore_search_codebase"):
         _register_search_codebase_tool(mcp_instance, repo_path)
     if permitted("aletheore_managed_audit"):

--- a/src/aletheore/query.py
+++ b/src/aletheore/query.py
@@ -70,7 +70,15 @@ def find_symbol_source(
 
 
 def find_branch(evidence: dict, target: str | None) -> dict:
-    for branch in evidence["git"]["branches"]:
+    # A repo with no commits yields git == {"available": False} - see
+    # air_schema.py's git section docstring and list_branches' matching
+    # guard. No branch named `target` can exist there, so this is a normal
+    # not-found rather than a special case: same exception as any other
+    # missing branch name, not a raw KeyError on a missing "branches" key.
+    git = evidence["git"]
+    if git.get("available") is False:
+        raise BranchNotFoundInEvidenceError(target)
+    for branch in git["branches"]:
         if branch["name"] == target:
             return branch
     raise BranchNotFoundInEvidenceError(target)

--- a/src/aletheore/query.py
+++ b/src/aletheore/query.py
@@ -164,7 +164,15 @@ def list_clusters(evidence: dict) -> list[dict]:
 
 
 def list_branches(evidence: dict) -> list[str]:
-    return [branch["name"] for branch in evidence["git"]["branches"]]
+    # A repo with no commits yields git == {"available": False} - see
+    # air_schema.py's git section docstring. There are no branches to list
+    # in that case, but that's honestly indistinguishable from "no branches
+    # were found" via a plain list return; callers that need to tell those
+    # apart should use aletheore_overview's git.available instead.
+    git = evidence["git"]
+    if git.get("available") is False:
+        return []
+    return [branch["name"] for branch in git["branches"]]
 
 
 def find_repo_overview(evidence: dict) -> dict:
@@ -172,6 +180,20 @@ def find_repo_overview(evidence: dict) -> dict:
     git = evidence["git"]
     arch = evidence["architecture"]
     dependency_graph = repo["dependency_graph"]
+    # A repo with no commits yields git == {"available": False} and nothing
+    # else (see air_schema.py). Only `available` is safe to read
+    # unconditionally there - signal that honestly instead of indexing into
+    # keys that don't exist or silently reporting zero commits, which would
+    # be indistinguishable from a repo that genuinely has zero commits.
+    if git.get("available") is False:
+        git_summary: dict = {"available": False}
+    else:
+        git_summary = {
+            "repo_age_days": git["repo_age_days"],
+            "total_commits": git["total_commits"],
+            "commit_cadence": git["commit_cadence"],
+            "branch_count": len(git["branches"]),
+        }
     return {
         "languages": repo["languages"],
         "frameworks": repo["frameworks"],
@@ -183,12 +205,7 @@ def find_repo_overview(evidence: dict) -> dict:
         "module_count": len(repo["modules"]),
         "cluster_count": len(arch["clusters"]),
         "cross_cluster_edge_count": len(arch["cross_cluster_edges"]),
-        "git": {
-            "repo_age_days": git["repo_age_days"],
-            "total_commits": git["total_commits"],
-            "commit_cadence": git["commit_cadence"],
-            "branch_count": len(git["branches"]),
-        },
+        "git": git_summary,
     }
 
 

--- a/src/aletheore/query.py
+++ b/src/aletheore/query.py
@@ -167,6 +167,31 @@ def list_branches(evidence: dict) -> list[str]:
     return [branch["name"] for branch in evidence["git"]["branches"]]
 
 
+def find_repo_overview(evidence: dict) -> dict:
+    repo = evidence["repository"]
+    git = evidence["git"]
+    arch = evidence["architecture"]
+    dependency_graph = repo["dependency_graph"]
+    return {
+        "languages": repo["languages"],
+        "frameworks": repo["frameworks"],
+        "monorepo": repo["monorepo"],
+        "dependency_graph_summary": {
+            "node_count": len(dependency_graph["nodes"]),
+            "edge_count": len(dependency_graph["edges"]),
+        },
+        "module_count": len(repo["modules"]),
+        "cluster_count": len(arch["clusters"]),
+        "cross_cluster_edge_count": len(arch["cross_cluster_edges"]),
+        "git": {
+            "repo_age_days": git["repo_age_days"],
+            "total_commits": git["total_commits"],
+            "commit_cadence": git["commit_cadence"],
+            "branch_count": len(git["branches"]),
+        },
+    }
+
+
 QUERY_FUNCTIONS: dict[str, tuple[Callable[[dict, str | None], Any], bool]] = {
     "imports": (find_imports, True),
     "imported-by": (find_imported_by, True),

--- a/src/aletheore/query.py
+++ b/src/aletheore/query.py
@@ -152,6 +152,21 @@ def find_hotspots(evidence: dict, target: str | None) -> list[dict]:
     return evidence["git"].get("hotspots", [])
 
 
+def list_modules(evidence: dict) -> list[str]:
+    return [module["path"] for module in evidence["repository"]["modules"]]
+
+
+def list_clusters(evidence: dict) -> list[dict]:
+    return [
+        {"id": cluster["id"], "module_count": len(cluster["modules"])}
+        for cluster in evidence["architecture"]["clusters"]
+    ]
+
+
+def list_branches(evidence: dict) -> list[str]:
+    return [branch["name"] for branch in evidence["git"]["branches"]]
+
+
 QUERY_FUNCTIONS: dict[str, tuple[Callable[[dict, str | None], Any], bool]] = {
     "imports": (find_imports, True),
     "imported-by": (find_imported_by, True),

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -37,6 +37,10 @@ class IndexNotFoundError(Exception):
     pass
 
 
+class IndexDimensionMismatchError(Exception):
+    pass
+
+
 def _default_confirm_openai_fallback() -> bool:
     print(
         "Ollama is unavailable. Aletheore can fall back to OpenAI's "
@@ -1122,6 +1126,24 @@ def search_index(
         language = _detect_query_language(query_text)
     table = open_index(repo_path)
     query_vector = embed_texts([query_text])[0]
+
+    # The index and the query must come from the same embedding model - see
+    # build_index's dimension-drift handling for the mechanism that keeps
+    # the index internally consistent. This is the mirror check for the
+    # query itself: the available provider can differ between when the
+    # index was built and when it's searched (e.g. a hosted token was
+    # revoked, or Ollama came up where it wasn't before), and a raw
+    # dimension mismatch otherwise surfaces as an opaque LanceDB error deep
+    # inside table.search() rather than a message telling the user what to
+    # do about it.
+    table_dimension = table.schema.field("vector").type.list_size
+    if len(query_vector) != table_dimension:
+        raise IndexDimensionMismatchError(
+            f"the index at {_index_path(repo_path)} holds {table_dimension}-dimension "
+            f"vectors but the query embedded to {len(query_vector)} dimensions with the "
+            f"embedding provider available right now - re-run 'aletheore index {repo_path}' "
+            "to rebuild the index with the current provider"
+        )
 
     # Over-fetch, then thin by file: the chunks displaced by the per-file cap
     # have to be replaced by something, and that something is only available

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -1138,11 +1138,21 @@ def search_index(
     # do about it.
     table_dimension = table.schema.field("vector").type.list_size
     if len(query_vector) != table_dimension:
+        # Query embeddings are always local (Ollama, or OpenAI as a fallback -
+        # see embed_texts above); they never consult ALETHEORE_API_TOKEN. So
+        # this mismatch is typically an index built with hosted embeddings
+        # (_embed_in_batches, which does use that token) while queries embed
+        # locally at a different dimension. Telling the user to just re-run
+        # 'aletheore index' is bad advice here: with the token still set,
+        # the rebuild uses hosted again, reproduces the same dimension, and
+        # the mismatch recurs forever. Point at what actually fixes it.
         raise IndexDimensionMismatchError(
             f"the index at {_index_path(repo_path)} holds {table_dimension}-dimension "
-            f"vectors but the query embedded to {len(query_vector)} dimensions with the "
-            f"embedding provider available right now - re-run 'aletheore index {repo_path}' "
-            "to rebuild the index with the current provider"
+            f"vectors but the query embedded to {len(query_vector)} dimensions - search "
+            "always embeds queries with the local embedding provider, never the hosted "
+            "one, so this index was likely built with hosted embeddings (ALETHEORE_API_TOKEN "
+            f"set). Unset ALETHEORE_API_TOKEN and re-run 'aletheore index {repo_path}' to "
+            "rebuild the index with the local provider that queries actually use"
         )
 
     # Over-fetch, then thin by file: the chunks displaced by the per-file cap

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -732,7 +732,10 @@ EMBED_BATCH_SIZE = 200
 
 
 def _embed_in_batches(
-    texts: list[str], batch_size: int = EMBED_BATCH_SIZE, repo_id: str | None = None
+    texts: list[str],
+    batch_size: int = EMBED_BATCH_SIZE,
+    repo_id: str | None = None,
+    allow_hosted: bool = True,
 ) -> list[list[float]]:
     """Embed everything, preferring Aletheore's endpoint when entitled.
 
@@ -749,11 +752,25 @@ def _embed_in_batches(
 
     repo_id: forwarded to embed_texts_hosted so the hosted rate limit can be
     keyed per repo rather than per installation - see _repo_id.
+
+    allow_hosted: the caller's consent to transmit this repository's code to
+    Aletheore's hosted embedding endpoint. Defaults to True to preserve the
+    CLI's existing interactive behavior. MCP's aletheore_index tool passes
+    False unless the operator has explicitly permitted EFFECT_EXTERNAL (see
+    mcp_server.py's consent model) - MCP tool calls are always
+    non-interactive, so there is no equivalent of embed_texts's isatty()
+    prompt available to ask for consent in the moment.
     """
     token = get_api_key(
         "ALETHEORE_API_TOKEN", "aletheore-managed-audit", prompt_fn=lambda _: ""
     )
-    use_hosted = bool(token)
+    use_hosted = bool(token) and allow_hosted
+    if token and not allow_hosted:
+        print(
+            "aletheore: hosted embeddings available but not permitted in this "
+            "context; using local provider",
+            file=sys.stderr,
+        )
     vectors: list[list[float]] = []
 
     for start in range(0, len(texts), batch_size):
@@ -811,16 +828,20 @@ def _reusable_vectors(index_path: Path) -> dict[str, list[float]]:
         return {}
 
 
-def _embed_stale_by_hash(stale: list[dict], repo_id: str | None = None) -> dict[str, list[float]]:
+def _embed_stale_by_hash(
+    stale: list[dict], repo_id: str | None = None, allow_hosted: bool = True
+) -> dict[str, list[float]]:
     stale_by_hash = {chunk["chunk_hash"]: chunk["text"] for chunk in stale}
     stale_hashes = list(stale_by_hash)
     fresh_vectors = _embed_in_batches(
-        [stale_by_hash[chunk_hash] for chunk_hash in stale_hashes], repo_id=repo_id
+        [stale_by_hash[chunk_hash] for chunk_hash in stale_hashes],
+        repo_id=repo_id,
+        allow_hosted=allow_hosted,
     )
     return dict(zip(stale_hashes, fresh_vectors))
 
 
-def build_index(repo_path: Path, evidence: dict) -> int:
+def build_index(repo_path: Path, evidence: dict, allow_hosted: bool = True) -> int:
     chunks = build_chunks(evidence, repo_path)
     if not chunks:
         return 0
@@ -842,7 +863,7 @@ def build_index(repo_path: Path, evidence: dict) -> int:
     reusable = _reusable_vectors(index_path)
     stale = [chunk for chunk in chunks if chunk["chunk_hash"] not in reusable]
     repo = _repo_id(repo_path)
-    fresh = _embed_stale_by_hash(stale, repo_id=repo)
+    fresh = _embed_stale_by_hash(stale, repo_id=repo, allow_hosted=allow_hosted)
     fresh_vectors = list(fresh.values())
 
     # Vectors from two different embedding models cannot share an index -
@@ -878,13 +899,13 @@ def build_index(repo_path: Path, evidence: dict) -> int:
         current_dimension = (
             len(fresh_vectors[0])
             if fresh_vectors
-            else len(_embed_in_batches([chunks[0]["text"]], repo_id=repo)[0])
+            else len(_embed_in_batches([chunks[0]["text"]], repo_id=repo, allow_hosted=allow_hosted)[0])
         )
         reused_dimensions = {len(vector) for vector in reusable.values()}
         if reused_dimensions != {current_dimension}:
             reusable = {}
             stale = chunks
-            fresh = _embed_stale_by_hash(stale, repo_id=repo)
+            fresh = _embed_stale_by_hash(stale, repo_id=repo, allow_hosted=allow_hosted)
 
     rows = [
         {**chunk, "vector": reusable.get(chunk["chunk_hash"]) or fresh[chunk["chunk_hash"]]}

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -986,6 +986,20 @@ def test_query_search_codebase_prints_toon_results(tmp_path):
     assert "auth.py" in result.output
 
 
+def test_query_search_codebase_prints_friendly_error_on_dimension_mismatch(tmp_path):
+    from aletheore.search_index import IndexDimensionMismatchError
+
+    with patch(
+        "aletheore.search_index.search_index",
+        side_effect=IndexDimensionMismatchError("the index at ... holds 1536-dimension vectors ..."),
+    ):
+        result = runner.invoke(
+            app, ["query", "search-codebase", "how does auth work", "--path", str(tmp_path)]
+        )
+    assert result.exit_code == 1
+    assert "1536-dimension" in result.output
+
+
 def test_query_answer_reuses_selected_adapter(tmp_path):
     fake_adapter = MagicMock()
     fake_adapter.name = "ollama"
@@ -1015,6 +1029,36 @@ def test_query_answer_reuses_selected_adapter(tmp_path):
     assert result.exit_code == 0
     assert "Login uses auth.py::login" in result.output
     mock_answer.assert_called_once()
+
+
+def test_query_answer_prints_friendly_error_on_dimension_mismatch(tmp_path):
+    from aletheore.search_index import IndexDimensionMismatchError
+
+    fake_adapter = MagicMock()
+    fake_adapter.name = "ollama"
+    fake_adapter.requires_consent = False
+    with patch("aletheore.cli.select_adapter", return_value=fake_adapter):
+        with patch(
+            "aletheore.answer.answer_question",
+            side_effect=IndexDimensionMismatchError(
+                "the index at ... holds 1536-dimension vectors ..."
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "query",
+                    "answer",
+                    "how does auth work",
+                    "--path",
+                    str(tmp_path),
+                    "--agent",
+                    "ollama",
+                ],
+            )
+
+    assert result.exit_code == 1
+    assert "1536-dimension" in result.output
 
 
 def test_main_mcp_invokes_mcp_flow(tmp_path):

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -253,7 +253,7 @@ def test_api_mcp_tools_reflects_the_configured_consent_posture(tmp_path):
 
     assert response.status_code == 200
     tools = response.json()
-    assert len(tools) == 27
+    assert len(tools) == 30
     names = {t["name"] for t in tools}
     assert "aletheore_managed_audit" not in names
     assert "aletheore_scan" in names

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -247,6 +247,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_environment_variables",
         "aletheore_changes",
         "aletheore_neighborhood",
+        "aletheore_list",
         "aletheore_search",
         "aletheore_symbol_source",
         "aletheore_scan",
@@ -259,7 +260,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_find_evidence_for_dependency",
     }
     assert expected.issubset(names)
-    assert len(names) == 28
+    assert len(names) == 29
     assert "aletheore_answer" not in names
 
 
@@ -939,3 +940,23 @@ async def test_aletheore_healthcheck_tool_rejects_file_scheme_base_url(tmp_path)
 
     body = tool_result_body(result)["result"]
     assert "http or https" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_aletheore_list_modules(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_list", {"kind": "modules"})
+
+    assert tool_result_body(result) == {"result": ["a.py", "b.py"]}
+
+
+@pytest.mark.asyncio
+async def test_aletheore_list_unknown_kind_returns_an_error(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_list", {"kind": "nonsense"})
+
+    assert "error" in tool_result_body(result)["result"]

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -352,6 +352,22 @@ async def test_aletheore_search_codebase_returns_friendly_error_when_index_not_b
 
 
 @pytest.mark.asyncio
+async def test_aletheore_search_codebase_returns_friendly_error_on_dimension_mismatch(tmp_path):
+    from aletheore.mcp_server import IndexDimensionMismatchError
+
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    with patch(
+        "aletheore.mcp_server.search_index",
+        side_effect=IndexDimensionMismatchError("the index at ... holds 1536-dimension vectors ..."),
+    ):
+        result = await server.call_tool("aletheore_search_codebase", {"query": "where is foo"})
+
+    assert "1536-dimension" in tool_result_body(result)["result"]["error"]
+
+
+@pytest.mark.asyncio
 async def test_aletheore_answer_returns_friendly_error_when_index_not_built(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
     server = build_server(repo, answer_adapter=MagicMock())

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -627,6 +627,28 @@ async def test_aletheore_changes_tool_reports_no_prior_snapshot(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aletheore_changes_returns_clear_error_for_incompatible_snapshot(tmp_path):
+    from aletheore.history import save_snapshot
+    from tests.air_fixtures import minimal_air_evidence
+
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    evidence = minimal_air_evidence()
+    save_snapshot(evidence, repo)  # first snapshot, compatible version
+
+    bad = minimal_air_evidence()
+    bad["aletheore_version"] = "0.0.1-does-not-exist"
+    save_snapshot(bad, repo)  # second snapshot, incompatible
+
+    result = await server.call_tool("aletheore_changes", {})
+
+    body = tool_result_body(result)["result"]
+    assert "error" in body
+    assert "0.0.1-does-not-exist" in body["error"]
+
+
+@pytest.mark.asyncio
 async def test_aletheore_neighborhood_combines_imports_imported_by_and_cluster(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
     server = build_server(repo)

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -389,6 +389,27 @@ async def test_aletheore_answer_returns_friendly_error_when_index_not_built(tmp_
 
 
 @pytest.mark.asyncio
+async def test_aletheore_answer_returns_friendly_error_on_dimension_mismatch(tmp_path):
+    # Same class of bug as aletheore_search_codebase above: answer_question
+    # calls search_index too (see aletheore/answer.py), so it can raise the
+    # same IndexDimensionMismatchError. Before this fix, aletheore_answer
+    # only caught IndexNotFoundError and let this one escape as a raw
+    # traceback.
+    from aletheore.mcp_server import IndexDimensionMismatchError
+
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo, answer_adapter=MagicMock())
+
+    with patch(
+        "aletheore.mcp_server.answer_question",
+        side_effect=IndexDimensionMismatchError("the index at ... holds 1536-dimension vectors ..."),
+    ):
+        result = await server.call_tool("aletheore_answer", {"question": "what does foo do"})
+
+    assert "1536-dimension" in tool_result_body(result)["result"]["error"]
+
+
+@pytest.mark.asyncio
 async def test_aletheore_index_tool_builds_the_search_index(tmp_path):
     # Before this fix, aletheore_search_codebase/aletheore_answer required
     # .aletheore/index.lancedb, buildable only via the CLI's `aletheore

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -98,6 +98,8 @@ def make_repo_with_evidence(tmp_path: Path) -> Path:
         "branches": [{"name": "main", "ahead_of_main": 0}],
         "ownership": [{"path": "a.py", "top_author": "alice"}],
         "total_commits": 5,
+        "repo_age_days": 30,
+        "commit_cadence": {"weekly_counts": [1, 2, 1], "trend": "stable", "most_recent_week_partial": False},
         "hotspots": [
             {
                 "path": "a.py",
@@ -248,6 +250,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_changes",
         "aletheore_neighborhood",
         "aletheore_list",
+        "aletheore_overview",
         "aletheore_search",
         "aletheore_symbol_source",
         "aletheore_scan",
@@ -260,7 +263,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_find_evidence_for_dependency",
     }
     assert expected.issubset(names)
-    assert len(names) == 29
+    assert len(names) == 30
     assert "aletheore_answer" not in names
 
 
@@ -449,6 +452,19 @@ async def test_aletheore_imports_tool_returns_correct_result(tmp_path):
     result = await server.call_tool("aletheore_imports", {"target": "a.py"})
 
     assert tool_result_body(result) == {"result": ["b.py"]}
+
+
+@pytest.mark.asyncio
+async def test_aletheore_overview_returns_repo_summary(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_overview", {})
+
+    body = tool_result_body(result)["result"]
+    assert body["module_count"] == 2
+    assert "languages" in body
+    assert "git" in body
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -384,6 +384,33 @@ async def test_aletheore_index_tool_builds_the_search_index(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aletheore_index_tool_forbids_hosted_embeddings_by_default(tmp_path):
+    # Default MCP posture is EFFECT_WRITE + EFFECT_NETWORK only (mcp_server.py's
+    # _DEFAULT_ALLOWED_EFFECTS) - EFFECT_EXTERNAL is off, so a logged-in user's
+    # code must not silently reach the hosted embedding endpoint through MCP.
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)  # default effects, no `allow=` override
+
+    with patch("aletheore.search_index.build_index", return_value=3) as mock_build_index:
+        await server.call_tool("aletheore_index", {})
+
+    _, kwargs = mock_build_index.call_args
+    assert kwargs["allow_hosted"] is False
+
+
+@pytest.mark.asyncio
+async def test_aletheore_index_tool_permits_hosted_embeddings_when_external_is_allowed(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo, allow=frozenset({"write", "network", "external"}))
+
+    with patch("aletheore.search_index.build_index", return_value=3) as mock_build_index:
+        await server.call_tool("aletheore_index", {})
+
+    _, kwargs = mock_build_index.call_args
+    assert kwargs["allow_hosted"] is True
+
+
+@pytest.mark.asyncio
 async def test_aletheore_index_tool_returns_error_instead_of_raising(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
     server = build_server(repo)

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -253,6 +253,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_overview",
         "aletheore_search",
         "aletheore_symbol_source",
+        "aletheore_verify_citations",
         "aletheore_scan",
         "aletheore_healthcheck",
         "aletheore_index",
@@ -263,7 +264,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_find_evidence_for_dependency",
     }
     assert expected.issubset(names)
-    assert len(names) == 30
+    assert len(names) == 31
     assert "aletheore_answer" not in names
 
 
@@ -475,6 +476,22 @@ async def test_aletheore_symbol_source_returns_exact_source(tmp_path):
     result = await server.call_tool("aletheore_symbol_source", {"module": "a.py", "symbol": "foo"})
 
     assert tool_result_body(result)["result"]["source"] == "def foo():"
+
+
+@pytest.mark.asyncio
+async def test_aletheore_verify_citations_reports_verified_and_unverified(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    (repo / "a.py").write_text("def foo():\n    pass\n")
+    server = build_server(repo)
+
+    report = "See `a.py:1` for the real one and `nonexistent.py:5` for the fake one."
+    result = await server.call_tool("aletheore_verify_citations", {"report_text": report})
+
+    body = tool_result_body(result)["result"]
+    assert body["total_citations"] == 2
+    assert len(body["verified"]) == 1
+    assert len(body["unverified"]) == 1
+    assert body["unverified"][0]["file"] == "nonexistent.py"
 
 
 @pytest.mark.asyncio

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -800,6 +800,23 @@ async def test_aletheore_search_caps_at_200_and_flags_truncated(tmp_path):
     assert result_body["truncated"] is True
 
 
+@pytest.mark.asyncio
+async def test_aletheore_search_respects_repo_config_ignored_paths(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    (repo / "vendor").mkdir()
+    (repo / "vendor" / "bundle.js").write_text("needle in a vendored file")
+    (repo / "real.py").write_text("needle in a real file")
+    (repo / ".aletheore.json").write_text(json.dumps({"ignored_paths": ["vendor/**"]}))
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_search", {"pattern": "needle"})
+
+    matches = tool_result_body(result)["result"]["matches"]
+    matched_paths = {m["path"] for m in matches}
+    assert "real.py" in matched_paths
+    assert "vendor/bundle.js" not in matched_paths
+
+
 def make_git_repo_with_source(tmp_path: Path) -> Path:
     repo = tmp_path / "git_repo"
     repo.mkdir()

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -197,6 +197,15 @@ def test_find_branch_raises_for_unknown_branch():
         find_branch(make_evidence(), "does-not-exist")
 
 
+def test_find_branch_raises_not_found_instead_of_crashing_when_git_unavailable():
+    """A repo with no commits yields git == {"available": False} and
+    nothing else (see air_schema.py). No branch can exist there, so this
+    is a normal not-found - not a raw KeyError on a missing "branches" key."""
+    evidence = {"git": {"available": False}}
+    with pytest.raises(BranchNotFoundInEvidenceError):
+        find_branch(evidence, "main")
+
+
 def test_find_ownership_returns_the_whole_list_ignoring_target():
     result = find_ownership(make_evidence(), None)
     assert result == make_evidence()["git"]["ownership"]

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -345,3 +345,34 @@ def test_query_functions_registry_has_all_kinds_with_correct_requires_target():
     for kind, requires_target in expected.items():
         _func, actual_requires_target = QUERY_FUNCTIONS[kind]
         assert actual_requires_target == requires_target, kind
+
+
+def test_list_modules_returns_every_module_path():
+    from aletheore.query import list_modules
+
+    evidence = {"repository": {"modules": [{"path": "a.py"}, {"path": "b.py"}]}}
+    assert list_modules(evidence) == ["a.py", "b.py"]
+
+
+def test_list_clusters_returns_id_and_module_count():
+    from aletheore.query import list_clusters
+
+    evidence = {
+        "architecture": {
+            "clusters": [
+                {"id": 0, "modules": ["a.py", "b.py"], "internal_edges": 1},
+                {"id": 1, "modules": ["c.py"], "internal_edges": 0},
+            ]
+        }
+    }
+    assert list_clusters(evidence) == [
+        {"id": 0, "module_count": 2},
+        {"id": 1, "module_count": 1},
+    ]
+
+
+def test_list_branches_returns_every_branch_name():
+    from aletheore.query import list_branches
+
+    evidence = {"git": {"branches": [{"name": "main"}, {"name": "dev"}]}}
+    assert list_branches(evidence) == ["main", "dev"]

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -376,3 +376,45 @@ def test_list_branches_returns_every_branch_name():
 
     evidence = {"git": {"branches": [{"name": "main"}, {"name": "dev"}]}}
     assert list_branches(evidence) == ["main", "dev"]
+
+
+def test_find_repo_overview_summarizes_the_real_evidence_shape():
+    from aletheore.query import find_repo_overview
+
+    evidence = {
+        "repository": {
+            "languages": [{"name": "python", "file_count": 271, "loc": 65970}],
+            "frameworks": [{"name": "fastapi"}],
+            "monorepo": {"detected": False, "workspaces": []},
+            "dependency_graph": {"nodes": ["a.py", "b.py"], "edges": [["a.py", "b.py"]]},
+            "modules": [{"path": "a.py"}, {"path": "b.py"}],
+        },
+        "architecture": {
+            "clusters": [{"id": 0, "modules": ["a.py"], "internal_edges": 0}],
+            "cross_cluster_edges": [["a.py", "b.py"]],
+        },
+        "git": {
+            "repo_age_days": 400,
+            "total_commits": 1200,
+            "commit_cadence": {"weekly_counts": [10, 20], "trend": "increasing"},
+            "branches": [{"name": "main"}, {"name": "dev"}],
+        },
+    }
+
+    overview = find_repo_overview(evidence)
+
+    assert overview == {
+        "languages": [{"name": "python", "file_count": 271, "loc": 65970}],
+        "frameworks": [{"name": "fastapi"}],
+        "monorepo": {"detected": False, "workspaces": []},
+        "dependency_graph_summary": {"node_count": 2, "edge_count": 1},
+        "module_count": 2,
+        "cluster_count": 1,
+        "cross_cluster_edge_count": 1,
+        "git": {
+            "repo_age_days": 400,
+            "total_commits": 1200,
+            "commit_cadence": {"weekly_counts": [10, 20], "trend": "increasing"},
+            "branch_count": 2,
+        },
+    }

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -418,3 +418,60 @@ def test_find_repo_overview_summarizes_the_real_evidence_shape():
             "branch_count": 2,
         },
     }
+
+
+def test_list_branches_returns_empty_list_when_git_unavailable():
+    """A repo with no commits yields git == {"available": False} and
+    nothing else (see air_schema.py). list_branches must not raise a
+    KeyError trying to index into a "branches" key that doesn't exist."""
+    from aletheore.query import list_branches
+
+    evidence = {"git": {"available": False}}
+    assert list_branches(evidence) == []
+
+
+def test_find_repo_overview_signals_unavailable_git_instead_of_crashing():
+    """Same no-commits repo shape as above. find_repo_overview must not
+    raise, and must honestly report git as unavailable rather than
+    defaulting numeric fields to 0 - which would be indistinguishable from
+    a repo that genuinely has zero commits."""
+    from aletheore.query import find_repo_overview
+
+    evidence = {
+        "repository": {
+            "languages": [{"name": "python", "file_count": 10, "loc": 500}],
+            "frameworks": [],
+            "monorepo": {"detected": False, "workspaces": []},
+            "dependency_graph": {"nodes": [], "edges": []},
+            "modules": [],
+        },
+        "architecture": {
+            "clusters": [],
+            "cross_cluster_edges": [],
+        },
+        "git": {"available": False},
+    }
+
+    overview = find_repo_overview(evidence)
+
+    assert overview["git"] == {"available": False}
+
+
+def test_list_modules_does_not_depend_on_git_and_is_unaffected_by_unavailable_git():
+    from aletheore.query import list_modules
+
+    evidence = {
+        "repository": {"modules": [{"path": "a.py"}]},
+        "git": {"available": False},
+    }
+    assert list_modules(evidence) == ["a.py"]
+
+
+def test_list_clusters_does_not_depend_on_git_and_is_unaffected_by_unavailable_git():
+    from aletheore.query import list_clusters
+
+    evidence = {
+        "architecture": {"clusters": [{"id": 0, "modules": ["a.py"], "internal_edges": 0}]},
+        "git": {"available": False},
+    }
+    assert list_clusters(evidence) == [{"id": 0, "module_count": 1}]

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -247,6 +247,44 @@ def test_open_index_raises_when_missing(tmp_path):
         open_index(tmp_path)
 
 
+def test_search_index_raises_a_clear_error_on_dimension_mismatch(tmp_path):
+    """An index built with 1536-dim hosted vectors, searched with a 768-dim
+    local query vector, must fail with an actionable message - not an
+    opaque LanceDB internal error and not silently wrong rankings."""
+    from aletheore.search_index import (
+        IndexDimensionMismatchError,
+        TABLE_NAME,
+        _index_path,
+        search_index,
+    )
+    import lancedb
+
+    repo = tmp_path
+    index_path = _index_path(repo)
+    index_path.parent.mkdir(parents=True)
+    db = lancedb.connect(str(index_path))
+    db.create_table(
+        TABLE_NAME,
+        data=[
+            {
+                "module_path": "a.py",
+                "symbol_name": "foo",
+                "start_line": 1,
+                "end_line": 2,
+                "language": "python",
+                "imports": [],
+                "text": "def foo(): pass",
+                "chunk_hash": "abc",
+                "vector": [0.1] * 1536,
+            }
+        ],
+    )
+
+    with patch("aletheore.search_index.embed_texts", return_value=[[0.0] * 768]):
+        with pytest.raises(IndexDimensionMismatchError, match="1536.*768|768.*1536"):
+            search_index(repo, "where is foo")
+
+
 @patch("aletheore.search_index.embed_texts")
 def test_search_index_returns_ranked_results(mock_embed_texts, tmp_path):
     (tmp_path / "auth.py").write_text("def login():\n    return True\n")
@@ -336,6 +374,7 @@ def test_search_caps_chunks_per_file_and_backfills(tmp_path):
         for i in range(5)
     ]
     table = MagicMock()
+    table.schema.field.return_value.type.list_size = 1
     table.search.return_value.limit.return_value.to_list.return_value = hoggish + others
 
     with patch("aletheore.search_index.open_index", return_value=table), \
@@ -827,6 +866,7 @@ def test_fts_failure_degrades_to_vector_only(tmp_path):
     full of punctuation can be rejected by the tokenizer. Neither is worth
     losing search over."""
     table = MagicMock()
+    table.schema.field.return_value.type.list_size = 1
     table.search.return_value.limit.return_value.to_list.return_value = [
         {"module_path": "a.py", "symbol_name": "f", "start_line": 1, "end_line": 2,
          "language": "python", "imports": [], "text": "x", "_distance": 0.1}
@@ -885,6 +925,7 @@ def test_search_index_filters_both_retrievers_by_language(tmp_path):
     same where clause to both the vector query and the fts query, not only
     the vector one."""
     table = MagicMock()
+    table.schema.field.return_value.type.list_size = 1
     chain = table.search.return_value.limit.return_value
     chain.where.return_value.to_list.return_value = [
         {"module_path": "a.py", "symbol_name": "f", "start_line": 1, "end_line": 2,

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -1278,6 +1278,29 @@ def test_no_token_means_no_hosted_call_at_all():
     http.post.assert_not_called()
 
 
+def test_allow_hosted_false_skips_hosted_call_even_with_a_token(capsys):
+    http = MagicMock()
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http), \
+         patch("aletheore.search_index.embed_texts", side_effect=lambda t: [[0.0] * 768] * len(t)):
+        vectors = _embed_in_batches(["chunk"], allow_hosted=False)
+
+    http.post.assert_not_called()
+    assert len(vectors[0]) == 768
+    assert "not permitted in this context" in capsys.readouterr().err
+
+
+def test_allow_hosted_true_is_the_default_and_preserves_existing_behavior():
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.1] * 1536]})
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http):
+        vectors = _embed_in_batches(["chunk"])  # no allow_hosted kwarg at all
+
+    http.post.assert_called_once()
+    assert len(vectors[0]) == 1536
+
+
 def test_file_header_comment_stops_at_the_first_definition():
     """Skipping past code to find a comment does not find the file header - it
     finds the first class or function docstring, and then staples that one

--- a/website/developers.html
+++ b/website/developers.html
@@ -169,6 +169,9 @@ aletheore dashboard .</code></pre>
           <span>aletheore_environment_variables</span>
           <span>aletheore_changes</span>
           <span>aletheore_neighborhood</span>
+          <span>aletheore_list</span>
+          <span>aletheore_overview</span>
+          <span>aletheore_verify_citations</span>
           <span>aletheore_search</span>
           <span>aletheore_symbol_source</span>
           <span>aletheore_find_evidence_for_endpoint</span>
@@ -178,9 +181,9 @@ aletheore dashboard .</code></pre>
           <span>aletheore_index</span>
           <span>aletheore_search_codebase</span>
           <span class="optional" title="Only registered when the MCP server is started with --agent">aletheore_answer*</span>
-          <span>aletheore_managed_audit</span>
+          <span class="optional" title="Requires ALETHEORE_MCP_ALLOW to include 'external' - off by default">aletheore_managed_audit*</span>
         </div>
-        <p class="mcp-tool-note">28 tools are always available. <code>aletheore_answer</code>* is registered only when the server is started with <code>--agent</code>.</p>
+        <p class="mcp-tool-note">30 tools are available by default. <code>aletheore_answer</code>* is registered only when the server is started with <code>--agent</code>; <code>aletheore_managed_audit</code>* requires explicit consent to transmit evidence externally (<code>ALETHEORE_MCP_ALLOW=...,external</code>) and is off by default.</p>
       </section>
 
       <section class="developer-section evidence-contract">

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -47,11 +47,11 @@ This matters if you build on Aletheore: a key rename is a breaking change and is
 
 `aletheore diff` compares two evidence snapshots. `aletheore verify` checks a report's `file:line` citations against a repository's actual evidence — including reports Aletheore did not write.
 
-## MCP server — free, local, 27 tools
+## MCP server — free, local, 30 tools
 
 `aletheore mcp` runs a stdio MCP server. `aletheore mcp-install` writes client config for Claude Code, Cursor, VS Code, Kiro, Opencode, and Codex CLI.
 
-**27 tools by default; 23 in read-only mode; 28 with evidence upload enabled.** No account required.
+**30 tools by default; 26 in read-only mode; 31 with evidence upload enabled.** No account required.
 
 Tools are grouped by effect class — `write`, `network`, `external` — and a tool whose effects are not permitted is **never registered**, so it cannot be called at all. Evidence upload to the hosted service is off by default. Set `ALETHEORE_MCP_ALLOW` to change it.
 


### PR DESCRIPTION
## Summary

Fixes 6 real bugs and closes 3 capability gaps found in a live audit of `src/aletheore/mcp_server.py` — the MCP server was confirmed dead on the auditing machine (26/27 tools failing with an evidence-version-incompatibility error), which motivated this whole pass.

**Bugs fixed:**
- **Consent gap**: `aletheore_index` silently uploaded code to Aletheore's hosted embedding endpoint under the default MCP posture, with no consent check — every MCP call is non-interactive, unlike the CLI's own OpenAI-fallback path which explicitly refuses on non-TTY. Now gated behind the existing `EFFECT_EXTERNAL` consent class.
- **Dimension-mismatch corruption**: `search_index()` had no guard against an index built with one embedding provider being searched with vectors from another (768 vs 1536-dim) — would crash inside LanceDB with an opaque error or silently rank garbage. Now raises a clear, actionable `IndexDimensionMismatchError`, caught at all 4 real call sites (2 MCP tools, 2 CLI commands).
- **`aletheore_changes`** bypassed the evidence version-compatibility check every other reader in the file uses (bare `json.loads` instead of `load_evidence_file`).
- **`aletheore_search`** ignored `.aletheore.json`'s `ignored_paths` config, unlike the real scanner.
- **`find_repo_overview`, `list_branches`, `find_branch`** all raised raw `KeyError`s on schema-valid evidence from a repo with no git history (`git == {"available": False}`) — found across a per-task review, a final whole-branch review, and one follow-up fix.
- **Stale docs**: tool counts and gating markers were wrong in `README.md`, `src/README.md`, `website/developers.html`, `website/llms.txt`.

**New tools** (closing capability gaps — 8 of 16 existing tools need an exact name with nothing to list valid ones, and no tool answered "what is this repo?"):
- `aletheore_list` — list modules/clusters/branches by name
- `aletheore_overview` — repo-level summary (languages, frameworks, git cadence, etc.)
- `aletheore_verify_citations` — exposes citation verification via MCP

Default tool count: 26 (read-only) → 30 (default posture) → 31 (with `ALETHEORE_MCP_ALLOW=...,external`).

## Process

Built via `superpowers:subagent-driven-development`: 9 planned tasks, each independently implemented and task-reviewed (spec + quality), followed by a whole-branch review (opus) that found 4 additional cross-cutting Important findings invisible to per-task review — all fixed in one wave and re-reviewed clean. One more instance of the same git-availability bug class was found afterward and folded in as a 10th fix.

## Test plan
- [x] 337 tests passing across `test_mcp_server.py`, `test_mcp_consent.py`, `test_query.py`, `test_search_index.py`, `test_cli.py`
- [x] Real end-to-end verification: regenerated this repo's own evidence with a fresh scan, confirmed the version-incompatibility failure mode is gone, then called 7+ tools for real (not mocked) against the live server — real repo data, real file paths, a real symbol location, a real citation check
- [x] Final whole-branch review (opus) — Ready to merge: With fixes, all 4 findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)