### PR TITLE
fix: citation quote regex cross-pairs contractions/possessives into fake quotes

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -559,7 +559,22 @@ _MIN_QUOTED_STRING_LENGTH = 8
 # quote pairs are always identified correctly regardless of length, so a
 # short pair is just dropped by the length check rather than bleeding into
 # neighboring text.
-_QUOTED_STRING_RE = re.compile(r"'([^'\n]*)'|\"([^\"\n]*)\"")
+#
+# The (?<!\w)/(?!\w) guards around each delimiter are a second, related fix:
+# an apostrophe used as a contraction or possessive ("doesn't", "user's")
+# sits directly between two word characters, and without the guards it's
+# indistinguishable from a real opening or closing single-quote. Two such
+# apostrophes on the same line - e.g. "The API doesn't validate the user's
+# session token" - paired into a fabricated 20-char "quote" ("t validate the
+# user") that never appears verbatim in any source file, which would reject
+# a correct finding the same way the cross-pairing bug above did. A real
+# quote delimiter is essentially never flanked by a word character on the
+# delimiter side that faces outward (whitespace, punctuation, or
+# start/end-of-string instead), so excluding word-flanked apostrophes drops
+# only contractions/possessives, not genuine quoted spans - confirmed against
+# the original cross-pairing regression case and ordinary code-ish quoting
+# (`'value'.method()`, `class='name'`) below.
+_QUOTED_STRING_RE = re.compile(r"(?<!\w)'([^'\n]*)'(?!\w)|(?<!\w)\"([^\"\n]*)\"(?!\w)")
 LINE_CITATION_CONTEXT_WINDOW = 8
 
 

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -222,6 +222,36 @@ def test_quoted_strings_still_extracts_a_long_quote_next_to_a_short_one():
     assert _quoted_strings(text) == ["a real error message here"]
 
 
+def test_quoted_strings_does_not_pair_contraction_apostrophes_into_a_fake_quote():
+    # Second regex bug in the same family as the cross-pairing regression
+    # above, found by auditing _QUOTED_STRING_RE for other quote-adjacent
+    # failure modes after that fix landed. An English contraction or
+    # possessive apostrophe ("doesn't", "user's") sits directly between two
+    # word characters and is otherwise indistinguishable from a real
+    # single-quote delimiter. Two of them on the same line paired into a
+    # fabricated "quote" spanning the prose between them - never real quoted
+    # content, so it can never appear verbatim in any source file, and would
+    # reject a correct finding the same way the original bug did.
+    text = "The API doesn't validate the user's session token which isn't checked."
+    assert _quoted_strings(text) == []
+
+
+def test_quoted_strings_does_not_pair_possessive_plural_apostrophes():
+    # Companion case: a trailing-only possessive apostrophe ("users'") has
+    # no word character after it, but still has one before - must not pair
+    # with a later apostrophe either.
+    text = "Check the users' permissions before granting the admins' access here."
+    assert _quoted_strings(text) == []
+
+
+def test_quoted_strings_still_extracts_real_quotes_next_to_a_contraction():
+    # Companion to both fixes above: a genuine long quoted anchor must still
+    # come through even when a contraction apostrophe appears elsewhere in
+    # the same text.
+    text = "It doesn't check that 'a_specific_config_value' is set before using it."
+    assert _quoted_strings(text) == ["a_specific_config_value"]
+
+
 def test_line_citation_content_matches_true_when_quoted_string_is_at_claimed_line():
     finding = {"file": "a.py", "line": 3, "issue": 'missing quote: \'a specific buggy string here\''}
     file_contents = {"a.py": "one\ntwo\na specific buggy string here\nfour"}


### PR DESCRIPTION
## Summary
- Second bug in the same family as #292's cross-pairing fix, found by auditing `_QUOTED_STRING_RE` for other quote-adjacent failure modes after that one landed.
- A contraction (`doesn't`) or possessive (`user's`) apostrophe sits directly between two word characters and is otherwise indistinguishable from a real single-quote delimiter. Two of them on the same line pair into a fabricated multi-word "quote" that never appears verbatim in any source file, causing `_line_citation_content_matches` to reject a correct finding for a citation problem that isn't real.
- Fix: guard each delimiter with `(?<!\w)`/`(?!\w)` so only apostrophes flanked by whitespace/punctuation can pair. Genuine quoted spans (including code-ish ones like `'value'.method()` or `class='name'`) are unaffected.

## Test plan
- [x] `pytest github-app/tests/test_flash_review.py` — 133 passed (3 new regression tests: contraction pairing, possessive-plural pairing, real quote survives next to a contraction)
- [x] Verified against a standalone script covering both this bug and the original #292 regression together — neither reintroduces the other
- [ ] CI green