### PR TITLE
fix: deleted comment line shaped like a file marker collided with the diff parser

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -657,19 +657,24 @@ def _diff_valid_lines(
     valid_lines: dict[str, set[int]] = {}
     current_file: str | None = None
     current_line: int | None = None
+    prev_blank = True  # start-of-text counts as a boundary
     for line in diff_text.splitlines():
         file_match = _FILE_MARKER_RE.match(line)
-        if file_match:
+        if file_match and prev_blank:
             current_file = file_match.group(1)
             valid_lines.setdefault(current_file, set())
             current_line = None
+            prev_blank = False
             continue
         hunk_match = _HUNK_HEADER_RE.match(line)
         if hunk_match:
             current_line = int(hunk_match.group(1))
+            prev_blank = False
             continue
         if line == "":
+            prev_blank = True
             continue
+        prev_blank = False
         if current_file is None or current_line is None:
             continue
         valid_lines[current_file].add(current_line)

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -81,6 +81,54 @@ def test_structured_patches_keep_genuine_two_file_diff_separate():
     assert _diff_valid_lines("", patches) == {"a.py": {4}, "b.py": {20}}
 
 
+def test_deleted_comment_line_shaped_like_file_marker_not_misread_as_boundary():
+    diff = "--- db/schema.sql ---\n@@ -10,6 +10,6 @@\n CREATE TABLE users (\n--- users table ---\n-  id INT,\n+  id BIGINT,\n   name TEXT\n );"
+
+    result = _diff_valid_lines(diff)
+
+    assert "users table" not in result
+    assert "db/schema.sql" in result
+    assert 12 in result["db/schema.sql"]
+
+
+def test_second_marker_shaped_line_with_no_blank_line_before_it_is_not_a_boundary():
+    # "---- x ---" (four leading dashes) never matches _FILE_MARKER_RE at all
+    # (the regex requires exactly three dashes then a space), so it can't
+    # exercise the boundary check regardless of whether the fix exists -
+    # verified empirically before writing this test. A second genuine
+    # "--- name ---"-shaped line immediately after a real marker, with no
+    # blank line between them, is the actual collision case that
+    # distinguishes old from new behavior: on the old code this second line
+    # gets misread as a new file marker (silently invents a "b.py" entry
+    # and abandons "a.py"); the fix must keep treating it as content of the
+    # still-current file since it isn't preceded by a boundary.
+    diff = "--- a.py ---\n--- b.py ---\n@@ -1,1 +1,1 @@\n+content"
+
+    result = _diff_valid_lines(diff)
+
+    assert set(result) == {"a.py"}
+    assert 1 in result["a.py"]
+
+
+def test_context_line_starting_with_space_and_marker_shape_not_misread():
+    diff = "--- app.py ---\n@@ -1,3 +1,3 @@\n context\n -- x ---\n+replaced\n context2"
+
+    result = _diff_valid_lines(diff)
+
+    assert set(result) == {"app.py"}
+    assert 3 in result["app.py"]
+
+
+def test_genuine_two_file_diff_with_blank_line_separators_still_works():
+    diff = "--- a.py ---\n@@ -1,1 +1,1 @@\n+in a\n\n--- b.py ---\n@@ -10,1 +10,1 @@\n+in b"
+
+    result = _diff_valid_lines(diff)
+
+    assert set(result) == {"a.py", "b.py"}
+    assert 1 in result["a.py"]
+    assert 10 in result["b.py"]
+
+
 def test_lookup_valid_lines_falls_back_to_unambiguous_path_suffix():
     valid_lines = {"benchmark-sandbox/case-1/pkg/module.py": {5, 6, 7}}
     assert _lookup_valid_lines("pkg/module.py", valid_lines) == {5, 6, 7}


### PR DESCRIPTION
## Summary
- `fetch_pr_diff` flattens GitHub's per-file diff into text using a `--- {filename} ---` marker; `_diff_valid_lines` recovers it with a regex matching that exact shape.
- A deleted line whose content is `-- x ---` (SQL/Lua/Haskell comments, or a `--- section ---` divider in any language) arrives in the flattened text as `--- x ---` after the diff's own `-` prefix — indistinguishable from a real marker.
- The real change following it got silently attributed to a phantom file and dropped from the diff's valid-line set — surfaced to the customer as "No issues found in this diff."
- Fixed by requiring a marker to sit at an actual file boundary (start of text, or immediately after a blank line — the only place `fetch_pr_diff` ever puts a real one).

## Verification
- Reproduction confirmed directly: before, `{'db/schema.sql': {10}, 'users table': set()}`; after, `{'db/schema.sql': {10, 11, 12, 13}}` — real change captured, no phantom file.
- One originally-planned test case (four leading dashes) turned out to be vacuous on inspection — the marker regex never matches four dashes regardless of the fix, confirmed empirically against old and new code. Replaced with a case that actually distinguishes old from new behavior.
- `github-app` full test suite: 1369 passed, 8 skipped, 0 failed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj