### PR TITLE
fix: MCP tool gaps — dead-code, ownership target, layer markers, secret regex

### DIFF
--- a/.aletheore.json
+++ b/.aletheore.json
@@ -1,5 +1,5 @@
 {
-  "layer_markers": {},
+  "layer_markers": { "aletheore": 0, "github-app": 1 },
   "cluster_resolution": 1.0,
   "dead_code_entry_points": [],
   "accepted_secrets": [],

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -11,6 +11,7 @@ ENTRY_POINT_FILENAMES = {
     "app.py",
     "asgi.py",
     "cli.py",
+    "conftest.py",
     "index.js",
     "index.jsx",
     "index.ts",
@@ -45,6 +46,38 @@ PACKAGE_IMPORT_ALIASES = {
 _MAIN_GUARD_PATTERN = re.compile(r"if\s+__name__\s*==\s*[\'\"]__main__[\'\"]\s*:")
 
 _HTML_SCRIPT_SRC_PATTERN = re.compile(r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE)
+
+# A module dispatched by dotted-string name (RQ's queue.enqueue("pkg.mod.func", ...),
+# Celery task names, cron-style job registries) is never imported by another module
+# either - the same blind spot as the __main__-guard case above, just for library-level
+# dynamic dispatch instead of direct script invocation. Confirmed on this repo:
+# scan_worker/jobs.py and scan_worker/demo_scan.py are the busiest modules in the
+# worker, dispatched exclusively via `queue.enqueue("scan_worker.jobs.<fn>", ...)`
+# string literals from scheduler.py and friends, and looked completely unreachable
+# without this check. Minimum 2 dotted segments required - a single bare segment
+# (just "jobs") collides with too many unrelated identifiers to be a reliable signal.
+_DOTTED_STRING_REF_MIN_SEGMENTS = 2
+
+
+def _dotted_path_candidates(path: str) -> list[str]:
+    if not path.endswith(".py"):
+        return []
+    parts = [part for part in path[: -len(".py")].split("/") if part and part != "__init__"]
+    span = len(parts) - _DOTTED_STRING_REF_MIN_SEGMENTS + 1
+    return [".".join(parts[start:]) for start in range(max(span, 0))]
+
+
+def _referenced_by_dotted_string(path: str, sources: dict[str, str]) -> bool:
+    candidates = _dotted_path_candidates(path)
+    if not candidates:
+        return False
+    patterns = [re.compile(r'["\']' + re.escape(candidate) + r'(?=[.\'"])') for candidate in candidates]
+    for other_path, content in sources.items():
+        if other_path == path:
+            continue
+        if any(pattern.search(content) for pattern in patterns):
+            return True
+    return False
 
 
 def _is_entry_point(path: str, custom_entry_points: set[str]) -> bool:
@@ -143,6 +176,25 @@ def find_dead_code(
             unreachable_modules.append(
                 {"path": path, "reason": "no other module imports this file"}
             )
+
+    if any(entry["path"].endswith(".py") for entry in unreachable_modules):
+        py_sources = {}
+        for module in modules:
+            if not module["path"].endswith(".py"):
+                continue
+            try:
+                py_sources[module["path"]] = (repo_path / module["path"]).read_text(
+                    encoding="utf-8", errors="ignore"
+                )
+            except OSError:
+                continue
+        still_unreachable = []
+        for entry in unreachable_modules:
+            if entry["path"].endswith(".py") and _referenced_by_dotted_string(entry["path"], py_sources):
+                entry_points_detected.append(entry["path"])
+            else:
+                still_unreachable.append(entry)
+        unreachable_modules = still_unreachable
 
     imported_roots = _import_roots(modules)
     unused_dependencies = []

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -122,7 +122,8 @@ _QUERY_TOOL_DESCRIPTIONS = {
     "imported-by": "Which modules import this one. target: file path exactly as it appears in evidence.",
     "symbols": "This module's extracted functions and classes. target: file path exactly as it appears in evidence.",
     "branch": "Git branch metadata (head commit, tracking info). target: branch name (e.g. 'main').",
-    "ownership": "Per-file code ownership derived from git blame history. Takes no target.",
+    "ownership": "Code ownership derived from git blame history. Optional target: a file path "
+    "exactly as it appears in evidence, for that file's ownership; omit for repo-wide aggregate.",
     "secrets": "Secret-scanner findings for one file. target: file path exactly as it appears in evidence.",
     "vulnerabilities": "All dependency vulnerability findings for this repo. Takes no target.",
     "licenses": "All dependency license findings for this repo. Takes no target.",
@@ -282,6 +283,18 @@ READ_ONLY_ANNOTATIONS = ToolAnnotations(
 
 
 def _register_query_wrapper_tools(mcp_instance: MCPServer, repo_path: Path) -> None:
+    # Query kinds whose function treats `target` as an optional refinement (None ->
+    # repo-wide aggregate, a real value -> scoped result) rather than an unused
+    # parameter kept only for signature uniformity - find_ownership branches on
+    # target to return evidence["git"]["file_ownership"][target] instead of the
+    # aggregate. The CLI's _query already forwards target for every kind
+    # regardless of requires_target, so this only affects the generated MCP tool's
+    # signature: without it, requires_target=False (correct - target was never
+    # mandatory for ownership) meant the wrapper generated a zero-argument tool(),
+    # so an MCP caller could never pass a target at all, even though the
+    # underlying query already supported one.
+    optional_target_kinds = {"ownership"}
+
     for tool_name, kind in _TOOL_NAME_TO_QUERY_KIND.items():
         func, requires_target = QUERY_FUNCTIONS[kind]
 
@@ -289,6 +302,12 @@ def _register_query_wrapper_tools(mcp_instance: MCPServer, repo_path: Path) -> N
             if requires_target:
 
                 def tool(target: str) -> str:
+                    evidence = read_evidence(repo_path)
+                    return _toon_result(func(evidence, target))
+
+            elif kind in optional_target_kinds:
+
+                def tool(target: str | None = None) -> str:
                     evidence = read_evidence(repo_path)
                     return _toon_result(func(evidence, target))
 

--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -75,8 +75,13 @@ SECRET_PATTERNS = [
     (
         "generic_credential_assignment",
         re.compile(
+            # The value class includes "." for key formats that embed one (e.g. newer
+            # Google AI Studio keys: "AQ.Ab8R..." rather than the older AIza-prefixed
+            # google_api_key shape above) - without it, GEMINI_API_KEY=AQ.Ab8R... matched
+            # only the 2 characters before the dot, fell under the 16-char minimum, and
+            # the whole credential silently went undetected rather than just unredacted.
             r"(?i)(?:^|[\s_-])(PASSWORD|SECRET|API_KEY)\s*[:=]\s*"
-            r"['\"]?([A-Za-z0-9+/=_-]{16,})['\"]?(?=\s|$|[,#;)])"
+            r"['\"]?([A-Za-z0-9+/=_.-]{16,})['\"]?(?=\s|$|[,#;)])"
         ),
         2,
     ),

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -74,6 +74,51 @@ def test_script_without_main_guard_is_still_unreachable(tmp_path):
     assert "orphan.py" in paths
 
 
+def test_conftest_py_is_never_unreachable(tmp_path):
+    # pytest auto-discovers conftest.py by filename alone - never imported by
+    # test files or anything else, which is the whole point of the convention.
+    modules = [_module("tests/conftest.py"), _module("github-app/tests/conftest.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert set(result["entry_points_detected"]) == {"tests/conftest.py", "github-app/tests/conftest.py"}
+
+
+def test_module_dispatched_by_dotted_string_is_never_unreachable(tmp_path):
+    # Found on this repo: RQ's queue.enqueue("scan_worker.jobs.<fn>", ...) dispatches
+    # by dotted-string module path, never a Python import - scan_worker/jobs.py, the
+    # busiest module in the worker, looked completely unreachable without this check.
+    (tmp_path / "scan_worker").mkdir()
+    (tmp_path / "scan_worker" / "jobs.py").write_text("def run_pr_scan_job():\n    pass\n")
+    (tmp_path / "scan_worker" / "scheduler.py").write_text(
+        'queue.enqueue("scan_worker.jobs.run_pr_scan_job")\n'
+    )
+    modules = [
+        _module("scan_worker/jobs.py"),
+        _module("scan_worker/scheduler.py", imported_by=["scan_worker/worker.py"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "scan_worker/jobs.py" in result["entry_points_detected"]
+
+
+def test_module_referenced_only_by_unrelated_substring_is_still_unreachable(tmp_path):
+    # False-negative guard rail: a module whose name merely happens to be a substring
+    # of something else in the repo (not a real dotted-path dispatch reference) must
+    # still be flagged - this isn't a license to treat any name collision as reachable.
+    (tmp_path / "scan_worker").mkdir()
+    (tmp_path / "scan_worker" / "jobs.py").write_text("def helper():\n    pass\n")
+    (tmp_path / "scan_worker" / "other.py").write_text(
+        "# unrelated comment mentioning scan_worker.jobsxyz elsewhere\n"
+    )
+    modules = [
+        _module("scan_worker/jobs.py"),
+        _module("scan_worker/other.py", imported_by=["scan_worker/worker.py"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [module["path"] for module in result["unreachable_modules"]]
+    assert "scan_worker/jobs.py" in paths
+
+
 def test_js_referenced_by_html_script_tag_is_never_unreachable(tmp_path):
     # Found on this repo: plain <script src="..."> tags (no bundler, no ES
     # module imports) load website JS - the import graph never sees these

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -663,6 +663,27 @@ async def test_aletheore_ownership_tool_needs_no_target(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aletheore_ownership_tool_accepts_an_optional_target(tmp_path):
+    # Regression test: aletheore_ownership was wired as a zero-argument MCP
+    # tool (requires_target=False), so it could never forward a target even
+    # though find_ownership already branches on one for file-scoped ownership
+    # via evidence["git"]["file_ownership"]. Confirms both ends of the fix -
+    # a target is now accepted at all, and it actually reaches find_ownership.
+    repo = make_repo_with_evidence(tmp_path)
+    evidence_path = repo / ".aletheore" / "air.json"
+    evidence = json.loads(evidence_path.read_text())
+    evidence["git"]["file_ownership"] = {"a.py": [{"author": "alice", "commits": 3}]}
+    evidence_path.write_text(json.dumps(evidence))
+    server = build_server(repo)
+
+    scoped = await server.call_tool("aletheore_ownership", {"target": "a.py"})
+    aggregate = await server.call_tool("aletheore_ownership", {})
+
+    assert tool_result_body(scoped) == {"result": [{"author": "alice", "commits": 3}]}
+    assert tool_result_body(aggregate) == {"result": [{"path": "a.py", "top_author": "alice"}]}
+
+
+@pytest.mark.asyncio
 async def test_aletheore_imports_tool_raises_for_unknown_module(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
     server = build_server(repo)

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -124,6 +124,23 @@ def test_find_secrets_detects_unquoted_generic_credentials_and_multiple_matches(
     assert sum(f["pattern"] == "aws_access_key_id" for f in findings) == 2
 
 
+def test_find_secrets_detects_credential_value_containing_a_dot(tmp_path):
+    # Regression: newer Google AI Studio keys use a dotted shape
+    # ("AQ.Ab8R...") rather than the older AIza-prefixed google_api_key
+    # format - the generic value class didn't include ".", so the match
+    # stopped after 2 characters, fell under the 16-char minimum, and the
+    # whole credential went undetected rather than just unredacted.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env").write_text(
+        "GEMINI_API_KEY=AQ.NotARealKey0123456789ABCDEFGHIJKLMNOPqrstuv\n"
+    )
+
+    findings = find_secrets(repo)["findings"]
+
+    assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 1
+
+
 def test_find_secrets_detects_fine_grained_github_and_sts_aws_tokens(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary

Four gaps found by running paired Aletheore-vs-Repowise MCP tool comparison agents against this repo (dead code, security surface, hotspots/ownership) as an internal quality check — not a benchmark, just dogfooding our own MCP surface the way an external agent actually would.

- **`aletheore_dead_code` false-positived on RQ string-dispatch and pytest `conftest.py`.** 3/3 spot-checked "unreachable module" findings (`scan_worker/jobs.py`, `scan_worker/demo_scan.py`, `src/conftest.py`) were live code, invisible to static import analysis because they're invoked via `queue.enqueue("module.func", ...)` string dispatch or pytest's filename-based auto-discovery. Added `conftest.py` to `ENTRY_POINT_FILENAMES` (matching `wiki_mapping.py`'s existing special-casing, which `dead_code.py` didn't reuse), and added a dotted-string-reference check before flagging an otherwise-orphaned module dead.
- **`aletheore_ownership` had no target parameter at all**, even though `find_ownership` already branched on one internally (file-scoped vs. repo-wide aggregate). `_register_query_wrapper_tools`'s binary required/no-target split meant the tool could never receive it. Added an `optional_target_kinds` set so ownership gets `target: str | None = None`.
- **`aletheore_layer_violations` returned "inconclusive" for this repo.** Not a code bug — the already-wired `.aletheore.json` → `layer_markers` override was just never populated for this repo's actual folder structure (`LAYER_FOLDER_MARKERS` only recognizes classic Clean-Architecture names). Set to `{"aletheore": 0, "github-app": 1}`, verified via grep the boundary is unambiguous, re-scanned: now reports 2 layers, 0 violations.
- **Secrets scanner missed a real API key shape.** Newer Google AI Studio keys contain a literal `.` that `generic_credential_assignment`'s value character class didn't allow, truncating the match below the 16-char minimum and silently dropping the whole finding. Added `.` to the value class.

Each fix ships with a regression test naming the real case that exposed it.

## Test plan
- [x] `pytest src/tests/test_dead_code.py src/tests/test_mcp_server.py src/tests/test_secrets.py` — new + existing tests pass
- [x] Full suite: `pytest src/tests/` — 1289 passed
- [x] `.aletheore.json` layer-marker change verified against a fresh `aletheore scan` (2 layers detected, 0 violations, matching a manual grep confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj