### PR TITLE
marketing: add Enterprise contact section to pricing page

### DIFF
--- a/website/pricing.html
+++ b/website/pricing.html
@@ -92,6 +92,17 @@
         <span>MCP tools for coding agents</span>
       </div>
     </section>
+
+    <section class="proof-panel" id="enterprise">
+      <div>
+        <p class="eyebrow">Enterprise</p>
+        <h2>Need something custom?</h2>
+      </div>
+      <p>A larger team, a custom seat or repo allotment, a procurement or security questionnaire, or billing terms the self-serve plans don't cover - talk to us directly and we'll work out something that fits.</p>
+    </section>
+    <div class="cta-actions" style="margin-top: 20px;">
+      <a class="btn btn-primary" href="mailto:support@aletheore.com?subject=Enterprise%20inquiry">Contact us</a>
+    </div>
   </div>
 
   <footer>


### PR DESCRIPTION
## Summary
- Adds a "Need something custom?" section below the pricing cards on `website/pricing.html`, matching the existing `.proof-panel` design pattern used elsewhere on the site.
- A simple mailto CTA to `support@aletheore.com` (existing inbox, no new infra) with a pre-filled subject line - no new promises about specific enterprise features (SSO, on-prem, etc.) that don't exist yet, just a real path for larger-team/custom/procurement conversations.

Replaces #295, which was accidentally built from a locally-stale `master` (2 orphaned commits duplicating already-merged PR content under different SHAs), causing a spurious merge conflict against real `origin/master`. This branch is built cleanly from current `origin/master` with just the intended one-file change.

## Test plan
- [x] Rendered locally via a local static server and visually verified desktop + mobile (section stacks correctly, matches existing site styling, no new CSS needed)
- [x] Confirmed the mailto link resolves to the site's existing, real contact address used everywhere else (footer, security.html, refund.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)