### PR TITLE
fix: ops-monitor alerts re-fired on every check with no cooldown

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2485,7 +2485,35 @@ def _fetch_app_health(url: str) -> tuple[bool, str]:
     return False, f"HTTP {response.status_code}: {response.text[:200]}"
 
 
-def _send_ops_alert(source: str, message: str, context: str) -> None:
+# Must stay comfortably under _check_threshold_duration's own state-key TTL
+# (OPS_THRESHOLD_DURATION_SECONDS * 3 = 1800s, never refreshed once set,
+# counted from the condition's original detection - not from when an
+# alert fires) - a cooldown too close to that window risks the underlying
+# "how long has this persisted" tracking expiring and resetting before the
+# cooldown clears, which would silently skip the next legitimate reminder
+# alert instead of sending it. 900s (15min) leaves real margin: the
+# earliest an alert (and so a cooldown) can start is
+# OPS_THRESHOLD_DURATION_SECONDS (600s) after first detection, so the
+# latest a cooldown started then could still clear before the 1800s
+# state-key TTL is 1800 - 600 = 1200s - 900s has real headroom under that.
+OPS_ALERT_COOLDOWN_SECONDS = 900
+
+
+def _send_ops_alert(redis_conn, source: str, message: str, context: str) -> None:
+    # Real incident: a condition that crossed its threshold once (e.g. a
+    # month-old, since-fixed failed-jobs count that was never cleared from
+    # the registry) kept re-alerting on every ~3-minute ops_monitor run
+    # indefinitely, with no way for it to ever go quiet on its own - 918
+    # emails accumulated in production before this was caught. Neither
+    # caller previously had any notion of "already alerted for this
+    # condition, and how recently" - this is the shared fix for both
+    # (_check_threshold_duration and _check_app_health), not a per-caller
+    # patch, so any future ops-alert source gets the same protection
+    # without having to remember to add it again.
+    cooldown_key = f"ops_monitor:alert_cooldown:{source}"
+    if redis_conn.get(cooldown_key) is not None:
+        return
+    _set_with_expiry(redis_conn, cooldown_key, "1", OPS_ALERT_COOLDOWN_SECONDS)
     send_error_alert(source, OpsMonitorError(message), context)
 
 
