### PR TITLE
fix: live demo showed [object Object] and 0-line language counts

### DIFF
--- a/github-app/scan_worker/demo_scan.py
+++ b/github-app/scan_worker/demo_scan.py
@@ -96,12 +96,16 @@ def _summarize_for_public_display(evidence: dict) -> dict:
 
     return {
         "languages": [
-            {"name": lang.get("name"), "lines": lang.get("lines")} for lang in languages[:MAX_LISTED_ITEMS]
+            {"name": lang.get("name"), "lines": lang.get("loc")} for lang in languages[:MAX_LISTED_ITEMS]
         ],
         "dead_code": {
             "unreachable_module_count": len(unreachable_modules),
             "unused_dependency_count": len(unused_dependencies),
-            "sample": unreachable_modules[:MAX_LISTED_ITEMS],
+            # unreachable_modules entries are {"path": ..., "reason": ...} dicts
+            # (dead_code.py) - the live-demo frontend renders each sample item as
+            # a plain path string, so extract that field rather than passing the
+            # dict through (it would otherwise render as "[object Object]").
+            "sample": [m.get("path") for m in unreachable_modules[:MAX_LISTED_ITEMS]],
         },
         "secrets": {
             "finding_count": len(secrets_findings),

--- a/github-app/tests/test_demo_scan.py
+++ b/github-app/tests/test_demo_scan.py
@@ -45,9 +45,12 @@ def _fake_urlopen_raising_http_error(status: int, reason: str):
 def _fake_evidence(**overrides) -> dict:
     base = {
         "repository": {
-            "languages": [{"name": "Python", "lines": 1000}],
+            "languages": [{"name": "Python", "loc": 1000}],
             "dead_code": {
-                "unreachable_modules": [f"module_{i}.py" for i in range(8)],
+                "unreachable_modules": [
+                    {"path": f"module_{i}.py", "reason": "no other module imports this file"}
+                    for i in range(8)
+                ],
                 "unused_dependencies": ["requests"],
             },
             "api_endpoints": {"endpoints": [{"path": "/a"}, {"path": "/b"}]},
@@ -82,6 +85,23 @@ def test_summarize_caps_sample_list_size_but_keeps_true_count():
     summary = _summarize_for_public_display(_fake_evidence())
     assert summary["dead_code"]["unreachable_module_count"] == 8
     assert len(summary["dead_code"]["sample"]) == 5
+
+
+def test_summarize_dead_code_sample_is_plain_path_strings():
+    # unreachable_modules entries are {"path": ..., "reason": ...} dicts
+    # (dead_code.py) - the sample must extract the path string, not pass
+    # the dict through, or it renders as "[object Object]" on the live
+    # demo page.
+    summary = _summarize_for_public_display(_fake_evidence())
+    assert summary["dead_code"]["sample"][0] == "module_0.py"
+    assert all(isinstance(path, str) for path in summary["dead_code"]["sample"])
+
+
+def test_summarize_language_lines_reads_the_real_loc_field():
+    # air.json's language entries use "loc", not "lines" - confirmed
+    # against a real scan output, not assumed.
+    summary = _summarize_for_public_display(_fake_evidence())
+    assert summary["languages"][0]["lines"] == 1000
 
 
 def test_summarize_handles_empty_evidence_gracefully():


### PR DESCRIPTION
## Summary
Found via a real screenshot of the live app.aletheore.com demo widget: dead-code sample entries
rendered as `[object Object]` three times, and every language showed 0 lines.

Root cause, both in `_summarize_for_public_display` (`github-app/scan_worker/demo_scan.py`):
- Language line count read `lang.get("lines")` - the real evidence field (confirmed against a real
  `air.json`) is `loc`, so this was always `None` → rendered as 0.
- `dead_code.sample` passed raw `unreachable_modules` entries straight through. Those are
  `{"path": ..., "reason": ...}` dicts (`src/aletheore/dead_code.py:143-145`), but the frontend
  (`website/live-demo.js:48-50`) expects each sample item to already be a plain path string -
  hence `String({...})` → `"[object Object]"`.

The existing test fixture (`tests/test_demo_scan.py`) encoded both wrong shapes (`"lines"` instead
of `"loc"`, plain strings instead of `{"path", "reason"}` dicts for unreachable modules), which is
exactly why this shipped and stayed green.

## Test plan
- [x] Fixed the fixture to match the real evidence shape
- [x] Added two regression tests: `test_summarize_dead_code_sample_is_plain_path_strings`,
      `test_summarize_language_lines_reads_the_real_loc_field`
- [x] `pytest tests/test_demo_scan.py -v` - 13 passed (was 11, +2 new)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj