### PR TITLE
fix: suppress CVE-2026-53615 (libblkid) - no fix published yet

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -17,3 +17,24 @@
 # for a caller to supply a different model to load.
 CVE-2026-4372
 CVE-2026-5241
+
+# CVE-2026-53615 (bsdutils/libblkid1/liblastlog2-2/libmount1/libsmartcols1/
+# libuuid1/login/mount/util-linux - every image, base OS packages, not an
+# app dependency): integer overflow in libblkid's partition-table parser
+# (dos.c). Fixed version is 2.41.5-0+deb13u1, but not yet published:
+# pulled and scanned the current `python:3.12-slim` tag directly (not just
+# our pinned digest) on 2026-08-17 and it carries the identical vulnerable
+# 2.41-5 build - there is nothing newer to pin to yet, so bumping the
+# digest would not close this.
+#
+# Accepted temporarily because none of these images ever parse a
+# partition table: they're FastAPI/uvicorn services (app-server,
+# jina-embed, scan-worker, demo-scan-worker, demo-sandbox(-runner)) that
+# never mount a filesystem, read a raw block device, or invoke
+# mount/blkid/lsblk as part of any request-handling code path - libblkid
+# is pulled in transitively by util-linux as a base Debian package, not
+# something this application code calls. Revisit once Debian actually
+# ships the patched package - bump the pinned digest and remove this
+# entry then, don't leave it here longer than the fix is actually
+# unavailable.
+CVE-2026-53615


### PR DESCRIPTION
## Summary
- Blocking every PR's required Image scan check right now, not specific to any code change: a fresh HIGH CVE in `util-linux`/`libblkid` (base OS packages in `python:3.12-slim`, not an app dependency) across all three scanned images.
- Verified before suppressing: pulled and scanned the current `python:3.12-slim` tag directly (not just our pinned digest) and it carries the identical vulnerable `2.41-5` build - Debian hasn't actually published the patched package yet, despite Trivy's database already listing a fix version. Nothing newer to bump the digest to right now.
- Accepted temporarily because `libblkid` parses partition tables, and none of these images ever mount a filesystem, read a raw block device, or invoke `mount`/`blkid`/`lsblk` in any request-handling path - it's a transitive base-OS package, never called by application code.

## Test plan
- [x] Built all three CI-scanned images locally, ran the exact CI trivy invocation against each - all three exit 0, zero findings
- [x] Confirmed the fix genuinely isn't published yet by scanning `python:3.12-slim`'s current tag directly

Revisit once Debian ships the patch - bump the digest and remove this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)