### PR TITLE
fix: Flash Review citation-matching bug + local-logic review instruction

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -531,19 +531,46 @@ def build_referenced_symbol_context(
     return "\n\n".join(parts)
 
 
-_QUOTED_STRING_RE = re.compile(r"'([^'\n]{8,})'|\"([^\"\n]{8,})\"")
+_MIN_QUOTED_STRING_LENGTH = 8
+# The {8,} minimum used to live inside the regex itself. Real bug, found
+# via a real deepseek-v4-flash Flash Review output (pr-review-benchmark
+# case 018-axios-missing-null-check-charset): when a genuine quoted span is
+# too short to satisfy an in-regex minimum, the character class still
+# can't cross that span's own closing delimiter (it excludes the quote
+# character entirely) - so the engine abandons that pairing and retries
+# from the next quote character it finds, which is that same short span's
+# closing delimiter now reinterpreted as an OPENING delimiter for an
+# entirely different, unrelated span later in the text. On text like
+# `...(e.g. \`charset="utf-8"\`), so the function returns \`"utf-8"\`...`,
+# both "utf-8" occurrences are individually only 5 chars (correctly too
+# short to count as evidence) - but the in-regex minimum caused this
+# specific text to instead extract '"), so the function returns "'
+# spanning from one "utf-8" pair's closing quote to the next pair's
+# opening quote: real content that will never appear verbatim anywhere in
+# the source, so a correct, well-formed finding was rejected outright by
+# _line_citation_content_matches for a citation problem that isn't real.
+# Matching any length first, then filtering afterward, fixes this: real
+# quote pairs are always identified correctly regardless of length, so a
+# short pair is just dropped by the length check rather than bleeding into
+# neighboring text.
+_QUOTED_STRING_RE = re.compile(r"'([^'\n]*)'|\"([^\"\n]*)\"")
 LINE_CITATION_CONTEXT_WINDOW = 8
 
 
 def _quoted_strings(text: str) -> list[str]:
     """Literal quoted snippets in a finding's own text - a real anchor to
     check the finding's claimed line against, when one exists. Short
-    quotes (under 8 chars) are skipped: real code is full of short quoted
-    tokens ('x', "ok") that aren't meaningful evidence of a specific
-    location."""
+    quotes (under _MIN_QUOTED_STRING_LENGTH) are skipped: real code is full
+    of short quoted tokens ('x', "ok") that aren't meaningful evidence of a
+    specific location. Filtered after matching, not inside the regex
+    itself - see _QUOTED_STRING_RE's comment for why matching first and
+    filtering after avoids a real cross-pairing bug the in-regex minimum
+    caused."""
     matches = []
     for match in _QUOTED_STRING_RE.finditer(text):
-        matches.append(match.group(1) if match.group(1) is not None else match.group(2))
+        value = match.group(1) if match.group(1) is not None else match.group(2)
+        if len(value) >= _MIN_QUOTED_STRING_LENGTH:
+            matches.append(value)
     return matches
 
 

--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -45,7 +45,13 @@ Review procedure:
 2. Trace every changed call into its provided referenced definition when one is available.
 3. Compare the old and new control/data flow for exceptions, mutation, iteration, retries,
    concurrency, scaling, and ordering.
-4. Report only a concrete regression supported by that comparison. Do not report unused code,
+4. Check each changed expression on its own terms, independent of any cross-file evidence: does a
+   newly added or moved property/index access have a null/undefined/None guard where the value can
+   be absent; does a changed regex or string-matching pattern behave correctly on edge-case input
+   (empty string, no match, a boundary value); does a changed string literal shown to a user (an
+   error message, a log line, a CLI message) accurately describe the condition it fires on, with
+   correct punctuation and quoting.
+5. Report only a concrete regression supported by that comparison. Do not report unused code,
    missing definitions, or style concerns when the supplied current file or referenced source
    disproves the claim.
 

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -1420,6 +1420,24 @@ def test_system_prompt_requires_changed_behavior_comparison_before_reporting():
     assert "do not report unused code" in normalized
 
 
+def test_system_prompt_instructs_checking_local_logic_independent_of_cross_file_evidence():
+    # Real gap found via the mixed-repo benchmark (aletheore-benchmarks
+    # pr_review, deepseek-v4-flash compact arm, 2026-08-19): every one of a
+    # cluster of consistent misses (missing null check, regex matching an
+    # empty string, a missing closing quote in a CLI error message) was a
+    # pure local-logic bug the diff itself fully contains - no cross-file
+    # evidence (blast radius, referenced symbols) could ever surface it,
+    # and the review procedure's existing steps are framed entirely around
+    # cross-file call tracing and control/data-flow comparison, with no
+    # explicit instruction to sanity-check a changed expression on its own
+    # terms. This only proves the instruction exists, not that a live
+    # model obeys it - untestable without a real call.
+    normalized = " ".join(FLASH_REVIEW_SYSTEM_PROMPT.lower().split())
+    assert "null/undefined/none guard" in normalized
+    assert "edge-case input" in normalized
+    assert "accurately describe the condition it fires on" in normalized
+
+
 def test_system_prompt_warns_about_host_language_escaping_in_generated_source():
     # Real false positive, caught dogfooding Flash review against this
     # repo's own frontend.py (which builds JS via a Python f-string): a

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -192,6 +192,36 @@ def test_quoted_strings_returns_empty_for_no_quotes():
     assert _quoted_strings("this issue names no literal string") == []
 
 
+def test_quoted_strings_does_not_bleed_across_two_separate_short_quotes():
+    # Real regression, found via a real deepseek-v4-flash Flash Review
+    # output (pr-review-benchmark case
+    # 018-axios-missing-null-check-charset). Two separate short quoted
+    # spans ("utf-8", 5 chars each) used to make the old {8,}-inside-the-
+    # regex version extract garbage: unable to satisfy the minimum length
+    # within either short pair (the character class can't cross a real
+    # quote character), the engine retried from the next quote it found -
+    # which was the first pair's closing delimiter, reinterpreted as an
+    # opening delimiter reaching all the way to the second pair's opening
+    # delimiter. The extracted "quote" was real narrative text that will
+    # never appear verbatim in any source file, so a correct, well-formed
+    # finding citing this text got rejected by _line_citation_content_matches
+    # for a citation problem that was never real.
+    text = (
+        'The regex captures surrounding quotes (e.g. `charset="utf-8"`), '
+        'so the function returns `"utf-8"` with quotes instead of `utf-8`.'
+    )
+    assert _quoted_strings(text) == []
+
+
+def test_quoted_strings_still_extracts_a_long_quote_next_to_a_short_one():
+    # Companion to the regression above: the fix must not overcorrect into
+    # dropping every quote just because a short one is nearby - only the
+    # short pair itself should be filtered, and a genuinely long, real
+    # anchor right next to it must still come through.
+    text = 'returns "ok" but should return "a real error message here" instead'
+    assert _quoted_strings(text) == ["a real error message here"]
+
+
 def test_line_citation_content_matches_true_when_quoted_string_is_at_claimed_line():
     finding = {"file": "a.py", "line": 3, "issue": 'missing quote: \'a specific buggy string here\''}
     file_contents = {"a.py": "one\ntwo\na specific buggy string here\nfour"}


### PR DESCRIPTION
## Summary

Two related fixes found while investigating why Flash Review's compact/context arms were missing real bugs on a mixed-repo benchmark, bundled together since the second fix's own regression test was directly caused by output the first fix's investigation produced.

### 1. Citation-matching regex could cross-pair two separate quotes

`_QUOTED_STRING_RE` had its 8-char minimum length *inside* the regex itself. When a genuine quoted span is too short to satisfy that minimum, the character class still can't cross that span's own closing delimiter (it excludes the quote character entirely) — so the engine abandons the pairing and retries from the next quote it finds, which is that same short span's closing delimiter now reinterpreted as an *opening* delimiter for a different, unrelated span later in the text.

Found via a real deepseek-v4-flash output (`pr-review-benchmark` case `018-axios-missing-null-check-charset`): text mentioning `"utf-8"` twice (5 chars each, correctly too short to count as evidence) produced a garbage extracted "quote" spanning from the first mention's closing quote to the second's opening quote — narrative text that could never appear verbatim in the source file, so a correct, well-formed finding was rejected by `_line_citation_content_matches` for a citation problem that was never real.

Fixed by matching quote pairs at any length first, then filtering by length afterward — real pairs are always identified correctly regardless of length, so a short pair is just dropped rather than bleeding into neighboring text.

**Verified end-to-end, real API, case 018:** context arm 1 proposed/0 grounded → 1/1 (now correctly surfaces the actual target bug); compact arm 1/0 → 2/2.

### 2. Instruct Flash Review to check local logic independent of cross-file evidence

The review procedure's existing steps are framed entirely around cross-file call tracing and control/data-flow comparison, with no explicit instruction to sanity-check a changed expression on its own terms. Real gap found via the same mixed-repo benchmark: a cluster of consistent misses (missing null check, regex matching an empty string, a missing closing quote in a CLI error message) were all pure local-logic bugs the diff itself fully contains.

Adds a new step 4 instructing the model to check, independent of cross-file evidence: null/undefined/None guards on newly-added-or-moved property access, regex/string-matching correctness on edge-case input, and whether a user-facing string literal accurately describes the condition it fires on.

**Verified end-to-end, real API:**
- Case 001 (`flask-cli-key-quote`, missing closing quote): miss → exact match.
- Case 003 (`requests-proxy-bypass-registry`, regex treats empty string as wildcard): baseline 0 proposed / context 1 proposed-0 grounded / compact 0 proposed → **all three arms now propose and ground the exact target bug** (line 101, `filter(None, proxyOverride)`).

## Test plan
- [x] `tests/test_flash_review.py`: 130 passed
- [x] Full `github-app` suite: 805 passed, 605 skipped, 3 failed — all 3 pre-existing, environment-only (real Redis unavailable locally; `test_llm_suggestion_opt_out.py`, `test_migrate.py`, `test_redis_client.py`), none touching a file this PR changes
- [ ] CI green