### PR TITLE
fix: jina-embed's shared Llama context crashes under concurrent access

### DIFF
--- a/github-app/jina_embed/server.py
+++ b/github-app/jina_embed/server.py
@@ -22,10 +22,29 @@ a dev machine, doesn't silently take a different code path than prod runs).
 The single-text contract remains for scan-worker caches; the additive batch
 endpoint is used by hosted index builds so one request can encode many
 chunks in one call.
+
+_MODEL_LOCK below is not an optimization - it is required for correctness.
+A single `Llama` instance is not safe for concurrent use from multiple
+threads (abetlen/llama-cpp-python#1241: concurrent calls into one context
+corrupt its internal GGML tensor state), and both routes below are sync
+`def` handlers, which FastAPI/Starlette dispatches onto its worker
+threadpool rather than the event loop - so two requests arriving close
+together genuinely can call into `_model` from two different threads at
+once. Reproduced directly: profiling a real hosted index build crashed the
+container with `GGML_ASSERT(offset + size <= ggml_nbytes(tensor) &&
+"tensor read out of bounds")` after dozens of successful requests, on two
+different corpora (gson after ~33 requests, apache/thrift after ~38
+minutes) - not tied to any one input's size or content, consistent with a
+race rather than a bad chunk. This process serves exactly one shared model
+to every caller (two scan-worker replicas, demo-scan-worker, hosted `aletheore
+index` traffic), so concurrent callers are the normal case, not an edge
+case - serializing access to the model is the correct fix, not a
+workaround.
 """
 import logging
 import math
 import os
+import threading
 
 from fastapi import FastAPI
 from llama_cpp import Llama
@@ -54,6 +73,8 @@ _model = Llama(
     verbose=False,
 )
 logger.info("Model loaded")
+
+_model_lock = threading.Lock()
 
 
 class EmbedRequest(BaseModel):
@@ -85,14 +106,16 @@ def _normalize(vector: list[float]) -> list[float]:
 
 @app.post("/embed", response_model=EmbedResponse)
 def embed(req: EmbedRequest) -> EmbedResponse:
-    result = _model.create_embedding(req.text)
+    with _model_lock:
+        result = _model.create_embedding(req.text)
     vector = _normalize(result["data"][0]["embedding"])
     return EmbedResponse(embedding=vector)
 
 
 @app.post("/embed_batch", response_model=EmbedBatchResponse)
 def embed_batch(req: EmbedBatchRequest) -> EmbedBatchResponse:
-    result = _model.create_embedding(req.texts)
+    with _model_lock:
+        result = _model.create_embedding(req.texts)
     # Sorted explicitly rather than trusting list order: app-server checks
     # the returned count matches the request but has no way to check order,
     # so a reordered response would silently attach the wrong vector to the

--- a/github-app/tests/test_jina_embed.py
+++ b/github-app/tests/test_jina_embed.py
@@ -1,6 +1,8 @@
 import importlib
 import math
 import sys
+import threading
+import time
 import types
 
 
@@ -106,3 +108,53 @@ def test_thread_count_defaults_to_one(monkeypatch):
     _, requested_threads = _import_server(monkeypatch)
 
     assert requested_threads == [1]
+
+
+def test_concurrent_requests_do_not_call_the_model_at_the_same_time(monkeypatch):
+    """A single Llama instance is not safe for concurrent use from multiple
+    threads (abetlen/llama-cpp-python#1241) - both routes are sync `def`
+    handlers, which FastAPI dispatches onto its worker threadpool, so two
+    requests arriving close together really can reach the model from two
+    threads at once without a lock. Reproduced in production as a
+    GGML_ASSERT "tensor read out of bounds" crash after dozens of
+    successful requests. This fake model raises if it is ever entered while
+    another call is still inside it, which only a correctly-held lock in
+    server.py prevents."""
+    server, _ = _import_server(monkeypatch)
+
+    class ConcurrencyDetectingLlama:
+        def __init__(self, *args, **kwargs):
+            self._inside = threading.Lock()
+
+        def create_embedding(self, input):
+            if not self._inside.acquire(blocking=False):
+                raise AssertionError("create_embedding entered concurrently")
+            try:
+                time.sleep(0.05)  # widen the race window
+                texts = [input] if isinstance(input, str) else input
+                return {
+                    "data": [
+                        {"index": index, "embedding": [1.0, 0.0, 0.0]}
+                        for index, _ in enumerate(texts)
+                    ]
+                }
+            finally:
+                self._inside.release()
+
+    server._model = ConcurrencyDetectingLlama()
+
+    errors: list[Exception] = []
+
+    def call_embed():
+        try:
+            server.embed(server.EmbedRequest(text="x"))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=call_embed) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []


### PR DESCRIPTION
## Summary

Found while investigating `project_indexing_speed_needs_investigation.md` (indexing speed) — profiling a real hosted `aletheore index` build on the gson corpus to break down wall-clock time by phase (chunking / embed-request-count / embed-compute) instead of continuing to guess. The profiling run itself crashed the production `jina-embed` container: `GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds")`, matching a crash already logged separately on `apache/thrift` after ~38 minutes (`project_jina_embed_ggml_crash.md`). Reproduced twice on two different corpora, at request #33 (gson, ~230s) and request #60 (gson, second run, ~430s) — much faster to reproduce than the original thrift observation, which made root-causing tractable in this session.

**Not input-dependent.** The same 5030-char chunk that appeared in the fatal batch had already succeeded in several earlier batches in the same run — ruled out "one bad chunk" as the cause.

**Root cause**: `abetlen/llama-cpp-python#1241` — a single `Llama` instance is not safe for concurrent use from multiple threads. `jina_embed/server.py`'s `/embed` and `/embed_batch` are sync `def` routes, which FastAPI/Starlette dispatches onto its worker threadpool rather than the event loop. Two requests arriving close together — two `scan-worker` replicas indexing different repos, or a background `/embed` caching call racing an `/embed_batch` index build, all hitting the one shared `jina-embed` instance — can call into the model from two threads simultaneously and corrupt its internal GGML tensor state. This is the normal case for this service, not an edge case: it serves exactly one shared model to every caller in the deployment (2 scan-worker replicas, demo-scan-worker, and hosted `aletheore index` traffic).

## Changes
- `github-app/jina_embed/server.py`: `threading.Lock()` around both routes' `_model.create_embedding()` calls. Serializing access is the correct fix here, not a workaround — a shared model instance can't safely do anything else.
- `github-app/tests/test_jina_embed.py`: new test spawning 8 concurrent threads against a fake model that raises if entered while another call is still inside it — fails 7/8 times against the pre-fix code, passes against the fix.

## Deliberately not attempted here
`search_index.py`'s `_embed_in_batches` raises (rather than falling back) on any hosted failure once a batch has already succeeded, to avoid mixing embedding dimensions in one index — correct for data integrity, but it means a crash like this discarded all prior progress on the run, forcing a full restart. Fixing the actual crash cause removes most of the exposure to that; preserving partial progress across a hosted failure is a separate, more involved design question (where to persist partial vectors, retry semantics) and isn't attempted in this PR.

## Test plan
- [x] New concurrency test: fails 7/8 threads against pre-fix `server.py` (verified via `git stash` on just that file), passes against the fix
- [x] `pytest github-app/tests/test_jina_embed.py` — 6 passed
- [ ] Full `github-app` suite — running, will confirm before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)