### PR TITLE
fix: aletheore query ownership <file> ignored its own argument

### DIFF
--- a/docs/AIR-SCHEMA.md
+++ b/docs/AIR-SCHEMA.md
@@ -32,6 +32,9 @@ bump signals the breaking change — `0.2.0` and `0.2.7` are the same schema,
 than misreading it. Once AIR reaches `1.0.0`, that comparison moves to major
 alone.
 
+Version `0.4.0` adds `git.file_ownership`, a current-source-file keyed
+ownership breakdown used by file-scoped ownership queries.
+
 ## Migration rules
 
 1. **Any change to `AIR_JSON_SCHEMA` requires an `EVIDENCE_VERSION` MINOR bump.**

--- a/github-app/migrations/020_evidence_git_graph.sql
+++ b/github-app/migrations/020_evidence_git_graph.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS evidence_git_file_churn (
     churn_count        INT NOT NULL,
     recent_commits     JSONB NOT NULL,
     co_change_counts   JSONB NOT NULL,
+    owners             JSONB NOT NULL DEFAULT '{}'::jsonb,
     PRIMARY KEY (installation_id, repo_full_name, branch, path)
 );
 

--- a/github-app/migrations/050_evidence_git_file_owners.sql
+++ b/github-app/migrations/050_evidence_git_file_owners.sql
@@ -1,0 +1,3 @@
+-- Per-file ownership breakdown for file-scoped ownership queries.
+ALTER TABLE evidence_git_file_churn
+ADD COLUMN IF NOT EXISTS owners JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -477,7 +477,13 @@ def _sync_persistent_git_graph(installation_id: int, repo_full_name: str, repo_d
         settings = get_settings()
         store = PostgresRepoGraphStore(settings.database_url, installation_id, repo_full_name)
         modules = evidence.get("repository", {}).get("modules", [])
-        git_data = analyze_git(repo_dir, store=store, depth_cap=GRAPH_COLD_SYNC_DEPTH_CAP, branch=GRAPH_BRANCH)
+        git_data = analyze_git(
+            repo_dir,
+            modules,
+            store=store,
+            depth_cap=GRAPH_COLD_SYNC_DEPTH_CAP,
+            branch=GRAPH_BRANCH,
+        )
         if git_data.get("available"):
             git_data["hotspots"] = compute_hotspots(
                 repo_dir, modules, store=store, depth_cap=GRAPH_COLD_SYNC_DEPTH_CAP, branch=GRAPH_BRANCH

--- a/github-app/scan_worker/postgres_graph_store.py
+++ b/github-app/scan_worker/postgres_graph_store.py
@@ -69,11 +69,11 @@ class PostgresRepoGraphStore:
 
                 file_churn: dict[str, FileChurnTotal] = {}
                 cur.execute(
-                    "SELECT path, churn_count, recent_commits, co_change_counts FROM evidence_git_file_churn "
+                    "SELECT path, churn_count, recent_commits, co_change_counts, owners FROM evidence_git_file_churn "
                     "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
                     (self._installation_id, self._repo_full_name, branch),
                 )
-                for path, churn_count, recent_commits, co_change_counts in cur.fetchall():
+                for path, churn_count, recent_commits, co_change_counts, owners in cur.fetchall():
                     file_churn[path] = FileChurnTotal(
                         path=path,
                         churn_count=churn_count,
@@ -91,6 +91,14 @@ class PostgresRepoGraphStore:
                             for r in recent_commits
                         ],
                         co_change_counts=co_change_counts,
+                        owners={
+                            email: OwnershipTotal(
+                                email=email,
+                                names=set(owner["names"]),
+                                commit_count=owner["commit_count"],
+                            )
+                            for email, owner in (owners or {}).items()
+                        },
                     )
 
         return GraphSnapshot(
@@ -179,7 +187,7 @@ class PostgresRepoGraphStore:
                     cur.executemany(
                         "INSERT INTO evidence_git_file_churn "
                         "(installation_id, repo_full_name, branch, path, churn_count, recent_commits, "
-                        "co_change_counts) VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb)",
+                        "co_change_counts, owners) VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb)",
                         (
                             (
                                 self._installation_id,
@@ -200,6 +208,15 @@ class PostgresRepoGraphStore:
                                     ]
                                 ),
                                 json.dumps(churn.co_change_counts),
+                                json.dumps(
+                                    {
+                                        email: {
+                                            "names": sorted(owner.names),
+                                            "commit_count": owner.commit_count,
+                                        }
+                                        for email, owner in churn.owners.items()
+                                    }
+                                ),
                             )
                             for path, churn in merged.file_churn.items()
                         ),

--- a/github-app/tests/test_postgres_graph_store.py
+++ b/github-app/tests/test_postgres_graph_store.py
@@ -60,6 +60,13 @@ async def test_apply_commits_then_load_round_trips_correctly(pool):
     assert snapshot.file_churn["a.txt"].co_change_counts == {"b.txt": 1}
     assert len(snapshot.file_churn["a.txt"].recent_commits) == 2
     assert snapshot.file_churn["a.txt"].recent_commits[0].sha == "s2"
+    # Per-file ownership must round-trip independently of the repo-wide
+    # ownership dict above - a.txt was touched by both authors, b.txt by
+    # only Alice, so the two files' owner sets must differ.
+    assert snapshot.file_churn["a.txt"].owners["a@example.com"].commit_count == 1
+    assert snapshot.file_churn["a.txt"].owners["b@example.com"].commit_count == 1
+    assert snapshot.file_churn["b.txt"].owners["a@example.com"].commit_count == 1
+    assert "b@example.com" not in snapshot.file_churn["b.txt"].owners
 
 
 @pytest.mark.asyncio

--- a/schemas/air.schema.json
+++ b/schemas/air.schema.json
@@ -105,6 +105,9 @@
           ],
           "type": "object"
         },
