### PR TITLE
fix: cap concurrent hosted-embed requests, not just requests per hour

### DIFF
--- a/github-app/CHANGELOG.md
+++ b/github-app/CHANGELOG.md
@@ -21,6 +21,18 @@ file is the history; that one is the current state.
   per-token timing evidence measured directly against `jina-embed` post-multi-instance (#267, 2
   instances): 88,859 tokens took 124.70s, close to the new ceiling rather than an untested
   extrapolation past it.
+- **`/v1/embeddings` now caps concurrent hosted-embed requests, not just requests per hour.**
+  The existing rate limiter throttled request *count per window*, which did nothing about several
+  requests landing on `jina-embed` at the same moment - it runs `JINA_EMBED_INSTANCES=2`, each
+  single-threaded, so a third concurrent request just queues behind a lock until one frees up,
+  inside whatever's left of the 120s timeout above. A Redis sorted-set semaphore now admits at
+  most `MAX_CONCURRENT_HOSTED_EMBED_REQUESTS` (default 2, matched to `JINA_EMBED_INSTANCES`) at
+  once, refusing the rest with 429 and a short `Retry-After` (3s, not the rate limiter's hour) -
+  self-healing against a crashed holder via a TTL slightly above the 120s request timeout, so a
+  process that dies mid-request leaks its slot for at most that long, never permanently. The CLI's
+  `embed_texts_hosted` now retries on 429 (bounded, capped sleep) before falling back to local
+  embeddings or failing an in-progress index build, so the common case - a momentary capacity blip
+  under concurrent load - costs a short wait instead of degrading the result.
 
 ## 2026-08-16
 

--- a/github-app/app_server/embeddings_api.py
+++ b/github-app/app_server/embeddings_api.py
@@ -22,6 +22,7 @@ import functools
 import hashlib
 import logging
 import os
+import uuid
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request
@@ -30,7 +31,7 @@ from pydantic import BaseModel, Field
 from app_server.db import (
     get_installation_by_token_hash,
 )
-from app_server.rate_limit import is_rate_limited
+from app_server.rate_limit import acquire_concurrency_slot, is_rate_limited, release_concurrency_slot
 from app_server.redis_client import get_redis_client
 
 embeddings_router = APIRouter()
@@ -63,6 +64,35 @@ MAX_CHARS_PER_TEXT = 8_000
 # stops a caller from turning one token into unbounded CPU-bound upstream volume.
 RATE_LIMIT_REQUESTS = 2000
 RATE_LIMIT_WINDOW_SECONDS = 3600
+
+# The rate limiter above throttles *request count per hour*, which does
+# nothing about several requests landing on jina-embed at the same moment -
+# it has JINA_EMBED_INSTANCES=2 (docker-compose.yml), each single-threaded,
+# so a third concurrent request just queues behind a lock until one frees
+# up, inside whatever's left of get_jina_client's 120s budget. This caps how
+# many hosted-embed calls this process will admit to jina-embed at once;
+# keep it in sync with JINA_EMBED_INSTANCES by hand if that ever changes -
+# admitting more than jina-embed can actually run concurrently just moves
+# the queueing from here to there, which is exactly what this exists to
+# avoid.
+MAX_CONCURRENT_HOSTED_EMBED_REQUESTS = int(
+    os.environ.get("MAX_CONCURRENT_HOSTED_EMBED_REQUESTS", "2")
+)
+
+# Comfortably above get_jina_client's 120s request timeout, so a slot for a
+# request that's still genuinely in flight is never mistaken for a crashed
+# holder's leaked slot and evicted out from under it.
+HOSTED_EMBED_CONCURRENCY_SLOT_TTL_SECONDS = 130
+
+# Short on purpose: jina-embed frees a slot in low tens of seconds for a
+# typical batch (real measurement: 59,903 tokens in 83.24s), not the hour
+# RATE_LIMIT_WINDOW_SECONDS implies for the request-count limiter above.
+# The CLI's own retry loop (embed_texts_hosted) honours this and retries a
+# bounded number of times rather than treating a capacity 429 the same as a
+# hard failure.
+HOSTED_EMBED_CONCURRENCY_RETRY_AFTER_SECONDS = 3
+
+_HOSTED_EMBED_CONCURRENCY_KEY = "concurrency:hosted-embed"
 
 # Bucket key length, not a content limit: repo_id is a 16-char hex prefix of
 # a sha256 (see aletheore.search_index._repo_id) client-side, but the field
@@ -174,6 +204,30 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
             headers={"Retry-After": str(RATE_LIMIT_WINDOW_SECONDS)},
         )
 
+    slot_id = uuid.uuid4().hex
+    try:
+        admitted = acquire_concurrency_slot(
+            get_redis_client(),
+            _HOSTED_EMBED_CONCURRENCY_KEY,
+            MAX_CONCURRENT_HOSTED_EMBED_REQUESTS,
+            slot_id,
+            HOSTED_EMBED_CONCURRENCY_SLOT_TTL_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Fails open like the rate limit check above: jina-embed's own
+        # per-instance locks are the hard backstop against real overload,
+        # this is only the soft admission control that keeps requests from
+        # piling up behind them. A Redis outage should cost that
+        # smoothing, not availability.
+        logger.warning("hosted embed concurrency check failed (%s); allowing request", exc)
+        admitted = True
+    if not admitted:
+        raise HTTPException(
+            status_code=429,
+            detail="embedding service at capacity - retry shortly",
+            headers={"Retry-After": str(HOSTED_EMBED_CONCURRENCY_RETRY_AFTER_SECONDS)},
+        )
+
     client = get_jina_client()
     try:
         response = await asyncio.to_thread(
@@ -194,6 +248,13 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
             type(exc).__name__,
         )
         raise HTTPException(status_code=502, detail="embedding provider unavailable") from exc
+    finally:
+        try:
+            release_concurrency_slot(get_redis_client(), _HOSTED_EMBED_CONCURRENCY_KEY, slot_id)
+        except Exception as exc:  # noqa: BLE001
+            # Not fatal: the slot ages out via HOSTED_EMBED_CONCURRENCY_SLOT_TTL_SECONDS
+            # on its own if this can't reach Redis either.
+            logger.warning("failed to release hosted embed concurrency slot (%s)", exc)
 
     return {
         "model": EMBEDDING_MODEL,

--- a/github-app/app_server/rate_limit.py
+++ b/github-app/app_server/rate_limit.py
@@ -1,3 +1,5 @@
+import time
+
 # Managed audits are billed to us, not the customer (a shared DeepSeek key, see
 # scan_worker/managed_audit.py) - an uncapped endpoint lets anyone with a valid token
 # spam audits and drain that balance. Cooldown scales with repo size because that's
@@ -44,3 +46,44 @@ def is_rate_limited(redis_conn, key: str, limit: int, window_seconds: int) -> bo
     pipe.expire(key, window_seconds, nx=True)
     count, _ = pipe.execute()
     return count > limit
+
+
+# Sorted-set semaphore: each holder is a member scored by acquire time, so a
+# holder that dies mid-request (crash, OOM kill) doesn't leak its slot
+# forever the way a plain INCR/DECR counter would - ZREMRANGEBYSCORE below
+# ages it out ttl_seconds after acquiring regardless of whether anyone ever
+# calls release_concurrency_slot for it. Runs as a single Lua script so the
+# evict-count-admit sequence is atomic in Redis (single-threaded execution),
+# not a check-then-act race across concurrent app-server processes doing
+# their own read-then-write.
+_ACQUIRE_SLOT_SCRIPT = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local ttl = tonumber(ARGV[2])
+local capacity = tonumber(ARGV[3])
+local slot_id = ARGV[4]
+redis.call('ZREMRANGEBYSCORE', key, 0, now - ttl)
+if redis.call('ZCARD', key) >= capacity then
+    return 0
+end
+redis.call('ZADD', key, now, slot_id)
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+
+def acquire_concurrency_slot(
+    redis_conn, key: str, capacity: int, slot_id: str, ttl_seconds: int
+) -> bool:
+    """Admit one more concurrent holder under `key`, up to `capacity`.
+
+    ttl_seconds must exceed the real worst-case duration of the work a slot
+    guards - the caller is trusted to release its own slot promptly on the
+    success path via release_concurrency_slot; this TTL only bounds how long
+    a *crashed* holder's slot stays leaked.
+    """
+    return bool(redis_conn.eval(_ACQUIRE_SLOT_SCRIPT, 1, key, time.time(), ttl_seconds, capacity, slot_id))
+
+
+def release_concurrency_slot(redis_conn, key: str, slot_id: str) -> None:
+    redis_conn.zrem(key, slot_id)

--- a/github-app/tests/test_embeddings_api.py
+++ b/github-app/tests/test_embeddings_api.py
@@ -230,6 +230,70 @@ async def test_rate_limit_key_falls_back_to_installation_only_without_repo_id(po
 
 
 @pytest.mark.asyncio
+async def test_hosted_embed_concurrency_cap_returns_429_with_a_short_retry_after(pool):
+    """Distinct from the hourly rate limit's 429: jina-embed frees a slot in
+    low tens of seconds for a typical batch, not an hour, and the CLI's
+    retry loop (embed_texts_hosted) needs a short Retry-After to know it's
+    worth retrying rather than giving up."""
+    await _installation_with_token(pool, 9014, "air", "saturated-token")
+
+    with patch("app_server.embeddings_api.acquire_concurrency_slot", return_value=False):
+        response = await _post(pool, "saturated-token", ["x"])
+
+    assert response.status_code == 429
+    assert "capacity" in response.json()["detail"]
+    assert int(response.headers["retry-after"]) < 60
+
+
+@pytest.mark.asyncio
+async def test_hosted_embed_releases_its_concurrency_slot_after_a_successful_call(pool):
+    await _installation_with_token(pool, 9015, "air", "release-token")
+
+    with patch("app_server.embeddings_api.get_jina_client", return_value=_fake_jina()), \
+         patch("app_server.embeddings_api.acquire_concurrency_slot", return_value=True), \
+         patch("app_server.embeddings_api.release_concurrency_slot") as release:
+        response = await _post(pool, "release-token", ["x"])
+
+    assert response.status_code == 200
+    release.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_hosted_embed_releases_its_concurrency_slot_even_when_jina_fails(pool):
+    """The slot must not leak just because the upstream call failed - the
+    finally block is what makes this safe, not the happy path."""
+    await _installation_with_token(pool, 9016, "air", "release-on-fail-token")
+    failing = MagicMock()
+    failing.post.side_effect = RuntimeError("boom")
+
+    with patch("app_server.embeddings_api.get_jina_client", return_value=failing), \
+         patch("app_server.embeddings_api.acquire_concurrency_slot", return_value=True), \
+         patch("app_server.embeddings_api.release_concurrency_slot") as release:
+        response = await _post(pool, "release-on-fail-token", ["x"])
+
+    assert response.status_code == 502
+    release.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_hosted_embed_concurrency_check_fails_open_on_redis_error(pool):
+    """Matches the rate limiter's own fail-open policy: jina-embed's
+    per-instance locks are the hard backstop against real overload, this is
+    only the soft admission control - a Redis outage should cost that
+    smoothing, not availability."""
+    await _installation_with_token(pool, 9017, "air", "redis-down-token")
+
+    with patch("app_server.embeddings_api.get_jina_client", return_value=_fake_jina()), \
+         patch(
+             "app_server.embeddings_api.acquire_concurrency_slot",
+             side_effect=RuntimeError("redis unreachable"),
+         ):
+        response = await _post(pool, "redis-down-token", ["x"])
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_one_repo_being_rate_limited_does_not_block_another_repo_on_the_same_token(pool):
     """The actual point of per-repo keying: one repo's rebase-heavy burst
     hitting its own limit must not starve a second repo watched on the same

--- a/github-app/tests/test_rate_limit.py
+++ b/github-app/tests/test_rate_limit.py
@@ -1,4 +1,12 @@
-from app_server.rate_limit import cooldown_seconds_for_loc, is_rate_limited, total_loc_from_evidence
+import time
+
+from app_server.rate_limit import (
+    acquire_concurrency_slot,
+    cooldown_seconds_for_loc,
+    is_rate_limited,
+    release_concurrency_slot,
+    total_loc_from_evidence,
+)
 
 
 def test_cooldown_seconds_for_loc_small_repo_is_three_hours():
@@ -56,3 +64,41 @@ def test_is_rate_limited_keys_are_independent(redis_conn):
         is_rate_limited(redis_conn, "test:ratelimit:a", limit=3, window_seconds=60)
     # A different key starts its own fresh window.
     assert is_rate_limited(redis_conn, "test:ratelimit:b", limit=3, window_seconds=60) is False
+
+
+def test_acquire_concurrency_slot_admits_up_to_capacity(redis_conn):
+    key = "test:concurrency:cap"
+    assert acquire_concurrency_slot(redis_conn, key, capacity=2, slot_id="a", ttl_seconds=60) is True
+    assert acquire_concurrency_slot(redis_conn, key, capacity=2, slot_id="b", ttl_seconds=60) is True
+    assert acquire_concurrency_slot(redis_conn, key, capacity=2, slot_id="c", ttl_seconds=60) is False
+
+
+def test_release_concurrency_slot_frees_capacity_for_a_new_holder(redis_conn):
+    key = "test:concurrency:release"
+    acquire_concurrency_slot(redis_conn, key, capacity=1, slot_id="a", ttl_seconds=60)
+    assert acquire_concurrency_slot(redis_conn, key, capacity=1, slot_id="b", ttl_seconds=60) is False
+
+    release_concurrency_slot(redis_conn, key, "a")
+
+    assert acquire_concurrency_slot(redis_conn, key, capacity=1, slot_id="b", ttl_seconds=60) is True
+
+
+def test_acquire_concurrency_slot_evicts_a_crashed_holders_leaked_slot(redis_conn):
+    """A holder that dies without releasing (crash, OOM kill) must not
+    permanently occupy its slot - it should age out after ttl_seconds."""
+    key = "test:concurrency:leak"
+    stale_timestamp = time.time() - 120
+    redis_conn.zadd(key, {"crashed-holder": stale_timestamp})
+
+    admitted = acquire_concurrency_slot(redis_conn, key, capacity=1, slot_id="new-holder", ttl_seconds=60)
+
+    assert admitted is True
+    assert redis_conn.zscore(key, "crashed-holder") is None
+
+
+def test_acquire_concurrency_slot_keys_are_independent(redis_conn):
+    acquire_concurrency_slot(redis_conn, "test:concurrency:a", capacity=1, slot_id="x", ttl_seconds=60)
+    assert (
+        acquire_concurrency_slot(redis_conn, "test:concurrency:b", capacity=1, slot_id="y", ttl_seconds=60)
+        is True
+    )

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import re
 import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
 
@@ -614,6 +615,21 @@ def _repo_id(repo_path: Path) -> str:
     return hashlib.sha256(str(repo_path.resolve()).encode("utf-8")).hexdigest()[:16]
 
 
+# A 429 from /v1/embeddings means one of two different things: the hourly
+# per-installation quota (Retry-After in the thousands of seconds) or
+# app-server's concurrency cap on jina-embed momentarily saturated
+# (Retry-After a few seconds - see embeddings_api's
+# HOSTED_EMBED_CONCURRENCY_RETRY_AFTER_SECONDS). embed_texts_hosted can't
+# tell which from the status code alone, so it retries a bounded number of
+# times with a capped sleep either way: cheap in the quota case (a few short
+# waits before falling through to the existing terminal behavior), and turns
+# the common case - a momentary capacity blip under concurrent load - into a
+# short wait instead of silently dropping to local embeddings or losing an
+# in-progress index build (_embed_in_batches' fallback is all-or-nothing).
+_HOSTED_EMBED_429_RETRY_ATTEMPTS = 3
+_HOSTED_EMBED_429_MAX_SLEEP_SECONDS = 10.0
+
+
 def embed_texts_hosted(
     texts: list[str],
     token: str,
@@ -633,16 +649,27 @@ def embed_texts_hosted(
     body: dict = {"texts": texts}
     if repo_id:
         body["repo_id"] = repo_id
-    try:
-        response = client.post(
-            HOSTED_EMBEDDING_PATH,
-            json=body,
-            headers={"Authorization": f"Bearer {token}"},
-        )
-    except httpx.HTTPError as exc:
-        raise HostedEmbeddingUnavailableError(
-            f"could not reach Aletheore's embedding service ({type(exc).__name__})"
-        ) from exc
+
+    for attempt in range(_HOSTED_EMBED_429_RETRY_ATTEMPTS + 1):
+        try:
+            response = client.post(
+                HOSTED_EMBEDDING_PATH,
+                json=body,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        except httpx.HTTPError as exc:
+            raise HostedEmbeddingUnavailableError(
+                f"could not reach Aletheore's embedding service ({type(exc).__name__})"
+            ) from exc
+
+        if response.status_code == 429 and attempt < _HOSTED_EMBED_429_RETRY_ATTEMPTS:
+            retry_after = min(
+                float(response.headers.get("Retry-After", _HOSTED_EMBED_429_MAX_SLEEP_SECONDS)),
+                _HOSTED_EMBED_429_MAX_SLEEP_SECONDS,
+            )
+            time.sleep(retry_after)
+            continue
+        break
 
     if response.status_code == 402:
         raise HostedEmbeddingUnavailableError(_detail_of(response))

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -1261,6 +1261,7 @@ def _hosted_response(status: int, payload: dict | None = None):
     response.json.return_value = payload or {}
     response.reason_phrase = "Error"
     response.text = str(payload)
+    response.headers = {}
     return response
 
 
@@ -1301,6 +1302,55 @@ def test_embed_texts_hosted_omits_repo_id_when_not_given():
     embed_texts_hosted(["chunk"], "tok", http_client=http)
 
     assert "repo_id" not in http.post.call_args.kwargs["json"]
+
+
+def test_embed_texts_hosted_retries_after_a_429_and_succeeds():
+    """A 429 here can be app-server's concurrency cap on jina-embed
+    momentarily saturated, not a hard failure - retrying should recover
+    silently rather than falling back to local embeddings or raising."""
+    http = MagicMock()
+    http.post.side_effect = [
+        _hosted_response(429, {"detail": "embedding service at capacity - retry shortly"}),
+        _hosted_response(200, {"vectors": [[0.1] * 1536]}),
+    ]
+
+    with patch("aletheore.search_index.time.sleep") as sleep:
+        vectors = embed_texts_hosted(["chunk"], "tok", http_client=http)
+
+    assert vectors == [[0.1] * 1536]
+    assert http.post.call_count == 2
+    sleep.assert_called_once()
+
+
+def test_embed_texts_hosted_gives_up_after_repeated_429s():
+    http = MagicMock()
+    http.post.return_value = _hosted_response(
+        429, {"detail": "embedding service at capacity - retry shortly"}
+    )
+
+    with patch("aletheore.search_index.time.sleep"):
+        with pytest.raises(HostedEmbeddingUnavailableError):
+            embed_texts_hosted(["chunk"], "tok", http_client=http)
+
+    # The initial attempt plus every retry, no more.
+    assert http.post.call_count == 1 + 3
+
+
+def test_embed_texts_hosted_caps_the_retry_sleep_below_a_large_retry_after():
+    """The hourly per-installation rate limit also returns 429 with a
+    Retry-After in the thousands of seconds - retrying must not actually
+    sleep anywhere near that long before giving up and falling through to
+    the existing terminal behavior."""
+    http = MagicMock()
+    response = _hosted_response(429, {"detail": "too many embedding requests"})
+    response.headers = {"Retry-After": "3600"}
+    http.post.return_value = response
+
+    with patch("aletheore.search_index.time.sleep") as sleep:
+        with pytest.raises(HostedEmbeddingUnavailableError):
+            embed_texts_hosted(["chunk"], "tok", http_client=http)
+
+    assert all(call.args[0] <= 10.0 for call in sleep.call_args_list)
 
 
 def test_embed_in_batches_forwards_repo_id_to_every_hosted_batch():


### PR DESCRIPTION
## Summary
- Closes the "hosted scan queue" gap: the existing rate limiter throttles *requests per hour*, not *concurrent* requests - with `JINA_EMBED_INSTANCES=2` (each single-threaded), a third simultaneous request just queues behind a lock inside whatever's left of the 120s timeout (#271). `scan-worker` jobs already have real admission control via RQ's 2-replica pool; `aletheore index`/`watch` calls (direct, synchronous, unbounded) did not.
- New Redis sorted-set semaphore (`acquire_concurrency_slot`/`release_concurrency_slot` in `rate_limit.py`) admits at most `MAX_CONCURRENT_HOSTED_EMBED_REQUESTS` (default 2) into `/v1/embeddings` at once, 429s the rest with a short `Retry-After` (3s). Self-healing: a crashed holder's slot ages out on its own via TTL, never leaks permanently.
- CLI's `embed_texts_hosted` now retries on 429 (bounded, capped sleep) before falling back/failing - shipping the server-side cap without this would make concurrent load *worse* for users (today, any non-200 either silently drops to local embeddings or hard-fails an in-progress index build).

## Test plan
- [x] `ruff check` clean on all touched files
- [x] Verified for real, not just CI: spun up throwaway local Postgres+Redis containers, ran both test files end-to-end - `test_rate_limit.py` 13/13, `test_embeddings_api.py` 19/19, `test_search_index.py` 99/99
- [x] New tests cover: admits up to capacity, refuses beyond it, releases on success and on jina failure (finally block), evicts a simulated crashed holder's leaked slot, fails open on a simulated Redis error, CLI retries on 429 and succeeds, CLI gives up after bounded retries, CLI caps its sleep even against a large Retry-After (the hourly-quota 429 case)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj