### PR TITLE
fix: Flash Review grounding filter rejects correct findings on path-nested repos

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -410,6 +410,28 @@ def _line_is_near_diff(line: int, valid: set[int]) -> bool:
     return any(abs(line - candidate) <= DIFF_LINE_TOLERANCE for candidate in valid)
 
 
+def _lookup_valid_lines(file: str, valid_lines: dict[str, set[int]]) -> set[int]:
+    """Exact match first; fall back to a path-suffix match so a citation
+    naming a file relative to its own repo root still resolves when the
+    diff's own filename is longer (nested under a wrapper directory), or
+    the reverse. Matches on a '/' boundary, never a bare substring, so
+    'foo.py' cannot match 'not_foo.py'. Ambiguous matches (more than one
+    diff filename sharing that suffix, e.g. two 'utils.py' in different
+    packages) are treated as no match rather than guessed at - a wrong
+    guess here would ground a finding against the wrong file's line
+    numbers, which is worse than dropping it.
+    """
+    if file in valid_lines:
+        return valid_lines[file]
+    candidates = [
+        key for key in valid_lines
+        if key.endswith("/" + file) or file.endswith("/" + key)
+    ]
+    if len(candidates) == 1:
+        return valid_lines[candidates[0]]
+    return set()
+
+
 def _validate_findings(
     findings: list[dict], diff_text: str, file_contents: dict[str, str] | None = None
 ) -> list[dict]:
@@ -429,7 +451,9 @@ def _validate_findings(
     in_diff = []
     out_of_diff = []
     for finding in findings:
-        if _line_is_near_diff(finding["line"], valid_lines.get(finding["file"], set())):
+        if _line_is_near_diff(
+            finding["line"], _lookup_valid_lines(finding["file"], valid_lines)
+        ):
             in_diff.append(finding)
         else:
             out_of_diff.append(finding)

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -7,6 +7,7 @@ from scan_worker.flash_review import (
     FLASH_REVIEW_SYSTEM_PROMPT,
     files_missing_from_review_context,
     _diff_valid_lines,
+    _lookup_valid_lines,
     _line_citation_content_matches,
     _names_referenced_in_diff,
     _quoted_strings,
@@ -48,6 +49,36 @@ def test_diff_valid_lines_tracks_multiple_files_separately():
     )
 
     assert _diff_valid_lines(diff_text) == {"a.py": {5}, "b.py": {10}}
+
+
+def test_lookup_valid_lines_falls_back_to_unambiguous_path_suffix():
+    valid_lines = {"benchmark-sandbox/case-1/pkg/module.py": {5, 6, 7}}
+    assert _lookup_valid_lines("pkg/module.py", valid_lines) == {5, 6, 7}
+
+
+def test_lookup_valid_lines_matches_the_reverse_direction_too():
+    valid_lines = {"pkg/module.py": {5, 6, 7}}
+    assert _lookup_valid_lines("benchmark-sandbox/case-1/pkg/module.py", valid_lines) == {5, 6, 7}
+
+
+def test_lookup_valid_lines_refuses_to_guess_between_ambiguous_matches():
+    valid_lines = {
+        "service_a/utils.py": {1, 2},
+        "service_b/utils.py": {10, 11},
+    }
+    assert _lookup_valid_lines("utils.py", valid_lines) == set()
+
+
+def test_lookup_valid_lines_does_not_match_on_a_bare_substring():
+    valid_lines = {"pkg/not_foo.py": {1, 2}}
+    assert _lookup_valid_lines("foo.py", valid_lines) == set()
+
+
+def test_validate_findings_keeps_a_finding_whose_path_is_a_suffix_of_the_diffs_filename():
+    diff_text = "--- pkg/module.py ---\n@@ -5,3 +5,3 @@\n+line\n"
+    findings = [{"file": "module.py", "line": 5, "issue": "should still ground"}]
+    # Only one file in the diff, so suffix resolution is unambiguous.
+    assert _validate_findings(findings, diff_text) == findings
 
 
 def test_validate_findings_keeps_findings_inside_diff_hunks():


### PR DESCRIPTION
## Summary
- `_diff_valid_lines` keys its dict by the diff's exact filename string. A finding citing a file relative to its own repo root was silently dropped as "outside the diff" whenever the diff's own filename was longer (nested under a wrapper directory) — even when the citation was otherwise perfect.
- Confirmed on a real SWE-bench-derived case: the model cited the *exact* SWE-bench ground-truth fix line, and Flash Review's own grounding filter rejected it purely on a filename string mismatch, not a bad citation.
- Adds `_lookup_valid_lines()`: exact match still wins; falls back to an unambiguous `/`-boundary path-suffix match; anything with more than one candidate match fails closed (never guesses between two files sharing a basename).

## Test plan
- [x] 5 new regression tests in `test_flash_review.py` (suffix match both directions, ambiguous-match refusal, no-bare-substring-match, end-to-end `_validate_findings` keep)
- [x] Flash Review suite: 70 passed
- [x] Full github-app suite: 711 passed, 592 skipped (env-only DB/Redis), 3 failed (same env-only failures)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)