### PR TITLE
marketing: update Benchmarks page to 0.8.13, disclose zod regression

### DIFF
--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -60,6 +60,7 @@
           </div>
           <pre><code>git clone https://github.com/Aletheore/aletheore-benchmarks
 cd aletheore-benchmarks
+python scripts/score_retrieval_matrix.py results/retrieval_raw_0813.json
 python scripts/score_fallback_judge.py</code></pre>
         </div>
       </section>
@@ -68,7 +69,7 @@ python scripts/score_fallback_judge.py</code></pre>
         <h3>Locating code, head-to-head against RepoWise</h3>
         <div class="toon-counters">
           <div class="toon-counter">
-            <div class="toon-counter-value">5–0–2</div>
+            <div class="toon-counter-value">6–1–0</div>
             <div class="toon-counter-label">wins–losses–ties on top-1,<br>all 7 shared corpora</div>
           </div>
           <div class="toon-counter">
@@ -106,21 +107,24 @@ python scripts/score_fallback_judge.py</code></pre>
               <tr><th>Corpus</th><th>Language</th><th>Aletheore</th><th>RepoWise semantic</th><th>RepoWise full-text</th><th>Winner</th></tr>
             </thead>
             <tbody>
-              <tr><td>gin</td><td>Go</td><td><strong>80.0%</strong></td><td>60.0%</td><td>46.7%</td><td>✅ Aletheore</td></tr>
+              <tr><td>gin</td><td>Go</td><td><strong>86.7%</strong></td><td>60.0%</td><td>46.7%</td><td>✅ Aletheore</td></tr>
+              <tr><td>Slim</td><td>PHP</td><td><strong>60.0%</strong></td><td>26.7%</td><td>20.0%</td><td>✅ Aletheore</td></tr>
               <tr><td>serde</td><td>Rust</td><td><strong>53.3%</strong></td><td>6.7%</td><td>13.3%</td><td>✅ Aletheore</td></tr>
               <tr><td>gson</td><td>Java</td><td><strong>40.0%</strong></td><td>26.7%</td><td>0.0%</td><td>✅ Aletheore</td></tr>
+              <tr><td>guzzle</td><td>PHP</td><td><strong>33.3%</strong></td><td>13.3%</td><td>20.0%</td><td>✅ Aletheore</td></tr>
               <tr><td>jekyll</td><td>Ruby</td><td><strong>26.7%</strong></td><td>13.3%</td><td>6.7%</td><td>✅ Aletheore</td></tr>
-              <tr><td>Slim</td><td>PHP</td><td>26.7%</td><td>26.7%</td><td>20.0%</td><td>🟰 tie</td></tr>
-              <tr><td>guzzle</td><td>PHP</td><td>20.0%</td><td>13.3%</td><td>20.0%</td><td>🟰 tie</td></tr>
-              <tr><td>zod</td><td>TypeScript</td><td><strong>20.0%</strong></td><td>6.7%</td><td>13.3%</td><td>✅ Aletheore</td></tr>
+              <tr><td>zod</td><td>TypeScript</td><td>0.0%</td><td>6.7%</td><td><strong>13.3%</strong></td><td>❌ RepoWise</td></tr>
             </tbody>
           </table>
         </div>
-        <p class="dogfood-p"><strong>Top-1: 5 wins, 0 losses, 2 ties.</strong> Our weakest
-          languages still match or beat them. Flask (measured separately, not one of the
-          seven shared corpora above): Aletheore 68.8% / 93.8% / 100% (top-1/3/5) against
-          RepoWise semantic 28.1% / 56.2% / 56.2%. Where we lose: jekyll top-5, 46.7%
-          against their 66.7% — see "Where we lose" below.</p>
+        <p class="dogfood-p"><strong>Top-1: 6 wins, 1 loss, 0 ties</strong> — up from 5-0-2
+          under the previous release; Slim and guzzle both moved from ties to clear wins.
+          Flask (measured separately, not one of the seven shared corpora above): Aletheore
+          78.1% / 100.0% / 100.0% (top-1/3/5) against RepoWise semantic 28.1% / 56.2% / 56.2%.
+          <strong>The loss is real and new</strong>: zod flipped from a win (20.0% vs their
+          13.3%) to a loss (0.0% vs their 13.3%) after our latest release — the one corpus
+          that got worse. We're not hiding it behind an average; see "Where we lose" below
+          for what's known about the cause, and it's marked openly unresolved.</p>
 
         <p class="dogfood-p">Both systems were also given <strong>vocabulary</strong>-phrased
           questions on the same wikis. RepoWise gains from this too — its wiki pages name the
@@ -131,17 +135,19 @@ python scripts/score_fallback_judge.py</code></pre>
               <tr><th>Corpus</th><th>Aletheore general</th><th>RepoWise general</th><th>Aletheore vocabulary</th><th>RepoWise vocabulary</th></tr>
             </thead>
             <tbody>
-              <tr><td>Slim</td><td>26.7%</td><td>26.7%</td><td><strong>73.3%</strong></td><td>66.7%</td></tr>
-              <tr><td>gson</td><td><strong>40.0%</strong></td><td>26.7%</td><td><strong>60.0%</strong></td><td>46.7%</td></tr>
-              <tr><td>zod</td><td><strong>20.0%</strong></td><td>13.3%</td><td><strong>60.0%</strong></td><td>26.7%</td></tr>
-              <tr><td>guzzle</td><td>20.0%</td><td>20.0%</td><td>53.3%</td><td>53.3%</td></tr>
+              <tr><td>Slim</td><td><strong>60.0%</strong></td><td>26.7%</td><td><strong>80.0%</strong></td><td>66.7%</td></tr>
+              <tr><td>gson</td><td><strong>40.0%</strong></td><td>26.7%</td><td><strong>53.3%</strong></td><td>46.7%</td></tr>
+              <tr><td>zod</td><td>0.0%</td><td><strong>13.3%</strong></td><td>6.7%</td><td><strong>26.7%</strong></td></tr>
+              <tr><td>guzzle</td><td><strong>33.3%</strong></td><td>20.0%</td><td><strong>66.7%</strong></td><td>53.3%</td></tr>
               <tr><td>jekyll</td><td><strong>26.7%</strong></td><td>13.3%</td><td>66.7%</td><td><strong>80.0%</strong></td></tr>
             </tbody>
           </table>
         </div>
