### PR TITLE
legal: relicense from Apache 2.0 to PolyForm Noncommercial 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Notable changes to Aletheore, by release. The working code lives in `src/` — see
 [`src/README.md`](src/README.md) for the full command reference.
 
+## 0.8.13 — 2026-08-17
+
+- **License changed from Apache 2.0 to the [PolyForm Noncommercial License
+  1.0.0](LICENSE).** Aletheore remains free for personal, noncommercial use -
+  individual developers, research, hobby projects, evaluation. Using it for or
+  within a company or other organization (including as internal tooling at a
+  company you work for) is a commercial use and requires a separate commercial
+  license. This is not retroactive: anyone who obtained a copy under the prior
+  Apache 2.0 license (every release through 0.8.12, and any clone or fork made
+  before this change) keeps their Apache 2.0 rights for that copy. Only new
+  releases and new distributions from this point forward are under the new
+  terms. See the [Licensing](README.md#licensing) section of the README.
+
 ## 0.8.12 — 2026-08-15
 
 - **C# repositories had almost no dependency graph, because C# does not need

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,133 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
+# PolyForm Noncommercial License 1.0.0
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-1. Definitions.
+Required Notice: Copyright Arihant Kaul (https://aletheore.com)
 
-"License" shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
+## Acceptance
 
-"Licensor" shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
-"Legal Entity" shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
+## Copyright License
 
-"You" (or "Your") shall mean an individual or Legal Entity
-exercising permissions granted by this License.
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
 
-"Source" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
+## Distribution License
 
-"Object" form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
 
-"Work" shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
+## Notices
 
-"Derivative Works" shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
 
-"Contribution" shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as "Not a Contribution."
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
 
-"Contributor" shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
+## Changes and New Works License
 
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
 
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
+## Patent License
 
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
 
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
+## Noncommercial Purposes
 
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
+Any noncommercial purpose is a permitted purpose.
 
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
+## Personal Uses
 
-(d) If the Work includes a "NOTICE" text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
 
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
+## Noncommercial Organizations
 
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
 
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
+## Fair Use
 
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
 
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
+## No Other Rights
 
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
 
-END OF TERMS AND CONDITIONS
+## Patent Defense
 
-APPENDIX: How to apply the Apache License to your work.
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
 
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "[]"
-replaced with your own identifying information. Do not include
-the brackets. The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same "printed page" as the copyright notice for easier
-identification within third-party archives.
+## Violations
 
-Copyright 2026 Veridion contributors
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+## No Liability
 
-http://www.apache.org/licenses/LICENSE-2.0
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
   <a href="https://pypi.org/project/aletheore/"><img src="https://img.shields.io/pypi/v/aletheore?color=blue" alt="PyPI version"></a>
   <a href="https://pypi.org/project/aletheore/"><img src="https://img.shields.io/pypi/pyversions/aletheore" alt="Python versions"></a>
-  <a href="https://github.com/Aletheore/Aletheore/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License"></a>
+  <a href="https://github.com/Aletheore/Aletheore/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm--Noncommercial--1.0.0-blue" alt="License"></a>
   <a href="https://github.com/Aletheore/Aletheore/actions/workflows/tests.yml"><img src="https://github.com/Aletheore/Aletheore/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
 </p>
 
@@ -92,6 +92,16 @@ configuration options: **[`src/README.md`](src/README.md)**.
   deployment verification, branch protection, support process.
 - `SECURITY.md` — vulnerability reporting and response targets.
 
-Aletheore is free and open source. If it's useful to you, consider
+## Licensing
+
+Aletheore is licensed under the
+[PolyForm Noncommercial License 1.0.0](LICENSE), not an OSI-approved open-source license.
+It's free for individuals: personal use, research, hobby projects, and evaluation. Any use
+for or within a company or other organization — including internal tooling at a company you
+work for — is a commercial use and requires a separate commercial license. Reach out at
+[arihantkaul@outlook.com](mailto:arihantkaul@outlook.com) for commercial licensing, or see
+[Aletheore AIR](https://aletheore.com) for the hosted, paid tier.
+
+If it's useful to you personally, consider
 [sponsoring development](https://github.com/sponsors/ArihantK15) — no accounts, no tracking,
 nothing leaves your machine when you run it.

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -3,7 +3,7 @@ name = "aletheore"
 version = "0.8.13"
 description = "Evidence-grounded repository audit CLI: deterministic scanner, MCP server, live dashboard, and a GitHub Action that posts PR diffs."
 readme = "README.md"
-license = "Apache-2.0"
+license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
 license-files = ["LICENSE"]
 authors = [{ name = "Arihant Kaul", email = "arihantkaul@outlook.com" }]
 requires-python = ">=3.11"

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -99,14 +99,65 @@ def test_detect_repo_license_from_package_json(tmp_path):
     assert "package.json" in result["detected_from"]
 
 
+# The real, verbatim opening of the Apache License 2.0 (as published at
+# apache.org/licenses/LICENSE-2.0.txt) - not a hand-typed guess at what an
+# Apache license file looks like. This used to be read live from this
+# repo's own LICENSE file, but that file is PolyForm Noncommercial as of
+# this project's own license change; embedding the real text here keeps the
+# test's original intent (verify against genuine license text) without
+# coupling a dependency-license-detection test to this repo's own license.
+_REAL_APACHE_2_0_TEXT = """\
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by nam"""
+
+
 def test_detect_repo_license_from_real_apache_license_file_text(tmp_path):
-    # The exact real LICENSE file already committed at this repo's own root -
-    # verifying against the actual file content, not a hand-typed guess at what
-    # an Apache license file looks like.
-    real_license = Path(__file__).resolve().parents[2] / "LICENSE"
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "LICENSE").write_text(real_license.read_text(encoding="utf-8")[:2000])
+    (repo / "LICENSE").write_text(_REAL_APACHE_2_0_TEXT)
 
     result = detect_repo_license(repo)
 

--- a/website/developers.html
+++ b/website/developers.html
@@ -251,7 +251,7 @@ aletheore dashboard .</code></pre>
           <img src="assets/logo-mark.png" alt="" width="24" height="24">
           Aletheore
         </a>
-        <p class="footer-note">Evidence-grounded repository audits. Open source, local-first.</p>
+        <p class="footer-note">Evidence-grounded repository audits. Free for individuals, local-first.</p>
       </div>
       <div>
         <h4>Product</h4>

--- a/website/dogfooding.html
+++ b/website/dogfooding.html
@@ -202,7 +202,7 @@ aletheore scan flask</code></pre>
           <img src="assets/logo-mark.png" alt="" width="24" height="24">
           Aletheore
         </a>
-        <p class="footer-note">Evidence-grounded repository audits. Open source, local-first.</p>
+        <p class="footer-note">Evidence-grounded repository audits. Free for individuals, local-first.</p>
       </div>
       <div>
         <h4>Product</h4>

--- a/website/index.html
+++ b/website/index.html
@@ -503,7 +503,7 @@
           <img src="assets/logo-mark.png" alt="" width="24" height="24">
           Aletheore
         </a>
-        <p class="footer-note">Evidence-grounded repository audits. Open source, local-first.</p>
+        <p class="footer-note">Evidence-grounded repository audits. Free for individuals, local-first.</p>
       </div>
       <div>
         <h4>Product</h4>

--- a/website/security.html
+++ b/website/security.html
@@ -100,7 +100,7 @@
           <img src="assets/logo-mark.png" alt="" width="24" height="24">
           Aletheore
         </a>
-        <p class="footer-note">Evidence-grounded repository audits. Open source, local-first.</p>
+        <p class="footer-note">Evidence-grounded repository audits. Free for individuals, local-first.</p>
       </div>
       <div>
         <h4>Product</h4>

--- a/website/status.html
+++ b/website/status.html
@@ -95,7 +95,7 @@
           <img src="assets/logo-mark.png" alt="" width="24" height="24">
           Aletheore
         </a>
-        <p class="footer-note">Evidence-grounded repository audits. Open source, local-first.</p>
+        <p class="footer-note">Evidence-grounded repository audits. Free for individuals, local-first.</p>
       </div>
       <div>
         <h4>Product</h4>

--- a/website/terms.html
+++ b/website/terms.html
@@ -29,7 +29,7 @@
       <p>Last updated: July 2026</p>
 
       <h2>What Aletheore is</h2>
-      <p>Aletheore is a repository audit tool: a free, open-source, local-first CLI and a paid GitHub App tier for managed audits, Slack/Teams alerts, branch-protection Check Runs, and endpoint health monitoring. The free tier is available under the terms of its open-source license in the project repository.</p>
+      <p>Aletheore is a repository audit tool: a local-first CLI, free for personal, noncommercial use under the <a href="https://github.com/Aletheore/Aletheore/blob/master/LICENSE">PolyForm Noncommercial License 1.0.0</a>, and a paid GitHub App tier for managed audits, Slack/Teams alerts, branch-protection Check Runs, and endpoint health monitoring. Using the CLI for or within a company or other organization is a commercial use and requires a separate commercial license, regardless of whether you also subscribe to the paid GitHub App tier.</p>
 
       <h2>The paid subscription</h2>
       <p>The paid plan is Aletheore AIR ($29.99/month or $299.90/year, up to 5 team members), with additional members beyond the plan's included seats billed at $4.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>


### PR DESCRIPTION
## Summary
Aletheore remains free for personal, noncommercial use. Using it for or within a company or other organization is now a commercial use requiring a separate commercial license.

**Not retroactive** - every release through 0.8.12, and any existing clone/fork, keeps its Apache 2.0 rights for that copy. Only new releases and distributions going forward are under the new terms.

- `LICENSE`: verbatim PolyForm Noncommercial License 1.0.0 (fetched from polyformproject.org), with a Required Notice naming the copyright holder.
- `src/pyproject.toml`: license field updated (PEP 639 `LicenseRef-` form - PolyForm has no SPDX identifier).
- `README.md`: fixed the badge, added a real Licensing section.
- `website/terms.html` + 5 page footers: fixed "free, open-source" claims that would otherwise now be false.
- `src/tests/test_licenses.py`: decoupled a dependency-license-detection test from reading this repo's own (now-changed) LICENSE file live.
- `CHANGELOG.md`: 0.8.13 entry.

## Test plan
- [x] Full `src` test suite: 1289 passed
- [ ] CI green
- [ ] Not merged - holding for review (a website deploy will follow once merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj