### PR TITLE
fix: lower HOSTED_EMBED_MAX_CHARS to 120,000 on the real worst-case ratio

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -856,7 +856,29 @@ EMBED_BATCH_SIZE = 200
 # rounded down to 50,000 for headroom - comfortably inside both tested
 # points, not a new extreme. 50,000 / 3.89 =~ 200,600 chars, rounded down
 # to 180,000.
-HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "180000"))
+#
+# Lowered to 120,000 - 180,000 was still using 3.89 (thrift's *corpus-wide
+# average*) as the worst-case ratio, but individual batches vary around
+# that average, and _hosted_batches' real output was never checked against
+# a real tokenizer before this. Simulated the actual batches this function
+# produces across 13 benchmark corpora with jina-embeddings-v2-base-code's
+# real tokenizer (jinaai/jina-embeddings-v2-base-code, WordPiece, 61,056
+# vocab - loaded via HF `tokenizers` against tokenizer.json, not llama.cpp,
+# to check the *char cap's* assumption independent of the serving stack):
+# three corpora (zod, thrift, jq) already produce real batches over the
+# 50,000-token target this cap exists to protect, up to 59,895 tokens
+# (~89.5s at the measured ~669 tok/s, still under the 120s timeout but
+# eating into intended margin). The worst single real batch found - jq,
+# ordinary pointer-heavy C source, nothing anomalous - was 125,514 chars /
+# 48,944 tokens, a 2.564 chars/token ratio, denser than 3.89 assumed.
+# 50,000 tokens * 2.564 =~ 128,200 chars; rounded down to 120,000 for
+# headroom, the same margin discipline as every cap change above. A stopgap
+# on the existing char-cap design, not the fix: true token-based batching
+# (see the "not folded into this recalibration" comment above) removes
+# this whole failure mode by bounding batches on real per-chunk token
+# counts instead of a char proxy with an assumed ratio, however carefully
+# that ratio is chosen.
+HOSTED_EMBED_MAX_CHARS = int(os.environ.get("ALETHEORE_HOSTED_EMBED_MAX_CHARS", "120000"))
 
 
 def _hosted_batches(texts: list[str], batch_size: int) -> list[tuple[int, int]]:


### PR DESCRIPTION
## Summary
- Stopgap discovered while scoping true token-based batching: the live 180,000-char cap (#272) used 3.89 chars/token (thrift's *corpus-wide average*) as the worst-case ratio, but individual real batches vary around that average and were never checked against a real tokenizer.
- Simulated `_hosted_batches`' actual output across 13 benchmark corpora with jina-embeddings-v2-base-code's real tokenizer (HF `tokenizers` + the model's own `tokenizer.json`, WordPiece, 61,056 vocab): 3 corpora (zod, thrift, jq) already produce real batches over the 50,000-token target, up to 59,895 tokens (~89.5s, still under the 120s timeout but with less margin than intended - no observed production failure).
- Worst single real batch found: jq, ordinary C source, 2.564 chars/token. 50,000 × 2.564 ≈ 128,200 chars, rounded down to 120,000. Re-verified: every real batch across all 13 corpora now stays under the 50,000-token target.

## Test plan
- [x] `pytest src/tests/test_search_index.py -q` — 99 passed
- [x] Re-ran the same 13-corpus real-batch simulation against the new 120,000 cap: all under the 50,000-token target (worst: jq at 46,289)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj