### PR TITLE
fix: raise HOSTED_EMBED_MAX_CHARS from 20,000 to 150,000 on measured throughput

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -746,11 +746,19 @@ EMBED_BATCH_SIZE = 200
 # the local embedder. Every hosted index build did this, which is why the
 # feature looked configured and never actually ran.
 #
-# 20,000 characters is deliberately sized against the *old* rate as the floor:
-# ~59s even if the service is still single-threaded, and comfortable once it
-# is not. Raise it after measuring, not before - and if the timeout in
-# embeddings_api.get_jina_client changes, this has to move with it.
-HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "20000"))
+# After fixing the thread-pool oversubscription (JINA_EMBED_THREADS matched
+# to `cpus: "2.0"` instead of torch sizing its pool from the host's core
+# count), measured throughput against the deployed service came back at
+# ~9,800-13,150 characters/second across batch sizes 2/5/8/12 - a floor of
+# roughly 30x the old ~340 chars/s.
+#
+# 150,000 characters keeps a wide margin below the naive ceiling that rate
+# implies (~700k+ in the 60s budget): this box also runs app-server and
+# scan-worker on the same 2 CPUs, real chunks are not identical strings like
+# the probe used, and other requests can share the service concurrently. If
+# the timeout in embeddings_api.get_jina_client changes, this has to move
+# with it.
+HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "150000"))
 
 
 def _hosted_batches(texts: list[str], batch_size: int) -> list[tuple[int, int]]:

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -1591,11 +1591,19 @@ def test_hosted_batches_bound_a_request_by_characters_not_just_count():
     against Ollama, where it costs per request. A 200-chunk batch of real code
     is ~1MB, which needed roughly eleven minutes against embeddings_api's 60s
     timeout - so it returned 502 and silently fell back to local on every
-    hosted index build."""
-    texts = ["x" * 1000] * 40
+    hosted index build.
+
+    Sized relative to HOSTED_EMBED_MAX_CHARS rather than a literal, so this
+    keeps testing the same thing after that cap is raised on new throughput
+    evidence: four chunks each exactly half the cap, so pairs fit a request
+    (2 * half <= cap) but a third would not (3 * half > cap) - well under the
+    EMBED_BATCH_SIZE count cap, so the character bound is what forces the
+    split into two spans of two."""
+    half_cap = search_index_module.HOSTED_EMBED_MAX_CHARS // 2
+    texts = ["x" * half_cap] * 4
     spans = search_index_module._hosted_batches(texts, search_index_module.EMBED_BATCH_SIZE)
 
-    assert len(spans) == 2, "40k characters must not go out as one request"
+    assert len(spans) == 2, "characters over the cap must not go out as one request"
     for start, end in spans:
         assert sum(len(t) for t in texts[start:end]) <= search_index_module.HOSTED_EMBED_MAX_CHARS
 


### PR DESCRIPTION
## Summary
- #259's jina thread-pool fix is deployed and verified live (`torch threads=2`, `JINA_EMBED_THREADS=2` in the running container).
- Measured throughput against the deployed service: ~9,800-13,150 chars/s across batch sizes 2/5/8/12 — roughly 30x the old ~340 chars/s the 20,000 cap was sized against.
- Raised `HOSTED_EMBED_MAX_CHARS` default to 150,000, well under the naive ~700k ceiling the new rate implies in the 60s timeout, since this box shares 2 CPUs with app-server/scan-worker and real traffic isn't identical dummy chunks under zero concurrency.
- Fixed `test_hosted_batches_bound_a_request_by_characters_not_just_count`, which hardcoded a 40k-char scenario against the old cap and would have gone blind to the character bound once the default moved past it — now sized relative to the constant.

## Test plan
- [x] `pytest src/tests/test_search_index.py` — 94 passed
- [x] `pytest src/tests` (full CLI suite) — 1281 passed
- [x] Deployed #259 to prod, confirmed threading fix live via container logs/env before measuring

🤖 Generated with [Claude Code](https://claude.com/claude-code)