-        <p class="dogfood-p">Across those ten cells we lead in seven, tie in two, and lose one
-          — jekyll's vocabulary regime, where RepoWise's wiki naming its own symbols overtakes
-          us 80.0% to 66.7%. Two things this deliberately doesn't claim: RepoWise's
+        <p class="dogfood-p">Across those ten cells we now lead in seven and lose three — zod
+          on both regimes, plus jekyll's vocabulary regime where RepoWise's wiki naming its own
+          symbols overtakes us 80.0% to 66.7%. The two ties from the previous release (Slim and
+          guzzle's general regime) both resolved into wins; zod's lead resolved into a loss
+          instead. Two things this deliberately doesn't claim: RepoWise's
           <code>--mode symbol</code> returned 0.0% on every corpus and is excluded as a
           misapplied mode, not counted as a loss; and search latencies aren't comparable as
           measured (RepoWise runs per-query as a CLI process, Aletheore in-process) — the one
@@ -163,20 +169,32 @@ python scripts/score_fallback_judge.py</code></pre>
 
         <details class="bench-details">
           <summary>Full retrieval matrix — top-1 / top-3 / top-5 / MRR, all 12 corpora, 23 regime rows</summary>
-          <p>Aletheore 0.8.11 installed from PyPI, each corpus re-scanned and re-indexed from
+          <p>Aletheore 0.8.13 installed from PyPI, each corpus re-scanned and re-indexed from
             scratch with local <code>nomic-embed-text</code> (768-dim) embeddings, no API key.
             Two phrasing regimes are published per corpus where available: <em>general</em>
             deliberately avoids the project's own vocabulary, <em>vocabulary</em> uses it — real
             users ask somewhere between the two, so a language's true figure is bracketed by
-            both rather than given by either. Every weak corpus moves 20-47 points on phrasing
-            alone, larger than any ranking change in this programme.</p>
+            both rather than given by either. Four of five weak corpora still move 13-40 points
+            on phrasing alone; zod is the exception, and not a good one — see the callout below
+            the chart.</p>
 
           <div class="bench-chart">
             <p class="bench-chart-title">Top-1, general phrasing, by corpus — the spread the average hides</p>
-            <p class="bench-chart-sub">Go and Python are strong; Java, Ruby, PHP, and TypeScript are not — and the weak corpora were measured last</p>
+            <p class="bench-chart-sub">Go and Python are strong; Java, Ruby, PHP, and TypeScript are not — and zod is now the weakest corpus measured</p>
             <div class="bench-chart-canvas-wrap" style="height: 360px;">
-              <canvas id="chart-spread" role="img" aria-label="Bar chart: top-1 accuracy under general phrasing across 12 corpora, ranging from 6.7 percent to 80.0 percent."></canvas>
+              <canvas id="chart-spread" role="img" aria-label="Bar chart: top-1 accuracy under general phrasing across 12 corpora, ranging from 0 percent (zod) to 86.7 percent (gin)."></canvas>
             </div>
+          </div>
+
+          <div class="dogfood-callout">
+            <p><strong>zod regressed hard on our latest release, and we don't yet know why.</strong>
+              20.0% → 0.0% top-1 (general), 60.0% → 6.7% (vocabulary) — the one corpus that got
+              worse across this whole upgrade, and worse enough to flip it from a win over
+              RepoWise into a loss (see the head-to-head table above). Retrieval is confirmed
+              deterministic and chunk counts are stable, so it isn't noise or a re-chunking
+              artifact; root cause is still open. Full writeup, including what's been ruled
+              out, in
+              <a href="https://github.com/Aletheore/aletheore-benchmarks/blob/master/METHODOLOGY.md#zod-regresses-under-0813---found-not-yet-root-caused-2026-08-20" rel="noopener">METHODOLOGY.md</a>.</p>
           </div>
 
           <div class="dogfood-table-wrap">
@@ -185,29 +203,29 @@ python scripts/score_fallback_judge.py</code></pre>
                 <tr><th>Corpus</th><th>Regime</th><th>Top-1</th><th>Top-3</th><th>Top-5</th><th>MRR</th><th>n</th></tr>
               </thead>
               <tbody>
-                <tr><td>location (Flask)</td><td>general</td><td>71.9%</td><td>93.8%</td><td>100.0%</td><td>0.832</td><td>32</td></tr>
-                <tr><td>gin</td><td>general</td><td>80.0%</td><td>100.0%</td><td>100.0%</td><td>0.878</td><td>15</td></tr>
-                <tr><td>serde</td><td>general</td><td>53.3%</td><td>66.7%</td><td>73.3%</td><td>0.617</td><td>15</td></tr>
-                <tr><td>Slim</td><td>general</td><td>26.7%</td><td>60.0%</td><td>66.7%</td><td>0.458</td><td>15</td></tr>
-                <tr><td>Slim</td><td>vocabulary</td><td>73.3%</td><td>80.0%</td><td>93.3%</td><td>0.797</td><td>15</td></tr>
-                <tr><td>guzzle</td><td>general</td><td>20.0%</td><td>53.3%</td><td>66.7%</td><td>0.374</td><td>15</td></tr>
-                <tr><td>guzzle</td><td>vocabulary</td><td>53.3%</td><td>93.3%</td><td>100.0%</td><td>0.728</td><td>15</td></tr>
-                <tr><td>jekyll</td><td>general</td><td>26.7%</td><td>33.3%</td><td>46.7%</td><td>0.337</td><td>15</td></tr>
-                <tr><td>jekyll</td><td>vocabulary</td><td>66.7%</td><td>86.7%</td><td>93.3%</td><td>0.778</td><td>15</td></tr>
-                <tr><td>zod</td><td>general</td><td>20.0%</td><td>40.0%</td><td>40.0%</td><td>0.289</td><td>15</td></tr>
-                <tr><td>zod</td><td>vocabulary</td><td>60.0%</td><td>73.3%</td><td>73.3%</td><td>0.667</td><td>15</td></tr>
-                <tr><td>gson</td><td>general</td><td>40.0%</td><td>66.7%</td><td>80.0%</td><td>0.544</td><td>15</td></tr>
-                <tr><td>gson</td><td>vocabulary</td><td>60.0%</td><td>86.7%</td><td>86.7%</td><td>0.749</td><td>15</td></tr>
-                <tr><td>axios</td><td>general</td><td>20.0%</td><td>46.7%</td><td>66.7%</td><td>0.407</td><td>15</td></tr>
-                <tr><td>axios</td><td>vocabulary</td><td>73.3%</td><td>93.3%</td><td>100.0%</td><td>0.850</td><td>15</td></tr>
-                <tr><td>jq</td><td>general</td><td>53.3%</td><td>66.7%</td><td>80.0%</td><td>0.648</td><td>15</td></tr>
-                <tr><td>jq</td><td>vocabulary</td><td>73.3%</td><td>100.0%</td><td>100.0%</td><td>0.867</td><td>15</td></tr>
-                <tr><td>fmt</td><td>general</td><td>40.0%</td><td>60.0%</td><td>86.7%</td><td>0.527</td><td>15</td></tr>
+                <tr><td>location (Flask)</td><td>general</td><td>78.1%</td><td>100.0%</td><td>100.0%</td><td>0.885</td><td>32</td></tr>
+                <tr><td>gin</td><td>general</td><td>86.7%</td><td>100.0%</td><td>100.0%</td><td>0.933</td><td>15</td></tr>
+                <tr><td>serde</td><td>general</td><td>53.3%</td><td>66.7%</td><td>73.3%</td><td>0.639</td><td>15</td></tr>
+                <tr><td>Slim</td><td>general</td><td>60.0%</td><td>66.7%</td><td>86.7%</td><td>0.680</td><td>15</td></tr>
+                <tr><td>Slim</td><td>vocabulary</td><td>80.0%</td><td>100.0%</td><td>100.0%</td><td>0.878</td><td>15</td></tr>
+                <tr><td>guzzle</td><td>general</td><td>33.3%</td><td>73.3%</td><td>80.0%</td><td>0.539</td><td>15</td></tr>
+                <tr><td>guzzle</td><td>vocabulary</td><td>66.7%</td><td>93.3%</td><td>100.0%</td><td>0.806</td><td>15</td></tr>
+                <tr><td>jekyll</td><td>general</td><td>26.7%</td><td>46.7%</td><td>53.3%</td><td>0.378</td><td>15</td></tr>
+                <tr><td>jekyll</td><td>vocabulary</td><td>66.7%</td><td>86.7%</td><td>93.3%</td><td>0.780</td><td>15</td></tr>
+                <tr><td>zod</td><td>general</td><td><strong>0.0%</strong></td><td>6.7%</td><td>20.0%</td><td>0.075</td><td>15</td></tr>
+                <tr><td>zod</td><td>vocabulary</td><td><strong>6.7%</strong></td><td>40.0%</td><td>66.7%</td><td>0.272</td><td>15</td></tr>
+                <tr><td>gson</td><td>general</td><td>40.0%</td><td>66.7%</td><td>73.3%</td><td>0.560</td><td>15</td></tr>
+                <tr><td>gson</td><td>vocabulary</td><td>53.3%</td><td>80.0%</td><td>86.7%</td><td>0.665</td><td>15</td></tr>
+                <tr><td>axios</td><td>general</td><td>20.0%</td><td>53.3%</td><td>66.7%</td><td>0.428</td><td>15</td></tr>
+                <tr><td>axios</td><td>vocabulary</td><td>80.0%</td><td>93.3%</td><td>93.3%</td><td>0.878</td><td>15</td></tr>
+                <tr><td>jq</td><td>general</td><td>53.3%</td><td>93.3%</td><td>100.0%</td><td>0.728</td><td>15</td></tr>
+                <tr><td>jq</td><td>vocabulary</td><td>80.0%</td><td>100.0%</td><td>100.0%</td><td>0.889</td><td>15</td></tr>
+                <tr><td>fmt</td><td>general</td><td>46.7%</td><td>73.3%</td><td>73.3%</td><td>0.621</td><td>15</td></tr>
                 <tr><td>fmt</td><td>vocabulary</td><td>66.7%</td><td>93.3%</td><td>93.3%</td><td>0.789</td><td>15</td></tr>
-                <tr><td>AutoMapper</td><td>general</td><td>6.7%</td><td>20.0%</td><td>33.3%</td><td>0.177</td><td>15</td></tr>
-                <tr><td>AutoMapper</td><td>vocabulary</td><td>86.7%</td><td>100.0%</td><td>100.0%</td><td>0.933</td><td>15</td></tr>
-                <tr><td>thrift</td><td>general</td><td>6.7%</td><td>33.3%</td><td>53.3%</td><td>0.241</td><td>15</td></tr>
-                <tr><td>thrift</td><td>cross-language</td><td>53.3%</td><td>73.3%</td><td>93.3%</td><td>0.677</td><td>15</td></tr>
+                <tr><td>AutoMapper</td><td>general</td><td>13.3%</td><td>40.0%</td><td>40.0%</td><td>0.294</td><td>15</td></tr>
+                <tr><td>AutoMapper</td><td>vocabulary</td><td>93.3%</td><td>100.0%</td><td>100.0%</td><td>0.956</td><td>15</td></tr>
+                <tr><td>thrift</td><td>general</td><td>13.3%</td><td>26.7%</td><td>53.3%</td><td>0.269</td><td>15</td></tr>
+                <tr><td>thrift</td><td>cross-language</td><td>73.3%</td><td>93.3%</td><td>93.3%</td><td>0.833</td><td>15</td></tr>
               </tbody>
             </table>
           </div>
@@ -216,10 +234,12 @@ python scripts/score_fallback_judge.py</code></pre>
             languages, none above a third of the modules), which implements the same protocol
             separately in each language and tests whether retrieval can tell one language's
             implementation from another's. A 0.8.10→0.8.11 fix added a <code>language</code>
