### PR TITLE
fix: jina-embed runs llama.cpp against Q8_0 GGUF, not raw PyTorch

### DIFF
--- a/github-app/CHANGELOG.md
+++ b/github-app/CHANGELOG.md
@@ -12,6 +12,21 @@ re-verified snapshot of exactly what's running in production right now, see
 [`docs/operations/DEPLOYMENT-VERIFICATION.md`](docs/operations/DEPLOYMENT-VERIFICATION.md) — this
 file is the history; that one is the current state.
 
+## 2026-08-16
+
+- **jina-embed now runs llama.cpp against a Q8_0 GGUF quantization of jinaai/jina-embeddings-v2-base-code,
+  replacing the raw PyTorch/HuggingFace `transformers` backend.** Earlier the same day, two production
+  incidents against that backend (a request that never finished within the 60s timeout, then an
+  OOM kill under a mem_limit already raised to accommodate it) traced back to comparing the wrong
+  things: nomic-embed-text, which this service replaced, was served by Ollama's llama.cpp engine -
+  quantized weights, hand-tuned CPU kernels - while jina-embed ran unquantized in eager-mode PyTorch.
+  Measured directly on this host against a real 133k-char, 38-chunk flask source sample: the old
+  backend hadn't finished the first fifth of the batch after 164s before OOM-killing; llama.cpp
+  finished the same batch in 24.55s (~5,400 chars/s) at a 375MB peak, against the old backend's
+  2.44GB+. Quantization cost was checked directly too - 0.9997 cosine similarity against the
+  full-precision embedding on the same input. `jina-embed`'s `mem_limit` comes back down from the
+  emergency-raised 6000m to 2000m on this evidence.
+
 ## 2026-08-12
 
 - AIRview depth: file-level reference pages. Each important file now gets a sectioned page

--- a/github-app/Dockerfile.jina-embed
+++ b/github-app/Dockerfile.jina-embed
@@ -26,6 +26,16 @@ RUN curl -sSL -o /build/model.gguf \
 
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
+# libllama.so links against libgomp (GNU OpenMP) at build time via
+# build-essential/gcc - that dependency is a runtime one too, and this
+# stage doesn't have build-essential. Confirmed by testing the compiled
+# library against a bare python:3.12-slim without this: it fails to import
+# at all with "libgomp.so.1: cannot open shared object file", not a
+# degraded-but-working fallback.
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /build/model.gguf /app/model.gguf

--- a/github-app/Dockerfile.jina-embed
+++ b/github-app/Dockerfile.jina-embed
@@ -1,31 +1,37 @@
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de AS builder
+
+# llama-cpp-python has no prebuilt wheel for this base image/Python
+# combination, so it compiles from source - build-essential/cmake are only
+# needed here, in the discarded builder stage, not the final image.
+RUN apt-get update -qq \
+    && apt-get install -y -qq --no-install-recommends build-essential cmake curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /build
+COPY github-app/requirements-jina-embed.txt .
+RUN pip install --no-cache-dir -r requirements-jina-embed.txt \
+    # pulled in transitively; carries the same setuptools CVE-2025-47273
+    # (path traversal) the old torch-based image upgraded explicitly.
+    && pip install --no-cache-dir --upgrade "setuptools>=78.1.1"
+
+# Baked into the image at build time rather than downloaded on first
+# request, same reasoning as the old sentence-transformers weights: a cold
+# start that also needs a ~170MB download is a worse failure mode than a
+# slower image build.
+RUN curl -sSL -o /build/model.gguf \
+    "https://huggingface.co/ggml-org/jina-embeddings-v2-base-code-Q8_0-GGUF/resolve/main/jina-embeddings-v2-base-code-q8_0.gguf"
+
 FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
 WORKDIR /app
-
-COPY github-app/requirements-jina-embed.txt .
-# CPU-only torch wheel - these hosts have no GPU, and the default PyPI
-# wheel pulls CUDA libraries that roughly double image size for nothing.
-RUN pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir -r requirements-jina-embed.txt \
-    # torch's CPU wheel pulls setuptools 78.1.0, which carries CVE-2025-47273
-    # (path traversal) - fixed in 78.1.1. Upgraded explicitly since torch
-    # itself doesn't pin a fixed floor.
-    && pip install --no-cache-dir --upgrade "setuptools>=78.1.1"
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /build/model.gguf /app/model.gguf
+ENV PATH="/opt/venv/bin:$PATH"
 
 COPY github-app/jina_embed ./jina_embed
-
-# HF_HOME set before the download below so the cache lands under /app,
-# where the aletheore user (whose $HOME is /app) can actually read it -
-# the default ~/.cache/huggingface would be under /root, invisible to a
-# non-root user with a different $HOME, silently forcing a re-download
-# on every cold start despite the weights already being baked in.
-ENV HF_HOME=/app/.cache/huggingface
-
-# Bake the model weights into the image at build time rather than
-# downloading on first request - a cold start that also needs a ~300MB
-# HuggingFace download is a worse failure mode (timeout, no retry budget)
-# than a slower image build.
-RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('jinaai/jina-embeddings-v2-base-code', trust_remote_code=True, device='cpu')"
 
 RUN groupadd --system aletheore \
     && useradd --system --gid aletheore --home-dir /app --no-create-home aletheore \

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -400,9 +400,10 @@ services:
       # a busy host doesn't get flagged unhealthy before it's had a chance.
       start_period: 60s
     environment:
-      # Must match `cpus` below - see server.py's comment on why torch's
-      # default (host core count) is actively harmful inside a cpu-limited
-      # cgroup.
+      # Passed straight through to llama.cpp's n_threads. Must match `cpus`
+      # below - the 24.55s/2-thread real-batch measurement server.py's
+      # docstring cites was made at this exact thread count, not a larger
+      # one this box's 4 cores could technically support.
       - JINA_EMBED_THREADS=2
     # Bumped from 1.0. This service is the only CPU-bound one in the stack -
     # everything else is I/O-bound on Postgres, Redis or the GitHub API -
@@ -422,16 +423,17 @@ services:
     # still the ceiling on usable hosted indexing, the answer is a dedicated
     # host for this service, not a bigger share of this one.
     cpus: "2.0"
-    # Bumped from 2500m after #260 raised HOSTED_EMBED_MAX_CHARS to 150,000:
-    # a real 200-chunk/~150k-char batch (flask, 515 real code chunks) pushed
-    # anon-rss to ~2.44GB and the cgroup OOM-killer took uvicorn out mid
-    # request - confirmed via dmesg, same second app-server logged the
-    # resulting RemoteProtocolError. The earlier throughput measurement that
-    # justified the char-cap raise only used synthetic ~21k-char batches, far
-    # below what the new cap actually allows a real index build to send, so
-    # it never touched this ceiling. Host has 13GB+ available; this is still
-    # cheap insurance, not the whole margin the host could give it.
-    mem_limit: 6000m
+    # 6000m was sized for the old sentence-transformers/PyTorch backend,
+    # which OOM-killed at ~2.44GB on a 133k-char real-code batch even after
+    # being raised from 2500m (see git history). This backend is llama.cpp
+    # against a Q8_0 GGUF quantization instead - measured directly on this
+    # host, the identical 133k-char real flask batch peaked at 375MB, not
+    # 2.44GB+. 2000m keeps ~5x headroom over that single-request peak for
+    # concurrent requests sharing the process (endpoints are sync `def`s,
+    # so FastAPI's threadpool can run more than one at once) without
+    # carrying forward a limit sized for a backend this image no longer
+    # runs. Not concurrency-load-tested; a further reduction should be too.
+    mem_limit: 2000m
 
   caddy:
     image: caddy:2-alpine

--- a/github-app/jina_embed/server.py
+++ b/github-app/jina_embed/server.py
@@ -1,48 +1,59 @@
 """Internal-only embedding service backed by jinaai/jina-embeddings-v2-base-code.
 
-Replaces Ollama+nomic-embed-text as the embedder behind scan_worker's
-evidence-packet and flash-review similarity caches - see
-docs/superpowers/specs (jina vs nomic vs bge-m3 retrieval benchmark) for
-why: real, corrected benchmark numbers across 6 languages showed jina
-beating nomic on every metric (75.0/93.1/95.8% vs 73.6/87.5/91.7% top-1/3/5),
-with bge-m3 actually worse than nomic.
+Served via llama.cpp against a Q8_0 GGUF quantization of the model, not raw
+PyTorch/HuggingFace `transformers`. That switch is the point of this file:
+measured on this exact production host against real source (a 133k-char,
+38-chunk flask sample), the previous sentence-transformers/PyTorch backend
+hadn't finished the first fifth of the batch after 164s and went on to
+OOM-kill the container; llama.cpp finished the same batch in 24.55s (~5,400
+chars/s) with no memory blowup. That gap isn't Apple Silicon vs. this host's
+CPU (both were checked directly - Accelerate/AMX locally, MKL with full
+AVX-512/VNNI here, neither crippled) and it isn't core count (2 threads
+performed the same as unconstrained locally). It's llama.cpp's quantized,
+hand-tuned CPU kernels against eager-mode PyTorch running an unquantized,
+custom `trust_remote_code` model - the same reason nomic-embed-text (served
+by Ollama, also llama.cpp underneath) never had this problem. Quantization
+cost was checked too: Q8_0 output measured at 0.9997 cosine similarity
+against the full-precision PyTorch embedding on the same input.
 
-CPU-only in production (no MPS/CUDA on these hosts). The single-text
-contract remains for scan-worker caches; the additive batch endpoint is used
-by hosted index builds so one request can encode many chunks efficiently.
+CPU-only in production (no GPU on these hosts - n_gpu_layers=0 is explicit
+below so a build that happens to have GPU support compiled in, e.g. Metal on
+a dev machine, doesn't silently take a different code path than prod runs).
+The single-text contract remains for scan-worker caches; the additive batch
+endpoint is used by hosted index builds so one request can encode many
+chunks in one call.
 """
 import logging
+import math
 import os
 
-import torch
 from fastapi import FastAPI
+from llama_cpp import Llama
 from pydantic import BaseModel
-from sentence_transformers import SentenceTransformer
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# torch sizes its thread pool from the number of cores it can *see*, which is
-# the host's, not the cgroup's. Under `cpus: "1.0"` that meant ~N threads
-# fighting over one core's worth of quota - the scheduler spends its time
-# context-switching instead of embedding. Measured against production before
-# this was set: a steady ~340 characters/second regardless of batch size,
-# which made a 60s request budget (embeddings_api's httpx timeout to this
-# service) top out around 20k characters and put a real index build out of
-# reach entirely.
-#
-# Set explicitly from the same number the compose file allocates, so the two
-# cannot drift: raising `cpus` without raising this buys nothing, and raising
-# this without raising `cpus` makes the thrashing worse.
 _THREADS = int(os.environ.get("JINA_EMBED_THREADS", "1"))
-torch.set_num_threads(_THREADS)
-logger.info("torch threads=%d", _THREADS)
+_MODEL_PATH = os.environ.get("JINA_EMBED_MODEL_PATH", "/app/model.gguf")
+# 2048 comfortably covers real chunk sizes (chunking upstream keeps
+# individual texts well under this); jina-embeddings-v2 supports up to 8192
+# but reserving that much KV-cache space for every request buys nothing here
+# and costs memory.
+_CTX = int(os.environ.get("JINA_EMBED_CTX", "2048"))
 
 app = FastAPI()
 
-logger.info("Loading jinaai/jina-embeddings-v2-base-code...")
-_model = SentenceTransformer("jinaai/jina-embeddings-v2-base-code", trust_remote_code=True, device="cpu")
-logger.info("Model loaded, dim=%d", _model.get_sentence_embedding_dimension())
+logger.info("Loading %s with %d threads...", _MODEL_PATH, _THREADS)
+_model = Llama(
+    model_path=_MODEL_PATH,
+    embedding=True,
+    n_threads=_THREADS,
+    n_ctx=_CTX,
+    n_gpu_layers=0,
+    verbose=False,
+)
+logger.info("Model loaded")
 
 
 class EmbedRequest(BaseModel):
@@ -61,15 +72,33 @@ class EmbedBatchResponse(BaseModel):
     embeddings: list[list[float]]
 
 
+def _normalize(vector: list[float]) -> list[float]:
+    # llama.cpp's pooled output is not unit-length (measured L2 norm ~14.5
+    # on real text) - callers downstream (LanceDB cosine search) expect the
+    # same normalized vectors the previous sentence-transformers backend
+    # produced via normalize_embeddings=True.
+    norm = math.sqrt(sum(v * v for v in vector))
+    if norm == 0:
+        return vector
+    return [v / norm for v in vector]
+
+
 @app.post("/embed", response_model=EmbedResponse)
 def embed(req: EmbedRequest) -> EmbedResponse:
-    vector = _model.encode(req.text, normalize_embeddings=True).tolist()
+    result = _model.create_embedding(req.text)
+    vector = _normalize(result["data"][0]["embedding"])
     return EmbedResponse(embedding=vector)
 
 
 @app.post("/embed_batch", response_model=EmbedBatchResponse)
 def embed_batch(req: EmbedBatchRequest) -> EmbedBatchResponse:
-    vectors = _model.encode(req.texts, normalize_embeddings=True).tolist()
+    result = _model.create_embedding(req.texts)
+    # Sorted explicitly rather than trusting list order: app-server checks
+    # the returned count matches the request but has no way to check order,
+    # so a reordered response would silently attach the wrong vector to the
+    # wrong chunk in the index.
+    ordered = sorted(result["data"], key=lambda item: item["index"])
+    vectors = [_normalize(item["embedding"]) for item in ordered]
     return EmbedBatchResponse(embeddings=vectors)
 
 

--- a/github-app/requirements-jina-embed.txt
+++ b/github-app/requirements-jina-embed.txt
@@ -1,6 +1,3 @@
 fastapi==0.141.1
 uvicorn==0.34.0
-sentence-transformers==3.3.1
-transformers==4.48.0
-einops==0.8.0
-torch==2.6.0
+llama-cpp-python==0.3.34

--- a/github-app/tests/test_jina_embed.py
+++ b/github-app/tests/test_jina_embed.py
@@ -1,67 +1,107 @@
 import importlib
+import math
 import sys
 import types
 
 
 def _import_server(monkeypatch):
-    """Import jina_embed.server with its two heavy deps stubbed out.
+    """Import jina_embed.server with llama_cpp stubbed out.
 