+        "file_ownership": {
+          "type": "object"
+        },
         "history_depth_limited": {
           "type": "boolean"
         },

--- a/src/aletheore/air_schema.py
+++ b/src/aletheore/air_schema.py
@@ -34,6 +34,7 @@ _INT: dict = {"type": "integer"}
 _NUM: dict = {"type": "number"}
 _BOOL: dict = {"type": "boolean"}
 _ANY_LIST: dict = {"type": "array"}
+_ANY_OBJECT: dict = {"type": "object"}
 
 
 def _obj(properties: dict, required: list[str] | None = None) -> dict:
@@ -174,6 +175,7 @@ AIR_JSON_SCHEMA: dict = {
                     }
                 ),
                 "ownership": _arr(_OWNERSHIP),
+                "file_ownership": _ANY_OBJECT,
                 "repo_age_days": _INT,
                 "total_commits": _INT,
                 "history_depth_limited": _BOOL,

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -35,7 +35,7 @@ from aletheore.secrets import (
 from aletheore.toon_encoding import to_toon
 from aletheore.vulnerabilities import check_vulnerabilities as check_dependency_vulnerabilities
 
-EVIDENCE_VERSION = "0.3.0"
+EVIDENCE_VERSION = "0.4.0"
 
 
 def _version_compatibility_key(version: str) -> tuple[int, int] | None:
@@ -417,7 +417,7 @@ def scan_repository(
     )
 
     report("Analyzing git history and ownership")
-    git_data = analyze_git(repo_path, depth_cap=_git_history_depth_cap())
+    git_data = analyze_git(repo_path, modules, depth_cap=_git_history_depth_cap())
 
     report("Scanning working tree for secrets")
     secrets_baseline = load_secrets_baseline(repo_path)

--- a/src/aletheore/git_intel/analyzer.py
+++ b/src/aletheore/git_intel/analyzer.py
@@ -221,6 +221,25 @@ def _ownership_summary(snapshot: GraphSnapshot) -> list[dict]:
     ]
 
 
+def _file_ownership_summary(snapshot: GraphSnapshot, modules: list[dict]) -> dict[str, list[dict]]:
+    current_paths = {module["path"] for module in modules}
+    result = {}
+    for path, churn in snapshot.file_churn.items():
+        if path not in current_paths or not churn.owners:
+            continue
+        total = sum(owner.commit_count for owner in churn.owners.values())
+        result[path] = [
+            {
+                "email": owner.email,
+                "names": sorted(owner.names),
+                "commit_count": owner.commit_count,
+                "percent": round(owner.commit_count / total, 4),
+            }
+            for owner in sorted(churn.owners.values(), key=lambda owner: -owner.commit_count)
+        ]
+    return result
+
+
 def _cadence_summary(snapshot: GraphSnapshot, now: datetime) -> dict:
     if not snapshot.cadence_weekly_counts:
         return {"weekly_counts": [], "trend": "flat", "most_recent_week_partial": False}
@@ -309,6 +328,7 @@ def _first_commit_at(repo_path: Path) -> datetime:
 
 def analyze_git(
     repo_path: Path,
+    modules: list[dict] | None = None,
     now: datetime | None = None,
     *,
     store: RepoGraphStore | None = None,
@@ -317,6 +337,7 @@ def analyze_git(
 ) -> dict:
     if now is None:
         now = datetime.now(timezone.utc)
+    modules = modules or []
 
     if not _has_commits(repo_path):
         return {"available": False}
@@ -341,6 +362,7 @@ def analyze_git(
         "branches": _parse_branches(repo_path, now),
         "commit_cadence": _cadence_summary(snapshot, now),
         "ownership": _ownership_summary(snapshot),
+        "file_ownership": _file_ownership_summary(snapshot, modules),
         "repo_age_days": repo_age_days,
         "total_commits": total_commits,
         "history_depth_limited": history_depth_limited,

--- a/src/aletheore/git_intel/graph_store.py
+++ b/src/aletheore/git_intel/graph_store.py
@@ -56,6 +56,10 @@ class FileChurnTotal:
     # hotspot algorithm's own noise filter (a mass rename/reformat commit
     # touching hundreds of files isn't a meaningful co-change signal).
     co_change_counts: dict[str, int]
+    # Per-file ownership, using the same lowercased-email convention as the
+    # repository-wide ownership aggregate. This is independent of the capped
+    # recent_commits list, which is intentionally not a complete history.
+    owners: dict[str, OwnershipTotal]
 
 
 @dataclass(frozen=True)

--- a/src/aletheore/git_intel/incremental.py
+++ b/src/aletheore/git_intel/incremental.py
@@ -209,7 +209,13 @@ def fold(snapshot: GraphSnapshot, commits: list[CommitTouch]) -> GraphSnapshot:
     ownership = {email: OwnershipTotal(o.email, set(o.names), o.commit_count) for email, o in snapshot.ownership.items()}
     cadence = dict(snapshot.cadence_weekly_counts)
     file_churn = {
-        path: FileChurnTotal(f.path, f.churn_count, list(f.recent_commits), dict(f.co_change_counts))
+        path: FileChurnTotal(
+            f.path,
+            f.churn_count,
+            list(f.recent_commits),
+            dict(f.co_change_counts),
+            {email: OwnershipTotal(o.email, set(o.names), o.commit_count) for email, o in f.owners.items()},
+        )
         for path, f in snapshot.file_churn.items()
     }
 
@@ -232,11 +238,17 @@ def fold(snapshot: GraphSnapshot, commits: list[CommitTouch]) -> GraphSnapshot:
         for path in unique_files:
             churn = file_churn.get(path)
             if churn is None:
-                churn = FileChurnTotal(path=path, churn_count=0, recent_commits=[], co_change_counts={})
+                churn = FileChurnTotal(path=path, churn_count=0, recent_commits=[], co_change_counts={}, owners={})
                 file_churn[path] = churn
             churn.churn_count += 1
             churn.recent_commits.insert(0, recent)
             del churn.recent_commits[RECENT_COMMITS_PER_FILE:]
+            file_owner = churn.owners.get(email_key)
+            if file_owner is None:
+                file_owner = OwnershipTotal(email=email_key, names=set(), commit_count=0)
+                churn.owners[email_key] = file_owner
+            file_owner.names.add(commit.author_name)
+            file_owner.commit_count += 1
 
         if len(unique_files) <= MASS_COMMIT_FILE_THRESHOLD:
             for i, first in enumerate(unique_files):

--- a/src/aletheore/git_intel/sqlite_store.py
+++ b/src/aletheore/git_intel/sqlite_store.py
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS file_churn (
     churn_count INTEGER NOT NULL,
     recent_commits TEXT NOT NULL,
     co_change_counts TEXT NOT NULL,
+    owners TEXT NOT NULL,
     PRIMARY KEY (repo_key, branch, path)
 );
 """
@@ -67,6 +68,10 @@ class SQLiteRepoGraphStore:
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(db_path)
         self._conn.executescript(_SCHEMA)
+        try:
+            self._conn.execute("ALTER TABLE file_churn ADD COLUMN owners TEXT NOT NULL DEFAULT '{}'")
+        except sqlite3.OperationalError:
+            pass  # column already exists
         self._conn.commit()
 
     def close(self) -> None:
@@ -101,11 +106,11 @@ class SQLiteRepoGraphStore:
 
         file_churn: dict[str, FileChurnTotal] = {}
         cur.execute(
-            "SELECT path, churn_count, recent_commits, co_change_counts FROM file_churn "
+            "SELECT path, churn_count, recent_commits, co_change_counts, owners FROM file_churn "
             "WHERE repo_key = ? AND branch = ?",
             (repo_key, branch),
         )
-        for path, churn_count, recent_json, co_change_json in cur.fetchall():
+        for path, churn_count, recent_json, co_change_json, owners_json in cur.fetchall():
             recent_commits = [
                 RecentCommit(
                     sha=r["sha"],
@@ -123,6 +128,10 @@ class SQLiteRepoGraphStore:
                 churn_count=churn_count,
                 recent_commits=recent_commits,
                 co_change_counts=json.loads(co_change_json),
+                owners={
+                    email: OwnershipTotal(email=email, names=set(owner["names"]), commit_count=owner["commit_count"])
+                    for email, owner in json.loads(owners_json).items()
+                },
             )
 
         return GraphSnapshot(
@@ -171,8 +180,8 @@ class SQLiteRepoGraphStore:
                 ),
             )
             self._conn.executemany(
-                "INSERT INTO file_churn (repo_key, branch, path, churn_count, recent_commits, co_change_counts) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
+                "INSERT INTO file_churn (repo_key, branch, path, churn_count, recent_commits, co_change_counts, owners) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     (
                         repo_key,
@@ -192,6 +201,12 @@ class SQLiteRepoGraphStore:
                             ]
                         ),
                         json.dumps(churn.co_change_counts),
+                        json.dumps(
+                            {
+                                email: {"names": sorted(owner.names), "commit_count": owner.commit_count}
+                                for email, owner in churn.owners.items()
+                            }
+                        ),
                     )
                     for path, churn in merged.file_churn.items()
                 ),

--- a/src/aletheore/query.py
+++ b/src/aletheore/query.py
@@ -85,6 +85,8 @@ def find_branch(evidence: dict, target: str | None) -> dict:
 
 
 def find_ownership(evidence: dict, target: str | None) -> list[dict]:
+    if target:
+        return evidence["git"].get("file_ownership", {}).get(target, [])
     return evidence["git"].get("ownership", [])
 
 

--- a/src/tests/test_air_schema.py
+++ b/src/tests/test_air_schema.py
@@ -22,8 +22,8 @@ from tests.air_fixtures import minimal_air_evidence
 # stays "compatible" by version check while actually having a different
 # shape - which is exactly the silent drift the version field exists to
 # prevent. See docs/AIR-SCHEMA.md for the migration rules.
-EXPECTED_SCHEMA_FINGERPRINT = "ae1f3063d2364b26"
-EXPECTED_EVIDENCE_VERSION = "0.3.0"
+EXPECTED_SCHEMA_FINGERPRINT = "a1913a5f5c1e8756"
+EXPECTED_EVIDENCE_VERSION = "0.4.0"
 
 
 def test_schema_changes_require_an_evidence_version_bump():

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -36,8 +36,12 @@ def run(repo: Path, *args: str):
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
 
 
-def test_evidence_version_is_0_3_0():
-    assert EVIDENCE_VERSION == "0.3.0"
+def test_evidence_version_is_0_4_0():
+    # Bumped 0.3.0 -> 0.4.0 alongside AIR_JSON_SCHEMA's new git.file_ownership
+    # field - see docs/AIR-SCHEMA.md's migration rules (any schema change
+    # requires a MINOR bump). This test asserts the exact pin deliberately,
+    # so it must move in lockstep with the next schema change too.
+    assert EVIDENCE_VERSION == "0.4.0"
 
 
 def make_repo(tmp_path: Path) -> Path:

--- a/src/tests/test_git_intel.py
+++ b/src/tests/test_git_intel.py
@@ -94,6 +94,18 @@ def test_analyze_git_ownership(tmp_path):
     assert by_email["a@example.com"]["percent"] == 0.6667
 
 
+def test_analyze_git_file_ownership_includes_current_modules_only(tmp_path):
+    repo = make_git_repo(tmp_path)
+    result = analyze_git(
+        repo,
+        modules=[{"path": "a.txt"}],
+        now=datetime(2026, 7, 14, tzinfo=timezone.utc),
+    )
+    assert set(result["file_ownership"]) == {"a.txt"}
+    assert result["file_ownership"]["a.txt"][0]["email"] == "a@example.com"
+    assert sum(owner["percent"] for owner in result["file_ownership"]["a.txt"]) == 1.0
+
+
 def test_analyze_git_ownership_merges_same_email_different_names(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_incremental.py
+++ b/src/tests/test_incremental.py
@@ -163,6 +163,22 @@ def test_fold_tracks_file_churn_and_co_change():
     assert result.file_churn["b.txt"].co_change_counts == {"a.txt": 1}
 
 
+def test_fold_tracks_complete_per_file_ownership_separately_from_recent_commits():
+    commits = [
+        _touch("s1", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", ("a.txt", "shared.txt")),
+        _touch("s2", "Bob", "b@example.com", "2026-06-02T00:00:00+00:00", ("shared.txt", "b.txt")),
+        _touch("s3", "Alice", "a@example.com", "2026-06-03T00:00:00+00:00", ("a.txt",)),
+    ]
+
+    result = fold(GraphSnapshot.empty(), commits)
+
+    assert result.file_churn["a.txt"].owners["a@example.com"].commit_count == 2
+    assert result.file_churn["a.txt"].owners.keys() == {"a@example.com"}
+    assert result.file_churn["shared.txt"].owners["a@example.com"].commit_count == 1
+    assert result.file_churn["shared.txt"].owners["b@example.com"].commit_count == 1
+    assert result.file_churn["b.txt"].owners.keys() == {"b@example.com"}
+
+
 def test_fold_skips_co_change_for_mass_commits():
     files = tuple(f"f{i}.txt" for i in range(60))  # over MASS_COMMIT_FILE_THRESHOLD (50)
     commits = [_touch("s1", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", files)]

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -102,6 +102,11 @@ def make_evidence():
             "ownership": [
                 {"email": "a@example.com", "names": ["Alice"], "commit_count": 5, "percent": 1.0}
             ],
+            "file_ownership": {
+                "app/auth.py": [
+                    {"email": "a@example.com", "names": ["Alice"], "commit_count": 3, "percent": 1.0}
+                ]
+            },
             "hotspots": [
                 {
                     "path": "app/auth.py",
@@ -206,9 +211,17 @@ def test_find_branch_raises_not_found_instead_of_crashing_when_git_unavailable()
         find_branch(evidence, "main")
 
 
-def test_find_ownership_returns_the_whole_list_ignoring_target():
+def test_find_ownership_returns_repository_ownership_without_target():
     result = find_ownership(make_evidence(), None)
     assert result == make_evidence()["git"]["ownership"]
+
+
+def test_find_ownership_returns_file_ownership_for_target():
+    assert find_ownership(make_evidence(), "app/auth.py") == make_evidence()["git"]["file_ownership"]["app/auth.py"]
+
+
+def test_find_ownership_does_not_fall_back_to_repository_ownership_for_unknown_target():
+    assert find_ownership(make_evidence(), "missing.py") == []
 
 
 def test_find_secrets_for_file_filters_by_path():

--- a/src/tests/test_sqlite_store.py
+++ b/src/tests/test_sqlite_store.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+import sqlite3
 from pathlib import Path
 
 from aletheore.git_intel.graph_store import CommitTouch, GraphSnapshot
@@ -42,6 +43,38 @@ def test_apply_commits_then_load_round_trips_correctly(tmp_path):
     assert snapshot.file_churn["a.txt"].co_change_counts == {"b.txt": 1}
     assert len(snapshot.file_churn["a.txt"].recent_commits) == 2
     assert snapshot.file_churn["a.txt"].recent_commits[0].sha == "s2"  # newest first
+    assert snapshot.file_churn["a.txt"].owners["a@example.com"].commit_count == 1
+    assert snapshot.file_churn["a.txt"].owners["b@example.com"].commit_count == 1
+
+
+def test_existing_database_without_file_owners_column_upgrades_in_place(tmp_path):
+    db_path = tmp_path / "graph.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE sync_state (repo_key TEXT NOT NULL, branch TEXT NOT NULL,
+            last_synced_sha TEXT NOT NULL, last_synced_at TEXT NOT NULL,
+            PRIMARY KEY (repo_key, branch));
+        CREATE TABLE ownership (repo_key TEXT NOT NULL, branch TEXT NOT NULL,
+            email TEXT NOT NULL, names TEXT NOT NULL, commit_count INTEGER NOT NULL,
+            PRIMARY KEY (repo_key, branch, email));
+        CREATE TABLE cadence (repo_key TEXT NOT NULL, branch TEXT NOT NULL,
+            week_start TEXT NOT NULL, commit_count INTEGER NOT NULL,
+            PRIMARY KEY (repo_key, branch, week_start));
+        CREATE TABLE file_churn (repo_key TEXT NOT NULL, branch TEXT NOT NULL,
+            path TEXT NOT NULL, churn_count INTEGER NOT NULL,
+            recent_commits TEXT NOT NULL, co_change_counts TEXT NOT NULL,
+            PRIMARY KEY (repo_key, branch, path));
+        INSERT INTO sync_state VALUES ('repo-1', 'main', 's1', '2026-06-01T00:00:00');
+        INSERT INTO file_churn VALUES ('repo-1', 'main', 'a.txt', 1, '[]', '{}');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    store = SQLiteRepoGraphStore(db_path)
+    snapshot = store.load("repo-1", "main")
+    assert snapshot.file_churn["a.txt"].owners == {}
 
 
 def test_incremental_apply_matches_a_single_full_fold(tmp_path):


### PR DESCRIPTION
## Summary
- `find_ownership()` returned the repo-wide ownership aggregate regardless of the `target` file passed — confirmed by diffing two different files' output and getting byte-identical results.
- Root cause: no per-file ownership data existed anywhere in the schema, only a repo-wide aggregate. Found while building `Aletheore/aletheore-benchmarks#1`, which needed real per-file ownership as ground truth.
- Adds a real per-file ownership aggregate (`FileChurnTotal.owners`), built in the same per-commit fold loop as the existing repo-wide aggregate and per-file churn/co-change data — not derived from `recent_commits`, which is capped at 10 and would be recency-biased on any file with more history than that.
- Persisted in both the CLI's SQLite store (with an `ALTER TABLE` upgrade guard for existing `.aletheore/graph.db` files) and the hosted Postgres store (migration `050_evidence_git_file_owners.sql`).
- Surfaced as `evidence.json`'s `git.file_ownership`, scoped to current source files only. AIR schema bumped `0.3.0` → `0.4.0`.

Implemented by Codex per a detailed instruction spec; reviewed and verified here rather than merged as-is — see Test plan.

## Test plan
- [x] Reviewed the full diff against the spec, file by file
- [x] `pytest src/tests/test_git_intel.py src/tests/test_incremental.py src/tests/test_sqlite_store.py src/tests/test_query.py src/tests/test_air_schema.py` — 105/105 pass
- [x] Found and closed a real gap: the Postgres round-trip test didn't assert on the new `owners` field — added assertions to `test_apply_commits_then_load_round_trips_correctly` (needs a live Postgres test DB, so only CI can run it — not locally verified, will confirm on this PR's checks)
- [x] Real end-to-end verification against a live flask clone: `aletheore query ownership src/flask/app.py` and `tests/test_basic.py` now return different, correct results (top owner of `app.py` is `davidism@gmail.com`, matching independently-verified ground truth), where before the fix both returned identical repo-wide data

🤖 Generated with [Claude Code](https://claude.com/claude-code)