@@ -2503,6 +2531,7 @@ def _check_app_health(redis_conn, health_url: str) -> None:
         return
 
     _send_ops_alert(
+        redis_conn,
         "ops_monitor.app_health",
         f"app server health check failed {failures} consecutive times",
         f"url={health_url} detail={detail}",
@@ -2532,6 +2561,7 @@ def _check_threshold_duration(
         return
 
     _send_ops_alert(
+        redis_conn,
         source,
         f"{metric_name} has been above threshold for at least {OPS_THRESHOLD_DURATION_SECONDS}s",
         f"{metric_name}={current_value} threshold={threshold} first_seen={first_seen:.0f}",
@@ -2576,10 +2606,11 @@ def _latest_backup_age_seconds(backup_dir: Path, now: float) -> float | None:
     return now - newest
 
 
-def _check_backup_freshness(now: float) -> None:
+def _check_backup_freshness(redis_conn, now: float) -> None:
     backup_dir = Path(os.environ.get(OPS_BACKUP_DIR_ENV, OPS_DEFAULT_BACKUP_DIR))
     if not backup_dir.is_dir():
         _send_ops_alert(
+            redis_conn,
             "ops_monitor.backup_freshness",
             "PostgreSQL backup directory is not available",
             f"backup_dir={backup_dir}",
@@ -2589,6 +2620,7 @@ def _check_backup_freshness(now: float) -> None:
     age_seconds = _latest_backup_age_seconds(backup_dir, now)
     if age_seconds is None:
         _send_ops_alert(
+            redis_conn,
             "ops_monitor.backup_freshness",
             "no PostgreSQL backup dump found",
             f"backup_dir={backup_dir} stale_after={OPS_BACKUP_STALE_SECONDS}s",
@@ -2599,6 +2631,7 @@ def _check_backup_freshness(now: float) -> None:
         return
 
     _send_ops_alert(
+        redis_conn,
         "ops_monitor.backup_freshness",
         "latest PostgreSQL backup is stale",
         f"backup_dir={backup_dir} age_seconds={age_seconds:.0f} "
@@ -2619,7 +2652,7 @@ def run_ops_monitor_job() -> None:
         os.environ.get(OPS_APP_HEALTH_URL_ENV, OPS_DEFAULT_APP_HEALTH_URL),
     )
     _check_queue_alerts(redis_conn, now)
-    _check_backup_freshness(now)
+    _check_backup_freshness(redis_conn, now)
 
 
 # Each template function takes exactly one positional string arg

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -4553,24 +4553,50 @@ def test_run_health_sweep_staleness_check_job_does_not_alert_when_no_data_yet(mo
 
 
 class _FakeRedis:
-    def __init__(self):
-        self.data = {}
+    """now_fn defaults to real time.time so existing callers of this fake
+    (none of which care about expiry) are unaffected; a test that does care
+    - see test_run_ops_monitor_job_does_not_repeat_alert_within_cooldown -
+    passes the same controllable time source it already uses to advance
+    jobs.time.time, so `ex=` expiry is real for that test rather than
+    silently ignored (which the old version of this fake did - `set`
+    dropped `ex` on the floor entirely, so a cooldown key could never
+    expire no matter how much simulated time passed)."""
+
+    def __init__(self, now_fn=time.time):
+        self.data = {}  # key -> (value, expire_at | None)
+        self._now_fn = now_fn
+
+    def _expire_if_due(self, key):
+        entry = self.data.get(key)
+        if entry is None:
+            return
+        _value, expire_at = entry
+        if expire_at is not None and self._now_fn() >= expire_at:
+            del self.data[key]
 
     def get(self, key):
-        return self.data.get(key)
+        self._expire_if_due(key)
+        entry = self.data.get(key)
+        return entry[0] if entry else None
 
     def set(self, key, value, ex=None):
-        self.data[key] = str(value)
+        expire_at = self._now_fn() + ex if ex is not None else None
+        self.data[key] = (str(value), expire_at)
 
     def delete(self, key):
         self.data.pop(key, None)
 
     def incr(self, key):
-        value = int(self.data.get(key, "0")) + 1
-        self.data[key] = str(value)
+        self._expire_if_due(key)
+        value = int(self.data.get(key, ("0", None))[0]) + 1
+        _prev_value, expire_at = self.data.get(key, ("0", None))
+        self.data[key] = (str(value), expire_at)
         return value
 
     def expire(self, key, seconds):
+        entry = self.data.get(key)
+        if entry is not None:
+            self.data[key] = (entry[0], self._now_fn() + seconds)
         return True
 
 
@@ -4582,7 +4608,7 @@ def test_run_ops_monitor_job_alerts_on_second_app_health_failure(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
     monkeypatch.setattr("scan_worker.jobs._fetch_app_health", lambda url: (False, "broken"))
     monkeypatch.setattr("scan_worker.jobs._check_queue_alerts", lambda redis_conn, now: None)
-    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
     monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
     monkeypatch.setenv("ALETHEORE_APP_HEALTH_URL", "http://bad-health.local/healthz")
 
@@ -4611,7 +4637,7 @@ def test_run_ops_monitor_job_broken_app_health_sends_ops_email(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
     monkeypatch.setattr("scan_worker.jobs._fetch_app_health", lambda url: (False, "broken"))
     monkeypatch.setattr("scan_worker.jobs._check_queue_alerts", lambda redis_conn, now: None)
-    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
     monkeypatch.setattr(
         error_alerts,
         "send_transactional_email",
@@ -4649,7 +4675,7 @@ def test_run_ops_monitor_job_alerts_when_queue_depth_stays_high(monkeypatch):
 
     monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
     monkeypatch.setattr("scan_worker.jobs._check_app_health", lambda redis_conn, url: None)
-    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
     monkeypatch.setattr("scan_worker.jobs.Queue", FakeQueue)
     monkeypatch.setattr("scan_worker.jobs.FailedJobRegistry", FakeFailedRegistry)
     monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
@@ -4667,6 +4693,81 @@ def test_run_ops_monitor_job_alerts_when_queue_depth_stays_high(monkeypatch):
     assert len(alerts) == 1
     assert alerts[0][0][0] == "ops_monitor.queue_depth.scans"
     assert "scans queue depth=26" in alerts[0][0][2]
+
+
+def test_run_ops_monitor_job_does_not_repeat_alert_within_cooldown(monkeypatch):
+    """Real incident this guards against: a condition that crossed its
+    threshold once (a month-old, since-fixed failed-jobs count that was
+    never cleared from the registry) kept re-alerting on every ~3-minute
+    ops_monitor run indefinitely - 918 emails accumulated in production
+    before this was caught. A persisting condition must alert once, then
+    stay quiet until OPS_ALERT_COOLDOWN_SECONDS has passed, not on every
+    single check."""
+    from scan_worker import jobs
+    from scan_worker.jobs import (
+        OPS_ALERT_COOLDOWN_SECONDS,
+        OPS_THRESHOLD_DURATION_SECONDS,
+        run_ops_monitor_job,
+    )
+
+    t = 1000.0
+    redis_conn = _FakeRedis(now_fn=lambda: t)
+    alerts = []
+
+    class FakeQueue:
+        def __init__(self, name, connection):
+            self.name = name
+            self.count = 26 if name == "scans" else 0
+
+    class FakeFailedRegistry:
+        def __init__(self, queue):
+            self.count = 0
+
+    monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
+    monkeypatch.setattr("scan_worker.jobs._check_app_health", lambda redis_conn, url: None)
+    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs.Queue", FakeQueue)
+    monkeypatch.setattr("scan_worker.jobs.FailedJobRegistry", FakeFailedRegistry)
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
+    monkeypatch.setenv("ALETHEORE_OPS_QUEUE_DEPTH_THRESHOLD", "25")
+
+    monkeypatch.setattr(jobs.time, "time", lambda: t)
+    run_ops_monitor_job()
+    assert alerts == []  # condition just started, not yet past OPS_THRESHOLD_DURATION_SECONDS
+
+    alert_fired_at = 1000.0 + OPS_THRESHOLD_DURATION_SECONDS + 1
+    t = alert_fired_at
+    monkeypatch.setattr(jobs.time, "time", lambda: t)
+    run_ops_monitor_job()
+    assert len(alerts) == 1  # first alert, condition has now persisted past the duration threshold
+
+    # Condition is still present (queue depth still 26) and only a little
+    # time has passed - this is exactly the "every ~3 minutes" repeat-check
+    # scenario that caused the real incident. Must NOT alert again.
+    t = alert_fired_at + 180
+    monkeypatch.setattr(jobs.time, "time", lambda: t)
+    run_ops_monitor_job()
+    assert len(alerts) == 1
+
+    t = alert_fired_at + 360
+    monkeypatch.setattr(jobs.time, "time", lambda: t)
+    run_ops_monitor_job()
+    assert len(alerts) == 1
+
+    # Once the cooldown has genuinely elapsed (anchored to when it was
+    # actually set - alert_fired_at - not to whatever t happens to be now),
+    # a still-persisting condition should alert again as a "this is still
+    # ongoing" reminder, not stay silent forever. Must land before
+    # _check_threshold_duration's own first_seen state (set at t=1000,
+    # TTL OPS_THRESHOLD_DURATION_SECONDS*3=1800s, expires at t=2800) also
+    # expires - otherwise this test would exercise a second, different
+    # pre-existing behavior (first_seen resetting) instead of the cooldown
+    # clearing.
+    t = alert_fired_at + OPS_ALERT_COOLDOWN_SECONDS + 1
+    assert t < 1000.0 + 1800  # stay inside first_seen's own TTL window
+    monkeypatch.setattr(jobs.time, "time", lambda: t)
+    run_ops_monitor_job()
+    assert len(alerts) == 2
 
 
 def test_run_ops_monitor_job_alerts_when_backup_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- `_check_threshold_duration` and `_check_app_health` both called `_send_ops_alert` unconditionally on every ~3-minute `ops_monitor` run for as long as a condition persisted past its threshold - no notion of "already alerted, how recently."
- In production: a health-check-sweep bug fixed a month ago (`c34aa6c`) left 186 failed jobs sitting in the "scans" queue's `FailedJobRegistry` that nothing ever cleared. The alert had been silently re-firing on that same stale condition ever since - **918 emails accumulated in Spam** before this was caught.
- Fix centralized in `_send_ops_alert` itself (not per-caller), so every current and future ops-alert source gets it automatically: a Redis cooldown key per alert source, checked before sending, set with a TTL on send.
- Cooldown is 900s (15min), deliberately kept under `_check_threshold_duration`'s own state-key TTL (`OPS_THRESHOLD_DURATION_SECONDS * 3` = 1800s, never refreshed once set) - a cooldown too close to that window risks the "how long has this persisted" tracking expiring and resetting before the cooldown clears, silently skipping a legitimate reminder alert.

## Production cleanup already done (separate from this code change)
Cleared the 349 stale failed jobs from the "scans" registry after verifying each failure category was either already fixed by this deploy or a resolved historical/external incident (GitHub API 503s during its own outage, not a code bug) - not blind cleanup, checked per category first.

## Verification
- Extended the shared `_FakeRedis` test double to actually honor `ex=` expiry (tied to a controllable time source) instead of silently dropping it - the previous version made it impossible to write a real test for cooldown-expiry behavior.
- New test proves the full lifecycle: doesn't repeat within cooldown, does send a reminder once cooldown genuinely clears.
- Full `github-app` test suite: 1371 passed, 8 skipped, 0 failed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj