### PR TITLE
feat: deterministic blast-radius context for Flash review

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -235,6 +235,94 @@ def build_dependency_impact_context(evidence: dict | None, changed_files: list[s
     return "--- deterministic dependency impact context (raw graph facts, not conclusions) ---\n" + "\n".join(lines)
 
 
+MAX_BLAST_RADIUS_SYMBOLS = 5
+MAX_BLAST_RADIUS_CANDIDATES = 20
+MAX_BLAST_RADIUS_CALLERS_SHOWN = 5
+
+def build_blast_radius_context(
+    evidence: dict | None,
+    changed_files: list[str],
+    diff_text: str,
+    fetch_file_content: Callable[[str], str | None],
+) -> str:
+    """For each symbol this diff actually touches, who else in the repo
+    calls it - confirmed by both a real import relationship (evidence's
+    own imported_by) AND the symbol name actually appearing in a
+    call-shaped position in that file's real content, not just "imports
+    the file at all" (which says nothing about which of possibly many
+    exported names is actually used).
+
+    This is deliberately the high-confidence case only: "imported_by AND
+    real call-shape match in real content" - not a bare repo-wide text
+    search for the symbol name, which would be a real false-positive risk
+    (name collisions between unrelated symbols in different modules are
+    common, especially for short/generic names). A lower-confidence,
+    name-only tier is explicitly out of scope for this pass.
+    """
+    if not evidence:
+        return ""
+    modules = evidence.get("repository", {}).get("modules", [])
+    by_path = {m["path"]: m for m in modules if m.get("path")}
+    valid_lines = _diff_valid_lines(diff_text)
+
+    lines: list[str] = []
+    symbols_analyzed = 0
+
+    for file_path in changed_files:
+        if symbols_analyzed >= MAX_BLAST_RADIUS_SYMBOLS:
+            break
+        module = by_path.get(file_path)
+        if module is None:
+            continue
+        touched = valid_lines.get(file_path, set())
+        if not touched:
+            continue
+        symbols = module.get("symbols", {})
+        for entry in symbols.get("functions", []) + symbols.get("classes", []):
+            if symbols_analyzed >= MAX_BLAST_RADIUS_SYMBOLS:
+                break
+            name = entry.get("name")
+            start, end = entry.get("start_line"), entry.get("end_line")
+            if not name or start is None or end is None:
+                continue
+            if not any(start <= line <= end for line in touched):
+                continue  # this symbol's range wasn't actually touched by the diff
+
+            symbols_analyzed += 1
+            candidates = (module.get("imported_by") or [])[:MAX_BLAST_RADIUS_CANDIDATES]
+            # No caching needed: at most MAX_BLAST_RADIUS_SYMBOLS (5) distinct
+            # patterns are ever compiled in one call, and a module-level cache
+            # here would grow unbounded over a long-running scan-worker
+            # process's whole lifetime (one entry per distinct symbol name
+            # ever analyzed across every PR it ever reviews).
+            call_re = re.compile(rf"\b{re.escape(name)}\s*\(")
+            callers: list[str] = []
+            for candidate_path in candidates:
+                if len(callers) >= MAX_BLAST_RADIUS_CALLERS_SHOWN:
+                    break
+                content = fetch_file_content(candidate_path)
+                if content is None:
+                    continue
+                if call_re.search(content):
+                    callers.append(candidate_path)
+
+            if callers:
+                total = len(module.get("imported_by") or [])
+                shown = f"{', '.join(callers)}" + (
+                    f" (+{total - len(callers)} more importers not shown)"
+                    if total > len(callers)
+                    else ""
+                )
+                lines.append(f"{file_path}:{name} is called from: {shown}")
+
+    if not lines:
+        return ""
+    return (
+        "--- deterministic blast-radius context (confirmed import + real call-shape match, "
+        "not conclusions) ---\n" + "\n".join(lines)
+    )
+
+
 MAX_REFERENCED_SYMBOLS = 8
 MAX_REFERENCED_SYMBOL_BYTES = 20_000
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -107,6 +107,7 @@ from scan_worker.db import (
 from scan_worker.docs_repo_commit import sync_docs_to_repo
 from scan_worker.flash_review import (
     FLASH_REVIEW_FALLBACK_MODEL,
+    build_blast_radius_context,
     build_change_impact_context,
     build_code_evidence_context,
     build_dependency_impact_context,
@@ -1492,6 +1493,14 @@ def _run_flash_review(
         if change_impact_context:
             code_evidence_context = "\n\n".join(
                 part for part in (code_evidence_context, change_impact_context) if part
+            )
+
+        blast_radius_context = build_blast_radius_context(
+            evidence, changed_files, diff_text, lambda p: fetch_file_content(client, token, repo_full_name, p, head_sha)
+        )
+        if blast_radius_context:
+            code_evidence_context = "\n\n".join(
+                part for part in (code_evidence_context, blast_radius_context) if part
             )
 
         def _fetch_symbol_source(file_path: str, start_line: int, end_line: int) -> str | None:

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -1656,3 +1656,172 @@ def test_semantic_checker_does_not_flag_ordinary_english_using_sql_keywords():
     findings = find_semantic_regressions(diff, {"notify.py": source}, "")
 
     assert findings == []
+
+
+# ── blast-radius context tests ──────────────────────────────────────────
+
+
+def test_build_blast_radius_context_finds_real_confirmed_caller():
+    """A changed symbol whose imported_by includes a file, and the fake fetcher
+    returns content containing the call shape for that file."""
+    from scan_worker.flash_review import build_blast_radius_context
+
+    evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "a.py",
+                    "imported_by": ["caller.py"],
+                    "symbols": {
+                        "functions": [
+                            {"name": "handler", "start_line": 1, "end_line": 10}
+                        ],
+                        "classes": [],
+                    },
+                }
+            ]
+        }
+    }
+
+    diff_text = "--- a.py ---\n@@ -1,10 +1,10 @@\n def handler():\n     pass\n"
+
+    def fake_fetch_file_content(candidate_path: str) -> str | None:
+        if candidate_path == "caller.py":
+            return "def call_handler():\n    handler()\n"
+        return None
+
+    context = build_blast_radius_context(evidence, ["a.py"], diff_text, fake_fetch_file_content)
+    assert "is called from:" in context
+    assert "caller.py" in context
+
+
+def test_build_blast_radius_context_omits_symbol_with_no_confirmed_callers():
+    """A symbol with imported_by present, but the fake fetcher never returns
+    content containing the call shape -> context omitted entirely ("")."""
+    from scan_worker.flash_review import build_blast_radius_context
+
+    evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "a.py",
+                    "imported_by": ["other.py"],
+                    "symbols": {
+                        "functions": [
+                            {"name": "unused_func", "start_line": 1, "end_line": 5}
+                        ],
+                        "classes": [],
+                    },
+                }
+            ]
+        }
+    }
+
+    diff_text = "--- a.py ---\n@@ -1,5 +1,5 @@\n def unused_func():\n     pass\n"
+
+    def fake_fetch_file_content(candidate_path: str) -> str | None:
+        return None
+
+    context = build_blast_radius_context(evidence, ["a.py"], diff_text, fake_fetch_file_content)
+    assert context == ""
+
+
+def test_build_blast_radius_context_does_not_flag_untouched_symbol():
+    """A file has two functions, the diff only touches one -> only the touched one appears."""
+    from scan_worker.flash_review import build_blast_radius_context
+
+    evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "a.py",
+                    "imported_by": ["some_import.py"],
+                    "symbols": {
+                        "functions": [
+                            {"name": "touch_func", "start_line": 1, "end_line": 5},
+                            {"name": "untouched_func", "start_line": 20, "end_line": 30},
+                        ],
+                        "classes": [],
+                    },
+                }
+            ]
+        }
+    }
+
+    diff_text = "--- a.py ---\n@@ -1,5 +1,5 @@\n def touch_func():\n     pass\n"
+
+    def fake_fetch_file_content(candidate_path: str) -> str | None:
+        return "def caller_usage():\n    touch_func()\n" if candidate_path == "some_import.py" else None
+
+    context = build_blast_radius_context(evidence, ["a.py"], diff_text, fake_fetch_file_content)
+    assert "touch_func" in context
+    assert "untouched_func" not in context
+
+
+def test_build_blast_radius_context_caps_candidates_checked():
+    """An imported_by list longer than MAX_BLAST_RADIUS_CANDIDATES ->
+    fetch_file_content should never be called for anything past the cap."""
+    from scan_worker.flash_review import build_blast_radius_context
+
+    imported_by_list = [f"caller_{i}.py" for i in range(30)]
+    evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "a.py",
+                    "imported_by": imported_by_list,
+                    "symbols": {
+                        "functions": [
+                            {"name": "handler", "start_line": 1, "end_line": 10}
+                        ],
+                        "classes": [],
+                    },
+                }
+            ]
+        }
+    }
+
+    diff_text = "--- a.py ---\n@@ -1,10 +1,10 @@\n def handler():\n     pass\n"
+
+    call_count = [0]
+
+    def fake_fetch_file_content(candidate_path: str) -> str | None:
+        call_count[0] += 1
+        if call_count[0] <= 20:
+            return f"def call_{call_count[0]}():\n    handler()\n"
+        return None
+
+    context = build_blast_radius_context(evidence, ["a.py"], diff_text, fake_fetch_file_content)
+    assert "is called from:" in context
+    assert call_count[0] <= 20
+
+
+def test_build_blast_radius_context_caller_using_different_symbol_not_flagged():
+    """A caller imports the file but uses a *different* symbol is not flagged.
+    This justifies requiring real content match, not just imported_by membership."""
+    from scan_worker.flash_review import build_blast_radius_context
+
+    evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "a.py",
+                    "imported_by": ["caller.py"],
+                    "symbols": {
+                        "functions": [
+                            {"name": "handler", "start_line": 1, "end_line": 10}
+                        ],
+                        "classes": [],
+                    },
+                }
+            ]
+        }
+    }
+
+    diff_text = "--- a.py ---\n@@ -1,10 +1,10 @@\n def handler():\n     pass\n"
+
+    def fake_fetch_file_content(candidate_path: str) -> str | None:
+        return "def caller_usage():\n    other_func()\n" if candidate_path == "caller.py" else None
+
+    context = build_blast_radius_context(evidence, ["a.py"], diff_text, fake_fetch_file_content)
+    assert "is called from:" not in context


### PR DESCRIPTION
## Summary
- For a symbol a diff actually touches (hunk-scoped, not whole-file), find real confirmed callers elsewhere in the repo: evidence's own `imported_by` plus the symbol name actually appearing in a call-shaped position in that file's real content — not just "imports the file at all," which says nothing about which of possibly many exported names is actually used.
- Fed into Flash review as deterministic context, capped at 5 symbols per diff / 20 candidate importers checked / 5 callers shown per symbol.
- Built from `docs/superpowers/specs/2026-08-17-flash-review-blast-radius-design.md`.

## Review notes
Implemented by a delegate agent, reviewed here like a senior would review a junior's PR — not taken at face value:
- Removed an unbounded module-level regex cache (`_CALL_SHAPE_RE_CACHE`) that would have grown one entry per distinct symbol name ever analyzed over scan-worker's whole long-running process lifetime. Compiling inline is cheap — at most 5 patterns per call (`MAX_BLAST_RADIUS_SYMBOLS`).
- Removed a leftover 178-line scratch script (`add_tests.py`) that wasn't mentioned in the "done" report.
- Ran the spec's mandatory real-data verification step (which had been skipped) against 3 real cloned swebench cases — confirmed sensible output, e.g. Django's `get_fieldsets` correctly resolves to real callers in `django/contrib/auth/admin.py` and `django/contrib/contenttypes/admin.py`.

## Test plan
- [x] `test_flash_review.py`: 113/113 passed, including 5 new tests for this feature
- [x] Full `github-app` suite: 1365 passed, 8 skipped, 0 failed
- [x] Real-data verification against 3 cloned swebench repos (not just unit tests)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj