### PR TITLE
fix: Flash Review spend-lock held for the whole review, causing failures under concurrent PR load

### DIFF
--- a/benchmarks/pr-review-benchmark/SWEBENCH_RUN_STATUS.md
+++ b/benchmarks/pr-review-benchmark/SWEBENCH_RUN_STATUS.md
@@ -1,0 +1,318 @@
+# SWE-bench citation-grounding run — status / handoff
+
+**Started:** 2026-08-15. **Owner:** Arihant + Claude (this session). Read this
+top to bottom before touching anything if you're picking this up cold.
+
+## Why this exists
+
+We wanted a real number for "what fraction of Aletheore Flash Review's PR
+citations are actually grounded in the code" (not `n=1`, which is all the
+*existing* 3-case benchmark run had produced — see
+`benchmarks/pr-review-benchmark/README.md` for that harness). The user
+explicitly chose to source cases from **SWE-bench Verified** instead of
+hand-authoring more cases, specifically *because* it's an external dataset
+we don't control — "for actual results with no control from our side, will
+show our worst side." Don't quietly swap back to a hand-picked or
+convenience sample; the whole point is the sample is externally fixed.
+
+## What "done" looks like
+
+1. 25 real SWE-bench Verified bugs, each opened as a real PR, each with a
+   real `aletheore[bot]` Flash Review comment.
+2. Run `scripts.check_citations.verify_findings_against_checkout` (via
+   `normalize_aletheore`, **after** the fix below) against all 25 to get a
+   real location-grounding rate and content-grounding rate.
+3. Report the number honestly, including the cases with zero findings
+   (that's real data too, not a gap in coverage).
+
+## State as of last update
+
+- [x] Downloaded SWE-bench Verified (500 instances, 12 Python repos) →
+      `/tmp/swebench_verified.parquet` (not committed; re-download if gone,
+      see "How to reproduce the sample" below).
+- [x] Drew a **reproducible random sample of 25** (`pandas.sample(n=25,
+      random_state=42)`) → `/tmp/swebench_sample_25.json`. Distribution:
+      9 django, 5 scikit-learn, 4 sphinx, 4 sympy, 1 each
+      astropy/matplotlib/xarray. **Seed is 42 — if this file is lost,
+      re-run the sample command below and you'll get the identical 25.**
+- [x] Validated the case-construction approach end-to-end, by hand, on one
+      instance (`sympy__sympy-23534`) before scaling — confirmed the
+      reverse-diff construction correctly reintroduces the real bug.
+- [x] Fixed a real bug in `scripts/normalize.py`'s `normalize_aletheore`:
+      it was checking a finding's *suggested fix* against the *current*
+      code for content-grounding, which can only fail by construction (see
+      git log / the Codex instructions file that was handed off for this —
+      search for "normalize_aletheore" in recent commits to confirm this
+      landed; if not, the instructions are preserved in this session's
+      transcript and need to be re-applied before trusting any
+      content-grounding number from this run).
+- [x] Created `Aletheore/pr-review-benchmark-sandbox` (private) — replaces
+      the old personal-account `ArihantK15/proctor-browser` scratch repo.
+      **Not needed anymore**: confirmed the Aletheore GitHub App is
+      installed **org-wide** on `Aletheore` (`repository_selection: all`,
+      installation id 147514632) so any new repo under the org gets Flash
+      Review automatically, no manual install step.
+- [x] Forked the 7 source repos under the `Aletheore` org (durable push
+      targets — can't push synthetic commits to the real upstream repos):
+      `Aletheore/astropy`, `Aletheore/django`, `Aletheore/matplotlib`,
+      `Aletheore/xarray`, `Aletheore/scikit-learn`, `Aletheore/sphinx`,
+      `Aletheore/sympy`.
+- [ ] **In progress, 21/25 PRs opened as of last check** (astropy ×1,
+      django ×9, matplotlib ×1, scikit-learn ×5, sphinx ×4, xarray ×1 —
+      all confirmed live on `Aletheore/pr-review-benchmark-sandbox` PR
+      #1-#21). Currently cloning sympy for the final 4 instances. The
+      Monitor watching for `PR:|ERROR|SKIP` lines went quiet even though
+      it's working: Python block-buffers stdout when piped through `tee`,
+      so log lines land in bursts, not real time. Don't assume "no
+      output" means stuck — check `gh pr list --repo
+      Aletheore/pr-review-benchmark-sandbox --state all` and `ps aux |
+      grep run_swebench` for real signs of life first.
+      `scratchpad/run_swebench_cases.py` running in the
+      background (Bash task id `bmz4c15zm`, log at
+      `.../tasks/bmz4c15zm.output`; a Monitor (task `b2md9z70s`) is
+      tailing it for `PR:|ERROR|SKIP|Built [0-9]+/` lines). This builds
+      all 25 cases into
+      `benchmarks/pr-review-benchmark/cases/swebench-<short-id>/` and
+      opens a real PR on `Aletheore/pr-review-benchmark-sandbox` for each.
+      **Check `/tmp/swebench_cases_built.json` for the authoritative
+      per-case result once it finishes** (case_id, instance_id, fork,
+      fixed_commit, pr_url for each successfully-built case).
+- [x] All 25 cases built, all 25 PRs opened — confirmed via
+      `gh pr list --repo Aletheore/pr-review-benchmark-sandbox --state all`
+      (PRs #1-#25). Authoritative record: `/tmp/swebench_cases_built.json`.
+- [ ] **Waiting on production queue backlog, not a bug.** Each PR enqueues
+      2 jobs (`run_pr_scan_job` + `run_flash_review_job`,
+      `github-app/app_server/webhooks/pull_request.py`). 25 PRs × 2 = 50
+      jobs landed on top of whatever else was already queued (66 total
+      seen in `rq:queue:scans` at last check). Only 2 worker processes
+      handle that queue (confirmed alive via `redis-cli HGETALL
+      rq:worker:<id>` — both `state: busy`, recent heartbeats, not
+      crashed), and a real Flash Review run has been measured at 5m50s in
+      production (see the comment on `FLASH_REVIEW_JOB_TIMEOUT_SECONDS` in
+      `pull_request.py`). At 2 concurrent workers this could realistically
+      take 30-90+ minutes to fully drain. **Don't mistake "no aletheore[bot]
+      comments yet" for broken** — check `docker exec
+      github-app-redis-1 redis-cli LLEN rq:queue:scans` (declining number =
+      draining) and worker `state`/`last_heartbeat` before assuming
+      anything is stuck.
+- [ ] A Monitor (task `b8mw95n5c`) is polling queue depth + comment count
+      across all 25 PRs every 90s and will report `ALL_DONE` or
+      `QUEUE_DRAINED`. If that Monitor is gone (session restart), just
+      re-run the same poll loop, or manually check comment counts:
+      `for n in $(seq 1 25); do gh api repos/Aletheore/pr-review-benchmark-sandbox/issues/$n/comments --jq '[.[] | select(.user.login=="aletheore[bot]")] | length'; done`
+- [ ] Not started: running the grounding check across all 25 and reporting
+      the real number.
+
+## How the case construction actually works (read before changing anything)
+
+The **existing 3 hand-authored `real_bug_fix` cases'** convention (see
+`cases/001-flask-cli-key-quote/repo.txt` + `pr.diff`):
+`repo.txt`'s `base_commit` is the **fixed** state (a real, upstream commit
+after the bug was fixed). `pr.diff` is the **inverse of the real fix** —
+applying it to `base_commit` reintroduces the bug, and that's the tree
+that gets reviewed as "the PR."
+
+SWE-bench's own schema is the opposite: its `base_commit` is the **buggy**
+(pre-fix) state, and its `patch` field is the real fix diff. There is no
+single canonical "fixed-state commit hash" in SWE-bench's data — it's
+implied by `base_commit + patch`, not a real commit that exists anywhere.
+
+So for each sampled instance, `scripts/run_swebench_cases.py`:
+1. Clones the real upstream repo (cached per-repo under
+   `scratchpad/swebench-run/source-clones/`, reused across all instances
+   from the same repo — e.g. all 9 django instances share one clone).
+2. Checks out SWE-bench's real `base_commit` (buggy).
+3. `git apply`s SWE-bench's real `patch` (the fix) → now at the fixed
+   state.
+4. Commits that locally, and pushes it to the matching `Aletheore/<repo>`
+   fork on a branch named `swebench/<instance_id>` — **this pushed commit
+   is what `repo.txt`'s `base_commit` points at**, matching the existing
+   convention exactly, just automated instead of a real historical commit
+   hash.
+5. `pr.diff` = `git diff HEAD HEAD~1` (fixed → buggy) computed from that
+   same local commit, before it's discarded.
+6. `ground_truth.yaml`'s `expected_file`/`expected_line` are parsed from
+   **the reverse diff's `+` side** (the buggy/PR-under-review state's line
+   numbers), **not** from SWE-bench's original `patch` (whose `+` side is
+   the *fixed* state's numbering — using that would point at the wrong
+   line entirely). This was a real bug caught and fixed before the first
+   real run; if expected_line looks systematically wrong later, check this
+   first.
+7. Copies the case into `Aletheore/pr-review-benchmark-sandbox`'s
+   `benchmark-sandbox/<case-id>/` (mirrors the existing convention from
+   the old proctor-browser cases) and opens a PR there.
+
+## How to reproduce the sample (if `/tmp` files are gone)
+
+```bash
+curl -sL "https://huggingface.co/datasets/princeton-nlp/SWE-bench_Verified/resolve/main/data/test-00000-of-00001.parquet" \
+  -o /tmp/swebench_verified.parquet
+python3 -c "
+import pandas as pd
+df = pd.read_parquet('/tmp/swebench_verified.parquet')
+sample = df.sample(n=25, random_state=42).sort_values('repo')
+sample.to_json('/tmp/swebench_sample_25.json', orient='records', indent=2)
+"
+```
+
+## How to check on / resume the background run
+
+```bash
+# Live progress
+tail -100 "/private/tmp/claude-501/-Users-arihantkaul-Documents-GitHub-Veridion/416e5ceb-2227-4fe5-bff0-4239553ed740/tasks/bmz4c15zm.output"
+
+# Once finished, the authoritative per-case result:
+cat /tmp/swebench_cases_built.json
+```
+
+If the background process died (e.g. session ended) before finishing all
+25, **it's safe to just re-run** `scratchpad/run_swebench_cases.py` — it's
+idempotent per-instance (force-pushes branches, `git checkout -B`, skips a
+case if the golden patch doesn't apply). Cases already fully built (files
+exist under `benchmarks/pr-review-benchmark/cases/swebench-*/`) will just
+get rebuilt identically since the source data is fixed by the seed.
+
+## Real bug found and fixed after the first full run (read this before trusting anything below the first measurement)
+
+The first citation-grounding measurement across all 25 PRs came back
+**0 citations in every single case**. That looked like either a
+remarkable result or a broken pipeline — it was the latter.
+
+**Root cause**: `run_swebench_cases.py`'s `open_sandbox_pr()` checked out
+the buggy state in the source clone and had a comment claiming it
+"materializes the actual (buggy) checkout tree under the case dir" —
+but the code never actually copied those files into the sandbox PR
+directory. Confirmed via `gh pr diff --name-only` on PR #25: every PR
+only ever contained `repo.txt`, `pr.diff`, `ground_truth.yaml`,
+`ground_truth.md` — 4 metadata files, zero real source code. Flash Review
+correctly reviewed what it was shown (text/YAML files) and correctly
+found nothing wrong with them. **That result measured nothing about
+citation grounding — it measured this bug.**
+
+**First fix attempt was also wrong**, and caught before pushing: rsync'ing
+the entire cloned repo into the sandbox dir produced a 1,968-file, 839K-
+insertion "PR" for what should be a one-line sympy bug. Checked this
+against the real hand-authored case 001's actual PR
+(`gh pr view 213 --repo ArihantK15/proctor-browser`): 1 changed file, 1069
+additions. The existing convention only ever materializes the file(s) the
+patch actually touches, at their real relative path — not the whole repo.
+
+**Actual fix** (now in `run_swebench_cases.py` and
+`fix_and_repush_cases.py`, both in `scratchpad/`): parse `diff --git a/X
+b/X` lines from each SWE-bench patch to get the touched-file list, copy
+only those files (at their buggy-state content) into
+`benchmark-sandbox/<case-id>/<same-relative-path>`. Validated on
+`swebench-sympy-23534` before scaling to all 25 again: 1 file changed, 925
+insertions, confirmed via `gh pr diff 25 --name-only` and grepping the
+diff body for the actual missing `cls=cls` bug. All 25 cases touch 1-3
+files (`fix_and_repush_cases.py`'s preview output), consistent with real
+PRs.
+
+**Lesson, stated plainly since it cost a full wasted measurement cycle**:
+this file's own earlier "How the case construction actually works"
+section was itself under-specified — it never said explicitly that only
+the *touched* files get copied in, not the whole tree, because the person
+writing it (me) hadn't actually checked what the real methodology does
+before describing it. Don't trust a methodology description in this file
+without cross-checking it against an actual real PR when something
+downstream looks off.
+
+**Since each fix push is a `synchronize` action** (in
+`pull_request.py`'s `ENQUEUE_ACTIONS`), it re-triggers Flash Review
+automatically on all 25 PRs — no need to reopen anything. Repushed all 25
+(24 actually changed; `swebench-sympy-23534` correctly no-op'd since it
+was already fixed and validated first). All pushed clean, 1-3 files per
+case, no warnings.
+
+**Gotcha caught before it wasted a second measurement**: the first
+attempt at a "wait for the re-review" poll checked "does any
+`aletheore[bot]` comment exist" — which was already true for all 25 from
+the *first, broken* review, so it would have reported done instantly
+without actually waiting for anything. Fixed by capturing each PR's
+comment `updated_at` as a baseline *before* the repush
+(`/tmp/swebench_comment_baseline.txt`) and polling for that timestamp to
+change, not just for a comment to exist. If re-deriving this baseline,
+capture it immediately after the repush script finishes, before checking
+progress.
+
+## Second round: 21/25 genuinely re-reviewed, 3 hit a real production bug, 1 needed no retrigger
+
+After the repush, polling (correctly, against the pre-repush baseline)
+showed 21/25 with a genuinely new review and the queue empty. 4 were
+missing:
+
+- **PR #25** (`swebench-sympy-23534`): not actually missing — its baseline
+  already reflected the fresh review from the earlier single-case
+  validation (before the 25-batch even ran), and the batch script
+  correctly no-op'd it (`nothing to commit`, identical content). Verified
+  by reading its comment directly: real review, real grounding line
+  (`_Grounding: 0 of 1 proposed finding(s) held up against this diff._`).
+  No action needed.
+- **PRs #1, #2, #3** (`swebench-astropy-14309`, `swebench-django-12262`,
+  `swebench-django-12155`): genuinely never got a new review. Root cause
+  found in production logs, not guessed: `run_flash_review_job` failed
+  outright with `psycopg.errors.LockNotAvailable: canceling statement due
+  to lock timeout` inside `installation_spend_lock`
+  (`scan_worker/db.py:329`) — pushing 24 synchronize events for the same
+  installation in quick succession created enough lock contention that
+  several Flash Review jobs couldn't acquire the per-installation
+  spend-lock in time and failed hard (no PR comment, no retry). **This is
+  a real production bug**, tracked as task #205 (`Fix
+  installation_spend_lock timeout under burst Flash Review load`) —
+  separate from and not blocking this benchmark.
+
+**Retrigger mistake, caught and fixed before it corrupted the
+measurement**: first attempt appended a `retrigger: <timestamp>` line to
+`ground_truth.md` to force a new `synchronize` event. This *worked* (new
+review landed) but polluted the diff — Flash Review correctly flagged the
+timestamp line itself as a benchmark-metadata leak into the diff, which
+is a real, correctly-grounded finding, but not what this case is supposed
+to measure. Fixed by reverting to the clean commit (`git reset --hard
+HEAD~1` + force-push) and retriggering with `git commit --allow-empty`
+instead — same effect (new synchronize event) with zero diff content
+change. **If retriggering again for any reason, always use `--allow-empty`,
+never a real file edit.**
+
+As of the last check, PRs #1/#2/#3 are mid-flight again after the clean
+retrigger: PR #3's comment has the evidence-diff half but not yet the
+flash-review half (job still running); PR #2 looks like a genuine clean
+re-review (`No issues held up... 0 grounded`, no mention of the old
+pollution); PR #1 still showed the *old, polluted-content* review as of
+the last direct check, meaning its clean retrigger hadn't been picked up
+by a worker yet. A Monitor (task `by72gwrmn`) is polling
+`/tmp/swebench_retrigger_baseline.txt` against fresh checks — importantly
+it also verifies the `aletheore-flash-review` HTML comment marker is
+present, not just that the comment changed, since PR #3 demonstrated a
+comment can update with only the evidence-diff half landed.
+
+## Next steps once all 25 PRs exist and Flash Review has commented
+
+1. Fetch each PR's `aletheore[bot]` issue comments (same pattern as
+   `scratchpad/measure_citations.py` from earlier this session — adapt the
+   `CASES` dict to read from `/tmp/swebench_cases_built.json` instead of
+   the 3 hardcoded cases).
+2. Run `normalize_aletheore` (make sure the suggestion-stripping fix is
+   actually in `scripts/normalize.py` before trusting content-grounding
+   numbers) → `verify_findings_against_checkout` per case.
+3. Aggregate: total findings, location-grounding rate, content-grounding
+   rate (with the checkable/uncheckable split reported honestly — don't
+   collapse "uncheckable" into either verified or unverified).
+4. Report the real number, including cases that got zero findings — that's
+   real signal (Flash Review declining to comment on a diff isn't a gap in
+   the measurement).
+
+## Known open items / things NOT done yet
+
+- The `normalize.py` suggestion-stripping fix was handed to Codex as
+  instructions, not necessarily applied by this session directly — verify
+  it actually landed (`git log -- benchmarks/pr-review-benchmark/scripts/normalize.py`)
+  before trusting any content-grounding number.
+- No comparison against repowise has started. The user mentioned wanting
+  "correct answer token vs repowise" as a follow-on use for this same
+  SWE-bench sandbox once citation grounding is done — that's a separate,
+  not-yet-scoped piece of work, not part of this run.
+- `benchmarks/pr-review-benchmark`'s original 3-case results (flask ×2,
+  requests) are unrelated to this SWE-bench run and shouldn't be conflated
+  with it in the final report — keep them as two clearly separate results
+  if both get reported (different corpora, different sample sizes,
+  different selection methodology).

--- a/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/ground_truth.md
@@ -1,0 +1,11 @@
+SWE-bench Verified instance `astropy__astropy-14309` (astropy/astropy). IndexError: tuple index out of range in identify_format (io.registry)
+<!-- This comments are hidden when you submit the issue,
+so you do not need to remove them! -->
+
+<!-- Please be sure to check out our contributing guidelines,
+https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md .
+Please be sure to check out our code of conduct,
+https://github.com/astropy/astropy/blob/main/CODE_OF_CONDUCT.md . -->
+
+<!-- Please have a search on our GitHub repository to see if a similar
+issue ha

--- a/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-astropy-14309
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: astropy/io/fits/connect.py
+expected_line: 65
+fix_reference: 'SWE-bench Verified instance: astropy__astropy-14309 (https://www.swebench.com/)'
+description: "IndexError: tuple index out of range in identify_format (io.registry) <!-- This comments\
+  \ are hidden when you submit the issue,\r so you do not need to remove them! -->\r \r <!-- Please be\
+  \ sure to check out our contributing guidelines,\r https://github.com/astropy/astropy/blob/main/CONTRIBUTING.md\
+  \ .\r Please be sure to check out our code of conduct,\r https://github.com/astropy/astropy/blob/main/CODE_OF_"

--- a/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/pr.diff
@@ -1,0 +1,17 @@
+diff --git a/astropy/io/fits/connect.py b/astropy/io/fits/connect.py
+index 210af2b96..4b6150f4a 100644
+--- a/astropy/io/fits/connect.py
++++ b/astropy/io/fits/connect.py
+@@ -65,9 +65,10 @@ def is_fits(origin, filepath, fileobj, *args, **kwargs):
+         fileobj.seek(pos)
+         return sig == FITS_SIGNATURE
+     elif filepath is not None:
+-        return filepath.lower().endswith(
++        if filepath.lower().endswith(
+             (".fits", ".fits.gz", ".fit", ".fit.gz", ".fts", ".fts.gz")
+-        )
++        ):
++            return True
+     return isinstance(args[0], (HDUList, TableHDU, BinTableHDU, GroupsHDU))
+ 
+ 

--- a/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-astropy-14309/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/astropy.git
+base_commit=1ccfaad6623bbe89274ce60ac33d8ebd6848df92

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11095/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11095/ground_truth.md
@@ -1,0 +1,5 @@
+SWE-bench Verified instance `django__django-11095` (django/django). add ModelAdmin.get_inlines() hook to allow set inlines based on the request or model instance.
+Description
+	
+add ModelAdmin.get_inlines() hook to allow set inlines based on the request or model instance.
+Currently, We can override the method get_inline_instances to do such a thing, but a for loop should be copied to my code. So I wished add a hook get_inlines(request, obj=None)

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11095/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11095/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-django-11095
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/contrib/admin/options.py
+expected_line: 327
+fix_reference: 'SWE-bench Verified instance: django__django-11095 (https://www.swebench.com/)'
+description: "add ModelAdmin.get_inlines() hook to allow set inlines based on the request or model instance.\
+  \ Description \t add ModelAdmin.get_inlines() hook to allow set inlines based on the request or model\
+  \ instance. Currently, We can override the method get_inline_instances to do such a thing, but a for\
+  \ loop should be copied to my code. So I wished add a hook get_inlines(request, obj=None)"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11095/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11095/pr.diff
@@ -1,0 +1,24 @@
+diff --git a/django/contrib/admin/options.py b/django/contrib/admin/options.py
+index d64a2e9a28..5e7b23f9a0 100644
+--- a/django/contrib/admin/options.py
++++ b/django/contrib/admin/options.py
+@@ -327,10 +327,6 @@ class BaseModelAdmin(metaclass=forms.MediaDefiningClass):
+             return self.fieldsets
+         return [(None, {'fields': self.get_fields(request, obj)})]
+ 
+-    def get_inlines(self, request, obj):
+-        """Hook for specifying custom inlines."""
+-        return self.inlines
+-
+     def get_ordering(self, request):
+         """
+         Hook for specifying field ordering.
+@@ -586,7 +582,7 @@ class ModelAdmin(BaseModelAdmin):
+ 
+     def get_inline_instances(self, request, obj=None):
+         inline_instances = []
+-        for inline_class in self.get_inlines(request, obj):
++        for inline_class in self.inlines:
+             inline = inline_class(self.model, self.admin_site)
+             if request:
+                 if not (inline.has_view_or_change_permission(request, obj) or

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11095/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11095/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=7797114bb7e225c850244c096cebbe63d87ed00d

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11999/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11999/ground_truth.md
@@ -1,0 +1,12 @@
+SWE-bench Verified instance `django__django-11999` (django/django). Cannot override get_FOO_display() in Django 2.2+.
+Description
+	
+I cannot override the get_FIELD_display function on models since version 2.2. It works in version 2.1.
+Example:
+class FooBar(models.Model):
+	foo_bar = models.CharField(_("foo"), choices=[(1, 'foo'), (2, 'bar')])
+	def __str__(self):
+		return self.get_foo_bar_display() # This returns 'foo' or 'bar' in 2.2, but 'something' in 2.1
+	def get_foo_bar_display(self):
+		return "something"
+What I expect is that I should be able to override thi

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11999/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11999/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-django-11999
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/db/models/fields/__init__.py
+expected_line: 763
+fix_reference: 'SWE-bench Verified instance: django__django-11999 (https://www.swebench.com/)'
+description: "Cannot override get_FOO_display() in Django 2.2+. Description \t I cannot override the get_FIELD_display\
+  \ function on models since version 2.2. It works in version 2.1. Example: class FooBar(models.Model):\
+  \ \tfoo_bar = models.CharField(_(\"foo\"), choices=[(1, 'foo'), (2, 'bar')]) \tdef __str__(self): \t\
+  \treturn self.get_foo_bar_display() # This returns 'foo' or 'bar' in 2.2, but 'something' in 2.1 \t\
+  def ge"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11999/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11999/pr.diff
@@ -1,0 +1,19 @@
+diff --git a/django/db/models/fields/__init__.py b/django/db/models/fields/__init__.py
+index fe550169bd..ee45bb941e 100644
+--- a/django/db/models/fields/__init__.py
++++ b/django/db/models/fields/__init__.py
+@@ -763,12 +763,8 @@ class Field(RegisterLookupMixin):
+             if not getattr(cls, self.attname, None):
+                 setattr(cls, self.attname, self.descriptor_class(self))
+         if self.choices is not None:
+-            if not hasattr(cls, 'get_%s_display' % self.name):
+-                setattr(
+-                    cls,
+-                    'get_%s_display' % self.name,
+-                    partialmethod(cls._get_FIELD_display, field=self),
+-                )
++            setattr(cls, 'get_%s_display' % self.name,
++                    partialmethod(cls._get_FIELD_display, field=self))
+ 
+     def get_filter_kwargs_for_object(self, obj):
+         """

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-11999/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-11999/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=914fe00a2cfdb6bd78cb42247b82ab1257d0a1e7

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12155/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12155/ground_truth.md
@@ -1,0 +1,13 @@
+SWE-bench Verified instance `django__django-12155` (django/django). docutils reports an error rendering view docstring when the first line is not empty
+Description
+	
+Currently admindoc works correctly only with docstrings where the first line is empty, and all Django docstrings are formatted in this way.
+However usually the docstring text starts at the first line, e.g.:
+def test():
+	"""test tests something.
+	"""
+and this cause an error:
+Error in "default-role" directive:
+no content permitted.
+.. default-role:: cmsreference
+The culprit is this code in trim_docstr

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12155/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12155/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-django-12155
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/contrib/admindocs/utils.py
+expected_line: 3
+fix_reference: 'SWE-bench Verified instance: django__django-12155 (https://www.swebench.com/)'
+description: "docutils reports an error rendering view docstring when the first line is not empty Description\
+  \ \t Currently admindoc works correctly only with docstrings where the first line is empty, and all\
+  \ Django docstrings are formatted in this way. However usually the docstring text starts at the first\
+  \ line, e.g.: def test(): \t\"\"\"test tests something. \t\"\"\" and this cause an error: Error in \"\
+  default-role\" dir"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12155/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12155/pr.diff
@@ -1,0 +1,62 @@
+diff --git a/django/contrib/admindocs/utils.py b/django/contrib/admindocs/utils.py
+index b44f151e48..4c0e7e2a56 100644
+--- a/django/contrib/admindocs/utils.py
++++ b/django/contrib/admindocs/utils.py
+@@ -3,7 +3,6 @@
+ import re
+ from email.errors import HeaderParseError
+ from email.parser import HeaderParser
+-from inspect import cleandoc
+ 
+ from django.urls import reverse
+ from django.utils.regex_helper import _lazy_re_compile
+@@ -25,13 +24,26 @@ def get_view_name(view_func):
+     return mod_name + '.' + view_name
+ 
+ 
++def trim_docstring(docstring):
++    """
++    Uniformly trim leading/trailing whitespace from docstrings.
++
++    Based on https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
++    """
++    if not docstring or not docstring.strip():
++        return ''
++    # Convert tabs to spaces and split into lines
++    lines = docstring.expandtabs().splitlines()
++    indent = min(len(line) - len(line.lstrip()) for line in lines if line.lstrip())
++    trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
++    return "\n".join(trimmed).strip()
++
++
+ def parse_docstring(docstring):
+     """
+     Parse out the parts of a docstring.  Return (title, body, metadata).
+     """
+-    if not docstring:
+-        return '', '', {}
+-    docstring = cleandoc(docstring)
++    docstring = trim_docstring(docstring)
+     parts = re.split(r'\n{2,}', docstring)
+     title = parts[0]
+     if len(parts) == 1:
+diff --git a/django/contrib/admindocs/views.py b/django/contrib/admindocs/views.py
+index c5a2f0e822..cacdeb91a0 100644
+--- a/django/contrib/admindocs/views.py
++++ b/django/contrib/admindocs/views.py
+@@ -1,6 +1,5 @@
+ import inspect
+ from importlib import import_module
+-from inspect import cleandoc
+ from pathlib import Path
+ 
+ from django.apps import apps
+@@ -257,7 +256,7 @@ class ModelDetailView(BaseAdminDocsView):
+                     continue
+                 verbose = func.__doc__
+                 verbose = verbose and (
+-                    utils.parse_rst(cleandoc(verbose), 'model', _('model:') + opts.model_name)
++                    utils.parse_rst(utils.trim_docstring(verbose), 'model', _('model:') + opts.model_name)
+                 )
+                 # Show properties and methods without arguments as fields.
+                 # Otherwise, show as a 'method with arguments'.

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12155/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12155/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=18474dc35dba38295b41441ec443a7ec65f92155

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12262/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12262/ground_truth.md
@@ -1,0 +1,12 @@
+SWE-bench Verified instance `django__django-12262` (django/django). Custom template tags raise TemplateSyntaxError when keyword-only arguments with defaults are provided.
+Description
+	 
+		(last modified by P-Seebauer)
+	 
+When creating simple tags without variable keyword args, but an keyword argument with a default value. It's not possible to supply any other variable.
+@register.simple_tag
+def hello(*, greeting='hello'):
+	return f'{greeting} world'
+{% hello greeting='hi' %}
+Raises “'hello' received unexpected keyword argument 'greeting'”
+Also supplying a keyword

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12262/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12262/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-django-12262
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/template/library.py
+expected_line: 261
+fix_reference: 'SWE-bench Verified instance: django__django-12262 (https://www.swebench.com/)'
+description: "Custom template tags raise TemplateSyntaxError when keyword-only arguments with defaults\
+  \ are provided. Description \t  \t\t(last modified by P-Seebauer) \t  When creating simple tags without\
+  \ variable keyword args, but an keyword argument with a default value. It's not possible to supply any\
+  \ other variable. @register.simple_tag def hello(*, greeting='hello'): \treturn f'{greeting} world'\
+  \ {% hello greeti"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12262/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12262/pr.diff
@@ -1,0 +1,13 @@
+diff --git a/django/template/library.py b/django/template/library.py
+index 2f74556268..20bc86dac8 100644
+--- a/django/template/library.py
++++ b/django/template/library.py
+@@ -261,7 +261,7 @@ def parse_bits(parser, bits, params, varargs, varkw, defaults,
+         if kwarg:
+             # The kwarg was successfully extracted
+             param, value = kwarg.popitem()
+-            if param not in params and param not in kwonly and varkw is None:
++            if param not in params and param not in unhandled_kwargs and varkw is None:
+                 # An unexpected keyword argument was supplied
+                 raise TemplateSyntaxError(
+                     "'%s' received unexpected keyword argument '%s'" %

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12262/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12262/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=eb5b660c247020238417a3cee78c8553f8d82b03

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12663/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12663/ground_truth.md
@@ -1,0 +1,15 @@
+SWE-bench Verified instance `django__django-12663` (django/django). Using SimpleLazyObject with a nested subquery annotation fails.
+Description
+	 
+		(last modified by Jordan Ephron)
+	 
+Prior to 35431298226165986ad07e91f9d3aca721ff38ec it was possible to use a SimpleLazyObject in a queryset as demonstrated below. This new behavior appears to be a regression.
+Models
+from django.contrib.auth.models import User
+from django.db import models
+class A(models.Model):
+	pass
+class B(models.Model):
+	a = models.ForeignKey(A, on_delete=models.CASCADE)
+class C(models.Model):
+	

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12663/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12663/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-django-12663
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/db/models/sql/query.py
+expected_line: 233
+fix_reference: 'SWE-bench Verified instance: django__django-12663 (https://www.swebench.com/)'
+description: "Using SimpleLazyObject with a nested subquery annotation fails. Description \t  \t\t(last\
+  \ modified by Jordan Ephron) \t  Prior to 35431298226165986ad07e91f9d3aca721ff38ec it was possible to\
+  \ use a SimpleLazyObject in a queryset as demonstrated below. This new behavior appears to be a regression.\
+  \ Models from django.contrib.auth.models import User from django.db import models class A(models.Model):\
+  \ \tpass"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12663/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12663/pr.diff
@@ -1,0 +1,14 @@
+diff --git a/django/db/models/sql/query.py b/django/db/models/sql/query.py
+index e5524a8198..9fe0c9a656 100644
+--- a/django/db/models/sql/query.py
++++ b/django/db/models/sql/query.py
+@@ -233,8 +233,7 @@ class Query(BaseExpression):
+     @property
+     def output_field(self):
+         if len(self.select) == 1:
+-            select = self.select[0]
+-            return getattr(select, 'target', None) or select.field
++            return self.select[0].field
+         elif len(self.annotation_select) == 1:
+             return next(iter(self.annotation_select.values())).output_field
+ 

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-12663/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-12663/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=14df9ba114a9d08016294536f3b216145b76cb7c

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13279/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13279/ground_truth.md
@@ -1,0 +1,5 @@
+SWE-bench Verified instance `django__django-13279` (django/django). Session data cannot be decoded during the transition to Django 3.1.
+Description
+	
+In d4fff711d4c97356bd6ba1273d2a5e349326eb5f (#31274) we've changed format for session data, that's why setting DEFAULT_HASHING_ALGORITHM to 'sha1' is not enough to support running multiple instances of the same project during the transition to Django 3.1.
+We could use the legacy encode() when DEFAULT_HASHING_ALGORITHM == 'sha1' (it's a bit hacky).

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13279/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13279/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-django-13279
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/contrib/sessions/backends/base.py
+expected_line: 108
+fix_reference: 'SWE-bench Verified instance: django__django-13279 (https://www.swebench.com/)'
+description: "Session data cannot be decoded during the transition to Django 3.1. Description \t In d4fff711d4c97356bd6ba1273d2a5e349326eb5f\
+  \ (#31274) we've changed format for session data, that's why setting DEFAULT_HASHING_ALGORITHM to 'sha1'\
+  \ is not enough to support running multiple instances of the same project during the transition to Django\
+  \ 3.1. We could use the legacy encode() when DEFAULT_HASHING_ALGORITH"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13279/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13279/pr.diff
@@ -1,0 +1,27 @@
+diff --git a/django/contrib/sessions/backends/base.py b/django/contrib/sessions/backends/base.py
+index 187e14b1b7..b5453160a5 100644
+--- a/django/contrib/sessions/backends/base.py
++++ b/django/contrib/sessions/backends/base.py
+@@ -108,9 +108,6 @@ class SessionBase:
+ 
+     def encode(self, session_dict):
+         "Return the given session dictionary serialized and encoded as a string."
+-        # RemovedInDjango40Warning: DEFAULT_HASHING_ALGORITHM will be removed.
+-        if settings.DEFAULT_HASHING_ALGORITHM == 'sha1':
+-            return self._legacy_encode(session_dict)
+         return signing.dumps(
+             session_dict, salt=self.key_salt, serializer=self.serializer,
+             compress=True,
+@@ -124,12 +121,6 @@ class SessionBase:
+         except Exception:
+             return self._legacy_decode(session_data)
+ 
+-    def _legacy_encode(self, session_dict):
+-        # RemovedInDjango40Warning.
+-        serialized = self.serializer().dumps(session_dict)
+-        hash = self._hash(serialized)
+-        return base64.b64encode(hash.encode() + b':' + serialized).decode('ascii')
+-
+     def _legacy_decode(self, session_data):
+         # RemovedInDjango40Warning: pre-Django 3.1 format will be invalid.
+         encoded_data = base64.b64decode(session_data.encode('ascii'))

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13279/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13279/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=97720fde317d11056cefbc0165de35562f1d8224

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13670/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13670/ground_truth.md
@@ -1,0 +1,10 @@
+SWE-bench Verified instance `django__django-13670` (django/django). dateformat.y() doesn't support years < 1000.
+Description
+	 
+		(last modified by Sam)
+	 
+When using the the dateformat of django with a date before 999 (or 99 and 9 for similar matters) and the format character "y" no leading zero will be printed. This is not consistent with the way the python datetime module and PHP handle that character "y" in format strings:
+django (version 3.1):
+>>> import datetime
+>>> from django.utils import dateformat
+>>> dateformat.format(datetime.datetime(123, 4, 5, 6, 7

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13670/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13670/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-django-13670
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/utils/dateformat.py
+expected_line: 325
+fix_reference: 'SWE-bench Verified instance: django__django-13670 (https://www.swebench.com/)'
+description: "dateformat.y() doesn't support years < 1000. Description \t  \t\t(last modified by Sam)\
+  \ \t  When using the the dateformat of django with a date before 999 (or 99 and 9 for similar matters)\
+  \ and the format character \"y\" no leading zero will be printed. This is not consistent with the way\
+  \ the python datetime module and PHP handle that character \"y\" in format strings: django (version\
+  \ 3.1): >>> import date"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13670/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13670/pr.diff
@@ -1,0 +1,15 @@
+diff --git a/django/utils/dateformat.py b/django/utils/dateformat.py
+index c4d9d035e4..afd36d79e0 100644
+--- a/django/utils/dateformat.py
++++ b/django/utils/dateformat.py
+@@ -325,8 +325,8 @@ class DateFormat(TimeFormat):
+         return self.data.isocalendar()[1]
+ 
+     def y(self):
+-        """Year, 2 digits with leading zeros; e.g. '99'."""
+-        return '%02d' % (self.data.year % 100)
++        "Year, 2 digits; e.g. '99'"
++        return str(self.data.year)[2:]
+ 
+     def Y(self):
+         "Year, 4 digits; e.g. '1999'"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-13670/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-13670/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=89928d281094155707a2e01ff229702f443278ed

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-14434/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-14434/ground_truth.md
@@ -1,0 +1,4 @@
+SWE-bench Verified instance `django__django-14434` (django/django). Statement created by _create_unique_sql makes references_column always false
+Description
+	
+This is due to an instance of Table is passed as an argument to Columns when a string is expected.

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-14434/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-14434/ground_truth.yaml
@@ -1,0 +1,9 @@
+case_id: swebench-django-14434
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/db/backends/base/schema.py
+expected_line: 1241
+fix_reference: 'SWE-bench Verified instance: django__django-14434 (https://www.swebench.com/)'
+description: "Statement created by _create_unique_sql makes references_column always false Description\
+  \ \t This is due to an instance of Table is passed as an argument to Columns when a string is expected."

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-14434/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-14434/pr.diff
@@ -1,0 +1,29 @@
+diff --git a/django/db/backends/base/schema.py b/django/db/backends/base/schema.py
+index 5cecbb7d60..ad2f5a7da1 100644
+--- a/django/db/backends/base/schema.py
++++ b/django/db/backends/base/schema.py
+@@ -1241,9 +1241,9 @@ class BaseDatabaseSchemaEditor:
+             return self.quote_name(self._create_index_name(*args, **kwargs))
+ 
+         compiler = Query(model, alias_cols=False).get_compiler(connection=self.connection)
+-        table = model._meta.db_table
++        table = Table(model._meta.db_table, self.quote_name)
+         if name is None:
+-            name = IndexName(table, columns, '_uniq', create_unique_name)
++            name = IndexName(model._meta.db_table, columns, '_uniq', create_unique_name)
+         else:
+             name = self.quote_name(name)
+         if condition or include or opclasses or expressions:
+@@ -1253,10 +1253,10 @@ class BaseDatabaseSchemaEditor:
+         if columns:
+             columns = self._index_columns(table, columns, col_suffixes=(), opclasses=opclasses)
+         else:
+-            columns = Expressions(table, expressions, compiler, self.quote_value)
++            columns = Expressions(model._meta.db_table, expressions, compiler, self.quote_value)
+         return Statement(
+             sql,
+-            table=Table(table, self.quote_name),
++            table=table,
+             name=name,
+             columns=columns,
+             condition=self._index_condition_sql(condition),

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-14434/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-14434/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=26db5a27942fa46580e1702cd814095b6de20121

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-15503/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-15503/ground_truth.md
@@ -1,0 +1,16 @@
+SWE-bench Verified instance `django__django-15503` (django/django). has_key, has_keys, and has_any_keys JSONField() lookups don't handle numeric keys on SQLite, MySQL, and Oracle.
+Description
+	 
+		(last modified by TheTerrasque)
+	 
+Problem
+When using models.​JSONField() ​has_key lookup with numerical keys on SQLite database it fails to find the keys.
+Versions:
+Django: 4.0.3
+Python: 3.9.6 (tags/v3.9.6:db3ff76, Jun 28 2021, 15:26:21) [MSC v.1929 64 bit (AMD64)] on win32
+sqlite3.version: '2.6.0'
+sqlite3.sqlite_version: '3.35.5'
+Example:
+Database
+DATABASES = {
+	'def

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-15503/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-15503/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-django-15503
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: django/db/models/fields/json.py
+expected_line: 172
+fix_reference: 'SWE-bench Verified instance: django__django-15503 (https://www.swebench.com/)'
+description: "has_key, has_keys, and has_any_keys JSONField() lookups don't handle numeric keys on SQLite,\
+  \ MySQL, and Oracle. Description \t  \t\t(last modified by TheTerrasque) \t  Problem When using models.\u200B\
+  JSONField() \u200Bhas_key lookup with numerical keys on SQLite database it fails to find the keys. Versions:\
+  \ Django: 4.0.3 Python: 3.9.6 (tags/v3.9.6:db3ff76, Jun 28 2021, 15:26:21) [MSC v.1929 64 bit (AMD64)]\
+  \ on w"

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-15503/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-15503/pr.diff
@@ -1,0 +1,72 @@
+diff --git a/django/db/models/fields/json.py b/django/db/models/fields/json.py
+index 7424f46e66..fdca700c9d 100644
+--- a/django/db/models/fields/json.py
++++ b/django/db/models/fields/json.py
+@@ -172,10 +172,6 @@ class ContainedBy(PostgresOperatorLookup):
+ class HasKeyLookup(PostgresOperatorLookup):
+     logical_operator = None
+ 
+-    def compile_json_path_final_key(self, key_transform):
+-        # Compile the final key without interpreting ints as array elements.
+-        return ".%s" % json.dumps(key_transform)
+-
+     def as_sql(self, compiler, connection, template=None):
+         # Process JSON path from the left-hand side.
+         if isinstance(self.lhs, KeyTransform):
+@@ -197,10 +193,13 @@ class HasKeyLookup(PostgresOperatorLookup):
+                 *_, rhs_key_transforms = key.preprocess_lhs(compiler, connection)
+             else:
+                 rhs_key_transforms = [key]
+-            *rhs_key_transforms, final_key = rhs_key_transforms
+-            rhs_json_path = compile_json_path(rhs_key_transforms, include_root=False)
+-            rhs_json_path += self.compile_json_path_final_key(final_key)
+-            rhs_params.append(lhs_json_path + rhs_json_path)
++            rhs_params.append(
++                "%s%s"
++                % (
++                    lhs_json_path,
++                    compile_json_path(rhs_key_transforms, include_root=False),
++                )
++            )
+         # Add condition for each key.
+         if self.logical_operator:
+             sql = "(%s)" % self.logical_operator.join([sql] * len(rhs_params))
+@@ -254,11 +253,6 @@ class HasAnyKeys(HasKeys):
+     logical_operator = " OR "
+ 
+ 
+-class HasKeyOrArrayIndex(HasKey):
+-    def compile_json_path_final_key(self, key_transform):
+-        return compile_json_path([key_transform], include_root=False)
+-
+-
+ class CaseInsensitiveMixin:
+     """
+     Mixin to allow case-insensitive comparison of JSON values on MySQL.
+@@ -393,7 +387,7 @@ class KeyTransformTextLookupMixin:
+ class KeyTransformIsNull(lookups.IsNull):
+     # key__isnull=False is the same as has_key='key'
+     def as_oracle(self, compiler, connection):
+-        sql, params = HasKeyOrArrayIndex(
++        sql, params = HasKey(
+             self.lhs.lhs,
+             self.lhs.key_name,
+         ).as_oracle(compiler, connection)
+@@ -407,7 +401,7 @@ class KeyTransformIsNull(lookups.IsNull):
+         template = "JSON_TYPE(%s, %%s) IS NULL"
+         if not self.rhs:
+             template = "JSON_TYPE(%s, %%s) IS NOT NULL"
+-        return HasKeyOrArrayIndex(self.lhs.lhs, self.lhs.key_name).as_sql(
++        return HasKey(self.lhs.lhs, self.lhs.key_name).as_sql(
+             compiler,
+             connection,
+             template=template,
+@@ -472,7 +466,7 @@ class KeyTransformExact(JSONExact):
+         rhs, rhs_params = super().process_rhs(compiler, connection)
+         if rhs_params == ["null"]:
+             # Field has key and it's NULL.
+-            has_key_expr = HasKeyOrArrayIndex(self.lhs.lhs, self.lhs.key_name)
++            has_key_expr = HasKey(self.lhs.lhs, self.lhs.key_name)
+             has_key_sql, has_key_params = has_key_expr.as_oracle(compiler, connection)
+             is_null_expr = self.lhs.get_lookup("isnull")(self.lhs, True)
+             is_null_sql, is_null_params = is_null_expr.as_sql(compiler, connection)

--- a/benchmarks/pr-review-benchmark/cases/swebench-django-15503/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-django-15503/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/django.git
+base_commit=d1f45f7a857f0d63a46b4c5c04b022fe7fa88c6d

--- a/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/ground_truth.md
@@ -1,0 +1,2 @@
+SWE-bench Verified instance `matplotlib__matplotlib-25775` (matplotlib/matplotlib). [ENH]: Add get/set_antialiased to Text objects
+### Problem

--- a/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-matplotlib-25775
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: lib/matplotlib/backends/backend_agg.py
+expected_line: 206
+fix_reference: 'SWE-bench Verified instance: matplotlib__matplotlib-25775 (https://www.swebench.com/)'
+description: '[ENH]: Add get/set_antialiased to Text objects ### Problem  Currently, Text objects always
+  retrieve their antialiasing state via the global rcParams["text.antialias"], unlike other artists for
+  which this can be configured on a per-artist basis via `set_antialiased` (and read via `set_antialiased`).  ###
+  Proposed solution  Add similar getters/setters on Text objects (also adjusting Annotations acco'

--- a/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/pr.diff
@@ -1,0 +1,135 @@
+diff --git a/lib/matplotlib/backends/backend_agg.py b/lib/matplotlib/backends/backend_agg.py
+index 22907b00d..7d038a998 100644
+--- a/lib/matplotlib/backends/backend_agg.py
++++ b/lib/matplotlib/backends/backend_agg.py
+@@ -206,7 +206,7 @@ class RendererAgg(RendererBase):
+         # space) in the following call to draw_text_image).
+         font.set_text(s, 0, flags=get_hinting_flag())
+         font.draw_glyphs_to_bitmap(
+-            antialiased=gc.get_antialiased())
++            antialiased=mpl.rcParams['text.antialiased'])
+         d = font.get_descent() / 64.0
+         # The descent needs to be adjusted for the angle.
+         xo, yo = font.get_bitmap_offset()
+diff --git a/lib/matplotlib/backends/backend_cairo.py b/lib/matplotlib/backends/backend_cairo.py
+index c733f3f9d..9ccadcdf1 100644
+--- a/lib/matplotlib/backends/backend_cairo.py
++++ b/lib/matplotlib/backends/backend_cairo.py
+@@ -25,6 +25,7 @@ except ImportError:
+             "cairo backend requires that pycairo>=1.14.0 or cairocffi "
+             "is installed") from err
+ 
++import matplotlib as mpl
+ from .. import _api, cbook, font_manager
+ from matplotlib.backend_bases import (
+     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
+@@ -203,7 +204,9 @@ class RendererCairo(RendererBase):
+             ctx.select_font_face(*_cairo_font_args_from_font_prop(prop))
+             ctx.set_font_size(self.points_to_pixels(prop.get_size_in_points()))
+             opts = cairo.FontOptions()
+-            opts.set_antialias(gc.get_antialiased())
++            opts.set_antialias(
++                cairo.ANTIALIAS_DEFAULT if mpl.rcParams["text.antialiased"]
++                else cairo.ANTIALIAS_NONE)
+             ctx.set_font_options(opts)
+             if angle:
+                 ctx.rotate(np.deg2rad(-angle))
+@@ -309,9 +312,6 @@ class GraphicsContextCairo(GraphicsContextBase):
+         self.ctx.set_antialias(
+             cairo.ANTIALIAS_DEFAULT if b else cairo.ANTIALIAS_NONE)
+ 
+-    def get_antialiased(self):
+-        return self.ctx.get_antialias()
+-
+     def set_capstyle(self, cs):
+         self.ctx.set_line_cap(_api.check_getitem(self._capd, capstyle=cs))
+         self._capstyle = cs
+diff --git a/lib/matplotlib/text.py b/lib/matplotlib/text.py
+index 4e377f485..4591316cf 100644
+--- a/lib/matplotlib/text.py
++++ b/lib/matplotlib/text.py
+@@ -115,7 +115,6 @@ class Text(Artist):
+                  wrap=False,
+                  transform_rotates_text=False,
+                  parse_math=None,    # defaults to rcParams['text.parse_math']
+-                 antialiased=None,  # defaults to rcParams['text.antialiased']
+                  **kwargs
+                  ):
+         """
+@@ -136,7 +135,6 @@ class Text(Artist):
+         super().__init__()
+         self._x, self._y = x, y
+         self._text = ''
+-        self._antialiased = mpl.rcParams['text.antialiased']
+         self._reset_visual_defaults(
+             text=text,
+             color=color,
+@@ -151,7 +149,6 @@ class Text(Artist):
+             transform_rotates_text=transform_rotates_text,
+             linespacing=linespacing,
+             rotation_mode=rotation_mode,
+-            antialiased=antialiased
+         )
+         self.update(kwargs)
+ 
+@@ -170,7 +167,6 @@ class Text(Artist):
+         transform_rotates_text=False,
+         linespacing=None,
+         rotation_mode=None,
+-        antialiased=None
+     ):
+         self.set_text(text)
+         self.set_color(
+@@ -191,8 +187,6 @@ class Text(Artist):
+             linespacing = 1.2  # Maybe use rcParam later.
+         self.set_linespacing(linespacing)
+         self.set_rotation_mode(rotation_mode)
+-        if antialiased is not None:
+-            self.set_antialiased(antialiased)
+ 
+     def update(self, kwargs):
+         # docstring inherited
+@@ -315,27 +309,6 @@ class Text(Artist):
+         """Return the text rotation mode."""
+         return self._rotation_mode
+ 
+-    def set_antialiased(self, antialiased):
+-        """
+-        Set whether to use antialiased rendering.
+-
+-        Parameters
+-        ----------
+-        antialiased : bool
+-
+-        Notes
+-        -----
+-        Antialiasing will be determined by :rc:`text.antialiased`
+-        and the parameter *antialiased* will have no effect if the text contains
+-        math expressions.
+-        """
+-        self._antialiased = antialiased
+-        self.stale = True
+-
+-    def get_antialiased(self):
+-        """Return whether antialiased rendering is used."""
+-        return self._antialiased
+-
+     def update_from(self, other):
+         # docstring inherited
+         super().update_from(other)
+@@ -349,7 +322,6 @@ class Text(Artist):
+         self._transform_rotates_text = other._transform_rotates_text
+         self._picker = other._picker
+         self._linespacing = other._linespacing
+-        self._antialiased = other._antialiased
+         self.stale = True
+ 
+     def _get_layout(self, renderer):
+@@ -765,7 +737,6 @@ class Text(Artist):
+             gc.set_foreground(self.get_color())
+             gc.set_alpha(self.get_alpha())
+             gc.set_url(self._url)
+-            gc.set_antialiased(self._antialiased)
+             self._set_gc_clip(gc)
+ 
+             angle = self.get_rotation()

--- a/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-matplotlib-25775/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/matplotlib.git
+base_commit=0325ab8eed1ba90ee306649ee792bc9f932ee199

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/ground_truth.md
@@ -1,0 +1,6 @@
+SWE-bench Verified instance `scikit-learn__scikit-learn-12973` (scikit-learn/scikit-learn). LassoLarsIC: unintuitive copy_X behaviour
+Hi, I would like to report what seems to be a bug in the treatment of the `copy_X` parameter of the `LassoLarsIC` class. Because it's a simple bug, it's much easier to see in the code directly than in the execution, so I am not posting steps to reproduce it.
+
+As you can see here, LassoLarsIC accepts a copy_X parameter.
+https://github.com/scikit-learn/scikit-learn/blob/7389dbac82d362f296dc2746f10e43ffa1615660/sklearn/linear_model/least_angle.py#L1487
+

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-scikit-learn-12973
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sklearn/linear_model/least_angle.py
+expected_line: 1479
+fix_reference: 'SWE-bench Verified instance: scikit-learn__scikit-learn-12973 (https://www.swebench.com/)'
+description: "LassoLarsIC: unintuitive copy_X behaviour Hi, I would like to report what seems to be a\
+  \ bug in the treatment of the `copy_X` parameter of the `LassoLarsIC` class. Because it's a simple bug,\
+  \ it's much easier to see in the code directly than in the execution, so I am not posting steps to reproduce\
+  \ it.\r \r As you can see here, LassoLarsIC accepts a copy_X parameter.\r https://github.com/scikit-learn/sc"

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/pr.diff
@@ -1,0 +1,38 @@
+diff --git a/sklearn/linear_model/least_angle.py b/sklearn/linear_model/least_angle.py
+index 82ecbc988..03b34a0dc 100644
+--- a/sklearn/linear_model/least_angle.py
++++ b/sklearn/linear_model/least_angle.py
+@@ -1479,7 +1479,7 @@ class LassoLarsIC(LassoLars):
+         self.eps = eps
+         self.fit_path = True
+ 
+-    def fit(self, X, y, copy_X=None):
++    def fit(self, X, y, copy_X=True):
+         """Fit the model using X, y as training data.
+ 
+         Parameters
+@@ -1490,9 +1490,7 @@ class LassoLarsIC(LassoLars):
+         y : array-like, shape (n_samples,)
+             target values. Will be cast to X's dtype if necessary
+ 
+-        copy_X : boolean, optional, default None
+-            If provided, this parameter will override the choice
+-            of copy_X made at instance creation.
++        copy_X : boolean, optional, default True
+             If ``True``, X will be copied; else, it may be overwritten.
+ 
+         Returns
+@@ -1500,12 +1498,10 @@ class LassoLarsIC(LassoLars):
+         self : object
+             returns an instance of self.
+         """
+-        if copy_X is None:
+-            copy_X = self.copy_X
+         X, y = check_X_y(X, y, y_numeric=True)
+ 
+         X, y, Xmean, ymean, Xstd = LinearModel._preprocess_data(
+-            X, y, self.fit_intercept, self.normalize, copy_X)
++            X, y, self.fit_intercept, self.normalize, self.copy_X)
+         max_iter = self.max_iter
+ 
+         Gram = self.precompute

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-12973/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/scikit-learn.git
+base_commit=58d1bc8141eb48b5354ddf7580902bf8063e6475

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/ground_truth.md
@@ -1,0 +1,17 @@
+SWE-bench Verified instance `scikit-learn__scikit-learn-13439` (scikit-learn/scikit-learn). Pipeline should implement __len__
+#### Description
+
+With the new indexing support `pipe[:len(pipe)]` raises an error.
+
+#### Steps/Code to Reproduce
+
+```python
+from sklearn import svm
+from sklearn.datasets import samples_generator
+from sklearn.feature_selection import SelectKBest
+from sklearn.feature_selection import f_regression
+from sklearn.pipeline import Pipeline
+
+# generate some data to play with
+X, y = samples_generator.make_classification(
+    n_informative=5, n_redundant=0,

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-scikit-learn-13439
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sklearn/pipeline.py
+expected_line: 199
+fix_reference: 'SWE-bench Verified instance: scikit-learn__scikit-learn-13439 (https://www.swebench.com/)'
+description: "Pipeline should implement __len__ #### Description\r \r With the new indexing support `pipe[:len(pipe)]`\
+  \ raises an error.\r \r #### Steps/Code to Reproduce\r \r ```python\r from sklearn import svm\r from\
+  \ sklearn.datasets import samples_generator\r from sklearn.feature_selection import SelectKBest\r from\
+  \ sklearn.feature_selection import f_regression\r from sklearn.pipeline import Pipeline\r \r # generate\
+  \ some d"

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/pr.diff
@@ -1,0 +1,17 @@
+diff --git a/sklearn/pipeline.py b/sklearn/pipeline.py
+index d1d03656d..7eaf9a46f 100644
+--- a/sklearn/pipeline.py
++++ b/sklearn/pipeline.py
+@@ -199,12 +199,6 @@ class Pipeline(_BaseComposition):
+             if trans is not None and trans != 'passthrough':
+                 yield idx, name, trans
+ 
+-    def __len__(self):
+-        """
+-        Returns the length of the Pipeline
+-        """
+-        return len(self.steps)
+-
+     def __getitem__(self, ind):
+         """Returns a sub-pipeline or a single esimtator in the pipeline
+ 

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-13439/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/scikit-learn.git
+base_commit=7484a44e848f3c97c946a62c77f5fb95602ca063

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/ground_truth.md
@@ -1,0 +1,18 @@
+SWE-bench Verified instance `scikit-learn__scikit-learn-14983` (scikit-learn/scikit-learn). RepeatedKFold and RepeatedStratifiedKFold do not show correct __repr__ string
+#### Description
+
+`RepeatedKFold` and `RepeatedStratifiedKFold` do not show correct \_\_repr\_\_ string.
+
+#### Steps/Code to Reproduce
+
+```python
+>>> from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
+>>> repr(RepeatedKFold())
+>>> repr(RepeatedStratifiedKFold())
+```
+
+#### Expected Results
+
+```python
+>>> repr(RepeatedKFold())
+RepeatedKFold(n_splits=5, n_repeats=10, random_state=No

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-scikit-learn-14983
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sklearn/model_selection/_split.py
+expected_line: 1163
+fix_reference: 'SWE-bench Verified instance: scikit-learn__scikit-learn-14983 (https://www.swebench.com/)'
+description: "RepeatedKFold and RepeatedStratifiedKFold do not show correct __repr__ string #### Description\r\
+  \ \r `RepeatedKFold` and `RepeatedStratifiedKFold` do not show correct \\_\\_repr\\_\\_ string.\r \r\
+  \ #### Steps/Code to Reproduce\r \r ```python\r >>> from sklearn.model_selection import RepeatedKFold,\
+  \ RepeatedStratifiedKFold\r >>> repr(RepeatedKFold())\r >>> repr(RepeatedStratifiedKFold())\r ```\r\
+  \ \r #### Expected Resu"

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/pr.diff
@@ -1,0 +1,23 @@
+diff --git a/sklearn/model_selection/_split.py b/sklearn/model_selection/_split.py
+index ceee1a081..c49a3ce6a 100644
+--- a/sklearn/model_selection/_split.py
++++ b/sklearn/model_selection/_split.py
+@@ -1163,9 +1163,6 @@ class _RepeatedSplits(metaclass=ABCMeta):
+                      **self.cvargs)
+         return cv.get_n_splits(X, y, groups) * self.n_repeats
+ 
+-    def __repr__(self):
+-        return _build_repr(self)
+-
+ 
+ class RepeatedKFold(_RepeatedSplits):
+     """Repeated K-Fold cross validator.
+@@ -2161,8 +2158,6 @@ def _build_repr(self):
+         try:
+             with warnings.catch_warnings(record=True) as w:
+                 value = getattr(self, key, None)
+-                if value is None and hasattr(self, 'cvargs'):
+-                    value = self.cvargs.get(key, None)
+             if len(w) and w[0].category == DeprecationWarning:
+                 # if the parameter is deprecated, don't show it
+                 continue

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-14983/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/scikit-learn.git
+base_commit=bb966db623c9762b1bf3ce30eadf57834f3b0810

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/ground_truth.md
@@ -1,0 +1,7 @@
+SWE-bench Verified instance `scikit-learn__scikit-learn-25232` (scikit-learn/scikit-learn). IterativeImputer has no parameter "fill_value"
+### Describe the workflow you want to enable
+
+In the first imputation round of `IterativeImputer`, an initial value needs to be set for the missing values. From its [docs](https://scikit-learn.org/stable/modules/generated/sklearn.impute.IterativeImputer.html):
+
+> **initial_strategy {‘mean’, ‘median’, ‘most_frequent’, ‘constant’}, default=’mean’**
+> Which strategy to use to initialize the missing values. Same as the strategy parameter in SimpleI

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-scikit-learn-25232
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sklearn/impute/_iterative.py
+expected_line: 117
+fix_reference: 'SWE-bench Verified instance: scikit-learn__scikit-learn-25232 (https://www.swebench.com/)'
+description: "IterativeImputer has no parameter \"fill_value\" ### Describe the workflow you want to enable\r\
+  \ \r In the first imputation round of `IterativeImputer`, an initial value needs to be set for the missing\
+  \ values. From its [docs](https://scikit-learn.org/stable/modules/generated/sklearn.impute.IterativeImputer.html):\r\
+  \ \r > **initial_strategy {\u2018mean\u2019, \u2018median\u2019, \u2018most_frequent\u2019, \u2018constant\u2019\
+  }, default=\u2019mean\u2019**\r"

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/pr.diff
@@ -1,0 +1,52 @@
+diff --git a/sklearn/impute/_iterative.py b/sklearn/impute/_iterative.py
+index 60b2013f9..1d918bc0c 100644
+--- a/sklearn/impute/_iterative.py
++++ b/sklearn/impute/_iterative.py
+@@ -117,15 +117,6 @@ class IterativeImputer(_BaseImputer):
+         Which strategy to use to initialize the missing values. Same as the
+         `strategy` parameter in :class:`~sklearn.impute.SimpleImputer`.
+ 
+-    fill_value : str or numerical value, default=None
+-        When `strategy="constant"`, `fill_value` is used to replace all
+-        occurrences of missing_values. For string or object data types,
+-        `fill_value` must be a string.
+-        If `None`, `fill_value` will be 0 when imputing numerical
+-        data and "missing_value" for strings or object data types.
+-
+-        .. versionadded:: 1.3
+-
+     imputation_order : {'ascending', 'descending', 'roman', 'arabic', \
+             'random'}, default='ascending'
+         The order in which the features will be imputed. Possible values:
+@@ -290,7 +281,6 @@ class IterativeImputer(_BaseImputer):
+         "initial_strategy": [
+             StrOptions({"mean", "median", "most_frequent", "constant"})
+         ],
+-        "fill_value": "no_validation",  # any object is valid
+         "imputation_order": [
+             StrOptions({"ascending", "descending", "roman", "arabic", "random"})
+         ],
+@@ -311,7 +301,6 @@ class IterativeImputer(_BaseImputer):
+         tol=1e-3,
+         n_nearest_features=None,
+         initial_strategy="mean",
+-        fill_value=None,
+         imputation_order="ascending",
+         skip_complete=False,
+         min_value=-np.inf,
+@@ -333,7 +322,6 @@ class IterativeImputer(_BaseImputer):
+         self.tol = tol
+         self.n_nearest_features = n_nearest_features
+         self.initial_strategy = initial_strategy
+-        self.fill_value = fill_value
+         self.imputation_order = imputation_order
+         self.skip_complete = skip_complete
+         self.min_value = min_value
+@@ -625,7 +613,6 @@ class IterativeImputer(_BaseImputer):
+             self.initial_imputer_ = SimpleImputer(
+                 missing_values=self.missing_values,
+                 strategy=self.initial_strategy,
+-                fill_value=self.fill_value,
+                 keep_empty_features=self.keep_empty_features,
+             )
+             X_filled = self.initial_imputer_.fit_transform(X)

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25232/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/scikit-learn.git
+base_commit=065be4a12d782cb7340b0559e41b13d951b1cbd5

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/ground_truth.md
@@ -1,0 +1,2 @@
+SWE-bench Verified instance `scikit-learn__scikit-learn-25973` (scikit-learn/scikit-learn). Unable to pass splits to SequentialFeatureSelector
+### Describe the bug

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-scikit-learn-25973
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sklearn/feature_selection/_sequential.py
+expected_line: 8
+fix_reference: 'SWE-bench Verified instance: scikit-learn__scikit-learn-25973 (https://www.swebench.com/)'
+description: "Unable to pass splits to SequentialFeatureSelector ### Describe the bug  This runs fine\
+  \ with e.g. `cv=5`, but according to the documentation, it should also be able to take an iterable of\
+  \ splits.\r However, passing splits from the cross validator fails\r \r Im fairly certain I have done\
+  \ similar things in the past to other classes in scikit-learn requiring a `cv` parameter.\r \r If somebody\
+  \ could confir"

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/pr.diff
@@ -1,0 +1,55 @@
+diff --git a/sklearn/feature_selection/_sequential.py b/sklearn/feature_selection/_sequential.py
+index 2498cd53b..e983c55de 100644
+--- a/sklearn/feature_selection/_sequential.py
++++ b/sklearn/feature_selection/_sequential.py
+@@ -8,12 +8,12 @@ import numpy as np
+ import warnings
+ 
+ from ._base import SelectorMixin
+-from ..base import BaseEstimator, MetaEstimatorMixin, clone, is_classifier
++from ..base import BaseEstimator, MetaEstimatorMixin, clone
+ from ..utils._param_validation import HasMethods, Hidden, Interval, StrOptions
+ from ..utils._param_validation import RealNotInt
+ from ..utils._tags import _safe_tags
+ from ..utils.validation import check_is_fitted
+-from ..model_selection import cross_val_score, check_cv
++from ..model_selection import cross_val_score
+ from ..metrics import get_scorer_names
+ 
+ 
+@@ -259,8 +259,6 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
+         if self.tol is not None and self.tol < 0 and self.direction == "forward":
+             raise ValueError("tol must be positive when doing forward selection")
+ 
+-        cv = check_cv(self.cv, y, classifier=is_classifier(self.estimator))
+-
+         cloned_estimator = clone(self.estimator)
+ 
+         # the current mask corresponds to the set of features:
+@@ -277,7 +275,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
+         is_auto_select = self.tol is not None and self.n_features_to_select == "auto"
+         for _ in range(n_iterations):
+             new_feature_idx, new_score = self._get_best_new_feature_score(
+-                cloned_estimator, X, y, cv, current_mask
++                cloned_estimator, X, y, current_mask
+             )
+             if is_auto_select and ((new_score - old_score) < self.tol):
+                 break
+@@ -293,7 +291,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
+ 
+         return self
+ 
+-    def _get_best_new_feature_score(self, estimator, X, y, cv, current_mask):
++    def _get_best_new_feature_score(self, estimator, X, y, current_mask):
+         # Return the best new feature and its score to add to the current_mask,
+         # i.e. return the best new feature and its score to add (resp. remove)
+         # when doing forward selection (resp. backward selection).
+@@ -311,7 +309,7 @@ class SequentialFeatureSelector(SelectorMixin, MetaEstimatorMixin, BaseEstimator
+                 estimator,
+                 X_new,
+                 y,
+-                cv=cv,
++                cv=self.cv,
+                 scoring=self.scoring,
+                 n_jobs=self.n_jobs,
+             ).mean()

--- a/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-scikit-learn-25973/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/scikit-learn.git
+base_commit=c39ca5027343ccfa5e73c30502a8f8dcf6b5f3ba

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/ground_truth.md
@@ -1,0 +1,2 @@
+SWE-bench Verified instance `sphinx-doc__sphinx-11510` (sphinx-doc/sphinx). source-read event does not modify include'd files source
+### Describe the bug

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-sphinx-11510
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sphinx/directives/other.py
+expected_line: 8
+fix_reference: 'SWE-bench Verified instance: sphinx-doc__sphinx-11510 (https://www.swebench.com/)'
+description: "source-read event does not modify include'd files source ### Describe the bug  In [Yocto\
+  \ documentation](https://git.yoctoproject.org/yocto-docs), we use a custom extension to do some search\
+  \ and replace in literal blocks, see https://git.yoctoproject.org/yocto-docs/tree/documentation/sphinx/yocto-vars.py.\r\
+  \ \r We discovered (https://git.yoctoproject.org/yocto-docs/commit/?id=b7375ea4380e716a02c736e42"

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/pr.diff
@@ -1,0 +1,61 @@
+diff --git a/sphinx/directives/other.py b/sphinx/directives/other.py
+index e65cbfdfe..19f7c0a8d 100644
+--- a/sphinx/directives/other.py
++++ b/sphinx/directives/other.py
+@@ -8,7 +8,6 @@ from docutils.parsers.rst import directives
+ from docutils.parsers.rst.directives.admonitions import BaseAdmonition
+ from docutils.parsers.rst.directives.misc import Class
+ from docutils.parsers.rst.directives.misc import Include as BaseInclude
+-from docutils.statemachine import StateMachine
+ 
+ from sphinx import addnodes
+ from sphinx.domains.changeset import VersionChange  # noqa: F401  # for compatibility
+@@ -18,7 +17,6 @@ from sphinx.util import docname_join, logging, url_re
+ from sphinx.util.docutils import SphinxDirective
+ from sphinx.util.matching import Matcher, patfilter
+ from sphinx.util.nodes import explicit_title_re
+-from sphinx.util.osutil import os_path
+ 
+ if TYPE_CHECKING:
+     from docutils.nodes import Element, Node
+@@ -371,40 +369,6 @@ class Include(BaseInclude, SphinxDirective):
+     """
+ 
+     def run(self) -> list[Node]:
+-
+-        # To properly emit "source-read" events from included RST text,
+-        # we must patch the ``StateMachine.insert_input()`` method.
+-        # In the future, docutils will hopefully offer a way for Sphinx
+-        # to provide the RST parser to use
+-        # when parsing RST text that comes in via Include directive.
+-        def _insert_input(include_lines, path):
+-            # First, we need to combine the lines back into text so that
+-            # we can send it with the source-read event.
+-            # In docutils 0.18 and later, there are two lines at the end
+-            # that act as markers.
+-            # We must preserve them and leave them out of the source-read event:
+-            text = "\n".join(include_lines[:-2])
+-
+-            # The docname to pass into the source-read event
+-            docname = self.env.path2doc(os_path(path))
+-            # Emit the "source-read" event
+-            arg = [text]
+-            self.env.app.events.emit("source-read", docname, arg)
+-            text = arg[0]
+-
+-            # Split back into lines and reattach the two marker lines
+-            include_lines = text.splitlines() + include_lines[-2:]
+-
+-            # Call the parent implementation.
+-            # Note that this snake does not eat its tail because we patch
+-            # the *Instance* method and this call is to the *Class* method.
+-            return StateMachine.insert_input(self.state_machine, include_lines, path)
+-
+-        # Only enable this patch if there are listeners for 'source-read'.
+-        if self.env.app.events.listeners.get('source-read'):
+-            # See https://github.com/python/mypy/issues/2427 for details on the mypy issue
+-            self.state_machine.insert_input = _insert_input  # type: ignore[method-assign]
+-
+         if self.arguments[0].startswith('<') and \
+            self.arguments[0].endswith('>'):
+             # docutils "standard" includes, do not do path processing

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-11510/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sphinx.git
+base_commit=e290b311016ede1c4a46cd4915dfdbe61d572d1c

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/ground_truth.md
@@ -1,0 +1,21 @@
+SWE-bench Verified instance `sphinx-doc__sphinx-7757` (sphinx-doc/sphinx). The default value for positional only argument has vanished
+**Describe the bug**
+The default value for positional only argument has vanished
+
+**To Reproduce**
+
+Build following document:
+```
+.. py:function:: foo(a, b=0, /, c=1)
+```
+
+Result:
+<img width="148" alt="スクリーンショット 2020-05-30 23 43 01" src="https://user-images.githubusercontent.com/748828/83331159-4eab4a80-a2cf-11ea-9559-9b17cc56bc01.png">
+
+**Expected behavior**
+The default value is shown.
+
+**Your project**
+No.
+
+**Enviro

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-sphinx-7757
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sphinx/util/inspect.py
+expected_line: 518
+fix_reference: 'SWE-bench Verified instance: sphinx-doc__sphinx-7757 (https://www.swebench.com/)'
+description: "The default value for positional only argument has vanished **Describe the bug**\r The default\
+  \ value for positional only argument has vanished\r \r **To Reproduce**\r \r Build following document:\r\
+  \ ```\r .. py:function:: foo(a, b=0, /, c=1)\r ```\r \r Result:\r <img width=\"148\" alt=\"\u30B9\u30AF\
+  \u30EA\u30FC\u30F3\u30B7\u30E7\u30C3\u30C8 2020-05-30 23 43 01\" src=\"https://user-images.githubusercontent.com/748828/83331159-4eab4a80-a2cf-11ea-9559-9b17cc56b"

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/pr.diff
@@ -1,0 +1,44 @@
+diff --git a/sphinx/util/inspect.py b/sphinx/util/inspect.py
+index bac02025c..15f0d66e2 100644
+--- a/sphinx/util/inspect.py
++++ b/sphinx/util/inspect.py
+@@ -518,34 +518,19 @@ def signature_from_str(signature: str) -> inspect.Signature:
+ 
+     # parameters
+     args = definition.args
+-    defaults = list(args.defaults)
+     params = []
+-    if hasattr(args, "posonlyargs"):
+-        posonlyargs = len(args.posonlyargs)  # type: ignore
+-        positionals = posonlyargs + len(args.args)
+-    else:
+-        posonlyargs = 0
+-        positionals = len(args.args)
+-
+-    for _ in range(len(defaults), positionals):
+-        defaults.insert(0, Parameter.empty)
+ 
+     if hasattr(args, "posonlyargs"):
+-        for i, arg in enumerate(args.posonlyargs):  # type: ignore
+-            if defaults[i] is Parameter.empty:
+-                default = Parameter.empty
+-            else:
+-                default = ast_unparse(defaults[i])
+-
++        for arg in args.posonlyargs:  # type: ignore
+             annotation = ast_unparse(arg.annotation) or Parameter.empty
+             params.append(Parameter(arg.arg, Parameter.POSITIONAL_ONLY,
+-                                    default=default, annotation=annotation))
++                                    annotation=annotation))
+ 
+     for i, arg in enumerate(args.args):
+-        if defaults[i + posonlyargs] is Parameter.empty:
+-            default = Parameter.empty
++        if len(args.args) - i <= len(args.defaults):
++            default = ast_unparse(args.defaults[-len(args.args) + i])
+         else:
+-            default = ast_unparse(defaults[i + posonlyargs])
++            default = Parameter.empty
+ 
+         annotation = ast_unparse(arg.annotation) or Parameter.empty
+         params.append(Parameter(arg.arg, Parameter.POSITIONAL_OR_KEYWORD,

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-7757/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sphinx.git
+base_commit=a34a32c54967fc89d20c455afab8448677028a9f

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/ground_truth.md
@@ -1,0 +1,13 @@
+SWE-bench Verified instance `sphinx-doc__sphinx-8551` (sphinx-doc/sphinx). :type: and :rtype: gives false ambiguous class lookup warnings
+**Describe the bug**
+The implicit xrefs created by the info fields ``:type:`` and ``:rtype:`` seems to do lookup differently than explicit xref roles. For unqualified names it seems like they search for the name in every (sub)module instead of in the current module and then parent modules.
+
+**To Reproduce**
+```rst
+.. py:class:: mod.A
+.. py:class:: mod.submod.A
+
+.. py:function:: f()
+
+	- :py:class:`mod.A`
+	- :py:class:`mod.s

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-sphinx-8551
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sphinx/domains/python.py
+expected_line: 272
+fix_reference: 'SWE-bench Verified instance: sphinx-doc__sphinx-8551 (https://www.swebench.com/)'
+description: ":type: and :rtype: gives false ambiguous class lookup warnings **Describe the bug**\r The\
+  \ implicit xrefs created by the info fields ``:type:`` and ``:rtype:`` seems to do lookup differently\
+  \ than explicit xref roles. For unqualified names it seems like they search for the name in every (sub)module\
+  \ instead of in the current module and then parent modules.\r \r **To Reproduce**\r ```rst\r .. py:class::\
+  \ mo"

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/pr.diff
@@ -1,0 +1,25 @@
+diff --git a/sphinx/domains/python.py b/sphinx/domains/python.py
+index c4d134d08..79d7e4f46 100644
+--- a/sphinx/domains/python.py
++++ b/sphinx/domains/python.py
+@@ -272,8 +272,6 @@ class PyXrefMixin:
+         result = super().make_xref(rolename, domain, target,  # type: ignore
+                                    innernode, contnode, env)
+         result['refspecific'] = True
+-        result['py:module'] = env.ref_context.get('py:module')
+-        result['py:class'] = env.ref_context.get('py:class')
+         if target.startswith(('.', '~')):
+             prefix, result['reftarget'] = target[0], target[1:]
+             if prefix == '.':
+diff --git a/sphinx/util/docfields.py b/sphinx/util/docfields.py
+index 9a57ccff7..404bb127f 100644
+--- a/sphinx/util/docfields.py
++++ b/sphinx/util/docfields.py
+@@ -295,7 +295,6 @@ class DocFieldTransformer:
+                         self.directive.domain,
+                         target,
+                         contnode=content[0],
+-                        env=self.directive.state.document.settings.env
+                     )
+                     if _is_single_paragraph(field_body):
+                         paragraph = cast(nodes.paragraph, field_body[0])

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8551/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sphinx.git
+base_commit=f00278e045c4917043c34755d8f8d1ebeb76cad4

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/ground_truth.md
@@ -1,0 +1,39 @@
+SWE-bench Verified instance `sphinx-doc__sphinx-8595` (sphinx-doc/sphinx). autodoc: empty __all__ attribute is ignored
+**Describe the bug**
+autodoc: empty `__all__` attribute is ignored
+
+**To Reproduce**
+```
+# example.py
+__all__ = []
+
+
+def foo():
+    "docstring"
+
+
+def bar():
+    "docstring"
+
+
+def baz():
+    "docstring"
+```
+```
+# index.rst
+.. automodule:: example
+   :members:
+```
+
+All foo, bar, and baz are shown.
+
+**Expected behavior**
+No entries should be shown because `__all__` is empty.
+
+**Your project**
+No
+
+**Screenshots**
+No
+
+**

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-sphinx-8595
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sphinx/ext/autodoc/__init__.py
+expected_line: 1074
+fix_reference: 'SWE-bench Verified instance: sphinx-doc__sphinx-8595 (https://www.swebench.com/)'
+description: "autodoc: empty __all__ attribute is ignored **Describe the bug**\r autodoc: empty `__all__`\
+  \ attribute is ignored\r \r **To Reproduce**\r ```\r # example.py\r __all__ = []\r \r \r def foo():\r\
+  \     \"docstring\"\r \r \r def bar():\r     \"docstring\"\r \r \r def baz():\r     \"docstring\"\r\
+  \ ```\r ```\r # index.rst\r .. automodule:: example\r    :members:\r ```\r \r All foo, bar, and baz\
+  \ are shown.\r \r **Expected behavior**\r No entr"

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/pr.diff
@@ -1,0 +1,13 @@
+diff --git a/sphinx/ext/autodoc/__init__.py b/sphinx/ext/autodoc/__init__.py
+index c9f90acca..d85d79617 100644
+--- a/sphinx/ext/autodoc/__init__.py
++++ b/sphinx/ext/autodoc/__init__.py
+@@ -1074,7 +1074,7 @@ class ModuleDocumenter(Documenter):
+     def get_object_members(self, want_all: bool) -> Tuple[bool, ObjectMembers]:
+         members = self.get_module_members()
+         if want_all:
+-            if self.__all__ is None:
++            if not self.__all__:
+                 # for implicit module members, check __module__ to avoid
+                 # documenting imported objects
+                 return True, list(members.values())

--- a/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sphinx-8595/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sphinx.git
+base_commit=01c7d19fcbc945c3a37e00f81bf72d3c1869ce87

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/ground_truth.md
@@ -1,0 +1,10 @@
+SWE-bench Verified instance `sympy__sympy-15599` (sympy/sympy). Mod(3*i, 2) unchanged
+`Mod(3*i, 2)` should reduce to `Mod(i, 2)` (as reported in [this post](https://stackoverflow.com/questions/53302669/sympify-does-not-simplify-remainder-as-expected)) and will do so with a change something like this:
+```diff
+diff --git a/sympy/core/mod.py b/sympy/core/mod.py
+index eae2563..b1ff867 100644
+--- a/sympy/core/mod.py
++++ b/sympy/core/mod.py
+@@ -123,9 +123,11 @@ def doit(p, q):
+             for arg in p.args:
+                 both_l[isinstance(arg, cls)].ap

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-sympy-15599
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sympy/core/mod.py
+expected_line: 1
+fix_reference: 'SWE-bench Verified instance: sympy__sympy-15599 (https://www.swebench.com/)'
+description: "Mod(3*i, 2) unchanged `Mod(3*i, 2)` should reduce to `Mod(i, 2)` (as reported in [this post](https://stackoverflow.com/questions/53302669/sympify-does-not-simplify-remainder-as-expected))\
+  \ and will do so with a change something like this:\r ```diff\r diff --git a/sympy/core/mod.py b/sympy/core/mod.py\r\
+  \ index eae2563..b1ff867 100644\r --- a/sympy/core/mod.py\r +++ b/sympy/core/mod.py\r @@ -123,9 +123,11\
+  \ @"

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/pr.diff
@@ -1,0 +1,49 @@
+diff --git a/sympy/core/mod.py b/sympy/core/mod.py
+index 0498f7a75d..eae25630cc 100644
+--- a/sympy/core/mod.py
++++ b/sympy/core/mod.py
+@@ -1,7 +1,6 @@
+ from __future__ import print_function, division
+ 
+-from sympy.core.numbers import nan, Integer
+-from sympy.core.compatibility import integer_types
++from sympy.core.numbers import nan
+ from .function import Function
+ 
+ 
+@@ -46,7 +45,7 @@ def doit(p, q):
+ 
+             if q.is_Number:
+                 if p.is_Number:
+-                    return p%q
++                    return (p % q)
+                 if q == 2:
+                     if p.is_even:
+                         return S.Zero
+@@ -65,7 +64,7 @@ def doit(p, q):
+             except TypeError:
+                 pass
+             else:
+-                if isinstance(d, integer_types):
++                if type(d) is int:
+                     rv = p - d*q
+                     if (rv*q < 0) == True:
+                         rv += q
+@@ -140,17 +139,6 @@ def doit(p, q):
+                 net = prod_mod1*prod_mod
+                 return prod_non_mod*cls(net, q)
+ 
+-            if q.is_Integer and q is not S.One:
+-                _ = []
+-                for i in non_mod_l:
+-                    if i.is_Integer and (i % q is not S.Zero):
+-                        _.append(i%q)
+-                    else:
+-                        _.append(i)
+-                non_mod_l = _
+-
+-            p = Mul(*(non_mod_l + mod_l))
+-
+         # XXX other possibilities?
+ 
+         # extract gcd; any further simplification should be done by the user

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-15599/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sympy.git
+base_commit=329bf8b3b207af901bbb1d4bbde08410fd0e0466

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/ground_truth.md
@@ -1,0 +1,8 @@
+SWE-bench Verified instance `sympy__sympy-23413` (sympy/sympy). bug with HNF removing rows
+I expect
+`np.flip (hermite_normal_form (Matrix (np.flip (np.array ([[5, 8, 12], [0, 0, 1]]))).T).T))`
+to give
+`[[5,  8, 0], [0,  0, 1]]`
+but instead I get
+`[[5,  8, 0]]`
+It seems to be falsely identifying my matrix as rank-deficient and removing the row when I try to achieve a row-style HNF using flips and transposes.

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-sympy-23413
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sympy/polys/matrices/normalforms.py
+expected_line: 205
+fix_reference: 'SWE-bench Verified instance: sympy__sympy-23413 (https://www.swebench.com/)'
+description: "bug with HNF removing rows I expect\r `np.flip (hermite_normal_form (Matrix (np.flip (np.array\
+  \ ([[5, 8, 12], [0, 0, 1]]))).T).T))`\r to give\r `[[5,  8, 0], [0,  0, 1]]`\r but instead I get\r `[[5,\
+  \  8, 0]]`\r It seems to be falsely identifying my matrix as rank-deficient and removing the row when\
+  \ I try to achieve a row-style HNF using flips and transposes."

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/pr.diff
@@ -1,0 +1,28 @@
+diff --git a/sympy/polys/matrices/normalforms.py b/sympy/polys/matrices/normalforms.py
+index e2c0546857..30f5534b08 100644
+--- a/sympy/polys/matrices/normalforms.py
++++ b/sympy/polys/matrices/normalforms.py
+@@ -205,19 +205,16 @@ def _hermite_normal_form(A):
+     if not A.domain.is_ZZ:
+         raise DMDomainError('Matrix must be over domain ZZ.')
+     # We work one row at a time, starting from the bottom row, and working our
+-    # way up.
++    # way up. The total number of rows we will consider is min(m, n), where
++    # A is an m x n matrix.
+     m, n = A.shape
++    rows = min(m, n)
+     A = A.to_dense().rep.copy()
+     # Our goal is to put pivot entries in the rightmost columns.
+     # Invariant: Before processing each row, k should be the index of the
+     # leftmost column in which we have so far put a pivot.
+     k = n
+-    for i in range(m - 1, -1, -1):
+-        if k == 0:
+-            # This case can arise when n < m and we've already found n pivots.
+-            # We don't need to consider any more rows, because this is already
+-            # the maximum possible number of pivots.
+-            break
++    for i in range(m - 1, m - 1 - rows, -1):
+         k -= 1
+         # k now points to the column in which we want to put a pivot.
+         # We want zeros in all entries to the left of the pivot column.

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23413/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sympy.git
+base_commit=05f5abf2551d9e7135c48d81a8dfcbdb3ec46b89

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/ground_truth.md
@@ -1,0 +1,8 @@
+SWE-bench Verified instance `sympy__sympy-23534` (sympy/sympy). Using symbols to create functions doesn't work if there is an extra layer of parentheses
+Sympy version == 1.10.1
+
+Using `symbols` to create symbol-like objects like instances of `Function` as shown in the [documentation](https://docs.sympy.org/latest/modules/core.html?highlight=symbols#symbols) creates objects of class `Symbol` instead of `Function` if there is an extra layer of parentheses.
+
+The extra layer of parentheses are necessary to deconstruct the output as separate tuples.
+
+Runnin

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/ground_truth.yaml
@@ -1,0 +1,12 @@
+case_id: swebench-sympy-23534
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sympy/core/symbol.py
+expected_line: 791
+fix_reference: 'SWE-bench Verified instance: sympy__sympy-23534 (https://www.swebench.com/)'
+description: "Using symbols to create functions doesn't work if there is an extra layer of parentheses\
+  \ Sympy version == 1.10.1\r \r Using `symbols` to create symbol-like objects like instances of `Function`\
+  \ as shown in the [documentation](https://docs.sympy.org/latest/modules/core.html?highlight=symbols#symbols)\
+  \ creates objects of class `Symbol` instead of `Function` if there is an extra layer of parentheses.\r\
+  \ \r "

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/pr.diff
@@ -1,0 +1,13 @@
+diff --git a/sympy/core/symbol.py b/sympy/core/symbol.py
+index 2aca8bab27..f4a555c13f 100644
+--- a/sympy/core/symbol.py
++++ b/sympy/core/symbol.py
+@@ -791,7 +791,7 @@ def literal(s):
+         return tuple(result)
+     else:
+         for name in names:
+-            result.append(symbols(name, cls=cls, **args))
++            result.append(symbols(name, **args))
+ 
+         return type(names)(result)
+ 

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-23534/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sympy.git
+base_commit=8a313865bc66e1982eded4289e86b6455e8ef4e3

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/ground_truth.md
@@ -1,0 +1,15 @@
+SWE-bench Verified instance `sympy__sympy-24213` (sympy/sympy). collect_factor_and_dimension does not detect equivalent dimensions in addition
+Code to reproduce:
+```python
+from sympy.physics import units
+from sympy.physics.units.systems.si import SI
+
+v1 = units.Quantity('v1')
+SI.set_quantity_dimension(v1, units.velocity)
+SI.set_quantity_scale_factor(v1, 2 * units.meter / units.second)
+
+a1 = units.Quantity('a1')
+SI.set_quantity_dimension(a1, units.acceleration)
+SI.set_quantity_scale_factor(a1, -9.8 * units.meter / units.second**2)
+
+t1 = units.Qua

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-sympy-24213
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: sympy/physics/units/unitsystem.py
+expected_line: 175
+fix_reference: 'SWE-bench Verified instance: sympy__sympy-24213 (https://www.swebench.com/)'
+description: "collect_factor_and_dimension does not detect equivalent dimensions in addition Code to reproduce:\r\
+  \ ```python\r from sympy.physics import units\r from sympy.physics.units.systems.si import SI\r \r v1\
+  \ = units.Quantity('v1')\r SI.set_quantity_dimension(v1, units.velocity)\r SI.set_quantity_scale_factor(v1,\
+  \ 2 * units.meter / units.second)\r \r a1 = units.Quantity('a1')\r SI.set_quantity_dimension(a1, units.acc"

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/pr.diff
@@ -1,0 +1,13 @@
+diff --git a/sympy/physics/units/unitsystem.py b/sympy/physics/units/unitsystem.py
+index 5705c821c2..a436880c4b 100644
+--- a/sympy/physics/units/unitsystem.py
++++ b/sympy/physics/units/unitsystem.py
+@@ -175,7 +175,7 @@ def _collect_factor_and_dimension(self, expr):
+             for addend in expr.args[1:]:
+                 addend_factor, addend_dim = \
+                     self._collect_factor_and_dimension(addend)
+-                if not self.get_dimension_system().equivalent_dims(dim, addend_dim):
++                if dim != addend_dim:
+                     raise ValueError(
+                         'Dimension of "{}" is {}, '
+                         'but it should be {}'.format(

--- a/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-sympy-24213/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/sympy.git
+base_commit=a21c56845de0f6c5f2ae2f81454dd84725464bb9

--- a/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/ground_truth.md
+++ b/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/ground_truth.md
@@ -1,0 +1,2 @@
+SWE-bench Verified instance `pydata__xarray-6992` (pydata/xarray). index refactor: more `_coord_names` than `_variables` on Dataset
+### What happened?

--- a/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/ground_truth.yaml
+++ b/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/ground_truth.yaml
@@ -1,0 +1,11 @@
+case_id: swebench-xarray-6992
+language: python
+category: real_bug_fix
+bug_type: swebench-derived
+expected_file: xarray/core/dataset.py
+expected_line: 4026
+fix_reference: 'SWE-bench Verified instance: pydata__xarray-6992 (https://www.swebench.com/)'
+description: 'index refactor: more `_coord_names` than `_variables` on Dataset ### What happened?  `xr.core.dataset.DataVariables`
+  assumes that everything that is in `ds._dataset._variables` and not in `self._dataset._coord_names`
+  is a "data variable". However, since the index refactor we can end up with more `_coord_names` than
+  `_variables` which breaks a number of stuff (e.g. the repr).  ### What did you expe'

--- a/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/pr.diff
+++ b/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/pr.diff
@@ -1,0 +1,204 @@
+diff --git a/xarray/core/dataset.py b/xarray/core/dataset.py
+index c500b537..620f32f8 100644
+--- a/xarray/core/dataset.py
++++ b/xarray/core/dataset.py
+@@ -4026,11 +4026,10 @@ class Dataset(
+         dim_coords = either_dict_or_kwargs(indexes, indexes_kwargs, "set_index")
+ 
+         new_indexes: dict[Hashable, Index] = {}
+-        new_variables: dict[Hashable, Variable] = {}
+-        drop_indexes: set[Hashable] = set()
+-        drop_variables: set[Hashable] = set()
++        new_variables: dict[Hashable, IndexVariable] = {}
++        maybe_drop_indexes: list[Hashable] = []
++        drop_variables: list[Hashable] = []
+         replace_dims: dict[Hashable, Hashable] = {}
+-        all_var_names: set[Hashable] = set()
+ 
+         for dim, _var_names in dim_coords.items():
+             if isinstance(_var_names, str) or not isinstance(_var_names, Sequence):
+@@ -4045,19 +4044,16 @@ class Dataset(
+                     + " variable(s) do not exist"
+                 )
+ 
+-            all_var_names.update(var_names)
+-            drop_variables.update(var_names)
++            current_coord_names = self.xindexes.get_all_coords(dim, errors="ignore")
+ 
+-            # drop any pre-existing index involved and its corresponding coordinates
+-            index_coord_names = self.xindexes.get_all_coords(dim, errors="ignore")
+-            all_index_coord_names = set(index_coord_names)
++            # drop any pre-existing index involved
++            maybe_drop_indexes += list(current_coord_names) + var_names
+             for k in var_names:
+-                all_index_coord_names.update(
++                maybe_drop_indexes += list(
+                     self.xindexes.get_all_coords(k, errors="ignore")
+                 )
+ 
+-            drop_indexes.update(all_index_coord_names)
+-            drop_variables.update(all_index_coord_names)
++            drop_variables += var_names
+ 
+             if len(var_names) == 1 and (not append or dim not in self._indexes):
+                 var_name = var_names[0]
+@@ -4069,14 +4065,10 @@ class Dataset(
+                     )
+                 idx = PandasIndex.from_variables({dim: var})
+                 idx_vars = idx.create_variables({var_name: var})
+-
+-                # trick to preserve coordinate order in this case
+-                if dim in self._coord_names:
+-                    drop_variables.remove(dim)
+             else:
+                 if append:
+                     current_variables = {
+-                        k: self._variables[k] for k in index_coord_names
++                        k: self._variables[k] for k in current_coord_names
+                     }
+                 else:
+                     current_variables = {}
+@@ -4091,17 +4083,8 @@ class Dataset(
+             new_indexes.update({k: idx for k in idx_vars})
+             new_variables.update(idx_vars)
+ 
+-        # re-add deindexed coordinates (convert to base variables)
+-        for k in drop_variables:
+-            if (
+-                k not in new_variables
+-                and k not in all_var_names
+-                and k in self._coord_names
+-            ):
+-                new_variables[k] = self._variables[k].to_base_variable()
+-
+         indexes_: dict[Any, Index] = {
+-            k: v for k, v in self._indexes.items() if k not in drop_indexes
++            k: v for k, v in self._indexes.items() if k not in maybe_drop_indexes
+         }
+         indexes_.update(new_indexes)
+ 
+@@ -4116,7 +4099,7 @@ class Dataset(
+                 new_dims = [replace_dims.get(d, d) for d in v.dims]
+                 variables[k] = v._replace(dims=new_dims)
+ 
+-        coord_names = self._coord_names - drop_variables | set(new_variables)
++        coord_names = self._coord_names - set(drop_variables) | set(new_variables)
+ 
+         return self._replace_with_new_dims(
+             variables, coord_names=coord_names, indexes=indexes_
+@@ -4156,60 +4139,35 @@ class Dataset(
+                 f"{tuple(invalid_coords)} are not coordinates with an index"
+             )
+ 
+-        drop_indexes: set[Hashable] = set()
+-        drop_variables: set[Hashable] = set()
+-        seen: set[Index] = set()
++        drop_indexes: list[Hashable] = []
++        drop_variables: list[Hashable] = []
++        replaced_indexes: list[PandasMultiIndex] = []
+         new_indexes: dict[Hashable, Index] = {}
+-        new_variables: dict[Hashable, Variable] = {}
+-
+-        def drop_or_convert(var_names):
+-            if drop:
+-                drop_variables.update(var_names)
+-            else:
+-                base_vars = {
+-                    k: self._variables[k].to_base_variable() for k in var_names
+-                }
+-                new_variables.update(base_vars)
++        new_variables: dict[Hashable, IndexVariable] = {}
+ 
+         for name in dims_or_levels:
+             index = self._indexes[name]
++            drop_indexes += list(self.xindexes.get_all_coords(name))
++
++            if isinstance(index, PandasMultiIndex) and name not in self.dims:
++                # special case for pd.MultiIndex (name is an index level):
++                # replace by a new index with dropped level(s) instead of just drop the index
++                if index not in replaced_indexes:
++                    level_names = index.index.names
++                    level_vars = {
++                        k: self._variables[k]
++                        for k in level_names
++                        if k not in dims_or_levels
++                    }
++                    if level_vars:
++                        idx = index.keep_levels(level_vars)
++                        idx_vars = idx.create_variables(level_vars)
++                        new_indexes.update({k: idx for k in idx_vars})
++                        new_variables.update(idx_vars)
++                replaced_indexes.append(index)
+ 
+-            if index in seen:
+-                continue
+-            seen.add(index)
+-
+-            idx_var_names = set(self.xindexes.get_all_coords(name))
+-            drop_indexes.update(idx_var_names)
+-
+-            if isinstance(index, PandasMultiIndex):
+-                # special case for pd.MultiIndex
+-                level_names = index.index.names
+-                keep_level_vars = {
+-                    k: self._variables[k]
+-                    for k in level_names
+-                    if k not in dims_or_levels
+-                }
+-
+-                if index.dim not in dims_or_levels and keep_level_vars:
+-                    # do not drop the multi-index completely
+-                    # instead replace it by a new (multi-)index with dropped level(s)
+-                    idx = index.keep_levels(keep_level_vars)
+-                    idx_vars = idx.create_variables(keep_level_vars)
+-                    new_indexes.update({k: idx for k in idx_vars})
+-                    new_variables.update(idx_vars)
+-                    if not isinstance(idx, PandasMultiIndex):
+-                        # multi-index reduced to single index
+-                        # backward compatibility: unique level coordinate renamed to dimension
+-                        drop_variables.update(keep_level_vars)
+-                    drop_or_convert(
+-                        [k for k in level_names if k not in keep_level_vars]
+-                    )
+-                else:
+-                    # always drop the multi-index dimension variable
+-                    drop_variables.add(index.dim)
+-                    drop_or_convert(level_names)
+-            else:
+-                drop_or_convert(idx_var_names)
++            if drop:
++                drop_variables.append(name)
+ 
+         indexes = {k: v for k, v in self._indexes.items() if k not in drop_indexes}
+         indexes.update(new_indexes)
+@@ -4219,11 +4177,9 @@ class Dataset(
+         }
+         variables.update(new_variables)
+ 
+-        coord_names = self._coord_names - drop_variables
++        coord_names = set(new_variables) | self._coord_names
+ 
+-        return self._replace_with_new_dims(
+-            variables, coord_names=coord_names, indexes=indexes
+-        )
++        return self._replace(variables, coord_names=coord_names, indexes=indexes)
+ 
+     def reorder_levels(
+         self: T_Dataset,
+diff --git a/xarray/core/indexes.py b/xarray/core/indexes.py
+index 1150cb6b..6df5439b 100644
+--- a/xarray/core/indexes.py
++++ b/xarray/core/indexes.py
+@@ -717,11 +717,8 @@ class PandasMultiIndex(PandasIndex):
+             level_coords_dtype = {k: self.level_coords_dtype[k] for k in index.names}
+             return self._replace(index, level_coords_dtype=level_coords_dtype)
+         else:
+-            # backward compatibility: rename the level coordinate to the dimension name
+             return PandasIndex(
+-                index.rename(self.dim),
+-                self.dim,
+-                coord_dtype=self.level_coords_dtype[index.name],
++                index, self.dim, coord_dtype=self.level_coords_dtype[index.name]
+             )
+ 
+     def reorder_levels(

--- a/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/repo.txt
+++ b/benchmarks/pr-review-benchmark/cases/swebench-xarray-6992/repo.txt
@@ -1,0 +1,2 @@
+repo_url=https://github.com/Aletheore/xarray.git
+base_commit=e0bcda3d67401e76fe62135c3dece13e616b71b4

--- a/benchmarks/pr-review-benchmark/scripts/normalize.py
+++ b/benchmarks/pr-review-benchmark/scripts/normalize.py
@@ -17,7 +17,7 @@ def normalize_aletheore(raw_comments: list[dict]) -> list[dict]:
                 findings.append({
                     "file": citation["file"],
                     "line": citation["line"],
-                    "message": paragraph.strip(),
+                    "message": paragraph.split("```", 1)[0].strip(),
                     "severity": None,
                 })
     return findings

--- a/benchmarks/pr-review-benchmark/tests/test_normalize.py
+++ b/benchmarks/pr-review-benchmark/tests/test_normalize.py
@@ -33,6 +33,41 @@ def test_normalize_aletheore_extracts_citations_from_bot_pr_comments():
     }]
 
 
+def test_normalize_aletheore_excludes_suggestion_from_message():
+    # Real captured excerpt from https://github.com/ArihantK15/
+    # proctor-browser/pull/214 (case 016-flask-sql-injection-user-lookup).
+    # The suggestion's quoted replacement query ("...WHERE username = ?")
+    # must not end up in `message`, or check_citations.py's content-
+    # grounding check quote-verifies it against the *current* (different,
+    # unparameterized) code and fails by construction -- see
+    # scripts/check_citations.py's own docstring on this exact trap.
+    raw_comments = [{
+        "body": (
+            "- `benchmark-sandbox/016-flask-sql-injection-user-lookup/"
+            "src/flask/helpers.py:655` — SQL injection vulnerability: "
+            "user-supplied username is concatenated directly into the SQL "
+            "query string without parameterization. An attacker can "
+            "inject arbitrary SQL.\n"
+            "  ```\n"
+            "  Use a parameterized query, e.g.: return \"SELECT id, "
+            "username, email FROM users WHERE username = ?\" and pass "
+            "username as a parameter to the database cursor.\n"
+            "  ```"
+        ),
+    }]
+    findings = normalize_aletheore(raw_comments)
+    assert len(findings) == 1
+    assert findings[0]["file"] == (
+        "benchmark-sandbox/016-flask-sql-injection-user-lookup/src/flask/helpers.py"
+    )
+    assert findings[0]["line"] == 655
+    assert (
+        "SELECT id, username, email FROM users WHERE username = ?"
+        not in findings[0]["message"]
+    )
+    assert "SQL injection vulnerability" in findings[0]["message"]
+
+
 def test_normalize_pr_agent_reads_recommended_focus_areas_from_real_comment():
     # Real PR-Agent 0.39.0 `review` output does not print JSON to stdout and
     # does not emit a `code_suggestions` list (that key belongs to PR-Agent's

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1376,6 +1376,21 @@ def run_flash_review_job(
     ):
         return
 
+    # The advisory lock only needs to guard the quick check-then-write
+    # spend bookkeeping (see installation_spend_lock's docstring) - NOT
+    # the review itself, which does a real LLM call plus several GitHub
+    # API round-trips and has been measured at up to 5m50s in production
+    # (see FLASH_REVIEW_JOB_TIMEOUT_SECONDS in
+    # app_server/webhooks/pull_request.py). Holding the lock for that
+    # whole duration serialized every Flash Review for one installation
+    # to run strictly one at a time, and ADVISORY_LOCK_TIMEOUT (5s) is far
+    # shorter than that review time, so any review queued behind another
+    # for the same installation reliably failed outright with
+    # psycopg.errors.LockNotAvailable instead of just waiting its turn -
+    # confirmed in production logs while opening 25 PRs on one
+    # installation in quick succession. The lock is now acquired twice,
+    # briefly, around the check and (inside _run_flash_review) around the
+    # final spend record - never around the expensive work in between.
     with installation_spend_lock(settings.database_url, installation_id):
         extra_seats = get_extra_seats(settings.database_url, installation_id)
         monthly_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
@@ -1385,17 +1400,17 @@ def run_flash_review_job(
         if get_flash_review_count_this_month(settings.database_url, installation_id) >= MAX_FLASH_REVIEWS_PER_MONTH:
             return
 
+    try:
+        _run_flash_review(
+            settings, installation_id, repo_full_name, pr_number, base_sha, head_sha, monthly_cap
+        )
+    except Exception as exc:  # noqa: BLE001
         try:
-            _run_flash_review(
-                settings, installation_id, repo_full_name, pr_number, base_sha, head_sha, monthly_cap
+            _post_flash_review_failure_comment(
+                settings, installation_id, repo_full_name, pr_number, exc
             )
-        except Exception as exc:  # noqa: BLE001
-            try:
-                _post_flash_review_failure_comment(
-                    settings, installation_id, repo_full_name, pr_number, exc
-                )
-            except Exception:  # noqa: BLE001
-                pass
+        except Exception:  # noqa: BLE001
+            pass
 
 
 def _run_flash_review(
@@ -1493,10 +1508,14 @@ def _run_flash_review(
                 file_contents=file_contents,
                 on_grounding_result=_on_grounding_result,
             )
-    record_llm_spend(
-        settings.database_url, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap
-    )
-    increment_flash_review_count(settings.database_url, installation_id)
+    # Briefly re-acquire the lock just for the write, now that the
+    # expensive review work above is done - see run_flash_review_job's
+    # comment on why the lock no longer wraps this whole function.
+    with installation_spend_lock(settings.database_url, installation_id):
+        record_llm_spend(
+            settings.database_url, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap
+        )
+        increment_flash_review_count(settings.database_url, installation_id)
 
     proposed = grounding_result.get("proposed", 0)
     kept = grounding_result.get("kept", 0)

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1601,6 +1601,64 @@ def test_flash_review_job_records_spend_and_count_while_the_lock_is_still_held(m
     assert lock_state["held"] is False  # released once the job actually finished
 
 
+def test_flash_review_job_releases_lock_during_the_review_itself(monkeypatch):
+    # Real production bug, found while opening 25 PRs on one installation
+    # in a benchmark run: the lock used to wrap the ENTIRE review (a real
+    # LLM call plus several GitHub API round-trips, measured up to 5m50s
+    # in production - see FLASH_REVIEW_JOB_TIMEOUT_SECONDS in
+    # app_server/webhooks/pull_request.py), not just the check-then-record
+    # spend bookkeeping it exists to protect (see installation_spend_lock's
+    # docstring). ADVISORY_LOCK_TIMEOUT is 5s, far shorter than a real
+    # review, so any review queued behind another for the same
+    # installation reliably failed with psycopg.errors.LockNotAvailable
+    # instead of just waiting its turn - confirmed in production logs.
+    # This asserts the lock is free during the expensive part, which the
+    # F25 test above doesn't check (it only checks record/increment).
+    from contextlib import contextmanager
+
+    lock_state = {"held": False, "observed_during_review": None}
+
+    @contextmanager
+    def _tracking_spend_lock(*args, **kwargs):
+        lock_state["held"] = True
+        try:
+            yield
+        finally:
+            lock_state["held"] = False
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _tracking_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+
+    def _review_diff(diff_text, file_context="", **kwargs):
+        lock_state["observed_during_review"] = lock_state["held"]
+        return [{"file": "app.py", "line": 1, "issue": "x"}]
+
+    monkeypatch.setattr("scan_worker.jobs.review_diff", _review_diff)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert lock_state["observed_during_review"] is False
+    assert lock_state["held"] is False
+
+
 def test_flash_review_job_posts_grounding_note_when_some_findings_are_dropped(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})


### PR DESCRIPTION
## The bug

Found while benchmarking Flash Review's citation grounding rate against a batch of 25 real PRs opened on one installation: several `run_flash_review_job` runs failed outright with `psycopg.errors.LockNotAvailable: canceling statement due to lock timeout` inside `installation_spend_lock`.

`installation_spend_lock` (5s timeout) wrapped the **entire** `_run_flash_review` call — a real LLM call plus several GitHub API round-trips, measured up to 5m50s in production (see `FLASH_REVIEW_JOB_TIMEOUT_SECONDS`'s own comment) — when its actual job, per its own docstring, is just to make the spend check-then-record cycle atomic per installation. Any review queued behind another for the same installation had no chance to wait its turn; it just failed, and the PR silently never got a comment.

This is a real production risk beyond the benchmark: any customer with several PRs opened or pushed to close together on one installation would hit the same silent failure.

## The fix

The lock is now acquired twice, briefly:
1. Once for the initial spend-cap check.
2. Again, inside `_run_flash_review`, just for the final `record_llm_spend`/`increment_flash_review_count` write.

Never around the expensive work in between. This preserves the original F25 invariant (two concurrent reviews for the same installation can't both pass the cap check before either records its cost — verified: the existing `test_flash_review_job_records_spend_and_count_while_the_lock_is_still_held` test passes unchanged) while letting reviews actually queue and wait instead of failing under load.

Added a new regression test (`test_flash_review_job_releases_lock_during_the_review_itself`) asserting the lock is free during the review, which the existing F25 test doesn't check.

## Scope

Fixed only `run_flash_review_job` / `_run_flash_review`, the site actually exercised by this benchmark run. The identical broad-lock pattern also exists in `run_managed_audit_pr_job` and `run_managed_audit_api_job` (both wrap the full `run_managed_audit(...)` LLM call the same way) — not fixed here, tracked as a follow-up so this PR stays focused and verifiable.

Also includes two unrelated fixes bundled from the same session: a `normalize_aletheore` bug in the pr-review-benchmark harness (was checking a finding's *suggested* code against the *current* diff, guaranteed to fail), and the 25-case SWE-bench-derived corpus this whole investigation came from.

## Tests

- `github-app/tests/test_jobs.py`: 146 passed, 1 skipped (pre-existing, unrelated).
- Full `github-app/tests/` suite: 702 passed, 592 skipped, 3 failed — all 3 failures confirmed environmental (no local redis/postgres in this sandbox; none reference `jobs.py` or `installation_spend_lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)