-            pre-filter that raised thrift's cross-language top-5 from 60.0% to 93.3% — the one
-            defect found here that good phrasing does not explain, since the cross-language
-            questions already use full vocabulary. Full methodology, including two ranking
-            fixes that were built and rejected on measurement, in
+            pre-filter that raised thrift's cross-language top-5 from 60.0% to 93.3% — a defect
+            good phrasing does not explain, since the cross-language questions already use full
+            vocabulary. This table was upgraded from a previously-published 0.8.11 version after
+            an audit found two rows (gin, serde) and one corpus's general regime (guzzle) had no
+            reproducible or, in guzzle's case, any committed source at all — full account,
+            including one real regression this upgrade surfaced, in
             <a href="https://github.com/Aletheore/aletheore-benchmarks/blob/master/METHODOLOGY.md" rel="noopener">METHODOLOGY.md</a>.</p>
         </details>
 
@@ -381,13 +401,20 @@ python scripts/score_fallback_judge.py</code></pre>
           <h2>Stated here rather than in a footnote.</h2>
         </div>
         <div class="dogfood-callout">
-          <p>⚠️ RepoWise's generated wiki scores higher on "how does X work?" questions — 2.35
+          <p>⚠️ <strong>zod lost to RepoWise on both phrasing regimes</strong> — 0.0% vs. their
+            13.3% general, 6.7% vs. their 26.7% vocabulary. New on our latest release; zod won
+            both under the previous one. Root cause open, not yet fixed — full account in
+            <a href="https://github.com/Aletheore/aletheore-benchmarks/blob/master/METHODOLOGY.md#zod-regresses-under-0813---found-not-yet-root-caused-2026-08-20" rel="noopener">METHODOLOGY.md</a>.<br>
+            ⚠️ RepoWise's generated wiki scores higher on "how does X work?" questions — 2.35
             vs. our 2.13 on a blind 0-3 judge, though we sit within roughly 0.2 of them at about
             one-seventh the cost.<br>
             ⚠️ RepoWise retrieval is faster in-process — 68ms against our 125ms.<br>
-            ⚠️ Five of eight corpora score below 35% top-1 under vocabulary-avoiding phrasing,
-            though most of that gap is our question authoring, not the product — every one
-            recovers 20-47 points when asked in the project's own terms.<br>
+            ⚠️ Five of nine corpora with a vocabulary variant score below 35% top-1 under
+            vocabulary-avoiding phrasing. Four of those five recover strongly (+33 to +80pp)
+            when asked in the project's own terms, so most of that gap is our question
+            authoring, not the product — zod is the exception, barely moving (+6.7pp) because
+            it's now failing on both regimes, not because phrasing stopped mattering for it.<br>
+            ⚠️ jekyll top-5 loses to RepoWise, 53.3% against 66.7%.<br>
             ⚠️ AIRview writes a page for only 21 of 100 changed files on Flask's last 30 commits;
             the rest are served by a deterministic fallback, not the generated wiki this project
             is named for.</p>

--- a/website/benchmarks.js
+++ b/website/benchmarks.js
@@ -60,11 +60,11 @@ function renderHeadToHeadChart() {
   new Chart(canvas, {
     type: "bar",
     data: {
-      labels: ["gin", "serde", "gson", "jekyll", "Slim", "guzzle", "zod"],
+      labels: ["gin", "Slim", "serde", "gson", "guzzle", "jekyll", "zod"],
       datasets: [
         {
           label: "Aletheore",
-          data: [80.0, 53.3, 40.0, 26.7, 26.7, 20.0, 20.0],
+          data: [86.7, 60.0, 53.3, 40.0, 33.3, 26.7, 0.0],
           backgroundColor: CHART_COLORS.accent,
           borderRadius: 4,
           barPercentage: 0.75,
@@ -72,7 +72,7 @@ function renderHeadToHeadChart() {
         },
         {
           label: "RepoWise (best mode)",
-          data: [60.0, 13.3, 26.7, 13.3, 26.7, 20.0, 13.3],
+          data: [60.0, 26.7, 13.3, 26.7, 20.0, 13.3, 13.3],
           backgroundColor: CHART_COLORS.muted,
           borderRadius: 4,
           barPercentage: 0.75,
@@ -109,13 +109,13 @@ function renderSpreadChart() {
     type: "bar",
     data: {
       labels: [
-        "gin", "flask", "serde", "jq", "gson", "fmt",
-        "Slim", "jekyll", "zod", "axios", "AutoMapper", "thrift",
+        "gin", "flask", "Slim", "jq", "serde", "fmt",
+        "gson", "jekyll", "axios", "AutoMapper", "thrift", "zod",
       ],
       datasets: [
         {
           label: "Top-1 (general phrasing)",
-          data: [80.0, 71.9, 53.3, 53.3, 40.0, 40.0, 26.7, 26.7, 20.0, 20.0, 6.7, 6.7],
+          data: [86.7, 78.1, 60.0, 53.3, 53.3, 46.7, 40.0, 26.7, 20.0, 13.3, 13.3, 0.0],
           backgroundColor: CHART_COLORS.accent,
           borderRadius: 4,
           barPercentage: 0.7,


### PR DESCRIPTION
## Summary
Companion to the aletheore-benchmarks repo's 0.8.13 upgrade (commit 036a50d there):
- Headline record: 5-0-2 -> 6-1-0 head-to-head vs RepoWise
- Full 23-row retrieval matrix updated (verified against the repo's own `score_retrieval_matrix.py`, 0 mismatches)
- Both Chart.js charts updated with new data/ordering
- zod's real regression (the one corpus that got worse, flipping it from a win to a loss against RepoWise) is disclosed with its own callout, not averaged away - links to the open root-cause writeup in METHODOLOGY.md

## Verification
- HTML tag-balanced, all CSS classes defined, all 8 tables column-consistent
- All 23 retrieval-matrix rows cross-checked programmatically against the actual scoring script's output - 0 mismatches
- cspell clean
- JS syntax valid

## Test plan
- [ ] Visual check of both charts (head-to-head grouped bars, spread chart) once deployed
- [ ] Confirm the zod callouts read clearly and the METHODOLOGY.md deep links resolve