### PR TITLE
fix: git-intel crashed on a commit with a malformed timezone offset

### DIFF
--- a/src/aletheore/git_intel/analyzer.py
+++ b/src/aletheore/git_intel/analyzer.py
@@ -7,6 +7,7 @@ from aletheore.git_intel.incremental import (
     CO_CHANGE_PARTNERS_RETURNED,
     GitLogStreamError,
     compute_repo_key,
+    parse_commit_date,
     stream_commit_touches,
 )
 from aletheore.git_intel.sqlite_store import SQLiteRepoGraphStore, default_graph_db_path
@@ -120,7 +121,7 @@ def _parse_branches(repo_path: Path, now: datetime) -> list[dict]:
         branch_type = "remote" if name.startswith("origin/") or (
             "/" in name and name.split("/")[0] in remotes
         ) else "local"
-        last_commit_at = datetime.fromisoformat(date_str)
+        last_commit_at = parse_commit_date(date_str)
         stale_days = (now - last_commit_at).days
 
         ahead, behind = 0, 0
@@ -322,7 +323,7 @@ def _first_commit_at(repo_path: Path) -> datetime:
     dates = []
     for sha in root_shas:
         date_result = _run_git_or_raise(repo_path, "log", "-1", "--format=%ad", "--date=iso-strict", sha)
-        dates.append(datetime.fromisoformat(date_result.stdout.strip()))
+        dates.append(parse_commit_date(date_result.stdout.strip()))
     return min(dates)
 
 

--- a/src/aletheore/git_intel/incremental.py
+++ b/src/aletheore/git_intel/incremental.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import subprocess
 from collections.abc import Iterator
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from aletheore.git_intel.graph_store import (
@@ -80,6 +80,36 @@ def _scan_root_prefix(repo_path: Path) -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
+# A fallback for a commit whose author/committer date is real garbage, not
+# just an unrecognized-but-valid timezone - confirmed on a real repo
+# (requests, upstream): git's own `--date=iso-strict` faithfully reproduces
+# whatever timezone offset was recorded at commit time, and at least one
+# real historical commit has an offset outside any valid UTC range
+# ('+518:00' - no such timezone exists; this is a corrupted local clock at
+# authorship time, not a git or Aletheore bug). Ownership/hotspot analysis
+# needs *some* real datetime for every commit, never a crash, and treating
+# a bad date as "very old" rather than dropping the commit keeps it counted
+# for ownership/authorship purposes without letting it skew recency-based
+# ranking as if it just happened.
+_EPOCH_UTC = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def parse_commit_date(date_str: str) -> datetime:
+    try:
+        return datetime.fromisoformat(date_str)
+    except ValueError:
+        pass
+    # The date/time portion of `--date=iso-strict` output is always exactly
+    # 19 characters (YYYY-MM-DDTHH:MM:SS) before the timezone offset - only
+    # the offset itself is ever malformed in the real case this guards
+    # against, so re-parsing just that prefix as UTC recovers the real
+    # commit date whenever it's the offset, specifically, that's bad.
+    try:
+        return datetime.fromisoformat(date_str[:19]).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return _EPOCH_UTC
+
+
 def stream_commit_touches(
     repo_path: Path, rev_range: str, *, max_commits: int | None = None
 ) -> Iterator[CommitTouch]:
@@ -118,7 +148,7 @@ def stream_commit_touches(
                 # something a real commit message would contain) lands
                 # whole in the subject rather than breaking the unpack.
                 sha, name, email, date_str, pending_subject = line[1:].split(_FIELD_SEP, 4)
-                pending_header = (sha, name, email, datetime.fromisoformat(date_str))
+                pending_header = (sha, name, email, parse_commit_date(date_str))
                 pending_files = []
             elif line.strip():
                 path = line.strip()

--- a/src/tests/test_incremental.py
+++ b/src/tests/test_incremental.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -12,6 +12,7 @@ from aletheore.git_intel.incremental import (
     GitLogStreamError,
     compute_repo_key,
     fold,
+    parse_commit_date,
     stream_commit_touches,
 )
 
@@ -44,6 +45,35 @@ def init_repo(tmp_path: Path) -> Path:
 
 def _touch(sha, name, email, date_str, files):
     return CommitTouch(sha, name, email, datetime.fromisoformat(date_str), files)
+
+
+# --- parse_commit_date: real git history has commits with genuinely
+# malformed author/committer dates, not just unusual-but-valid ones ---
+
+
+def test_parse_commit_date_parses_a_normal_iso_strict_date():
+    assert parse_commit_date("2026-06-01T00:00:00+00:00") == datetime.fromisoformat(
+        "2026-06-01T00:00:00+00:00"
+    )
+
+
+def test_parse_commit_date_recovers_the_real_date_from_a_corrupted_offset():
+    # Real, observed data: a historical commit in psf/requests' upstream
+    # history has this exact author date. '+518:00' is not a valid UTC
+    # offset (max is +/-14:00) - datetime.fromisoformat rejects it outright,
+    # which crashed the whole git-history analysis for this repo before this
+    # fix. The date/time itself (everything before the offset) is genuine
+    # and worth keeping, so this recovers it as UTC rather than discarding
+    # the commit or crashing.
+    result = parse_commit_date("2011-09-08T02:38:50+518:00")
+    assert result == datetime(2011, 9, 8, 2, 38, 50, tzinfo=timezone.utc)
+
+
+def test_parse_commit_date_falls_back_to_epoch_for_a_totally_unparseable_string():
+    # Not just a bad offset - the date/time portion itself is garbage, so
+    # even the first-19-characters fallback can't recover a real date.
+    result = parse_commit_date("not-a-date-at-all")
+    assert result == datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 # --- stream_commit_touches: reads real git output, never buffers it whole ---


### PR DESCRIPTION
## Summary
`datetime.fromisoformat()` rejected a real historical commit's author date from `git --date=iso-strict` output (`'2011-09-08T02:38:50+518:00'` - `+518:00` isn't a valid UTC offset). This crashed `analyze_git()` unconditionally for any repo containing such a commit, taking down the whole scan - not gated by `scan_git_history`. Discovered via `benchmarks/pr-review-benchmark`'s own corpus evaluator (3 of 25 real-world cases, all against `psf/requests`, errored on this before the fix).

`parse_commit_date()` recovers the real date whenever it's specifically the offset that's malformed (the common real-world shape) by re-parsing just the date/time prefix as UTC, and falls back to the Unix epoch only if the string is unparseable even then. Applied at all three git-log date-parse sites in this module (all exposed to the same class of data).

## Test plan
- [x] New tests verify against the exact real string that crashed, not a synthetic guess, plus a normal-date and a fully-unparseable-string case
- [x] `test_incremental.py` + `test_git_intel.py`: 47 passed
- [x] Full corpus evaluator rerun: all 25 cases run cleanly now (was 22/25, 3 errored), same 5/21 recall / 0/4 false-positive result - 3 more cases measurable, not a detection change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj