### PR TITLE
fix: revert HOSTED_EMBED_MAX_CHARS to 20,000 - char count hid real cost

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -750,15 +750,18 @@ EMBED_BATCH_SIZE = 200
 # to `cpus: "2.0"` instead of torch sizing its pool from the host's core
 # count), measured throughput against the deployed service came back at
 # ~9,800-13,150 characters/second across batch sizes 2/5/8/12 - a floor of
-# roughly 30x the old ~340 chars/s.
-#
-# 150,000 characters keeps a wide margin below the naive ceiling that rate
-# implies (~700k+ in the 60s budget): this box also runs app-server and
-# scan-worker on the same 2 CPUs, real chunks are not identical strings like
-# the probe used, and other requests can share the service concurrently. If
-# the timeout in embeddings_api.get_jina_client changes, this has to move
-# with it.
-HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "150000"))
+# roughly 30x the old ~340 chars/s. That number briefly raised this cap to
+# 150,000 (see git history), which turned out to be wrong: the probe text was
+# a single character repeated (~15.5 chars/token), while real source averages
+# ~3.97 chars/token - measured directly against a real flask-source batch,
+# whose first internal sub-batch alone took 164s and whose full ~133k-char
+# request pushed jina-embed to ~6GB and got OOM-killed at a 6000m mem_limit
+# raised specifically to accommodate it. Character count was never a valid
+# proxy for the model's real cost; token count is, and this was verified with
+# text that hid that fact. Reverted to 20,000 - the one number in this cap's
+# history actually measured against real production traffic - until batching
+# is redone against token count instead of character count.
+HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "20000"))
 
 
 def _hosted_batches(texts: list[str], batch_size: int) -> list[tuple[int, int]]:


### PR DESCRIPTION
## Summary
- #260's 150,000 cap was justified by throughput measured against synthetic text (a single character repeated), which tokenizes at ~15.5 chars/token vs ~3.97 chars/token for real flask source - measured directly with the model's own tokenizer.
- Rebuilding the retrieval-benchmark corpora against the raised cap, flask's real 515-chunk batch OOM-killed jina-embed even after #261 raised `mem_limit` to 6000m (confirmed via `dmesg`, anon-rss ~6GB, exactly at the new limit).
- Isolated the real cost directly: the same ~133k-char real flask batch, sent straight to jina-embed with a generous 180s timeout (bypassing app-server's 60s budget), still OOM'd - and its first internal sub-batch alone took 164s.
- Character count was never a valid proxy for the model's real cost; token count is. Reverting to 20,000, the one value in this cap's history actually measured against real production traffic, until batching is redone to bound tokens directly.

## Test plan
- [x] `pytest src/tests/test_search_index.py` - 94 passed (no test changes needed; already parameterized off the constant)
- [x] `pytest src/tests` (full suite) - 1281 passed
- [x] Confirmed real-code OOM and slowdown directly against jina-embed on prod, isolated from app-server's timeout

## Follow-up
Batching needs to bound token count (via the real tokenizer or a cheap approximation), not character count, before this cap can safely move past 20,000 again - this PR is the safety revert, not that redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)