### PR TITLE
fix: raise HOSTED_EMBED_MAX_CHARS to 180,000 now that the timeout is 120s

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -817,7 +817,19 @@ EMBED_BATCH_SIZE = 200
 # batching needs the CLI to tokenize client-side, which means bundling a
 # tokenizer (or the model itself) as a new dependency, scoped as separate,
 # larger follow-up work, not folded into this recalibration.
-HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "100000"))
+#
+# Raised again to 180,000 after app-server's own timeout to jina-embed
+# went from 60s to 120s (embeddings_api.get_jina_client) - it was cutting
+# itself off at half the budget the CLI's own client already tolerated
+# waiting (this file's HTTP client has used timeout=120.0 all along).
+# Interpolated within the already-measured range above rather than
+# extrapolating past it: the real 44,419/60.10s and 59,903/83.24s points
+# bracket a ~669 tok/s rate in that segment; targeting the same ~41%
+# margin against the new 120s budget (70.8s) lands at ~51,600 tokens,
+# rounded down to 50,000 for headroom - comfortably inside both tested
+# points, not a new extreme. 50,000 / 3.89 =~ 200,600 chars, rounded down
+# to 180,000.
+HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "180000"))
 
 
 def _hosted_batches(texts: list[str], batch_size: int) -> list[tuple[int, int]]:


### PR DESCRIPTION
## Summary
- Follows #271 (app-server's timeout to jina-embed raised 60s→120s, deployed to prod). That timeout was the actual binding constraint on `HOSTED_EMBED_MAX_CHARS` - the CLI's own client to app-server has tolerated 120s all along.
- Interpolated within already-measured data, not extrapolated: real points (44,419 tok/60.10s, 59,903 tok/83.24s) bracket ~669 tok/s; targeting the same ~41% margin used for the previous cap lands at ~50,000 tokens, converted at 3.89 chars/token to 180,000.

## Test plan
- [x] `pytest src/tests/test_search_index.py -q` — 96 passed
- [x] Real cold index build against flask through prod (post-#271 deploy): 3 hosted batches, 209.66s wall, zero fallback, zero timeout
- [x] Retrieval accuracy re-verified against the published jina baseline: byte-identical (81.2%/100.0%/100.0%/0.901 top-1/3/5/MRR, +0.0pp delta)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj