### PR TITLE
fix: jina-embed OOM-killed under a real production-sized batch

### DIFF
--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -422,11 +422,16 @@ services:
     # still the ceiling on usable hosted indexing, the answer is a dedicated
     # host for this service, not a bigger share of this one.
     cpus: "2.0"
-    # Bumped from 1500m: was already sitting at 84% of that cap after a
-    # single warm-up request (model-load baseline, not a leak), leaving
-    # almost no headroom for concurrent traffic before the cgroup OOM-kills
-    # it. Host has 12GB+ free, so this is cheap insurance.
-    mem_limit: 2500m
+    # Bumped from 2500m after #260 raised HOSTED_EMBED_MAX_CHARS to 150,000:
+    # a real 200-chunk/~150k-char batch (flask, 515 real code chunks) pushed
+    # anon-rss to ~2.44GB and the cgroup OOM-killer took uvicorn out mid
+    # request - confirmed via dmesg, same second app-server logged the
+    # resulting RemoteProtocolError. The earlier throughput measurement that
+    # justified the char-cap raise only used synthetic ~21k-char batches, far
+    # below what the new cap actually allows a real index build to send, so
+    # it never touched this ceiling. Host has 13GB+ available; this is still
+    # cheap insurance, not the whole margin the host could give it.
+    mem_limit: 6000m
 
   caddy:
     image: caddy:2-alpine


### PR DESCRIPTION
## Summary
- #260 raised `HOSTED_EMBED_MAX_CHARS` to 150,000 on throughput evidence from synthetic ~21k-char probe batches, which never approached real memory pressure.
- Rebuilding the retrieval-benchmark corpora against the fix, the first real index build (flask, 515 chunks) sent a real ~150k-char batch and the cgroup OOM-killer took `jina-embed`'s uvicorn process out mid-request at ~2.44GB anon-rss against the 2500m `mem_limit` - confirmed via `dmesg`, same second `app-server` logged the resulting `RemoteProtocolError` and fell back to local embeddings.
- Raises `mem_limit` to 6000m. Host has 13GB+ available; every other service in the stack together uses well under 1GB.

## Test plan
- [x] Confirmed via `dmesg` on prod that the kernel OOM-killer, not app logic, killed the process, at the same timestamp as the observed 502
- [x] Confirmed host has ample spare memory for the new limit (`free -h`: 13Gi available)
- [ ] After deploy: re-run a real corpus index build (flask) and confirm it completes via hosted embeddings without falling back to local

🤖 Generated with [Claude Code](https://claude.com/claude-code)