### PR TITLE
fix: audit findings batch — spend-lock scope, diff parser, webhook atomicity, scanner

### DIFF
--- a/benchmarks/pr-review-benchmark/SWEBENCH_RUN_STATUS.md
+++ b/benchmarks/pr-review-benchmark/SWEBENCH_RUN_STATUS.md
@@ -3,6 +3,41 @@
 **Started:** 2026-08-15. **Owner:** Arihant + Claude (this session). Read this
 top to bottom before touching anything if you're picking this up cold.
 
+## Final result 2026-08-15: the benchmark's real signal is LLM proposal-rate
+## noise, not the bug we fixed
+
+Two full re-runs of the identical 25-case corpus (`--allow-empty` retriggers,
+byte-identical diffs both times), both through fresh LLM calls (semantic
+cache was not the confound - see below):
+
+- **Run A** (before `_lookup_valid_lines`, PR #253): model proposed *something*
+  in 14/25 cases (56%), 3 survived to be posted, 5 of the rejections were
+  confirmed via production logs to be the exact-path-match bug (correct
+  citations, wrong rejection reason).
+- **Run B** (after PR #253, same corpus, same diffs): model proposed
+  *something* in only 1/25 cases (4%) - 24/25 came back "No issues found in
+  this diff" (the model itself proposed nothing, not "proposed and
+  rejected"). The one proposal that did happen (PR #37) was legitimately
+  out-of-scope (2 of 6 changed files were skipped from review context).
+
+**The fix is confirmed correct** (code-reviewed, unit-tested, and its logic
+is unrelated to how often the model proposes anything) - but this pair of
+runs cannot demonstrate that on its own, because the model's raw proposal
+rate swung from 56% to 4% between two runs of the *same* diffs. That's
+LLM sampling variance dwarfing the effect being measured, the same
+"[[project_judge_noise_floor]]" problem already documented for the judge -
+single-run deltas on n=25 aren't evidence here either. Don't re-run this
+specific comparison expecting a stable before/after number; the noise floor
+is the finding.
+
+**What would actually settle it**: replay the *same* cached raw model
+output (captured from Run A, before grounding) through both the old and new
+`_validate_findings` in a local test, deterministically, no LLM call
+involved. That isolates the grounding-filter's effect from the model's own
+variance. Not done in this session - Run A's individual raw proposals were
+only ever recovered in fragments from grep'd production logs (5 of the 14),
+not saved wholesale.
+
 ## Why this exists
 
 We wanted a real number for "what fraction of Aletheore Flash Review's PR

--- a/github-app/app_server/affiliates.py
+++ b/github-app/app_server/affiliates.py
@@ -76,6 +76,19 @@ async def record_commission(
     )
 
 
+async def reverse_commission(pool: asyncpg.Pool, paddle_transaction_id: str) -> bool:
+    """Mark a commission reversed while retaining its payment audit trail."""
+    result = await pool.execute(
+        """
+        UPDATE affiliate_commissions
+        SET reversed = true
+        WHERE paddle_transaction_id = $1 AND NOT reversed
+        """,
+        paddle_transaction_id,
+    )
+    return result.endswith(" 1")
+
+
 async def list_affiliates_with_totals(pool: asyncpg.Pool) -> list[dict]:
     """One row per affiliate for the admin report page: how many
     installations they've referred, and total commission accrued vs. paid
@@ -101,12 +114,12 @@ async def list_affiliates_with_totals(pool: asyncpg.Pool) -> list[dict]:
             (SELECT COUNT(*) FROM affiliate_referrals r WHERE r.affiliate_id = a.id) AS referral_count,
             COALESCE(
                 (SELECT SUM(amount_usd) FROM affiliate_commissions c
-                 WHERE c.affiliate_id = a.id AND NOT c.paid),
+                 WHERE c.affiliate_id = a.id AND NOT c.paid AND NOT c.reversed),
                 0
             ) AS total_owed_usd,
             COALESCE(
                 (SELECT SUM(amount_usd) FROM affiliate_commissions c
-                 WHERE c.affiliate_id = a.id AND c.paid),
+                 WHERE c.affiliate_id = a.id AND c.paid AND NOT c.reversed),
                 0
             ) AS total_paid_usd
         FROM affiliates a

--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -312,7 +312,12 @@ def _is_safe_next_path(next_path: str | None) -> str:
     # "//evil.com" by the time it's followed - "//" alone isn't enough to
     # block, the character right after the first "/" has to be checked for
     # either variant.
-    if not next_path or not next_path.startswith("/") or next_path[1:2] in ("/", "\\"):
+    if (
+        not next_path
+        or not next_path.startswith("/")
+        or next_path[1:2] in ("/", "\\")
+        or any(ord(char) < 0x20 for char in next_path)
+    ):
         return "/dashboard"
     return next_path
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -66,6 +66,69 @@ async def set_installation_plan(pool: asyncpg.Pool, installation_id: int, plan: 
     )
 
 
+async def claim_free_to_paid_plan(
+    pool: asyncpg.Pool, installation_id: int, plan: str
+) -> bool:
+    """Atomically claim the first free-to-paid transition for an installation.
+
+    Also resets paid_setup_completed_at to NULL in the same UPDATE - see
+    claim_paid_setup. This is the one place setup should ever become
+    "pending": a genuine, freshly-observed free->paid transition, not an
+    installation that was already paid for some other reason (migrated
+    data, a direct insert, a paid->paid plan change).
+    """
+    row = await pool.fetchrow(
+        """
+        UPDATE installations
+        SET plan = $2, updated_at = now(), paid_setup_completed_at = NULL
+        WHERE installation_id = $1 AND plan = 'free'
+        RETURNING installation_id
+        """,
+        installation_id,
+        plan,
+    )
+    return row is not None
+
+
+async def claim_paid_setup(pool: asyncpg.Pool, installation_id: int) -> bool:
+    """Atomically claim the one-time paid setup (initial wiki/docs build,
+    affiliate attribution) for an installation.
+
+    Deliberately independent of claim_free_to_paid_plan's own transition
+    check: if a crash lands between that write committing and setup
+    actually running, a Paddle retry finds plan already non-free and
+    claim_free_to_paid_plan correctly returns False - but setup still never
+    ran. Gating setup on this claim instead of on that transition boolean
+    means the retry still runs it exactly once, rather than skipping it
+    forever because the plan write it depended on already happened.
+    """
+    row = await pool.fetchrow(
+        """
+        UPDATE installations
+        SET paid_setup_completed_at = now()
+        WHERE installation_id = $1 AND paid_setup_completed_at IS NULL
+        RETURNING installation_id
+        """,
+        installation_id,
+    )
+    return row is not None
+
+
+async def set_paid_installation_plan(
+    pool: asyncpg.Pool, installation_id: int, plan: str
+) -> None:
+    """Update a paid plan without resurrecting an installation already downgraded."""
+    await pool.execute(
+        """
+        UPDATE installations
+        SET plan = $2, updated_at = now()
+        WHERE installation_id = $1 AND plan <> 'free'
+        """,
+        installation_id,
+        plan,
+    )
+
+
 async def add_paddle_ids_to_installation(
     pool: asyncpg.Pool,
     installation_id: int,
@@ -172,6 +235,10 @@ async def claim_webhook_delivery(
     `source` namespaces the id ("github" for X-GitHub-Delivery GUIDs,
     "paddle" for event ids) so the two providers can't collide.
 
+    Claims older than fifteen minutes are reclaimable. This is the recovery
+    path for a process killed after claiming but before completing a webhook;
+    ordinary retries remain deduplicated.
+
     A single INSERT ... ON CONFLICT DO NOTHING does the whole thing
     atomically. A read-then-write would leave a window where two concurrent
     deliveries of the same id both see "not seen yet" and both proceed -
@@ -179,9 +246,11 @@ async def claim_webhook_delivery(
     """
     row = await pool.fetchrow(
         """
-        INSERT INTO webhook_deliveries (source, delivery_id, event)
-        VALUES ($1, $2, $3)
-        ON CONFLICT (source, delivery_id) DO NOTHING
+        INSERT INTO webhook_deliveries (source, delivery_id, event, claimed_at)
+        VALUES ($1, $2, $3, now())
+        ON CONFLICT (source, delivery_id) DO UPDATE
+        SET received_at = now(), claimed_at = now()
+        WHERE webhook_deliveries.claimed_at < now() - interval '15 minutes'
         RETURNING delivery_id
         """,
         source,

--- a/github-app/app_server/embeddings_api.py
+++ b/github-app/app_server/embeddings_api.py
@@ -119,7 +119,8 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
                 detail=f"each text must be at most {MAX_CHARS_PER_TEXT} characters",
             )
 
-    # Per-repo when the caller sends one (see EmbeddingsRequest.repo_id):
+    # Keep the per-repo bucket for fairness, but always consume an installation-wide
+    # bucket too. repo_id is caller-controlled, so it cannot be the only limiter.
     # `aletheore watch` running against several repos on one token would
     # otherwise share a single counter, and one repo's rebase-heavy burst
     # could starve the others' embeddings on the same installation. Falls
@@ -127,6 +128,7 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
     # send it, rather than treating a missing repo_id as its own bucket -
     # an empty-string "no repo" bucket would just recreate the shared-budget
     # problem for every caller that omits the field.
+    installation_rate_limit_key = f"ratelimit:embeddings:{installation_id}"
     rate_limit_key = (
         f"ratelimit:embeddings:{installation_id}:{body.repo_id}"
         if body.repo_id
@@ -135,10 +137,17 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
     try:
         rate_limited = is_rate_limited(
             get_redis_client(),
-            rate_limit_key,
+            installation_rate_limit_key,
             RATE_LIMIT_REQUESTS,
             RATE_LIMIT_WINDOW_SECONDS,
         )
+        if not rate_limited and body.repo_id:
+            rate_limited = is_rate_limited(
+                get_redis_client(),
+                rate_limit_key,
+                RATE_LIMIT_REQUESTS,
+                RATE_LIMIT_WINDOW_SECONDS,
+            )
     except Exception as exc:  # noqa: BLE001
         # Fails open, matching every other rate limit here: a Redis outage
         # should cost abuse protection, not availability. The upstream Jina

--- a/github-app/app_server/ingest_limits.py
+++ b/github-app/app_server/ingest_limits.py
@@ -34,12 +34,14 @@ EMBEDDINGS_MAX_BODY_BYTES = 3 * 1024 * 1024
 # small so unauthenticated callers cannot force the server to materialize large
 # strings before Pydantic validation runs.
 DEMO_SCAN_MAX_BODY_BYTES = 4 * 1024
+MANAGED_AUDIT_MAX_BODY_BYTES = 26 * 1024 * 1024
 
 MAX_BODY_BYTES_BY_PATH = {
     "/v1/telemetry": TELEMETRY_MAX_BODY_BYTES,
     "/v1/runtime-events": RUNTIME_EVENT_MAX_BODY_BYTES,
     "/v1/embeddings": EMBEDDINGS_MAX_BODY_BYTES,
     "/v1/demo-scan": DEMO_SCAN_MAX_BODY_BYTES,
+    "/v1/managed-audit": MANAGED_AUDIT_MAX_BODY_BYTES,
 }
 
 

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -105,6 +105,14 @@ async def start_managed_audit(request: Request, body: StartManagedAuditRequest):
 
     decoded_evidence = _decode_and_validate_evidence(body.evidence)
 
+    # check_and_reserve_monthly_repo_scan_slot has a side effect - a True
+    # return permanently consumes one of this installation's limited monthly
+    # distinct-repo slots. It must run after decode succeeds, not before:
+    # moving it earlier (to avoid decoding evidence for a request that will
+    # fail the quota anyway) means a single malformed-evidence POST burns a
+    # slot for a scan that never actually happened. The pre-routing body-size
+    # cap (see MAX_BODY_BYTES_BY_PATH) is what protects against a caller
+    # forcing wasted decode work; this check protects the scan slot itself.
     if not await check_and_reserve_monthly_repo_scan_slot(
         pool, installation["installation_id"], body.repo_full_name, MAX_SCANNED_REPOS_PER_MONTH
     ):

--- a/github-app/app_server/webhooks/issue_comment.py
+++ b/github-app/app_server/webhooks/issue_comment.py
@@ -28,7 +28,11 @@ async def handle_issue_comment_event(payload: dict, pool, redis_url: str, queue=
         return
     if "pull_request" not in payload.get("issue", {}):
         return
-    if AUDIT_COMMAND not in payload.get("comment", {}).get("body", ""):
+    comment = payload.get("comment", {})
+    body = comment.get("body", "")
+    if not any(line.strip().startswith(AUDIT_COMMAND) for line in body.splitlines()):
+        return
+    if comment.get("user", {}).get("type") == "Bot":
         return
 
     installation_id = payload["installation"]["id"]

--- a/github-app/app_server/webhooks/marketplace.py
+++ b/github-app/app_server/webhooks/marketplace.py
@@ -2,9 +2,11 @@ import logging
 
 from app_server.db import (
     add_installation_member,
+    claim_free_to_paid_plan,
     get_installation_by_account_login,
     set_extra_seats,
     set_installation_plan,
+    set_paid_installation_plan,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,11 +56,16 @@ async def handle_marketplace_event(payload: dict, pool, redis_url: str, queue=No
         )
         return
     installation_id = installation["installation_id"]
-    previous_plan = installation["plan"]
 
     if action in ("purchased", "changed"):
         new_plan = _normalize_marketplace_plan_name(purchase["plan"]["name"])
-        await set_installation_plan(pool, installation_id, new_plan)
+        transitioned_to_paid = False
+        if new_plan != "free":
+            transitioned_to_paid = await claim_free_to_paid_plan(pool, installation_id, new_plan)
+            if not transitioned_to_paid:
+                await set_paid_installation_plan(pool, installation_id, new_plan)
+        else:
+            await set_installation_plan(pool, installation_id, new_plan)
 
         # Whoever completed the purchase becomes seat one, so they're never
         # locked out of their own installation's Settings by the seat check -
@@ -71,7 +78,7 @@ async def handle_marketplace_event(payload: dict, pool, redis_url: str, queue=No
         # One-time Live Wiki build, tier-independent - fires exactly once,
         # on the free -> paid transition. A paid-to-paid plan change (e.g.
         # Team -> Growth) must not re-trigger it.
-        if previous_plan == "free" and new_plan != "free":
+        if transitioned_to_paid:
             if queue is None:
                 from redis import Redis
                 from rq import Queue

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -10,11 +10,14 @@ from app_server.config import get_settings
 from app_server.db import (
     add_paddle_ids_to_installation,
     claim_webhook_delivery,
+    claim_free_to_paid_plan,
+    claim_paid_setup,
     get_installation,
     list_installation_member_emails,
     release_webhook_delivery,
     set_extra_seats,
     set_installation_plan,
+    set_paid_installation_plan,
 )
 from app_server.email_queue import enqueue_transactional_email
 from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
@@ -55,6 +58,13 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     event_type = payload.get("event_type")
     if event_type == "transaction.completed":
         await _handle_transaction_completed(payload.get("data") or {}, pool)
+        return
+    if event_type == "adjustment.created" or (
+        event_type == "transaction.updated"
+        and (payload.get("data") or {}).get("status")
+        in {"refunded", "partially_refunded", "charged_back"}
+    ):
+        await _handle_adjustment_created(payload.get("data") or {}, pool)
         return
     if event_type not in _SUBSCRIPTION_EVENT_TYPES:
         return
@@ -119,7 +129,22 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         )
         return
 
-    await set_installation_plan(pool, installation_id, plan)
+    transitioned_to_paid = False
+    if plan != "free":
+        transitioned_to_paid = await claim_free_to_paid_plan(pool, installation_id, plan)
+        if not transitioned_to_paid:
+            await set_paid_installation_plan(pool, installation_id, plan)
+    else:
+        await set_installation_plan(pool, installation_id, plan)
+
+    # Deliberately independent of transitioned_to_paid: if a crash lands
+    # between that write committing and the one-time setup below actually
+    # running, a Paddle retry finds plan already non-free, so
+    # claim_free_to_paid_plan correctly returns False on the retry - but
+    # setup still never ran once. This claim is what actually decides
+    # whether to run it, so a crash-then-retry still runs it exactly once
+    # instead of silently skipping it forever.
+    should_run_paid_setup = plan != "free" and await claim_paid_setup(pool, installation_id)
     if "id" in data and "customer_id" in data:
         await add_paddle_ids_to_installation(pool, installation_id, data["id"], data["customer_id"])
 
@@ -145,12 +170,12 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     # only the Marketplace webhook used to trigger it, so a Paddle
     # installation's wiki stayed limited to whatever clusters an
     # incremental push happened to touch after the fact.
-    if previous_plan == "free" and plan != "free":
+    if should_run_paid_setup:
         # Attribution: first time this installation goes free -> paid, if it
         # was checked out with a known affiliate's discount code, credit
-        # that affiliate. Gated the same free -> paid transition as the
-        # wiki/docs build below, so a later subscription.updated for the
-        # same installation (e.g. switching monthly <-> annual) can't
+        # that affiliate. Gated the same paid-setup claim as the wiki/docs
+        # build below, so a later subscription.updated for the same
+        # installation (e.g. switching monthly <-> annual) can't
         # re-attribute or steal credit - record_referral is also itself a
         # database-enforced no-op past the first row (installation_id is
         # that table's primary key).
@@ -270,6 +295,19 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
     )
 
 
+async def _handle_adjustment_created(data: dict, pool) -> None:
+    """Reverse a commission when Paddle refunds or charges back a transaction."""
+    transaction_id = (
+        data.get("transaction_id")
+        or data.get("id")
+        or (data.get("transaction") or {}).get("id")
+    )
+    if transaction_id:
+        from app_server.affiliates import reverse_commission
+
+        await reverse_commission(pool, transaction_id)
+
+
 @paddle_webhook_router.post("/webhooks/paddle")
 async def handle_paddle_webhook(request: Request) -> Response:
     raw_body = await request.body()
@@ -311,7 +349,7 @@ async def handle_paddle_webhook(request: Request) -> Response:
     # Claimed after signature and IP verification, so an unauthenticated
     # caller can't burn an event id and suppress the genuine delivery.
     #
-    # The signature's own 5s timestamp tolerance already makes captured
+    # The signature's own 60s timestamp tolerance already makes captured
     # payload replay a narrow window. This is here for concurrency:
     # handle_paddle_webhook_event reads installations.plan, then writes it,
     # and gates a pair of expensive full AIRview/Docs builds on that read

--- a/github-app/migrations/051_webhook_claim_recovery.sql
+++ b/github-app/migrations/051_webhook_claim_recovery.sql
@@ -1,0 +1,7 @@
+-- NOT NULL DEFAULT now() already stamps every existing row at migration
+-- time, so there is never a NULL claimed_at afterward - no backfill needed.
+ALTER TABLE webhook_deliveries
+    ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE affiliate_commissions
+    ADD COLUMN IF NOT EXISTS reversed BOOLEAN NOT NULL DEFAULT false;

--- a/github-app/migrations/052_paid_setup_completion.sql
+++ b/github-app/migrations/052_paid_setup_completion.sql
@@ -1,0 +1,20 @@
+-- Tracks whether the one-time paid-plan setup (initial Live Wiki/Docs
+-- build, affiliate attribution) has actually run, separately from the
+-- installation's current plan. A crash between the free->paid plan write
+-- and this setup running left plan already paid on Paddle's retry, so a
+-- gate derived from "did the plan just transition" silently and
+-- permanently skipped setup forever on retry.
+--
+-- Defaults to now() ("nothing pending") for every row, existing or new -
+-- an installation that is already paid (migrated data, a direct insert,
+-- a test fixture) was never a fresh transition this code observed, so it
+-- must not be treated as owing a first-time setup run. claim_free_to_paid_plan
+-- resets this to NULL as part of the same atomic UPDATE the moment it
+-- detects a genuine free->paid transition, which is the only place setup
+-- should ever become "pending" again.
+-- Nullable, not NOT NULL: claim_free_to_paid_plan explicitly resets this
+-- back to NULL to mark setup pending again, so the column must be able to
+-- hold NULL - only the DEFAULT (applied when a row is inserted without
+-- naming this column at all) is now().
+ALTER TABLE installations
+    ADD COLUMN IF NOT EXISTS paid_setup_completed_at TIMESTAMPTZ DEFAULT now();

--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -372,7 +372,27 @@ _FILE_MARKER_RE = re.compile(r"^--- (.+) ---$")
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
 
-def _diff_valid_lines(diff_text: str) -> dict[str, set[int]]:
+def _patch_valid_lines(patch: str) -> set[int]:
+    valid: set[int] = set()
+    current_line: int | None = None
+    for line in patch.splitlines():
+        hunk_match = _HUNK_HEADER_RE.match(line)
+        if hunk_match:
+            current_line = int(hunk_match.group(1))
+            continue
+        if line == "":
+            continue
+        if current_line is None:
+            continue
+        valid.add(current_line)
+        if not line.startswith("-"):
+            current_line += 1
+    return valid
+
+
+def _diff_valid_lines(
+    diff_text: str, patches: tuple[tuple[str, str], ...] | None = None
+) -> dict[str, set[int]]:
     """Maps each file to new-file line numbers its diff hunks touch.
 
     A removed line has no new-file line of its own, but the position it was
@@ -391,6 +411,9 @@ def _diff_valid_lines(diff_text: str) -> dict[str, set[int]]:
     real-world regression, so this silently suppressed a whole class of
     true positives.
     """
+    if patches is not None:
+        return {filename: _patch_valid_lines(patch) for filename, patch in patches}
+
     valid_lines: dict[str, set[int]] = {}
     current_file: str | None = None
     current_line: int | None = None
@@ -451,7 +474,10 @@ def _lookup_valid_lines(file: str, valid_lines: dict[str, set[int]]) -> set[int]
 
 
 def _validate_findings(
-    findings: list[dict], diff_text: str, file_contents: dict[str, str] | None = None
+    findings: list[dict],
+    diff_text: str,
+    file_contents: dict[str, str] | None = None,
+    diff_patches: tuple[tuple[str, str], ...] | None = None,
 ) -> list[dict]:
     """Drops findings whose cited location doesn't hold up, and says so.
 
@@ -464,7 +490,7 @@ def _validate_findings(
     Grounding that fails closed and silent is indistinguishable from a
     model that found nothing, which makes it unfixable and unmeasurable.
     """
-    valid_lines = _diff_valid_lines(diff_text)
+    valid_lines = _diff_valid_lines(diff_text, diff_patches)
 
     in_diff = []
     out_of_diff = []
@@ -543,6 +569,7 @@ def review_diff(
     model_used: str | None = None,
     file_contents: dict[str, str] | None = None,
     on_grounding_result: Callable[[dict], None] | None = None,
+    diff_patches: tuple[tuple[str, str], ...] | None = None,
 ) -> list[dict]:
     if not diff_text.strip():
         return []
@@ -562,7 +589,7 @@ def review_diff(
             logger.warning("flash review cache lookup failed (%s); treating as miss", type(exc).__name__)
             cached = None
         if cached is not None:
-            kept = _validate_findings(cached, diff_text, file_contents)
+            kept = _validate_findings(cached, diff_text, file_contents, diff_patches)
             if on_grounding_result is not None:
                 on_grounding_result({"proposed": len(cached), "kept": len(kept)})
             return kept
@@ -616,7 +643,7 @@ def review_diff(
         except Exception as exc:
             logger.warning("flash review cache write failed (%s); continuing without cache", type(exc).__name__)
 
-    kept = _validate_findings(valid, diff_text, file_contents)
+    kept = _validate_findings(valid, diff_text, file_contents, diff_patches)
     if on_grounding_result is not None:
         on_grounding_result({"proposed": len(valid), "kept": len(kept)})
     return kept

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -9,6 +9,15 @@ MAX_CONTEXT_FILE_BYTES = 40_000
 MAX_CONTEXT_TOTAL_BYTES = 200_000
 
 
+class PRDiff(str):
+    """Flattened diff text plus structured patches from GitHub."""
+
+    def __new__(cls, text: str, patches: tuple[tuple[str, str], ...]):
+        value = str.__new__(cls, text)
+        value.patches = patches
+        return value
+
+
 class BranchNotOwnedByAletheoreError(Exception):
     """Raised by ensure_branch_at when a branch with our reserved name
     already exists but its HEAD commit wasn't made by us - force-pushing
@@ -80,7 +89,7 @@ def fetch_pr_diff(
     repo_full_name: str,
     base_ref: str,
     head_ref: str,
-) -> str:
+) -> PRDiff:
     headers = {
         "Authorization": f"token {token}",
         "Accept": "application/vnd.github+json",
@@ -91,11 +100,13 @@ def fetch_pr_diff(
     )
     response.raise_for_status()
     parts = []
+    patches = []
     for file in response.json().get("files", []):
         patch = file.get("patch")
         if patch:
+            patches.append((file["filename"], patch))
             parts.append(f"--- {file['filename']} ---\n{patch}")
-    return "\n\n".join(parts)
+    return PRDiff("\n\n".join(parts), tuple(patches))
 
 
 def fetch_pr_changed_files(

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1448,7 +1448,9 @@ def _run_flash_review(
         settings.database_url, installation_id, repo_full_name, pr_number
     )
     diff_base = last_reviewed_sha or base_sha
-    diff_text = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha)
+    diff_result = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha)
+    diff_text = str(diff_result)
+    diff_patches = getattr(diff_result, "patches", None)
     changed_files = fetch_pr_changed_files(client, token, repo_full_name, diff_base, head_sha)
 
     spend_accumulator = {"total": 0.0}
@@ -1513,6 +1515,7 @@ def _run_flash_review(
                 model_used=flash_review_model,
                 file_contents=file_contents,
                 on_grounding_result=_on_grounding_result,
+                diff_patches=diff_patches,
             )
         else:
             findings = review_diff(
@@ -1525,6 +1528,7 @@ def _run_flash_review(
                 model_used=flash_review_model,
                 file_contents=file_contents,
                 on_grounding_result=_on_grounding_result,
+                diff_patches=diff_patches,
             )
     # Briefly re-acquire the lock just for the write, now that the
     # expensive review work above is done - see run_flash_review_job's
@@ -1846,42 +1850,45 @@ def _fix_suggestion_attachment(
 
         with installation_spend_lock(dsn, installation_id):
             cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-            if cap_reached:
-                return None
+        if cap_reached:
+            return None
 
-            app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
-            token = _token_sync(installation_id, app_jwt)
-            client = get_github_api_client()
-            file_content = fetch_file_content(client, token, repo_full_name, source_file)
-            if not file_content:
-                return None
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        token = _token_sync(installation_id, app_jwt)
+        client = get_github_api_client()
+        file_content = fetch_file_content(client, token, repo_full_name, source_file)
+        if not file_content:
+            return None
 
-            lines = file_content.splitlines()
-            anchor = (source_line or 1) - 1
-            snippet = "\n".join(lines[max(0, anchor - 15) : min(len(lines), anchor + 15)])
-            user_prompt = json.dumps(
-                {
-                    "endpoint": f"{method} {path}",
-                    "status_code": status_code,
-                    "file": source_file,
-                    "line": source_line,
-                    "symbol": _find_enclosing_symbol(evidence, source_file, source_line),
-                    "code_context": snippet,
-                }
+        lines = file_content.splitlines()
+        anchor = (source_line or 1) - 1
+        snippet = "\n".join(lines[max(0, anchor - 15) : min(len(lines), anchor + 15)])
+        user_prompt = json.dumps(
+            {
+                "endpoint": f"{method} {path}",
+                "status_code": status_code,
+                "file": source_file,
+                "line": source_line,
+                "symbol": _find_enclosing_symbol(evidence, source_file, source_line),
+                "code_context": snippet,
+            }
+        )
+        fix_suggestion_model = model_for_plan(plan)
+        spend_accumulator = {"total": 0.0}
+
+        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+            spend_accumulator["total"] += cost_for_usage(
+                fix_suggestion_model, prompt_tokens, completion_tokens
             )
-            fix_suggestion_model = model_for_plan(plan)
-            spend_accumulator = {"total": 0.0}
 
-            def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-                spend_accumulator["total"] += cost_for_usage(
-                    fix_suggestion_model, prompt_tokens, completion_tokens
-                )
-
-            raw = _health_fix_suggestion_adapter(on_usage=_on_usage).simple_completion(
-                FIX_SUGGESTION_SYSTEM_PROMPT, user_prompt, cwd="."
+        raw = _health_fix_suggestion_adapter(on_usage=_on_usage).simple_completion(
+            FIX_SUGGESTION_SYSTEM_PROMPT, user_prompt, cwd="."
+        )
+        with installation_spend_lock(dsn, installation_id):
+            record_llm_spend(
+                dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap
             )
-            record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
-            suggestion = raw.strip()
+        suggestion = raw.strip()
     except Exception as exc:  # noqa: BLE001
         logging.getLogger("scan_worker.jobs").warning(
             "fix-suggestion generation failed (%s); alerting without it", type(exc).__name__
@@ -2941,61 +2948,62 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
 
     with installation_spend_lock(dsn, installation_id):
         cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-        if cap_reached:
-            logging.getLogger("scan_worker.jobs").info(
-                "live wiki full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
-                installation_id, repo_full_name, monthly_cap,
-            )
-            set_wiki_build_status(
-                dsn, installation_id, repo_full_name, "failed",
-                f"monthly spend cap reached (${monthly_cap:.2f})",
-            )
-            return
+    if cap_reached:
+        logging.getLogger("scan_worker.jobs").info(
+            "live wiki full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
+            installation_id, repo_full_name, monthly_cap,
+        )
+        set_wiki_build_status(
+            dsn, installation_id, repo_full_name, "failed",
+            f"monthly spend cap reached (${monthly_cap:.2f})",
+        )
+        return
 
-        spend_accumulator = {"total": 0.0}
-        spend_lock = threading.Lock()
+    spend_accumulator = {"total": 0.0}
+    spend_lock = threading.Lock()
 
-        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            # live_wiki.generate_subsystems/generate_file_pages now run their
-            # per-item writing calls on a bounded thread pool, so this fires
-            # from multiple worker threads concurrently - += on a shared dict
-            # value is a read-modify-write race without the lock.
-            cost = cost_for_usage(model_used, prompt_tokens, completion_tokens)
-            with spend_lock:
-                spend_accumulator["total"] += cost
+    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+        # Generation runs on a bounded thread pool, so usage callbacks can
+        # arrive concurrently and need a local accumulator lock.
+        cost = cost_for_usage(model_used, prompt_tokens, completion_tokens)
+        with spend_lock:
+            spend_accumulator["total"] += cost
 
-        try:
-            naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
-            writing_adapter = _live_wiki_full_build_writing_adapter(plan, on_usage=_on_usage)
-            fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
-            records = live_wiki.generate_subsystems(
-                evidence,
-                naming_adapter,
-                writing_adapter,
-                cluster_ids=cluster_ids,
-                cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
-                cache_write=lambda packet, output, used: store_result(
-                    dsn, installation_id, repo_full_name, packet, output, used
-                ),
-                model_used=model_used,
-                fetch_line_count=fetch_line_count,
+    try:
+        naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
+        writing_adapter = _live_wiki_full_build_writing_adapter(plan, on_usage=_on_usage)
+        fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
+        records = live_wiki.generate_subsystems(
+            evidence,
+            naming_adapter,
+            writing_adapter,
+            cluster_ids=cluster_ids,
+            cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
+            cache_write=lambda packet, output, used: store_result(
+                dsn, installation_id, repo_full_name, packet, output, used
+            ),
+            model_used=model_used,
+            fetch_line_count=fetch_line_count,
+        )
+        _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count)
+        with installation_spend_lock(dsn, installation_id):
+            record_llm_spend(
+                dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap
             )
-            _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count)
-            record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
-            _store_wiki_generation(
-                dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
-                fetch_line_count=fetch_line_count,
-            )
-        except Exception as exc:  # noqa: BLE001
-            # Without this, a failed build (LLM error, DB error) just leaves the
-            # AIRview page permanently blank with no way for the customer to
-            # tell "still building" apart from "broke and is never coming back".
-            logging.getLogger("scan_worker.jobs").warning(
-                "live wiki full build failed for installation=%s repo=%s (%s)",
-                installation_id, repo_full_name, exc,
-            )
-            set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-            return
+        _store_wiki_generation(
+            dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
+            fetch_line_count=fetch_line_count,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Without this, a failed build (LLM error, DB error) just leaves the
+        # AIRview page permanently blank with no way for the customer to tell
+        # "still building" apart from "broke and is never coming back".
+        logging.getLogger("scan_worker.jobs").warning(
+            "live wiki full build failed for installation=%s repo=%s (%s)",
+            installation_id, repo_full_name, exc,
+        )
+        set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+        return
     set_wiki_build_status(dsn, installation_id, repo_full_name, "ready")
 
 
@@ -3079,64 +3087,59 @@ def _maybe_update_live_wiki(
     plan = installation["plan"]
     with installation_spend_lock(dsn, installation_id):
         cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-        if cap_reached:
-            logging.getLogger("scan_worker.jobs").info(
-                "live wiki incremental update skipped for installation=%s repo=%s - "
-                "monthly spend cap reached (${%.2f})",
-                installation_id, repo_full_name, monthly_cap,
-            )
-            set_wiki_build_status(
-                dsn, installation_id, repo_full_name, "failed",
-                f"monthly spend cap reached (${monthly_cap:.2f})",
-            )
-            return
+    if cap_reached:
+        logging.getLogger("scan_worker.jobs").info(
+            "live wiki incremental update skipped for installation=%s repo=%s - "
+            "monthly spend cap reached (${%.2f})",
+            installation_id, repo_full_name, monthly_cap,
+        )
+        set_wiki_build_status(
+            dsn, installation_id, repo_full_name, "failed",
+            f"monthly spend cap reached (${monthly_cap:.2f})",
+        )
+        return
 
-        update_model = resolve_model(live_wiki.UPDATE_MODEL)
-        spend_accumulator = {"total": 0.0}
-        spend_lock = threading.Lock()
+    update_model = resolve_model(live_wiki.UPDATE_MODEL)
+    spend_accumulator = {"total": 0.0}
+    spend_lock = threading.Lock()
 
-        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            # See matching comment in run_live_wiki_full_build_job: generation
-            # now runs on a bounded thread pool, so this callback is no
-            # longer single-threaded.
-            cost = cost_for_usage(update_model, prompt_tokens, completion_tokens)
-            with spend_lock:
-                spend_accumulator["total"] += cost
+    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+        cost = cost_for_usage(update_model, prompt_tokens, completion_tokens)
+        with spend_lock:
+            spend_accumulator["total"] += cost
 
-        try:
-            naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
-            writing_adapter = _live_wiki_update_writing_adapter(on_usage=_on_usage)
-            fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
-            records = live_wiki.generate_subsystems(
-                evidence,
-                naming_adapter,
-                writing_adapter,
-                cluster_ids=cluster_ids,
-                cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
-                cache_write=lambda packet, output, used: store_result(
-                    dsn, installation_id, repo_full_name, packet, output, used
-                ),
-                model_used=update_model,
-                fetch_line_count=fetch_line_count,
+    try:
+        naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
+        writing_adapter = _live_wiki_update_writing_adapter(on_usage=_on_usage)
+        fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
+        records = live_wiki.generate_subsystems(
+            evidence,
+            naming_adapter,
+            writing_adapter,
+            cluster_ids=cluster_ids,
+            cache_lookup=lambda packet: lookup_cached_result(dsn, installation_id, repo_full_name, packet),
+            cache_write=lambda packet, output, used: store_result(
+                dsn, installation_id, repo_full_name, packet, output, used
+            ),
+            model_used=update_model,
+            fetch_line_count=fetch_line_count,
+        )
+        _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count)
+        with installation_spend_lock(dsn, installation_id):
+            record_llm_spend(
+                dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap
             )
-            _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count)
-            record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
-            _store_wiki_generation(
-                dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
-                fetch_line_count=fetch_line_count,
-            )
-        except Exception as exc:  # noqa: BLE001
-            # Without this, a failed incremental update just leaves stale
-            # content in place with zero signal - the customer (and
-            # wiki_build_status) has no way to tell "stale" apart from
-            # "current", especially once a first full build has already
-            # succeeded and populated an overview.
-            logging.getLogger("scan_worker.jobs").warning(
-                "live wiki incremental update failed for installation=%s repo=%s (%s)",
-                installation_id, repo_full_name, exc,
-            )
-            set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-            return
+        _store_wiki_generation(
+            dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
+            fetch_line_count=fetch_line_count,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "live wiki incremental update failed for installation=%s repo=%s (%s)",
+            installation_id, repo_full_name, exc,
+        )
+        set_wiki_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+        return
     set_wiki_build_status(dsn, installation_id, repo_full_name, "ready")
 
 
@@ -3365,47 +3368,47 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
 
     with installation_spend_lock(dsn, installation_id):
         cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-        if cap_reached:
-            logging.getLogger("scan_worker.jobs").info(
-                "live docs full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
-                installation_id, repo_full_name, monthly_cap,
-            )
-            set_docs_build_status(
-                dsn, installation_id, repo_full_name, "failed",
-                f"monthly spend cap reached (${monthly_cap:.2f})",
-            )
-            return
-
-        full_build_model = model_for_plan(plan)
-        current_spend = get_llm_spend_this_month(dsn, installation_id)
-        spend_budget = _IncrementalSpendBudget(
-            dsn, installation_id, full_build_model, current_spend, monthly_cap
+    if cap_reached:
+        logging.getLogger("scan_worker.jobs").info(
+            "live docs full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
+            installation_id, repo_full_name, monthly_cap,
         )
-
-        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            spend_budget.record_usage(prompt_tokens, completion_tokens)
-
-        try:
-            writing_adapter = _live_docs_full_build_writing_adapter(plan, on_usage=_on_usage)
-        except Exception as exc:  # noqa: BLE001
-            logging.getLogger("scan_worker.jobs").warning(
-                "live docs full build could not start for installation=%s repo=%s (%s)",
-                installation_id, repo_full_name, exc,
-            )
-            set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-            return
-
-        succeeded, last_error = _run_docs_build_for_modules(
-            dsn,
-            installation_id,
-            repo_full_name,
-            modules,
-            writing_adapter,
-            client,
-            token,
-            None,
-            spend_budget=spend_budget,
+        set_docs_build_status(
+            dsn, installation_id, repo_full_name, "failed",
+            f"monthly spend cap reached (${monthly_cap:.2f})",
         )
+        return
+
+    full_build_model = model_for_plan(plan)
+    current_spend = get_llm_spend_this_month(dsn, installation_id)
+    spend_budget = _IncrementalSpendBudget(
+        dsn, installation_id, full_build_model, current_spend, monthly_cap
+    )
+
+    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+        spend_budget.record_usage(prompt_tokens, completion_tokens)
+
+    try:
+        writing_adapter = _live_docs_full_build_writing_adapter(plan, on_usage=_on_usage)
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "live docs full build could not start for installation=%s repo=%s (%s)",
+            installation_id, repo_full_name, exc,
+        )
+        set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+        return
+
+    succeeded, last_error = _run_docs_build_for_modules(
+        dsn,
+        installation_id,
+        repo_full_name,
+        modules,
+        writing_adapter,
+        client,
+        token,
+        None,
+        spend_budget=spend_budget,
+    )
     if succeeded == 0 and last_error is not None:
         # Every module in this run failed - genuinely nothing new landed,
         # unlike a partial run where some succeeded and persisted already.
@@ -3506,45 +3509,41 @@ def _maybe_update_live_docs(
     plan = installation["plan"]
     with installation_spend_lock(dsn, installation_id):
         cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-        if cap_reached:
-            logging.getLogger("scan_worker.jobs").info(
-                "live docs incremental update skipped for installation=%s repo=%s - "
-                "monthly spend cap reached (${%.2f})",
-                installation_id, repo_full_name, monthly_cap,
-            )
-            set_docs_build_status(
-                dsn, installation_id, repo_full_name, "failed",
-                f"monthly spend cap reached (${monthly_cap:.2f})",
-            )
-            return
-
-        spend_accumulator = {"total": 0.0}
-        update_model = resolve_model(live_docs.FLASH_MODEL)
-
-        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            spend_accumulator["total"] += cost_for_usage(update_model, prompt_tokens, completion_tokens)
-
-        try:
-            writing_adapter = _live_docs_update_writing_adapter(on_usage=_on_usage)
-        except Exception as exc:  # noqa: BLE001
-            logging.getLogger("scan_worker.jobs").warning(
-                "live docs incremental update could not start for installation=%s repo=%s (%s)",
-                installation_id, repo_full_name, exc,
-            )
-            set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
-            return
-
-        # Per-module resilience matters here too, even for a typically-small
-        # changed-file list: one file's transient API failure shouldn't
-        # discard descriptions already generated for the others in the same
-        # push. Deliberately doesn't skip already-covered symbols the way the
-        # full build does - these files just changed, so an existing stored
-        # description may no longer match the new source and needs a fresh
-        # look regardless of whether a docs_symbols row already exists.
-        succeeded, last_error = _run_docs_build_for_modules(
-            dsn, installation_id, repo_full_name, changed_modules, writing_adapter, client, token, head_sha
+    if cap_reached:
+        logging.getLogger("scan_worker.jobs").info(
+            "live docs incremental update skipped for installation=%s repo=%s - "
+            "monthly spend cap reached (${%.2f})",
+            installation_id, repo_full_name, monthly_cap,
         )
-        record_llm_spend(dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap)
+        set_docs_build_status(
+            dsn, installation_id, repo_full_name, "failed",
+            f"monthly spend cap reached (${monthly_cap:.2f})",
+        )
+        return
+
+    spend_accumulator = {"total": 0.0}
+    update_model = resolve_model(live_docs.FLASH_MODEL)
+
+    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+        spend_accumulator["total"] += cost_for_usage(update_model, prompt_tokens, completion_tokens)
+
+    try:
+        writing_adapter = _live_docs_update_writing_adapter(on_usage=_on_usage)
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "live docs incremental update could not start for installation=%s repo=%s (%s)",
+            installation_id, repo_full_name, exc,
+        )
+        set_docs_build_status(dsn, installation_id, repo_full_name, "failed", str(exc))
+        return
+
+    succeeded, last_error = _run_docs_build_for_modules(
+        dsn, installation_id, repo_full_name, changed_modules, writing_adapter, client, token, head_sha
+    )
+    with installation_spend_lock(dsn, installation_id):
+        record_llm_spend(
+            dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap
+        )
     if succeeded == 0 and last_error is not None:
         set_docs_build_status(dsn, installation_id, repo_full_name, "failed", last_error)
         return

--- a/github-app/tests/test_affiliates.py
+++ b/github-app/tests/test_affiliates.py
@@ -11,6 +11,7 @@ from app_server.affiliates import (
     mark_commissions_paid,
     record_commission,
     record_referral,
+    reverse_commission,
 )
 from app_server.db import upsert_installation
 
@@ -99,6 +100,24 @@ async def test_duplicate_paddle_transaction_id_does_not_double_count(pool):
 
     totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
     assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.50")
+
+
+@pytest.mark.asyncio
+async def test_reversed_commission_is_preserved_but_excluded_from_totals(pool):
+    affiliate = await create_affiliate(pool, "REV10", "dsc_rev", "Referred")
+    await upsert_installation(pool, 907, "acme")
+    await record_referral(pool, 907, affiliate["id"])
+    await record_commission(
+        pool, affiliate["id"], 907, "txn_refund", Decimal("4.50"), datetime.now(timezone.utc)
+    )
+
+    assert await reverse_commission(pool, "txn_refund") is True
+    assert await reverse_commission(pool, "txn_refund") is False
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("0")
+    assert await pool.fetchval(
+        "SELECT reversed FROM affiliate_commissions WHERE paddle_transaction_id = 'txn_refund'"
+    ) is True
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -125,6 +125,11 @@ def test_backslash_protocol_relative_next_url_rejected():
     assert _is_safe_next_path("/\\evil.example.com/phish") == "/dashboard"
 
 
+@pytest.mark.parametrize("control", ["\t", "\n", "\r", "\x1f"])
+def test_control_characters_in_next_path_rejected(control):
+    assert _is_safe_next_path(f"/{control}/evil.example.com") == "/dashboard"
+
+
 def test_next_path_not_starting_with_slash_rejected():
     assert _is_safe_next_path("evil.example.com") == "/dashboard"
 

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -51,6 +51,33 @@ def test_diff_valid_lines_tracks_multiple_files_separately():
     assert _diff_valid_lines(diff_text) == {"a.py": {5}, "b.py": {10}}
 
 
+def test_structured_patches_do_not_treat_deleted_comment_markers_as_filenames():
+    patch = "@@ -10,4 +10,4 @@\n context\n--- x ---\n-removed\n+added\n context"
+
+    result = _diff_valid_lines("flattened text is intentionally ignored", (("db/schema.sql", patch),))
+
+    assert set(result) == {"db/schema.sql"}
+    assert 10 in result["db/schema.sql"]
+    assert 11 in result["db/schema.sql"]
+
+
+def test_structured_patches_keep_marker_like_added_and_context_lines():
+    patch = "@@ -1,3 +1,3 @@\n---- x ---\n+---- x ---\n -- x ---"
+
+    result = _diff_valid_lines("", (("app.py", patch),))
+
+    assert result == {"app.py": {1, 2}}
+
+
+def test_structured_patches_keep_genuine_two_file_diff_separate():
+    patches = (
+        ("a.py", "@@ -4,1 +4,1 @@\n+one"),
+        ("b.py", "@@ -20,1 +20,1 @@\n+two"),
+    )
+
+    assert _diff_valid_lines("", patches) == {"a.py": {4}, "b.py": {20}}
+
+
 def test_lookup_valid_lines_falls_back_to_unambiguous_path_suffix():
     valid_lines = {"benchmark-sandbox/case-1/pkg/module.py": {5, 6, 7}}
     assert _lookup_valid_lines("pkg/module.py", valid_lines) == {5, 6, 7}

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -144,6 +144,7 @@ def test_fetch_pr_diff_concatenates_real_patches():
     assert "app.py" in diff_text
     assert "print('hi')" in diff_text
     assert "image.png" not in diff_text
+    assert diff_text.patches == (("app.py", "@@ -1,2 +1,3 @@\n def hello():\n+    print('hi')\n     pass"),)
 
 
 def test_fetch_pr_diff_returns_empty_string_when_no_files_changed():

--- a/github-app/tests/test_ingest_abuse_controls.py
+++ b/github-app/tests/test_ingest_abuse_controls.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app_server.ingest_limits import (
+    MANAGED_AUDIT_MAX_BODY_BYTES,
     RUNTIME_EVENT_MAX_BODY_BYTES,
     TELEMETRY_MAX_BODY_BYTES,
     BodyTooLargeError,
@@ -58,10 +59,14 @@ def test_a_non_numeric_content_length_is_refused():
         check_declared_body_size("/v1/telemetry", "POST", "not-a-number")
 
 
-def test_uncapped_paths_are_untouched():
-    # The cap is per-path on purpose: a global limit would break the managed
-    # audit API, which legitimately accepts large evidence payloads.
-    check_declared_body_size("/v1/managed-audit", "POST", str(50 * 1024 * 1024))
+def test_managed_audit_has_a_pre_routing_body_cap():
+    check_declared_body_size(
+        "/v1/managed-audit", "POST", str(MANAGED_AUDIT_MAX_BODY_BYTES)
+    )
+    with pytest.raises(BodyTooLargeError):
+        check_declared_body_size(
+            "/v1/managed-audit", "POST", str(MANAGED_AUDIT_MAX_BODY_BYTES + 1)
+        )
 
 
 def test_get_requests_are_untouched():

--- a/github-app/tests/test_issue_comment_webhook.py
+++ b/github-app/tests/test_issue_comment_webhook.py
@@ -113,6 +113,28 @@ async def test_non_audit_comment_does_not_enqueue(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_quoted_command_does_not_enqueue(pool, monkeypatch):
+    await _seed_paid_installation(pool)
+    _mock_permission_check(monkeypatch, "write")
+    fake_queue = MagicMock()
+    await handle_issue_comment_event(
+        _payload("Please do not run /aletheore audit here"), pool, "redis://unused", queue=fake_queue
+    )
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_command_does_not_enqueue(pool, monkeypatch):
+    await _seed_paid_installation(pool)
+    _mock_permission_check(monkeypatch, "write")
+    fake_queue = MagicMock()
+    payload = _payload("/aletheore audit")
+    payload["comment"]["user"]["type"] = "Bot"
+    await handle_issue_comment_event(payload, pool, "redis://unused", queue=fake_queue)
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_comment_on_plain_issue_not_pr_does_not_enqueue(pool, monkeypatch):
     await _seed_paid_installation(pool)
     _mock_permission_check(monkeypatch, "write")

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -15,6 +15,7 @@ from app_server.affiliates import create_affiliate, get_referral, list_affiliate
 from app_server.auth import sign_checkout_installation_id
 from app_server.db import (
     add_installation_member,
+    claim_free_to_paid_plan,
     claim_webhook_delivery,
     get_extra_seats,
     get_installation,
@@ -420,6 +421,46 @@ async def test_paid_to_paid_change_does_not_retrigger_live_wiki_full_build(pool)
 
     installation = await get_installation(pool, 201)
     assert installation["plan"] == "air"
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_crash_after_plan_write_still_runs_setup_on_retry(pool):
+    """Simulates a process death between the plan write committing and
+    setup (wiki/docs build, attribution) running: claim_free_to_paid_plan
+    already flipped the plan to 'air' and reset paid_setup_completed_at to
+    NULL (a real free->paid transition happened), but nothing past that
+    point ran - as if the process died right there. claim_free_to_paid_plan
+    would return False on a retry (plan isn't 'free' anymore) and silently
+    skip setup forever if setup were gated on that transition boolean - the
+    retry must still run it because setup itself was never actually
+    claimed."""
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 203, "acme")  # defaults to plan='free'
+    assert await claim_free_to_paid_plan(pool, 203, "air") is True  # the crashed attempt
+
+    payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 203)
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert fake_queue.enqueue.call_count == 2
+    job_names = {call.args[0] for call in fake_queue.enqueue.call_args_list}
+    assert job_names == {
+        "scan_worker.jobs.run_live_wiki_full_build_for_installation_job",
+        "scan_worker.jobs.run_live_docs_full_build_for_installation_job",
+    }
+
+
+@pytest.mark.asyncio
+async def test_setup_runs_only_once_across_repeated_deliveries(pool):
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 204, "acme")  # defaults to plan='free'
+    payload = _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 204)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+    assert fake_queue.enqueue.call_count == 2
+
+    fake_queue.reset_mock()
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
     fake_queue.enqueue.assert_not_called()
 
 

--- a/src/aletheore/citation_verifier.py
+++ b/src/aletheore/citation_verifier.py
@@ -72,7 +72,7 @@ def _extensionless_citation_pattern(known_paths: set[str]) -> re.Pattern | None:
         return None
     # Longest first so a nested path wins over a bare filename suffix of it.
     alternation = "|".join(re.escape(p) for p in sorted(targets, key=len, reverse=True))
-    return re.compile(rf"`?({alternation}):(\d+)`?")
+    return re.compile(rf"`?(?<![\w./-])({alternation}):(\d+)`?")
 
 
 def extract_citations(report_text: str, known_paths: set[str] | None = None) -> list[dict]:

--- a/src/aletheore/credentials.py
+++ b/src/aletheore/credentials.py
@@ -84,6 +84,10 @@ def _save_key(provider_name: str, key: str, credentials_path: Path) -> None:
         except json.JSONDecodeError:
             data = {}
     data[provider_name] = key
+    _write_credentials(data, credentials_path)
+
+
+def _write_credentials(data: dict, credentials_path: Path) -> None:
     content = json.dumps(data, indent=2)
     # os.open's mode only applies when it creates the file - an existing
     # file (e.g. one that pre-dates this restrictive-permissions fix, or
@@ -112,7 +116,7 @@ def clear_api_key(provider_name: str, credentials_path: Path = DEFAULT_CREDENTIA
     if not isinstance(data, dict) or provider_name not in data:
         return False
     del data[provider_name]
-    credentials_path.write_text(json.dumps(data, indent=2))
+    _write_credentials(data, credentials_path)
     return True
 
 

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -15,6 +15,7 @@ from aletheore.licenses import check_dependency_licenses
 from aletheore.repo_config import load_repo_config
 from aletheore.schema_map import extract_schema, skipped_schema
 from aletheore.scanner.detect import (
+    _nested_git_roots,
     detect_ai_usage,
     detect_build_tools,
     detect_database,
@@ -376,6 +377,14 @@ def scan_repository(
     report = progress or _noop_progress
     repo_path = repo_path.resolve()
     ignored_paths = load_repo_config(repo_path)["ignored_paths"]
+
+    # _nested_git_roots is @lru_cache'd for the life of the process, not one
+    # scan - a long-lived scan_worker reuses the same on-disk checkout_dir
+    # across many scans of different commits, and a linked worktree or
+    # submodule can appear or disappear between two of them. Clearing here
+    # keeps the within-scan caching win (it's still called up to 6 times per
+    # scan) without carrying a stale answer into the next scan of this path.
+    _nested_git_roots.cache_clear()
 
     # Must run before any file-counting walk below (detect_languages is the
     # first one), not after the scan in write_evidence as before - creating

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -578,7 +578,9 @@ _NO_INDEX_ERROR = {
 }
 
 
-def _register_search_codebase_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+def _register_search_codebase_tool(
+    mcp_instance: MCPServer, repo_path: Path, effects: frozenset[str]
+) -> None:
     @mcp_instance.tool(
         name="aletheore_search_codebase",
         # Writes nothing, but embeds the query text through the configured
@@ -594,7 +596,15 @@ def _register_search_codebase_tool(mcp_instance: MCPServer, repo_path: Path) -> 
         an unfiltered search ranks every language's chunks against each other.
         Names must match evidence's own repository.languages values."""
         try:
-            return _toon_result(search_index(repo_path, query, k=k, language=language))
+            return _toon_result(
+                search_index(
+                    repo_path,
+                    query,
+                    k=k,
+                    language=language,
+                    allow_hosted=EFFECT_EXTERNAL in effects,
+                )
+            )
         except IndexNotFoundError:
             return _toon_result(_NO_INDEX_ERROR)
         except IndexDimensionMismatchError as exc:
@@ -705,7 +715,7 @@ def build_server(
     if permitted("aletheore_index"):
         _register_index_tool(mcp_instance, repo_path, effects)
     if permitted("aletheore_search_codebase"):
-        _register_search_codebase_tool(mcp_instance, repo_path)
+        _register_search_codebase_tool(mcp_instance, repo_path, effects)
     if permitted("aletheore_managed_audit"):
         _register_managed_audit_tool(mcp_instance, repo_path)
     if answer_adapter is not None and permitted("aletheore_answer"):

--- a/src/aletheore/scanner/detect.py
+++ b/src/aletheore/scanner/detect.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 
 import yaml
@@ -215,6 +216,7 @@ def _npm_dependencies(repo_path: Path) -> dict[str, str]:
     return {**data.get("dependencies", {}), **data.get("devDependencies", {})}
 
 
+@lru_cache(maxsize=128)
 def _nested_git_roots(repo_path: Path) -> set[Path]:
     """Directories other than repo_path itself that contain their own `.git`
     entry (file or directory) - a linked worktree (`git worktree add`) or a
@@ -226,11 +228,20 @@ def _nested_git_roots(repo_path: Path) -> set[Path]:
     os.walk(followlinks=False) rather than Path.rglob(".git") - a symlinked
     directory shouldn't be descended into just to look for a nested repo.
     """
+    repo_path = repo_path.resolve()
     roots = set()
     for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
         current_dir = Path(dirpath)
-        if current_dir != repo_path and (".git" in dirnames or ".git" in filenames):
+        # Check for .git before pruning - IGNORED_DIRS contains ".git" itself
+        # (so descending into a found repo's own .git internals is skipped),
+        # and pruning first would remove ".git" from dirnames before this
+        # check ever sees it, silently disabling directory-style nested-clone
+        # detection entirely regardless of where it sits.
+        has_nested_git = ".git" in dirnames or ".git" in filenames
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        if current_dir != repo_path and has_nested_git:
             roots.add(current_dir)
+            dirnames[:] = []
     return roots
 
 

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import tree_sitter_c as tsc
@@ -64,6 +65,8 @@ KNOWN_SOURCE_EXTENSIONS_WITHOUT_GRAMMAR = {
     ".swift",
     ".kt", ".kts", ".m", ".mm", ".scala",
 }
+
+MAX_SOURCE_FILE_BYTES = 2 * 1024 * 1024
 
 
 def _iter_source_files(repo_path: Path, ignored_paths: list[str] | None = None):
@@ -1993,6 +1996,55 @@ def _resolve_csharp_using(prefix_map: dict[str, Path], dotted: str) -> list[Path
     return sorted(namespace_dir.glob("*.cs"))
 
 
+def _load_csharp_implicit_usings(repo_path: Path, source_paths: list[Path]) -> dict[Path, list[str]]:
+    """Load explicit MSBuild ``Using`` items for each C# file's scope."""
+    config_paths: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(repo_path, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        current = Path(dirpath)
+        for filename in filenames:
+            if filename == "Directory.Build.props" or filename.endswith(".csproj"):
+                config_paths.append(current / filename)
+
+    values_by_config: dict[Path, list[str]] = {}
+    for config_path in config_paths:
+        try:
+            root = ET.parse(config_path).getroot()
+        except (ET.ParseError, OSError):
+            continue
+        values = []
+        for element in root.iter():
+            if element.tag.rsplit("}", 1)[-1] == "Using":
+                include = element.attrib.get("Include", "").strip()
+                if include:
+                    values.append(include)
+        values_by_config[config_path] = values
+
+    result: dict[Path, list[str]] = {}
+    for source_path in source_paths:
+        ancestors = [source_path.parent, *source_path.parent.parents]
+        applicable_props = [
+            config for config in config_paths
+            if config.parent in ancestors
+            and config.name == "Directory.Build.props"
+        ]
+        project_configs = [
+            config for config in config_paths
+            if config.parent in ancestors and config.suffix == ".csproj"
+        ]
+        applicable = applicable_props
+        if project_configs:
+            applicable.append(max(project_configs, key=lambda p: (len(p.parts), str(p))))
+        imports: list[str] = []
+        for config in sorted(applicable, key=lambda p: (len(p.parts), str(p))):
+            for value in values_by_config.get(config, []):
+                if value not in imports:
+                    imports.append(value)
+        if imports:
+            result[source_path] = imports
+    return result
+
+
 def _python_source_roots(repo_path: Path) -> list[Path]:
     # A monorepo can hold several independent Python projects, each with its own
     # top-level package one or more directories below repo_path (src/aletheore/,
@@ -2157,19 +2209,18 @@ def build_module_graph(
     # declaration implies about its directory, so every .java file needs a quick
     # pre-parse before any of them can have their imports resolved.
     java_source_roots: list[Path] = []
-    # Cached alongside the source root inference below so the main loop's
-    # own per-file parse doesn't read and re-parse every .java file a
-    # second time from scratch - this pre-pass already did the identical
-    # work once.
-    java_pre_parsed: dict[Path, tuple[bytes, Tree]] = {}
+    oversized_paths: set[Path] = set()
     pre_parser = Parser()
     pre_parser.language = JAVA_LANGUAGE
     for path in _iter_source_files(repo_path, ignored_paths):
         if path.suffix != ".java":
             continue
+        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+            oversized_paths.add(path)
+            unparseable.append({"path": _rel(repo_path, path), "reason": "file exceeds size limit"})
+            continue
         pre_source = path.read_bytes()
         tree = pre_parser.parse(pre_source)
-        java_pre_parsed[path] = (pre_source, tree)
         package = _extract_java_package(tree.root_node, pre_source)
         root = _java_source_root_for(path, package)
         if root is not None and root not in java_source_roots:
@@ -2183,7 +2234,7 @@ def build_module_graph(
     # (prefix -> root) map rather than a plain root list, PSR-4-style, to handle
     # <RootNamespace>'s implicit prefix (see _csharp_prefix_and_root_for).
     csharp_prefix_map: dict[str, Path] = {}
-    csharp_pre_parsed: dict[Path, tuple[bytes, Tree]] = {}
+    csharp_source_paths: list[Path] = []
     # Which file declares each type name, for the type-reference edges below.
     csharp_type_owners: dict[str, set[Path]] = {}
     cs_pre_parser = Parser()
@@ -2191,9 +2242,13 @@ def build_module_graph(
     for path in _iter_source_files(repo_path, ignored_paths):
         if path.suffix != ".cs":
             continue
+        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+            oversized_paths.add(path)
+            unparseable.append({"path": _rel(repo_path, path), "reason": "file exceeds size limit"})
+            continue
+        csharp_source_paths.append(path)
         pre_source = path.read_bytes()
         tree = cs_pre_parser.parse(pre_source)
-        csharp_pre_parsed[path] = (pre_source, tree)
         namespace = _extract_csharp_namespace(tree.root_node, pre_source)
         result = _csharp_prefix_and_root_for(path, namespace)
         if result is not None:
@@ -2201,6 +2256,7 @@ def build_module_graph(
             csharp_prefix_map.setdefault(prefix, root)
         for declared in _csharp_declared_type_names(tree.root_node, pre_source):
             csharp_type_owners.setdefault(declared, set()).add(path)
+    csharp_implicit_usings = _load_csharp_implicit_usings(repo_path, csharp_source_paths)
 
     parser = Parser()
 
@@ -2224,14 +2280,15 @@ def build_module_graph(
             continue
 
         language_name, ts_language = language_info
-        if language_name == "java" and path in java_pre_parsed:
-            source, tree = java_pre_parsed[path]
-        elif language_name == "csharp" and path in csharp_pre_parsed:
-            source, tree = csharp_pre_parsed[path]
-        else:
-            parser.language = ts_language
-            source = path.read_bytes()
-            tree = parser.parse(source)
+        if path in oversized_paths:
+            continue
+        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+            oversized_paths.add(path)
+            unparseable.append({"path": rel_path, "reason": "file exceeds size limit"})
+            continue
+        parser.language = ts_language
+        source = path.read_bytes()
+        tree = parser.parse(source)
 
         constants: list[dict] = []
         if language_name != "python":
@@ -2340,6 +2397,7 @@ def build_module_graph(
                         imported_by_map.setdefault(target, []).append(rel_path)
         elif language_name == "csharp":
             raw_imports, functions, classes = _extract_csharp(tree.root_node, source)
+            raw_imports.extend(csharp_implicit_usings.get(path, []))
             resolved_imports = []
             for dotted in raw_imports:
                 for target_path in _resolve_csharp_using(csharp_prefix_map, dotted):

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -1118,40 +1118,53 @@ def _detect_query_language(query_text: str) -> str | None:
 
 
 def search_index(
-    repo_path: Path, query_text: str, k: int = 10, language: str | None = None
+    repo_path: Path,
+    query_text: str,
+    k: int = 10,
+    language: str | None = None,
+    allow_hosted: bool = True,
 ) -> list[dict]:
     if language is None:
         # The question may name its own language - see _detect_query_language.
         language = _detect_query_language(query_text)
     table = open_index(repo_path)
-    query_vector = embed_texts([query_text])[0]
+    # Must use the same hosted-vs-local preference as build_index - see
+    # _embed_in_batches. Previously this called embed_texts() directly,
+    # which is always local: a hosted-built index searched with a local
+    # query vector compared unrelated vector spaces. That was masked by the
+    # dimension guard below as long as the two providers' dimensions
+    # differed (OpenAI 1536 vs local nomic 768), which turned the mismatch
+    # into a loud, actionable error. It stopped being masked the moment the
+    # hosted provider became jina-embeddings-v2-base-code, which is also
+    # 768-dim: the guard fell silent and every hosted-index search since
+    # then returned nonsense ranked against the wrong vector space, with no
+    # error at all. Matching the same provider choice at query time removes
+    # the coincidence the guard was accidentally relying on.
+    query_vector = _embed_in_batches(
+        [query_text], repo_id=_repo_id(repo_path), allow_hosted=allow_hosted
+    )[0]
 
     # The index and the query must come from the same embedding model - see
     # build_index's dimension-drift handling for the mechanism that keeps
     # the index internally consistent. This is the mirror check for the
     # query itself: the available provider can differ between when the
     # index was built and when it's searched (e.g. a hosted token was
-    # revoked, or Ollama came up where it wasn't before), and a raw
+    # revoked, added, or rotated between index and search), and a raw
     # dimension mismatch otherwise surfaces as an opaque LanceDB error deep
     # inside table.search() rather than a message telling the user what to
-    # do about it.
+    # do about it. Two different models sharing a dimension (e.g. jina and
+    # nomic, both 768) can still slip past this check with unrelated vector
+    # spaces - it catches size mismatches, not model mismatches - which is
+    # exactly why the query above must choose its provider the same way the
+    # index build does, rather than relying on this guard to catch a drift.
     table_dimension = table.schema.field("vector").type.list_size
     if len(query_vector) != table_dimension:
-        # Query embeddings are always local (Ollama, or OpenAI as a fallback -
-        # see embed_texts above); they never consult ALETHEORE_API_TOKEN. So
-        # this mismatch is typically an index built with hosted embeddings
-        # (_embed_in_batches, which does use that token) while queries embed
-        # locally at a different dimension. Telling the user to just re-run
-        # 'aletheore index' is bad advice here: with the token still set,
-        # the rebuild uses hosted again, reproduces the same dimension, and
-        # the mismatch recurs forever. Point at what actually fixes it.
         raise IndexDimensionMismatchError(
             f"the index at {_index_path(repo_path)} holds {table_dimension}-dimension "
-            f"vectors but the query embedded to {len(query_vector)} dimensions - search "
-            "always embeds queries with the local embedding provider, never the hosted "
-            "one, so this index was likely built with hosted embeddings (ALETHEORE_API_TOKEN "
-            f"set). Unset ALETHEORE_API_TOKEN and re-run 'aletheore index {repo_path}' to "
-            "rebuild the index with the local provider that queries actually use"
+            f"vectors but the query embedded to {len(query_vector)} dimensions - the "
+            "embedding provider available now differs from the one used to build this "
+            f"index. Re-run 'aletheore index {repo_path}' to rebuild it with the "
+            "provider currently available"
         )
 
     # Over-fetch, then thin by file: the chunks displaced by the per-file cap

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -26,3 +26,44 @@ def _isolate_license_and_vulnerability_caches(tmp_path, monkeypatch):
         "aletheore.vulnerabilities.DEFAULT_VULNERABILITY_CACHE_PATH",
         tmp_path / "vulnerability-cache.json",
     )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_saved_credentials(tmp_path, monkeypatch):
+    """Global safety net: no test run should ever read this machine's real
+    ~/.config/aletheore/credentials.json.
+
+    Same class of bug as the cache isolation above, and it bit for real:
+    after `aletheore login` saved a hosted-embeddings token, eight
+    test_search_index.py tests started failing on this machine and passing in
+    CI. build_index/search_index prefer hosted embeddings whenever a token
+    resolves, so with a real credential on disk they took the hosted path and
+    never called the `embed_texts` those tests patch - the suite was reading
+    developer machine state, not the code under test.
+
+    DEFAULT_CREDENTIALS_PATH is computed from Path.home() at import time and
+    has no env override, so pointing it at tmp_path is the only isolation
+    that does not also relocate HOME (which breaks package resolution).
+    Tests that specifically exercise credential storage pass their own
+    credentials_path already, so this never gets in their way.
+    """
+    import aletheore.credentials as credentials
+
+    fake = tmp_path / "credentials.json"
+    real_default = credentials.DEFAULT_CREDENTIALS_PATH
+    real_loader = credentials._load_saved_key
+
+    def _loader_ignoring_the_real_file(provider_name, credentials_path):
+        # Redirect only the default path. Callers that pass an explicit path
+        # (test_credentials.py, and the CLI's own --credentials flag) are
+        # exercising credential storage deliberately and must keep working.
+        if credentials_path == real_default:
+            credentials_path = fake
+        return real_loader(provider_name, credentials_path)
+
+    # Patched at the loader rather than at DEFAULT_CREDENTIALS_PATH: several
+    # call sites reach it through a *default argument value*, which Python
+    # binds once at def time (e.g. search_index._embed_in_batches ->
+    # get_api_key(...) with no credentials_path). Rebinding the module
+    # constant afterwards cannot reach those.
+    monkeypatch.setattr(credentials, "_load_saved_key", _loader_ignoring_the_real_file)

--- a/src/tests/test_citation_verifier.py
+++ b/src/tests/test_citation_verifier.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from aletheore.citation_verifier import (
     citation_verification_section,
     extract_citations,
@@ -37,6 +39,20 @@ def test_extract_citations_finds_file_line_pairs():
 
 def test_extract_citations_returns_empty_for_no_citations():
     assert extract_citations("This report has no file references at all.") == []
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("see TestMakefile:3 for details", []),
+        ("see Makefile:3 for details", [{"file": "Makefile", "line": 3}]),
+        ("see docker/Dockerfile:5", [{"file": "docker/Dockerfile", "line": 5}]),
+        ("step 3:12 of the plan", []),
+        ("http://host:8080/x", []),
+    ],
+)
+def test_extensionless_citations_require_a_token_boundary(text, expected):
+    assert extract_citations(text, {"Makefile", "docker/Dockerfile"}) == expected
 
 
 def test_verify_citations_marks_known_file_as_verified():

--- a/src/tests/test_credentials.py
+++ b/src/tests/test_credentials.py
@@ -172,6 +172,15 @@ def test_clear_api_key_removes_saved_key(tmp_path):
     assert not has_api_key("UNUSED_ENV", "aletheore-managed-audit", credentials_path=path)
 
 
+def test_clear_api_key_repairs_existing_file_permissions(tmp_path):
+    path = tmp_path / "credentials.json"
+    save_api_token("provider-a", "tok-a", path)
+    path.chmod(0o644)
+
+    assert clear_api_key("provider-a", path) is True
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
 def test_clear_api_key_returns_false_when_nothing_to_clear(tmp_path):
     path = tmp_path / "credentials.json"
     assert clear_api_key("aletheore-managed-audit", path) is False

--- a/src/tests/test_detect.py
+++ b/src/tests/test_detect.py
@@ -39,6 +39,48 @@ def test_detect_languages_counts_files_and_loc(tmp_path):
     assert by_name["javascript"]["file_count"] == 1
 
 
+def test_nested_git_discovery_prunes_ignored_dependency_trees(tmp_path):
+    from aletheore.scanner.detect import _nested_git_roots
+
+    repo = tmp_path / "repo"
+    (repo / "node_modules" / "nested" / ".git").mkdir(parents=True)
+    (repo / "node_modules" / "nested" / "package.py").write_text("x = 1\n")
+    (repo / "app.py").write_text("x = 1\n")
+    _nested_git_roots.cache_clear()
+
+    assert _nested_git_roots(repo) == set()
+    assert [entry["file_count"] for entry in detect_languages(repo) if entry["name"] == "python"] == [1]
+
+
+def test_nested_git_discovery_still_finds_a_directory_style_clone_outside_ignored_dirs(tmp_path):
+    """IGNORED_DIRS contains ".git" itself (so a found root's own .git
+    internals aren't walked) - pruning dirnames against IGNORED_DIRS before
+    checking whether ".git" is present would silently disable directory-
+    style nested-clone detection everywhere, not just inside ignored dirs."""
+    from aletheore.scanner.detect import _nested_git_roots
+
+    repo = tmp_path / "repo"
+    (repo / "vendor" / "some-lib" / ".git").mkdir(parents=True)
+    (repo / "vendor" / "some-lib" / "lib.py").write_text("x = 1\n")
+    (repo / "app.py").write_text("x = 1\n")
+    _nested_git_roots.cache_clear()
+
+    assert _nested_git_roots(repo) == {repo / "vendor" / "some-lib"}
+
+
+def test_detect_languages_does_not_follow_symlinked_directories(tmp_path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (outside / "leaked.py").write_text("x = 1\n")
+    (repo / "linked").symlink_to(outside, target_is_directory=True)
+    (repo / "main.py").write_text("x = 1\n")
+
+    python_entries = [entry for entry in detect_languages(repo) if entry["name"] == "python"]
+    assert python_entries[0]["file_count"] == 1
+
+
 def test_detect_languages_returns_a_sorted_list(tmp_path):
     # Built from _iter_source_files' raw filesystem-walk order, which is
     # filesystem-dependent (confirmed elsewhere in this file: the same repo

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -2,8 +2,19 @@ from pathlib import Path
 
 import pytest
 
-from aletheore.scanner.graph import _is_public_symbol, build_module_graph
+from aletheore.scanner.graph import MAX_SOURCE_FILE_BYTES, _is_public_symbol, build_module_graph
 from conftest import symbol_names
+
+
+def test_build_module_graph_records_oversized_source_without_parsing(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "large.py").write_bytes(b"x = 1\n" + b"#" * MAX_SOURCE_FILE_BYTES)
+
+    modules, _graph, unparseable = build_module_graph(repo)
+
+    assert modules == []
+    assert unparseable == [{"path": "large.py", "reason": "file exceeds size limit"}]
 
 
 def make_python_repo(tmp_path: Path) -> Path:

--- a/src/tests/test_graph_csharp.py
+++ b/src/tests/test_graph_csharp.py
@@ -123,6 +123,21 @@ def test_build_module_graph_csharp_using_resolves_by_namespace_not_by_class_name
     assert ("Handlers/Handler.cs", "Store/Store.cs") in edges
 
 
+def test_build_module_graph_csharp_applies_directory_build_props_usings(tmp_path):
+    repo = make_csharp_repo(tmp_path)
+    (repo / "Directory.Build.props").write_text(
+        "<Project><ItemGroup><Using Include=\"App.Store\" /></ItemGroup></Project>"
+    )
+    (repo / "Handlers" / "Handler.cs").write_text(
+        "namespace App.Handlers { public class Handler { private UserStore _store; } }\n"
+    )
+
+    _, dependency_graph, _ = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert ("Handlers/Handler.cs", "Store/Store.cs") in edges
+
+
 def test_build_module_graph_csharp_unmapped_namespace_does_not_resolve(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -190,11 +205,10 @@ def test_build_module_graph_csharp_using_escaping_repo_root_does_not_crash(tmp_p
     assert dependency_graph["edges"] == []
 
 
-def test_build_module_graph_reads_each_csharp_file_only_once(tmp_path):
-    # Before this fix, the namespace/root-inference pre-pass and the main
-    # extraction loop each independently read_bytes() and re-parsed every
-    # .cs file from scratch - a real, avoidable 2x tree-sitter parse cost
-    # per file.
+def test_build_module_graph_reparses_csharp_without_retaining_prepass_trees(tmp_path):
+    # The namespace/type pre-pass keeps only extracted strings. The main loop
+    # therefore reads and parses each file again, trading a small amount of
+    # CPU for bounded memory rather than retaining every tree.
     repo = make_csharp_repo(tmp_path)
 
     real_read_bytes = Path.read_bytes
@@ -209,7 +223,7 @@ def test_build_module_graph_reads_each_csharp_file_only_once(tmp_path):
         build_module_graph(repo)
 
     assert read_counts
-    assert all(count == 1 for count in read_counts.values())
+    assert all(count == 2 for count in read_counts.values())
 
 
 def test_csharp_extracts_summary_from_xmldoc(tmp_path):

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -225,11 +225,10 @@ def test_build_module_graph_java_import_escaping_repo_root_does_not_crash(tmp_pa
     assert dependency_graph["edges"] == []
 
 
-def test_build_module_graph_reads_each_java_file_only_once(tmp_path):
-    # Before this fix, the source-root-inference pre-pass and the main
-    # extraction loop each independently read_bytes() and re-parsed every
-    # .java file from scratch - a real, avoidable 2x tree-sitter parse cost
-    # per file.
+def test_build_module_graph_reparses_java_without_retaining_prepass_trees(tmp_path):
+    # The source-root pre-pass keeps only the package string. The main loop
+    # therefore reads and parses each file again, trading a small amount of
+    # CPU for bounded memory rather than retaining every tree.
     repo = make_java_repo(tmp_path)
 
     real_read_bytes = Path.read_bytes
@@ -244,7 +243,7 @@ def test_build_module_graph_reads_each_java_file_only_once(tmp_path):
         build_module_graph(repo)
 
     assert read_counts
-    assert all(count == 1 for count in read_counts.values())
+    assert all(count == 2 for count in read_counts.values())
 
 
 def test_java_extracts_javadoc_and_return_type(tmp_path):

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -285,6 +285,50 @@ def test_search_index_raises_a_clear_error_on_dimension_mismatch(tmp_path):
             search_index(repo, "where is foo")
 
 
+def test_search_index_embeds_the_query_hosted_when_a_token_exists(tmp_path):
+    """A hosted-built index searched with a query embedded by the local
+    provider compares two unrelated vector spaces - previously caught only
+    when the two providers' dimensions happened to differ (OpenAI 1536 vs
+    local nomic 768). Two providers sharing a dimension (jina and nomic are
+    both 768) would pass the dimension guard while still returning nonsense
+    rankings, so the query must choose hosted-vs-local the same way the
+    index build does, not default to local unconditionally."""
+    from aletheore.search_index import TABLE_NAME, _index_path
+    import lancedb
+
+    repo = tmp_path
+    index_path = _index_path(repo)
+    index_path.parent.mkdir(parents=True)
+    db = lancedb.connect(str(index_path))
+    db.create_table(
+        TABLE_NAME,
+        data=[
+            {
+                "module_path": "a.py",
+                "symbol_name": "foo",
+                "start_line": 1,
+                "end_line": 2,
+                "language": "python",
+                "imports": [],
+                "text": "def foo(): pass",
+                "chunk_hash": "abc",
+                "vector": [0.1] * 768,
+            }
+        ],
+    )
+
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.2] * 768]})
+
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http), \
+         patch("aletheore.search_index.embed_texts") as local:
+        search_index(repo, "where is foo")
+
+    http.post.assert_called_once()
+    local.assert_not_called()
+
+
 @patch("aletheore.search_index.embed_texts")
 def test_search_index_returns_ranked_results(mock_embed_texts, tmp_path):
     (tmp_path / "auth.py").write_text("def login():\n    return True\n")


### PR DESCRIPTION
Seventeen findings from a file-by-file audit of `github-app/` and `src/aletheore/`, plus three regressions caught while reviewing the fixes and two bugs found during that investigation.

**37 files, +944/−289.** Tests: **github-app 1312 passed / 8 skipped**, **CLI 1278 passed**.

## Highest impact

**Flash Review silently dropped real findings on any PR deleting a `-- x ---` line.** `fetch_pr_diff` flattened GitHub's structured response into text with a `--- <file> ---` marker. A *deleted* line carries a `-` prefix, so a deleted SQL comment reading `-- users table ---` arrived as `--- users table ---` and matched the marker exactly:

```
file='db/schema.sql'   valid_lines=[10]     <- should cover 10-15
file='users table'     valid_lines=[]       <- phantom file
```

The parser invented a file, reset its line counter, and recorded nothing further — so the actual change never entered the valid set, the finding was classified out-of-diff, and the customer saw *"No issues found in this diff."* Trigger covers SQL, Lua, Haskell, Ada comments and `--- section ---` dividers. Fixed by carrying structured patches alongside the text (`PRDiff`) rather than re-deriving what the JSON already knew.

**Hosted embeddings were comparing two unrelated vector spaces.** `search_index()` always embedded the *query* locally even when the *index* was built hosted. Before Jina, a 1536-vs-768 dimension mismatch made this fail loudly. Jina is also 768-dim, so the guard went silent and every hosted search since #257 scored against the wrong space.

**`installation_spend_lock` held across entire LLM builds at five sites**, two firing on every push and PR. Concurrent jobs for the same installation failed outright with `LockNotAvailable` rather than queueing. The earlier flash-review fix narrowed the *victim's* hold — the party actually occupying the lock for minutes was never touched.

**A crash mid-webhook permanently lost a plan change.** Claim-before-handle with release only on a caught exception, so an OOM or deploy between the two left Paddle's retry discarded as a duplicate. Migration `051` adds stale-claim recovery; `052` adds an independent `paid_setup_completed_at` claim so a crash *after* the plan flip but *before* the one-time wiki/docs build no longer skips setup forever.

**C# dependency graphs were near-empty** — usings are declared in MSBuild (`<ImplicitUsings>`, `<Using Include>`), not source, so a source-only parser had nothing to resolve.

## Also fixed

| area | issue |
|---|---|
| abuse | `/v1/managed-audit` had no pre-routing body cap while accepting 25MB |
| abuse | embeddings rate limit partitioned by caller-supplied `repo_id` — rotate it, get unlimited budgets |
| money | affiliate commissions never reversed on refund or chargeback |
| trigger | audit ChatOps command matched anywhere in a comment body |
| hardening | redirect guard now rejects control chars (browsers strip tab/LF/CR, so `/<TAB>/evil.com` → `//evil.com`) |
| hardening | `clear_api_key` reuses `_save_key`'s fd+fchmod path instead of `write_text` |
| grounding | citation extraction anchored — `TestMakefile:3` no longer verifies as `Makefile:3` |
| scanner | 19 full-tree walks per scan, none pruning before descending; bounded pre-parse memory; file-size guard |

## Review process — three regressions caught and fixed

Five parallel reviews, one per theme. Two came back clean. Three found **real** regressions, each proven with a reproduction rather than argued:

1. **Scanner nested-clone detection broke.** The new prune set included `.git` itself, stripping it from `dirnames` *before* the nested-clone check ran — directory-style nested clones became undetectable, silently misattributing a vendored subrepo's files to the parent. Also made `_nested_git_roots`' cache per-scan rather than process-lifetime.
2. **A "pure reorder" burned quota.** Moving `check_and_reserve_monthly_repo_scan_slot` before evidence decode looked harmless, but that call *reserves* a slot — one malformed POST consumed one of ten monthly cross-feature slots. Caught by a pre-existing test that started failing. Reverted; the independently-correct body-cap fix kept.
3. **`_names_referenced_in_diff` silently regressed.** Rebuilt from a base predating #254's context-line-aware symbol grounding, which had closed a real production miss. Restored from origin/master with its two tests.

## Test isolation

`src/tests/conftest.py` gains a credentials fixture. After `aletheore login` saved a real token, eight `test_search_index.py` tests failed locally while passing in CI — the hosted-embedding preference is correct, so the tests took the hosted path and never called the `embed_texts` they patch. The suite was reading developer machine state.

Patched at `_load_saved_key`, **not** at `DEFAULT_CREDENTIALS_PATH`: several call sites reach it through a *default argument value*, bound once at `def` time, which rebinding a module constant cannot reach. Only the default path is redirected, so tests passing an explicit path (and the CLI's `--credentials` flag) keep working.

## Not included, deliberately

- Affiliate refund reversal is currently boolean, not proportional — a $1 partial refund on a $500 transaction erases the whole $75 commission. Real money-accuracy issue, deferred.
- `run_live_docs_full_build_job`'s per-module spend-recording loop runs unlocked. The lock-held-too-long bug is genuinely fixed there, but the bookkeeping lost concurrency-safety as a side effect.
- Per-site tests for the five spend-lock changes. The fix was verified by direct reading during review, but shipped without new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)