### PR TITLE
feat: run jina-embed with 2 model instances instead of 1x2 threads

### DIFF
--- a/github-app/CHANGELOG.md
+++ b/github-app/CHANGELOG.md
@@ -26,6 +26,25 @@ file is the history; that one is the current state.
   2.44GB+. Quantization cost was checked directly too - 0.9997 cosine similarity against the
   full-precision embedding on the same input. `jina-embed`'s `mem_limit` comes back down from the
   emergency-raised 6000m to 2000m on this evidence.
+- **`jina-embed` runs 2 independent model instances (`JINA_EMBED_INSTANCES=2`) instead of 1 instance
+  parallelizing across 2 threads.** Same total CPU budget, differently spent: a single instance
+  splitting one embedding call across threads pays real synchronization overhead inside llama.cpp's
+  matmul kernels, while N single-threaded instances processing N requests concurrently pay none of
+  that - pure task parallelism. Measured locally (4 concurrent streams of real `apache/thrift` source,
+  `--cpus=2` both configurations): 2x1 threads finished in 223.27s against 1x2's 238.83s, ~6.5% faster
+  on identical CPU. More importantly, it reduces queueing delay under concurrent load specifically -
+  every caller (two `scan-worker` replicas, `demo-scan-worker`, hosted index builds) previously queued
+  behind one locked instance even when their requests were otherwise fully independent, which
+  contributed to a real `ReadTimeout` on a thrift-scale request (see the char-cap entry below).
+  Memory checked under real concurrent load, not assumed: peaked at 620MiB, comfortably inside the
+  existing 2000m limit.
+- **`HOSTED_EMBED_MAX_CHARS` lowered from 130,000 to 60,000.** 130,000 was reasoned from a single
+  isolated request measurement (24.55s, zero concurrent load) and caused a real failure: a thrift
+  index build hit `ReadTimeout` at exactly 60.1s and lost 22 minutes of progress, because real latency
+  under concurrent load is compute time plus queueing delay, not compute time alone. 60,000 leaves
+  ~37s of margin against the 60s timeout at the measured ~2,630 chars/s real-world throughput, still
+  3x the original 20,000 baseline. Should be revisited once the multi-instance change above has real
+  concurrent-load evidence behind it, rather than another single-request extrapolation.
 
 ## 2026-08-12
 

--- a/github-app/docker-compose.yml
+++ b/github-app/docker-compose.yml
@@ -400,11 +400,28 @@ services:
       # a busy host doesn't get flagged unhealthy before it's had a chance.
       start_period: 60s
     environment:
-      # Passed straight through to llama.cpp's n_threads. Must match `cpus`
+      # Passed straight through to llama.cpp's n_threads (divided across
+      # instances - see JINA_EMBED_INSTANCES below). Must match `cpus`
       # below - the 24.55s/2-thread real-batch measurement server.py's
       # docstring cites was made at this exact thread count, not a larger
       # one this box's 4 cores could technically support.
       - JINA_EMBED_THREADS=2
+      # 2 instances x 1 thread each, not 1 instance x 2 threads. Measured
+      # locally (10-core/8GB Docker, 4 concurrent streams of real thrift
+      # source, --cpus=2 both configurations): 2x1 finished in 223.27s
+      # against 1x2's 238.83s, ~6.5% faster on identical total CPU. The
+      # mechanism isn't more compute - the container's thread budget is
+      # unchanged either way - it's that a single instance parallelizing
+      # one call across threads pays real synchronization overhead inside
+      # llama.cpp's matmul kernels, while N single-threaded instances
+      # processing N requests pay none of that. It also reduces queueing
+      # delay under concurrent load specifically: today every caller (two
+      # scan-worker replicas, demo-scan-worker, hosted index builds) queues
+      # behind one locked instance even when their requests are otherwise
+      # fully independent - this exact queueing was part of what pushed a
+      # thrift-scale request past the 60s embeddings_api timeout at the old
+      # HOSTED_EMBED_MAX_CHARS (see search_index.py's comment on that cap).
+      - JINA_EMBED_INSTANCES=2
     # Bumped from 1.0. This service is the only CPU-bound one in the stack -
     # everything else is I/O-bound on Postgres, Redis or the GitHub API -
     # and at 1.0 it was the hard ceiling on hosted indexing: measured at a

--- a/github-app/jina_embed/server.py
+++ b/github-app/jina_embed/server.py
@@ -23,24 +23,42 @@ The single-text contract remains for scan-worker caches; the additive batch
 endpoint is used by hosted index builds so one request can encode many
 chunks in one call.
 
-_MODEL_LOCK below is not an optimization - it is required for correctness.
-A single `Llama` instance is not safe for concurrent use from multiple
-threads (abetlen/llama-cpp-python#1241: concurrent calls into one context
-corrupt its internal GGML tensor state), and both routes below are sync
-`def` handlers, which FastAPI/Starlette dispatches onto its worker
+Per-instance locking below is not an optimization - it is required for
+correctness. A single `Llama` instance is not safe for concurrent use from
+multiple threads (abetlen/llama-cpp-python#1241: concurrent calls into one
+context corrupt its internal GGML tensor state), and both routes below are
+sync `def` handlers, which FastAPI/Starlette dispatches onto its worker
 threadpool rather than the event loop - so two requests arriving close
-together genuinely can call into `_model` from two different threads at
-once. Reproduced directly: profiling a real hosted index build crashed the
-container with `GGML_ASSERT(offset + size <= ggml_nbytes(tensor) &&
-"tensor read out of bounds")` after dozens of successful requests, on two
-different corpora (gson after ~33 requests, apache/thrift after ~38
-minutes) - not tied to any one input's size or content, consistent with a
-race rather than a bad chunk. This process serves exactly one shared model
-to every caller (two scan-worker replicas, demo-scan-worker, hosted `aletheore
-index` traffic), so concurrent callers are the normal case, not an edge
-case - serializing access to the model is the correct fix, not a
-workaround.
+together genuinely can call into the same `Llama` instance from two
+different threads at once. Reproduced directly: profiling a real hosted
+index build crashed the container with `GGML_ASSERT(offset + size <=
+ggml_nbytes(tensor) && "tensor read out of bounds")` after dozens of
+successful requests, on two different corpora (gson after ~33 requests,
+apache/thrift after ~38 minutes) - not tied to any one input's size or
+content, consistent with a race rather than a bad chunk. This process
+serves exactly one shared model to every caller (two scan-worker replicas,
+demo-scan-worker, hosted `aletheore index` traffic), so concurrent callers
+are the normal case, not an edge case - serializing access to any single
+instance is the correct fix, not a workaround.
+
+JINA_EMBED_INSTANCES (default 1, preserving prior single-instance
+behavior) loads that many independent Llama instances instead of one,
+each with its own lock and 1/N of JINA_EMBED_THREADS. This is not about
+using more CPU - the container's total thread budget is unchanged either
+way - it's about how that budget is spent. A single instance parallelizing
+one embedding call across N threads pays real synchronization/
+memory-bandwidth overhead inside llama.cpp's matrix-multiply kernels
+(measured well under linear scaling at 2 threads). N single-threaded
+instances processing N different requests at once pay none of that: pure
+task parallelism, no cross-thread coordination inside one call. It also
+directly fixes the serialization side effect of the lock above - today
+every caller queues behind one instance even when two scan-worker
+replicas or a background /embed cache call and an /embed_batch index
+build land at the same moment; multiple instances let genuinely
+independent requests actually run at once instead of just avoiding
+corruption while still queueing.
 """
+import itertools
 import logging
 import math
 import os
@@ -60,21 +78,61 @@ _MODEL_PATH = os.environ.get("JINA_EMBED_MODEL_PATH", "/app/model.gguf")
 # but reserving that much KV-cache space for every request buys nothing here
 # and costs memory.
 _CTX = int(os.environ.get("JINA_EMBED_CTX", "2048"))
+_NUM_INSTANCES = int(os.environ.get("JINA_EMBED_INSTANCES", "1"))
+# Divided, not duplicated: JINA_EMBED_THREADS is sized to the container's
+# `cpus` limit (see docker-compose.yml), so N instances each get a fair
+# share of that same budget rather than N times it. max(1, ...) so an
+# instance count larger than the thread budget still gets one real thread
+# each instead of zero.
+_THREADS_PER_INSTANCE = max(1, _THREADS // _NUM_INSTANCES)
 
 app = FastAPI()
 
-logger.info("Loading %s with %d threads...", _MODEL_PATH, _THREADS)
-_model = Llama(
-    model_path=_MODEL_PATH,
-    embedding=True,
-    n_threads=_THREADS,
-    n_ctx=_CTX,
-    n_gpu_layers=0,
-    verbose=False,
-)
-logger.info("Model loaded")
 
-_model_lock = threading.Lock()
+class _Instance:
+    __slots__ = ("model", "lock")
+
+    def __init__(self, model: Llama) -> None:
+        self.model = model
+        self.lock = threading.Lock()
+
+
+_instances: list[_Instance] = []
+for _i in range(_NUM_INSTANCES):
+    logger.info(
+        "Loading instance %d/%d (%s, %d threads)...",
+        _i + 1,
+        _NUM_INSTANCES,
+        _MODEL_PATH,
+        _THREADS_PER_INSTANCE,
+    )
+    _instances.append(
+        _Instance(
+            Llama(
+                model_path=_MODEL_PATH,
+                embedding=True,
+                n_threads=_THREADS_PER_INSTANCE,
+                n_ctx=_CTX,
+                n_gpu_layers=0,
+                verbose=False,
+            )
+        )
+    )
+logger.info("%d instance(s) loaded", _NUM_INSTANCES)
+
+# Round-robin rather than least-recently-used: request duration varies with
+# batch size, so "next in rotation" spreads load evenly on average without
+# needing per-instance timing to decide, and the counter itself is cheap
+# enough that contention on it is never the bottleneck (real work happens
+# inside the per-instance lock above, held for orders of magnitude longer).
+_next_instance = itertools.count()
+_rotation_lock = threading.Lock()
+
+
+def _pick_instance() -> _Instance:
+    with _rotation_lock:
+        index = next(_next_instance) % len(_instances)
+    return _instances[index]
 
 
 class EmbedRequest(BaseModel):
@@ -106,16 +164,18 @@ def _normalize(vector: list[float]) -> list[float]:
 
 @app.post("/embed", response_model=EmbedResponse)
 def embed(req: EmbedRequest) -> EmbedResponse:
-    with _model_lock:
-        result = _model.create_embedding(req.text)
+    instance = _pick_instance()
+    with instance.lock:
+        result = instance.model.create_embedding(req.text)
     vector = _normalize(result["data"][0]["embedding"])
     return EmbedResponse(embedding=vector)
 
 
 @app.post("/embed_batch", response_model=EmbedBatchResponse)
 def embed_batch(req: EmbedBatchRequest) -> EmbedBatchResponse:
-    with _model_lock:
-        result = _model.create_embedding(req.texts)
+    instance = _pick_instance()
+    with instance.lock:
+        result = instance.model.create_embedding(req.texts)
     # Sorted explicitly rather than trusting list order: app-server checks
     # the returned count matches the request but has no way to check order,
     # so a reordered response would silently attach the wrong vector to the

--- a/github-app/tests/test_jina_embed.py
+++ b/github-app/tests/test_jina_embed.py
@@ -1,4 +1,5 @@
 import importlib
+import itertools
 import math
 import sys
 import threading
@@ -74,7 +75,7 @@ def test_embed_batch_preserves_request_order_even_if_the_backend_does_not(monkey
                 ]
             }
 
-    server._model = ShufflingLlama()
+    server._instances = [server._Instance(ShufflingLlama())]
     response = server.embed_batch(server.EmbedBatchRequest(texts=["a", "b", "c"]))
 
     assert [[round(x) for x in v] for v in response.embeddings] == [
@@ -141,7 +142,7 @@ def test_concurrent_requests_do_not_call_the_model_at_the_same_time(monkeypatch)
             finally:
                 self._inside.release()
 
-    server._model = ConcurrencyDetectingLlama()
+    server._instances = [server._Instance(ConcurrencyDetectingLlama())]
 
     errors: list[Exception] = []
 
@@ -158,3 +159,53 @@ def test_concurrent_requests_do_not_call_the_model_at_the_same_time(monkeypatch)
         t.join()
 
     assert errors == []
+
+
+def test_multiple_instances_actually_run_concurrently(monkeypatch):
+    """The whole point of JINA_EMBED_INSTANCES > 1: independent requests on
+    different instances must be able to overlap in time, not just avoid
+    corrupting each other. A round-robin bug that always picked the same
+    instance would pass the concurrency-safety test above (nothing would
+    ever race) while silently defeating the entire feature - this test
+    would catch that, the one above would not."""
+    server, _ = _import_server(monkeypatch)
+
+    class SlowLlama:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def create_embedding(self, input):
+            concurrent_calls.append(1)
+            time.sleep(0.1)
+            concurrent_calls.append(-1)
+            texts = [input] if isinstance(input, str) else input
+            return {
+                "data": [
+                    {"index": index, "embedding": [1.0, 0.0, 0.0]}
+                    for index, _ in enumerate(texts)
+                ]
+            }
+
+    concurrent_calls: list[int] = []
+    server._instances = [server._Instance(SlowLlama()), server._Instance(SlowLlama())]
+    server._next_instance = itertools.count()
+
+    threads = [
+        threading.Thread(target=server.embed, args=(server.EmbedRequest(text="x"),))
+        for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Running total of in-flight calls across both instances at any point in
+    # time - if it never exceeds 1, the two instances never actually
+    # overlapped despite being separate objects.
+    running_total = 0
+    peak_concurrency = 0
+    for delta in concurrent_calls:
+        running_total += delta
+        peak_concurrency = max(peak_concurrency, running_total)
+
+    assert peak_concurrency == 2


### PR DESCRIPTION
## Summary
- `JINA_EMBED_INSTANCES` (default 1, preserving prior behavior) loads that many independent `Llama` instances instead of one, each with its own lock and `JINA_EMBED_THREADS / N` threads. Same total CPU budget, differently spent.
- Why it should win: a single instance parallelizing one embedding call across threads pays real synchronization/memory-bandwidth overhead inside llama.cpp's matmul kernels. N single-threaded instances processing N requests concurrently pay none of that - pure task parallelism.
- Measured locally (10-core/8GB Docker, 4 concurrent streams of real `apache/thrift` source, `--cpus=2` identical both configurations): 2x1 threads finished in 223.27s against 1x2's 238.83s - a real but modest ~6.5% win.
- More importantly, it reduces queueing delay under concurrent load specifically: every caller of this shared service (two `scan-worker` replicas, `demo-scan-worker`, hosted index builds) previously queued behind one locked instance even when their requests were otherwise fully independent. That queueing directly contributed to a production `ReadTimeout` on a thrift-scale request - see #266, which lowers `HOSTED_EMBED_MAX_CHARS` to compensate until this lands.
- `docker-compose.yml`: `JINA_EMBED_INSTANCES=2` for prod's 2-CPU allocation.
- Memory checked under real concurrent load, not assumed: two instances baseline ~442MB, peaked at 620MB under the 4-stream load test - comfortably inside the existing 2000m `mem_limit`, no change needed.

## A real gap this caught along the way
The route-handler wiring to the new instance pool was mid-flight when picked up - `/embed` and `/embed_batch` still referenced the deleted `_model`/`_model_lock` globals and would have `NameError`'d on the first request. Fixed, along with a more serious issue it exposed: the two existing tests that swap in a fake model did `server._model = ...`, which had become a silent no-op, so `test_concurrent_requests_do_not_call_the_model_at_the_same_time` was passing without exercising its own fake model at all - zero real coverage of the property it claims to test. Fixed both to use `server._instances`, and added `test_multiple_instances_actually_run_concurrently`, which the other two structurally cannot catch (a round-robin bug that always picked the same instance would still pass both). Verified that new test has real power: confirmed it fails (peak concurrency 1, not 2) against a deliberately broken round-robin.

## Test plan
- [x] `pytest github-app/tests/test_jina_embed.py` - 7 passed
- [x] `pytest github-app/tests` (full suite) - 1318 passed, 8 skipped
- [x] Built the real Dockerfile locally, ran under `--cpus=2 --memory=2000m` matching prod exactly, confirmed both instances load (`2 instance(s) loaded`) and the concurrent-load benchmark completes correctly
- [x] Memory measured under real load (620MB peak), not assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)