-    Neither torch nor sentence_transformers is installed in the test job -
-    they live only in the jina-embed image - so the module is imported
-    against fakes. Returns the module plus the thread counts torch was asked
-    for, since that call happens at import time and cannot be observed after.
+    llama-cpp-python is not installed in the test job - it lives only in
+    the jina-embed image, compiled from source against build tools that
+    aren't part of this image - so the module is imported against a fake.
+    Returns the module plus the n_threads values the fake Llama() was
+    constructed with, since that happens at import time and can't be
+    observed after.
     """
 
-    class Encoded(list):
-        def tolist(self):
-            return list(self)
-
-    class FakeModel:
+    class FakeLlama:
         def __init__(self, *args, **kwargs):
-            pass
+            requested_threads.append(kwargs.get("n_threads"))
 
-        def get_sentence_embedding_dimension(self):
-            return 3
+        def create_embedding(self, input):
+            texts = [input] if isinstance(input, str) else input
+            # Deliberately not unit-length, matching the real model's raw
+            # pooled output - exercises server.py's own normalization
+            # rather than a fake that does it for the code under test.
+            return {
+                "data": [
+                    {"index": index, "embedding": [float(index) + 1.0, 0.0, 3.0]}
+                    for index, _ in enumerate(texts)
+                ]
+            }
 
-        def encode(self, texts, normalize_embeddings):
-            if isinstance(texts, str):
-                texts = [texts]
-            return Encoded([[float(index), 0.0, 1.0] for index, _ in enumerate(texts)])
-
-    fake_sentence_transformers = types.ModuleType("sentence_transformers")
-    fake_sentence_transformers.SentenceTransformer = FakeModel
-    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_sentence_transformers)
-
-    requested_threads: list[int] = []
-    fake_torch = types.ModuleType("torch")
-    fake_torch.set_num_threads = requested_threads.append
-    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    requested_threads: list[int | None] = []
+    fake_llama_cpp = types.ModuleType("llama_cpp")
+    fake_llama_cpp.Llama = FakeLlama
+    monkeypatch.setitem(sys.modules, "llama_cpp", fake_llama_cpp)
 
     sys.modules.pop("jina_embed.server", None)
     server = importlib.import_module("jina_embed.server")
     return server, requested_threads
 
 
-def test_embed_batch_returns_one_vector_per_text(monkeypatch):
+def test_embed_batch_returns_one_normalized_vector_per_text(monkeypatch):
     server, _ = _import_server(monkeypatch)
     response = server.embed_batch(server.EmbedBatchRequest(texts=["a", "b"]))
 
     assert len(response.embeddings) == 2
-    assert all(len(vector) == 3 for vector in response.embeddings)
+    for vector in response.embeddings:
+        norm = math.sqrt(sum(v * v for v in vector))
+        assert math.isclose(norm, 1.0, rel_tol=1e-9)
 
 
-def test_torch_thread_count_follows_the_environment(monkeypatch):
-    # The compose file sets JINA_EMBED_THREADS to match the `cpus` it grants.
-    # If this stopped being read, torch would go back to sizing its pool from
-    # the host's core count and thrash against the cgroup quota - the exact
-    # failure that held hosted embedding to ~340 characters/second.
+def test_embed_batch_preserves_request_order_even_if_the_backend_does_not(monkeypatch):
+    server, _ = _import_server(monkeypatch)
+
+    class ShufflingLlama:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def create_embedding(self, input):
+            # Backend returns items out of order, and on orthogonal axes so
+            # normalization (which erases relative magnitude on the same
+            # axis) can't mask a mix-up - server.py must sort by index
+            # rather than trust list position, or a chunk gets the wrong
+            # vector attached silently in the index.
+            return {
+                "data": [
+                    {"index": 2, "embedding": [0.0, 0.0, 5.0]},
+                    {"index": 0, "embedding": [5.0, 0.0, 0.0]},
+                    {"index": 1, "embedding": [0.0, 5.0, 0.0]},
+                ]
+            }
+
+    server._model = ShufflingLlama()
+    response = server.embed_batch(server.EmbedBatchRequest(texts=["a", "b", "c"]))
+
+    assert [[round(x) for x in v] for v in response.embeddings] == [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+    ]
+
+
+def test_embed_returns_a_normalized_vector_for_a_single_text(monkeypatch):
+    server, _ = _import_server(monkeypatch)
+    response = server.embed(server.EmbedRequest(text="a"))
+
+    norm = math.sqrt(sum(v * v for v in response.embedding))
+    assert math.isclose(norm, 1.0, rel_tol=1e-9)
+
+
+def test_thread_count_follows_the_environment(monkeypatch):
+    # The compose file sets JINA_EMBED_THREADS to match the `cpus` it
+    # grants - the whole reason this backend is fast: the 24.55s/2-thread
+    # real-batch measurement server.py's docstring cites was made at this
+    # exact setting, not a default.
     monkeypatch.setenv("JINA_EMBED_THREADS", "2")
     _, requested_threads = _import_server(monkeypatch)
 
     assert requested_threads == [2]
 
 
-def test_torch_thread_count_defaults_to_one(monkeypatch):
+def test_thread_count_defaults_to_one(monkeypatch):
     monkeypatch.delenv("JINA_EMBED_THREADS", raising=False)
     _, requested_threads = _import_server(monkeypatch)
 


### PR DESCRIPTION
## Summary

Two production incidents today against jina-embed's PyTorch/sentence-transformers backend (a request that never finished the 60s timeout, then an OOM under a mem_limit already raised to cover it) both traced back to the same wrong assumption on my part: that the slowness was a hardware or config problem. It wasn't.

`nomic-embed-text` (the model this service replaced) was served by Ollama - llama.cpp underneath, quantized GGUF weights, hand-tuned CPU kernels. `jina-embed` ran the replacement model raw: eager-mode PyTorch, unquantized, through a custom `trust_remote_code` HuggingFace model. That's not a fair comparison at any CPU generation. Checked directly to rule out other explanations:
- **Not the CPU**: Accelerate/AMX locally vs. MKL with full AVX-512/VNNI on the prod host, neither crippled.
- **Not core count**: 2 threads performed the same as unconstrained locally.
- **Not quantization cost**: 0.9997 cosine similarity between the GGUF Q8_0 output and the full-precision PyTorch embedding, same input.

Measured directly on the production host, real code, not synthetic filler (a 133k-char, 38-chunk real flask source sample):

| Backend | Result |
|---|---|
| Old (PyTorch, 2 threads) | Hadn't finished the first fifth of the batch after 164s, then OOM-killed at ~2.44GB |
| New (llama.cpp/GGUF, 2 threads) | 24-27s (~5,000-5,400 chars/s), 375MB peak |

## Changes
- `jina_embed/server.py`: `Llama(..., embedding=True)` against a Q8_0 GGUF instead of `SentenceTransformer`. Same `/embed`, `/embed_batch`, `/healthz` contract - no caller changes needed. Output is explicitly L2-normalized (llama.cpp's raw pooled output isn't unit-length) and `embed_batch` sorts by the backend's returned `index` rather than trusting list order, since nothing downstream checks order, only count.
- `Dockerfile.jina-embed`: multi-stage build - `llama-cpp-python` compiles from source (no prebuilt wheel for this base image), so build tools live only in the discarded builder stage. GGUF weights baked in at build time, same reasoning as the old model weights. **`libgomp1` added to the final stage** - caught by actually building and running the real image end-to-end on the target host: the compiled `libllama.so` links against libgomp at build time, and without it in the final stage the image fails to import `llama_cpp` at all.
- `requirements-jina-embed.txt`: drops `torch`/`sentence-transformers`/`transformers`/`einops`, adds `llama-cpp-python`.
- `docker-compose.yml`: `mem_limit` 6000m → 2000m on the new measured peak (375MB, ~5x headroom for concurrent requests - FastAPI's threadpool can run more than one sync endpoint at once). Not concurrency-load-tested; a further reduction should be too.
- `tests/test_jina_embed.py`: rewritten against a fake `llama_cpp` module (real one isn't installed in the test job - it lives only in this image). Covers normalization, order-preservation against a deliberately-reordered fake backend, and thread-count wiring.
- `CHANGELOG.md`: dated entry.

## Test plan
- [x] `pytest github-app/tests` (full suite) - 1316 passed, 8 skipped
- [x] `pytest src/tests` (full CLI suite, unaffected) - 1281 passed
- [x] Built the real Dockerfile end-to-end on the production host (not just the pieces in isolation) and ran the resulting image under real `--cpus=2 --memory=2000m -e JINA_EMBED_THREADS=2` constraints
- [x] Hit the built container's real `/healthz`, `/embed`, and `/embed_batch` endpoints - `/embed_batch` against the same 38-chunk real flask payload returned 38/38 correct-dimension vectors in 26.09s over the full HTTP round-trip, consistent with the standalone measurement
- [x] Verified quantization didn't degrade output quality (0.9997 cosine similarity vs. full-precision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)