### PR TITLE
fix: installation spend/count cap check-then-act race — atomic reservation

### DIFF
--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -276,7 +276,24 @@ def get_flash_review_count_this_month(dsn: str, installation_id: int) -> int:
             return int(row[0]) if row else 0
 
 
-def increment_flash_review_count(dsn: str, installation_id: int) -> None:
+def reserve_flash_review_count(dsn: str, installation_id: int, limit: int) -> bool:
+    """Atomically checks the review-count cap and reserves a slot in one
+    statement, the same INSERT...ON CONFLICT...WHERE...RETURNING shape as
+    check_and_reserve_flash_review_attempt below. installation_spend_lock's
+    two-phase check-then-later-increment used to leave a real window open:
+    two concurrent reviews for the same installation could each read the
+    count as under-cap before either recorded an attempt, overshooting
+    `limit`. This closes it completely rather than narrowing it - Postgres
+    serializes concurrent UPSERTs on the same (installation_id, month) row
+    via its own row-level lock, so the second caller's WHERE clause always
+    evaluates against the first's already-applied increment. No advisory
+    lock needed.
+
+    Returns True (and increments) if a slot was available, False (no
+    increment - nothing to undo) if the cap was already reached. Call
+    release_flash_review_count_reservation if the reserved review then
+    never actually runs (e.g. every free-tier provider failed, or an
+    unrelated exception aborted the job before it produced a result)."""
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -285,8 +302,85 @@ def increment_flash_review_count(dsn: str, installation_id: int) -> None:
                 VALUES (%s, date_trunc('month', now())::date, 1)
                 ON CONFLICT (installation_id, month) DO UPDATE
                 SET review_count = flash_review_monthly_count.review_count + 1
+                WHERE flash_review_monthly_count.review_count < %s
+                RETURNING review_count
+                """,
+                (installation_id, limit),
+            )
+            row = cur.fetchone()
+        conn.commit()
+    return row is not None
+
+
+def release_flash_review_count_reservation(dsn: str, installation_id: int) -> None:
+    """Undoes one reserve_flash_review_count reservation for a review that
+    was counted against the cap but never actually ran. GREATEST(...,0)
+    guards against a double-release ever taking the count negative."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE flash_review_monthly_count
+                SET review_count = GREATEST(review_count - 1, 0)
+                WHERE installation_id = %s AND month = date_trunc('month', now())::date
                 """,
                 (installation_id,),
+            )
+        conn.commit()
+
+
+def reserve_llm_spend(dsn: str, installation_id: int, reserve_usd: float, monthly_cap: float) -> bool:
+    """Same atomic reserve-before-spend pattern as
+    reserve_flash_review_count, for the dollar cap - reserves a
+    conservative flat estimate (see jobs.py's FLASH_REVIEW_SPEND_RESERVE_USD)
+    up front, since the real cost of a Flash Review isn't known until the
+    LLM call and grounding pass complete. record_llm_spend's own additive
+    upsert then trues the reservation up to the real cost afterward (pass
+    `real_cost - reserve_usd` as the delta - negative if the real cost came
+    in under the reservation, which is the common case).
+
+    Note: on the very first reservation of a new month (no llm_spend row
+    yet for this installation), the ON CONFLICT...WHERE clause only gates
+    the UPDATE branch, not the INSERT branch, so that first reservation
+    always succeeds regardless of monthly_cap. This matches the pre-existing
+    check-then-act behavior, which also couldn't reject a single review
+    whose cost alone would exceed the cap - not a new gap, and not reachable
+    in practice since reserve_usd is always small relative to any real
+    monthly_cap.
+
+    Returns True (and reserves) if under cap, False (no reservation) if
+    already at/over it. Call release_llm_spend_reservation if the review
+    then never actually runs."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO llm_spend (installation_id, month, total_cost_usd)
+                VALUES (%s, date_trunc('month', now())::date, %s)
+                ON CONFLICT (installation_id, month) DO UPDATE
+                SET total_cost_usd = llm_spend.total_cost_usd + %s
+                WHERE llm_spend.total_cost_usd + %s <= %s
+                RETURNING total_cost_usd
+                """,
+                (installation_id, reserve_usd, reserve_usd, reserve_usd, monthly_cap),
+            )
+            row = cur.fetchone()
+        conn.commit()
+    return row is not None
+
+
+def release_llm_spend_reservation(dsn: str, installation_id: int, reserve_usd: float) -> None:
+    """Undoes one reserve_llm_spend reservation for a review that was
+    charged against the cap but never actually ran."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE llm_spend
+                SET total_cost_usd = GREATEST(total_cost_usd - %s, 0)
+                WHERE installation_id = %s AND month = date_trunc('month', now())::date
+                """,
+                (reserve_usd, installation_id),
             )
         conn.commit()
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -76,12 +76,15 @@ from scan_worker.db import (
     get_latest_evidence,
     get_llm_spend_this_month,
     get_seconds_since_last_health_check,
-    increment_flash_review_count,
     insert_audit_report,
     insert_endpoint_health,
     was_recently_down,
     insert_repo_history,
     installation_spend_lock,
+    release_flash_review_count_reservation,
+    release_llm_spend_reservation,
+    reserve_flash_review_count,
+    reserve_llm_spend,
     list_docs_symbols,
     list_health_check_targets_all,
     list_installation_member_emails,
@@ -235,6 +238,19 @@ MAX_FLASH_REVIEWS_PER_MONTH = 500
 # track paid 1:1.
 MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH = 150
 DEFAULT_LLM_NEXT_CALL_RESERVE_USD = 0.001
+
+# Conservative flat reserve for one paid-tier Flash Review, used by
+# reserve_llm_spend to make the dollar-cap check atomic with the reservation
+# (see run_flash_review_job). Deliberately generous relative to a real
+# review's likely cost: Luna/deepseek-v4-flash pricing is $0.20-1.20 per
+# million tokens (see app_server/llm_cost.py's MODEL_RATES_PER_MILLION_USD)
+# and compact mode keeps prompts to diff + evidence only, so a real review
+# should land well under this - but reasoning-token output on a single
+# unusually large diff is the failure mode this needs to survive without
+# under-reserving. Small relative to a real monthly cap (the base AIR plan's
+# is ~$15, see monthly_cap_for_installation), so it doesn't meaningfully
+# throttle legitimate usage near the cap boundary.
+FLASH_REVIEW_SPEND_RESERVE_USD = 0.50
 
 
 def _job_temp_dir() -> Path:
@@ -1339,20 +1355,22 @@ def run_managed_audit_api_job(
     include_suggestions = (
         installation.get("llm_suggestions_enabled", True) if installation is not None else True
     )
-    with installation_spend_lock(settings.database_url, installation_id):
-        extra_seats = get_extra_seats(settings.database_url, installation_id)
-        monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
-        current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
-        if current_spend >= monthly_cap:
-            raise RuntimeError(
-                f"monthly spend cap reached for this installation (${monthly_cap:.2f})"
-            )
-    # Everything below runs outside installation_spend_lock: run_managed_audit
-    # can make several sequential LLM calls (see _IncrementalSpendBudget) and
-    # has been observed to take minutes. record_usage's underlying SQL
-    # increment is already atomic, so only the cap check above needs the lock
-    # - holding it for the whole audit just serializes concurrent jobs for the
-    # same installation into LockNotAvailable failures (same bug as
+    # No lock: this is a fast-fail hint (skip the setup work below if the
+    # cap is obviously already blown), not the enforcement itself - real
+    # enforcement is each _IncrementalSpendBudget.can_start_next_call()
+    # reserving atomically against the live total, so a stale read here has
+    # no financial-integrity consequence, just a possibly-later-than-ideal
+    # rejection.
+    extra_seats = get_extra_seats(settings.database_url, installation_id)
+    monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
+    current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
+    if current_spend >= monthly_cap:
+        raise RuntimeError(
+            f"monthly spend cap reached for this installation (${monthly_cap:.2f})"
+        )
+    # run_managed_audit can make several sequential LLM calls (see
+    # _IncrementalSpendBudget) and has been observed to take minutes -
+    # nothing below needs a lock held for that whole duration (same bug as
     # run_flash_review_job, see its comment at jobs.py:1379).
     job_dir = _job_temp_dir()
     try:
@@ -1367,7 +1385,6 @@ def run_managed_audit_api_job(
             settings.database_url,
             installation_id,
             model_for_plan(plan),
-            current_spend,
             monthly_cap,
             feature="managed_audit",
         )
@@ -1420,50 +1437,53 @@ def run_flash_review_job(
     ):
         return
 
-    # The advisory lock only needs to guard the quick check-then-write
-    # spend bookkeeping (see installation_spend_lock's docstring) - NOT
-    # the review itself, which does a real LLM call plus several GitHub
-    # API round-trips and has been measured at up to 5m50s in production
-    # (see FLASH_REVIEW_JOB_TIMEOUT_SECONDS in
-    # app_server/webhooks/pull_request.py). Holding the lock for that
-    # whole duration serialized every Flash Review for one installation
-    # to run strictly one at a time, and ADVISORY_LOCK_TIMEOUT (5s) is far
-    # shorter than that review time, so any review queued behind another
-    # for the same installation reliably failed outright with
-    # psycopg.errors.LockNotAvailable instead of just waiting its turn -
-    # confirmed in production logs while opening 25 PRs on one
-    # installation in quick succession. The lock is now acquired twice,
-    # briefly, around the check and (inside _run_flash_review) around the
-    # final spend record - never around the expensive work in between.
+    # Both caps are reserved atomically up front via a single UPSERT each
+    # (reserve_flash_review_count / reserve_llm_spend), not read-then-later-
+    # written under an advisory lock. A held lock can only guard against two
+    # concurrent callers racing each other while both hold it - it does
+    # nothing once either releases it, and the actual review (a real LLM
+    # call plus several GitHub API round-trips, measured at up to 5m50s in
+    # production, see FLASH_REVIEW_JOB_TIMEOUT_SECONDS in
+    # app_server/webhooks/pull_request.py) can't run while a lock this
+    # narrow is held - ADVISORY_LOCK_TIMEOUT (5s) is far shorter than that,
+    # so any review queued behind another for the same installation used to
+    # fail outright with psycopg.errors.LockNotAvailable instead of just
+    # waiting its turn (confirmed in production logs while opening 25 PRs on
+    # one installation in quick succession). Reserving atomically at
+    # check-time - the same fix this PR's OpenAI daily-token cap already
+    # uses, see model_tiers._reserve_openai_free_tier_budget - closes the
+    # race completely instead of narrowing the window where it can occur:
+    # two concurrent Flash Reviews for the same installation can no longer
+    # both pass the cap check before either has "spent" anything, because
+    # the reservation itself IS the spend, applied atomically at the moment
+    # of the check.
+    reserved_spend = 0.0
     if is_free_tier:
-        # Free-tier: request-count cap, no dollar cap (providers are free/near-free).
-        # Locked the same way the paid branch below locks its own count
-        # check - without it, two concurrent Flash Reviews on the same free
-        # installation (e.g. two PRs pushed at once, landing on different
-        # scan-worker replicas) could both read the count as under-cap
-        # before either recorded an attempt, overshooting
-        # MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH by however many land in that
-        # window - the same class of race this PR's OpenAI daily-token cap
-        # fix (see model_tiers._reserve_openai_free_tier_budget) closes for
-        # a different counter.
-        with installation_spend_lock(settings.database_url, installation_id):
-            if get_flash_review_count_this_month(settings.database_url, installation_id) >= MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH:
-                return
+        if not reserve_flash_review_count(
+            settings.database_url, installation_id, MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH
+        ):
+            return
         monthly_cap = 0.0  # no dollar cap for free tier
     else:
-        with installation_spend_lock(settings.database_url, installation_id):
-            extra_seats = get_extra_seats(settings.database_url, installation_id)
-            monthly_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
-            current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
-            if current_spend >= monthly_cap:
-                return
-            if get_flash_review_count_this_month(settings.database_url, installation_id) >= MAX_FLASH_REVIEWS_PER_MONTH:
-                return
+        # Reads only, no lock needed - extra_seats/monthly_cap are inputs to
+        # this request's own reservation below, not shared mutable state
+        # that itself needs cross-process atomicity.
+        extra_seats = get_extra_seats(settings.database_url, installation_id)
+        monthly_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
+        if not reserve_flash_review_count(
+            settings.database_url, installation_id, MAX_FLASH_REVIEWS_PER_MONTH
+        ):
+            return
+        reserved_spend = FLASH_REVIEW_SPEND_RESERVE_USD
+        if not reserve_llm_spend(settings.database_url, installation_id, reserved_spend, monthly_cap):
+            release_flash_review_count_reservation(settings.database_url, installation_id)
+            return
 
+    review_ran = False
     try:
-        _run_flash_review(
+        review_ran = _run_flash_review(
             settings, installation_id, repo_full_name, pr_number, base_sha, head_sha, monthly_cap,
-            is_free_tier=is_free_tier,
+            reserved_spend, is_free_tier=is_free_tier,
         )
     except Exception as exc:  # noqa: BLE001
         try:
@@ -1472,6 +1492,17 @@ def run_flash_review_job(
             )
         except Exception:  # noqa: BLE001
             pass
+    finally:
+        # A reservation that never became a real review (every free-tier
+        # provider failed, no provider keys configured, or an unrelated
+        # exception aborted the job before it could produce a result) must
+        # not permanently consume a slot/dollar the installation never
+        # actually used - see release_flash_review_count_reservation and
+        # release_llm_spend_reservation.
+        if not review_ran:
+            release_flash_review_count_reservation(settings.database_url, installation_id)
+            if reserved_spend:
+                release_llm_spend_reservation(settings.database_url, installation_id, reserved_spend)
 
 
 def _run_flash_review(
@@ -1482,9 +1513,15 @@ def _run_flash_review(
     base_sha: str,
     head_sha: str,
     monthly_cap: float,
+    reserved_spend: float,
     *,
     is_free_tier: bool = False,
-) -> None:
+) -> bool:
+    """Returns True if a real review actually ran and its spend/count
+    reservation (see run_flash_review_job) was trued up to reflect it -
+    False if it bailed out before that point (no free-tier provider keys
+    configured, or every free-tier provider failed), in which case the
+    caller's reservation was never "spent" and must be released."""
     app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
     token = _token_sync(installation_id, app_jwt)
     client = get_github_api_client()
@@ -1504,6 +1541,10 @@ def _run_flash_review(
 
     spend_accumulator = {"total": 0.0}
     grounding_result: dict = {}
+    # Defined before the branch below so the tail of this function can
+    # always read it, whether or not the non-substantive-diff short-circuit
+    # (which never touches free-tier providers at all) was taken.
+    free_tier_exhausted = {"value": False}
 
     skipped_files: list[str] = []
 
@@ -1602,6 +1643,11 @@ def _run_flash_review(
             # human, not just a log line nobody's watching - reuses the
             # same cooldown-guarded ops-alert path other production
             # incidents already go through, so this can't spam either.
+            # Also flagged here (not inferred from empty findings downstream)
+            # so run_flash_review_job's caller can release this review's
+            # reservation - a review that never actually ran must not
+            # permanently consume a slot/dollar the installation never used.
+            free_tier_exhausted["value"] = True
             _send_ops_alert(
                 get_redis_client(),
                 "flash_review.free_tier_exhausted",
@@ -1621,7 +1667,7 @@ def _run_flash_review(
                     "free-tier: no provider keys configured, skipping review for %s#%s",
                     repo_full_name, pr_number,
                 )
-                return
+                return False
 
         if code_evidence_context:
             findings = review_diff(
@@ -1668,15 +1714,21 @@ def _run_flash_review(
                 adapter_chain=free_tier_chain,
                 on_free_tier_exhausted=_on_free_tier_exhausted,
             )
-    # Briefly re-acquire the lock just for the write, now that the
-    # expensive review work above is done - see run_flash_review_job's
-    # comment on why the lock no longer wraps this whole function.
-    with installation_spend_lock(settings.database_url, installation_id):
+    # The review-count reservation already happened atomically up front (see
+    # run_flash_review_job); nothing left to do for it here on the success
+    # path. The dollar reservation was a conservative flat estimate, not the
+    # real cost - true it up to what actually happened. No lock needed:
+    # record_llm_spend's own UPSERT is already atomic per call, and it was
+    # only ever paired with the (now-removed) count increment for the
+    # illusion of atomicity, not because either write needed one on its own.
+    # Skipped entirely when free-tier was fully exhausted before producing a
+    # result - that reservation gets released, not trued up, by the caller.
+    review_ran = not free_tier_exhausted["value"]
+    if review_ran:
         record_llm_spend(
-            settings.database_url, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap,
-            feature="flash_review",
+            settings.database_url, installation_id, spend_accumulator["total"] - reserved_spend,
+            monthly_cap=monthly_cap, feature="flash_review",
         )
-        increment_flash_review_count(settings.database_url, installation_id)
 
     proposed = grounding_result.get("proposed", 0)
     kept = grounding_result.get("kept", 0)
@@ -1731,6 +1783,7 @@ def _run_flash_review(
     set_last_reviewed_sha(
         settings.database_url, installation_id, repo_full_name, pr_number, head_sha
     )
+    return review_ran
 
 
 def _send_if_webhook_configured(installation: dict, message: dict) -> None:
@@ -2892,11 +2945,17 @@ def run_weekly_digest_sweep_job() -> None:
 
 
 def _llm_spend_cap_reached(dsn: str, installation_id: int, plan: str) -> tuple[bool, float]:
-    """(cap_reached, monthly_cap) - caller must hold installation_spend_lock,
-    same as every other spend-gated call site (managed audits, flash
-    review). Factored out because AIRview/Docs builds now have four call
-    sites needing the identical cap computation, where every existing
-    caller only ever needed it once.
+    """(cap_reached, monthly_cap) - a plain read, no lock required. For a
+    caller that goes on to gate every real LLM call through an
+    _IncrementalSpendBudget, this is a fast-fail hint only (skip setup work
+    if the cap is obviously already blown); real enforcement is that
+    budget's can_start_next_call() reserving atomically per call. A caller
+    with no such budget (a single LLM call, or none at all downstream)
+    should still treat this as its real enforcement and keep locking around
+    it - see run_flash_review_job's fix-suggestion attachment for that
+    shape. Factored out because AIRview/Docs builds have several call sites
+    needing the identical cap computation, where every existing caller only
+    ever needed it once.
     """
     extra_seats = get_extra_seats(dsn, installation_id)
     monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
@@ -2905,12 +2964,33 @@ def _llm_spend_cap_reached(dsn: str, installation_id: int, plan: str) -> tuple[b
 
 
 class _IncrementalSpendBudget:
+    """Gates a job that makes several sequential LLM calls (managed audits,
+    AIRview/Docs full builds) against the monthly dollar cap.
+
+    can_start_next_call() used to compare against a `current_spend` snapshot
+    read once when the budget object was created, plus an in-process
+    spent_this_job counter - invisible to any OTHER concurrent job spending
+    against the same installation's cap (a Flash Review, or a second
+    AIRview/Docs build) for the whole duration of this one, sometimes
+    minutes long. Now reserves atomically per call instead (see
+    reserve_llm_spend, the same primitive run_flash_review_job's cap check
+    uses): each call to can_start_next_call() re-reads and compares against
+    the real current total in one atomic statement, so two jobs racing each
+    other can no longer both see room for a call that only one of them can
+    actually afford.
+
+    Known residual gap, not addressed here: if the LLM call itself fails
+    after can_start_next_call() reserves but before record_usage() trues it
+    up, that reservation is never released - the same class of gap
+    model_tiers._reserve_openai_free_tier_budget already has for the OpenAI
+    free-tier daily token cap. Closing it needs a failure hook the adapter
+    chain doesn't expose yet; tracked separately, not part of this fix."""
+
     def __init__(
         self,
         dsn: str,
         installation_id: int,
         model: str,
-        current_spend: float,
         monthly_cap: float,
         next_call_reserve_usd: float = DEFAULT_LLM_NEXT_CALL_RESERVE_USD,
         feature: str = "unknown",
@@ -2918,24 +2998,21 @@ class _IncrementalSpendBudget:
         self.dsn = dsn
         self.installation_id = installation_id
         self.model = model
-        self.current_spend = current_spend
         self.monthly_cap = monthly_cap
         self.next_call_reserve_usd = next_call_reserve_usd
-        self.spent_this_job = 0.0
         self.feature = feature
 
     def can_start_next_call(self) -> bool:
-        return (
-            self.current_spend + self.spent_this_job + self.next_call_reserve_usd
-            <= self.monthly_cap
+        return reserve_llm_spend(
+            self.dsn, self.installation_id, self.next_call_reserve_usd, self.monthly_cap
         )
 
     def record_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
         cost = cost_for_usage(self.model, prompt_tokens, completion_tokens)
-        if cost <= 0:
+        delta = cost - self.next_call_reserve_usd
+        if delta == 0:
             return
-        record_llm_spend(self.dsn, self.installation_id, cost, feature=self.feature)
-        self.spent_this_job += cost
+        record_llm_spend(self.dsn, self.installation_id, delta, feature=self.feature)
 
     def cap_message(self) -> str:
         return (
@@ -3560,8 +3637,10 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         return
     client, token = client_and_token
 
-    with installation_spend_lock(dsn, installation_id):
-        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+    # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring;
+    # real enforcement is its can_start_next_call() reserving atomically per
+    # call below.
+    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
     if cap_reached:
         logging.getLogger("scan_worker.jobs").info(
             "live docs full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
@@ -3574,9 +3653,8 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         return
 
     full_build_model = model_for_plan(plan)
-    current_spend = get_llm_spend_this_month(dsn, installation_id)
     spend_budget = _IncrementalSpendBudget(
-        dsn, installation_id, full_build_model, current_spend, monthly_cap,
+        dsn, installation_id, full_build_model, monthly_cap,
         feature="docs_full_build",
     )
 
@@ -3702,8 +3780,13 @@ def _maybe_update_live_docs(
 
     dsn = settings.database_url
     plan = installation["plan"]
-    with installation_spend_lock(dsn, installation_id):
-        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+    # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring;
+    # real enforcement is its can_start_next_call() reserving atomically per
+    # call below. This closes the actual gap: two concurrent jobs spending
+    # against the same installation (e.g. this incremental update racing a
+    # Flash Review or a full build) no longer share one stale current_spend
+    # snapshot that neither can see the other invalidate mid-run.
+    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
     if cap_reached:
         logging.getLogger("scan_worker.jobs").info(
             "live docs incremental update skipped for installation=%s repo=%s - "
@@ -3717,9 +3800,8 @@ def _maybe_update_live_docs(
         return
 
     update_model = resolve_model(live_docs.FLASH_MODEL)
-    current_spend = get_llm_spend_this_month(dsn, installation_id)
     spend_budget = _IncrementalSpendBudget(
-        dsn, installation_id, update_model, current_spend, monthly_cap,
+        dsn, installation_id, update_model, monthly_cap,
         feature="docs_incremental",
     )
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import pytest
 
 from scan_worker.jobs import (
-    MAX_FLASH_REVIEWS_PER_MONTH,
+    FLASH_REVIEW_SPEND_RESERVE_USD,
     MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH,
     run_pr_scan_job,
 )
@@ -45,6 +45,12 @@ def _patch_no_spend_cap(monkeypatch) -> None:
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    # _IncrementalSpendBudget.can_start_next_call() now reserves atomically
+    # against the real DB per call instead of comparing an in-memory
+    # snapshot - always-succeed here for the same "well under any cap"
+    # reason as the mocks above.
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
 
 
 class _FakeCodeGraphStore:
@@ -1007,16 +1013,31 @@ def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeyp
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: 0.0012)
     monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a, **k: 0.0006)
-    recorded_spend = []
-    monkeypatch.setattr(
-        "scan_worker.jobs.record_llm_spend",
-        lambda dsn, iid, cost, **k: recorded_spend.append(cost),
-    )
+    # In-memory stand-in for the real atomic reserve_llm_spend/record_llm_spend
+    # pair, sharing running-total state the same way the real DB row does -
+    # reserve_llm_spend reserves next_call_reserve_usd up front (atomic
+    # check-and-add), record_llm_spend's delta then trues it up to the real
+    # cost. `cost_for_usage` mocked to 0.0006 < DEFAULT_LLM_NEXT_CALL_RESERVE_USD
+    # (0.001), so the true-up delta is negative: -0.0004.
+    spend_state = {"total": 0.0}
+    recorded_deltas = []
+
+    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+        if spend_state["total"] + reserve_usd <= monthly_cap:
+            spend_state["total"] += reserve_usd
+            return True
+        return False
+
+    def _record_llm_spend(dsn, iid, delta, **k):
+        spend_state["total"] += delta
+        recorded_deltas.append(delta)
+
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.insert_audit_report", lambda *a, **k: None)
 
@@ -1040,7 +1061,7 @@ def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeyp
     )
 
     assert "Partial managed audit" in result
-    assert recorded_spend == [0.0006]
+    assert recorded_deltas == [pytest.approx(-0.0004)]
     assert budget_checks == [True, False]
 
 
@@ -1523,7 +1544,10 @@ def test_flash_review_job_routes_free_tier_to_free_tier_path(monkeypatch):
         "scan_worker.jobs.record_llm_spend",
         lambda *a, **k: record_llm_spend_calls.append(a),
     )
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr(
@@ -1552,25 +1576,20 @@ def test_flash_review_job_routes_free_tier_to_free_tier_path(monkeypatch):
     assert cache_write_calls == []
 
 
-def test_flash_review_job_locks_the_free_tier_monthly_count_check(monkeypatch):
-    # Regression guard for a TOCTOU race: the paid branch reads its
-    # monthly-count cap inside installation_spend_lock (see the `else`
-    # branch a few lines below the free-tier one in jobs.py); the free-tier
-    # branch didn't, so two concurrent free-tier reviews on the same
-    # installation could both read "under cap" before either recorded an
-    # attempt. This only checks the lock is actually acquired around the
-    # check - the fix is the `with installation_spend_lock(...)` wrapper
-    # itself, not anything this test can observe about ordering under real
-    # concurrency (see test_model_tiers.py's own note on why that's hard to
-    # test directly for the sibling OpenAI-token-cap fix).
-    from contextlib import contextmanager
+def test_flash_review_job_reserves_the_free_tier_monthly_count_atomically(monkeypatch):
+    # Regression guard for a TOCTOU race: the old check-then-later-increment
+    # design under installation_spend_lock let two concurrent free-tier
+    # reviews on the same installation both read "under cap" before either
+    # recorded an attempt. The fix is reserve_flash_review_count - a single
+    # atomic UPSERT...WHERE...RETURNING, not a lock (see
+    # test_scan_worker_db.py's real-concurrency test for proof it holds
+    # under actual concurrent load). This just confirms jobs.py calls it
+    # with the right cap.
+    reserve_calls = []
 
-    lock_calls = []
-
-    @contextmanager
-    def _tracking_spend_lock(*args, **kwargs):
-        lock_calls.append(args)
-        yield
+    def _reserve_flash_review_count(dsn, installation_id, limit):
+        reserve_calls.append((installation_id, limit))
+        return True
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
@@ -1580,18 +1599,15 @@ def test_flash_review_job_locks_the_free_tier_monthly_count_check(monkeypatch):
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
-    monkeypatch.setattr(
-        "scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0
-    )
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _tracking_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", _reserve_flash_review_count)
     # Short-circuit before the review body runs - this test only cares
-    # whether the cap check itself was locked, not the rest of the job.
-    monkeypatch.setattr("scan_worker.jobs._run_flash_review", lambda *a, **k: None)
+    # whether the cap was reserved, not the rest of the job.
+    monkeypatch.setattr("scan_worker.jobs._run_flash_review", lambda *a, **k: True)
 
     from scan_worker.jobs import run_flash_review_job
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
-    assert len(lock_calls) >= 1
+    assert reserve_calls == [(1, MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH)]
 
 
 def test_flash_review_job_skips_when_over_the_free_tier_monthly_cap(monkeypatch):
@@ -1603,11 +1619,9 @@ def test_flash_review_job_skips_when_over_the_free_tier_monthly_cap(monkeypatch)
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
-    monkeypatch.setattr(
-        "scan_worker.jobs.get_flash_review_count_this_month",
-        lambda *a, **k: MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH,
-    )
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    # False = the atomic reservation itself found the cap already reached -
+    # nothing left to release, since nothing was ever reserved.
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: False)
     run_called = []
     monkeypatch.setattr(
         "scan_worker.jobs._run_flash_review", lambda *a, **k: run_called.append(True)
@@ -1668,7 +1682,10 @@ def test_flash_review_job_alerts_ops_when_all_free_tier_providers_fail(monkeypat
     monkeypatch.setattr("scan_worker.jobs.lookup_cached_flash_review_result", lambda *a: None)
     monkeypatch.setattr("scan_worker.jobs.store_flash_review_result", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
@@ -1713,9 +1730,18 @@ def test_flash_review_job_skips_when_spend_cap_reached(monkeypatch):
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
-    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 999.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    # The count reservation succeeds (a slot exists), but the dollar
+    # reservation is the one that finds the cap already reached - jobs.py
+    # must then release the count reservation it just took, since the
+    # review never actually gets to run.
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: False)
+    released = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.release_flash_review_count_reservation",
+        lambda *a, **k: released.append(True),
+    )
     llm_called = []
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
     from scan_worker.jobs import run_flash_review_job
@@ -1723,6 +1749,7 @@ def test_flash_review_job_skips_when_spend_cap_reached(monkeypatch):
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert llm_called == []
+    assert released == [True]
 
 
 def test_flash_review_job_skips_when_monthly_review_count_reached(monkeypatch):
@@ -1734,12 +1761,14 @@ def test_flash_review_job_skips_when_monthly_review_count_reached(monkeypatch):
         "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
-    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    # False = the atomic reservation itself found the count cap already
+    # reached - reserve_llm_spend must never even be attempted, since
+    # there's nothing to reserve it for.
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: False)
+    spend_reserve_called = []
     monkeypatch.setattr(
-        "scan_worker.jobs.get_flash_review_count_this_month",
-        lambda *a, **k: MAX_FLASH_REVIEWS_PER_MONTH,
+        "scan_worker.jobs.reserve_llm_spend", lambda *a, **k: spend_reserve_called.append(True)
     )
     llm_called = []
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
@@ -1748,6 +1777,7 @@ def test_flash_review_job_skips_when_monthly_review_count_reached(monkeypatch):
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert llm_called == []
+    assert spend_reserve_called == []
 
 
 def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
@@ -1773,7 +1803,10 @@ def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
     llm_called = []
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -1818,7 +1851,10 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
         "scan_worker.jobs.record_llm_spend",
         lambda dsn, iid, cost, **kwargs: recorded_spend.append(cost),
     )
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     set_sha_calls = []
     monkeypatch.setattr(
         "scan_worker.jobs.set_last_reviewed_sha",
@@ -1839,40 +1875,123 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     assert "real problem" in posted["body"]
     assert posted["marker"] == FLASH_REVIEW_MARKER
     assert set_sha_calls == ["bbb"]
-    assert recorded_spend == [0.0]
+    # True-up delta, not the raw total: real cost (0.0 - review_diff is
+    # mocked, no on_usage ever fires) minus the FLASH_REVIEW_SPEND_RESERVE_USD
+    # (0.5) reserved up front - record_llm_spend's additive upsert applies
+    # this negative delta to give back the unused portion of the reservation.
+    assert recorded_spend == [-FLASH_REVIEW_SPEND_RESERVE_USD]
 
 
-def test_flash_review_job_records_spend_and_count_while_the_lock_is_still_held(monkeypatch):
-    # F25: installation_spend_lock exists to make the check/run/record cycle
-    # atomic per installation - a prior version of this job read the cap
-    # inside the lock but recorded spend and incremented the review count
-    # after it had already been released, so two concurrent reviews for the
-    # same installation could both pass the cap check before either had
-    # recorded its cost. _noop_spend_lock (used by every other test in this
-    # file) can't catch that regression since it never tracks "held" at
-    # all - this test uses a real tracking fake instead.
-    from contextlib import contextmanager
-
-    lock_state = {"held": False, "observed_during_record": None, "observed_during_increment": None}
-
-    @contextmanager
-    def _tracking_spend_lock(*args, **kwargs):
-        lock_state["held"] = True
-        try:
-            yield
-        finally:
-            lock_state["held"] = False
+def test_flash_review_job_reserves_the_cap_before_running_the_review(monkeypatch):
+    # F25/atomic-reservation redesign: run_flash_review_job used to check the
+    # cap inside a lock, release it, run the (multi-minute) review unlocked,
+    # then re-acquire the lock just to record spend/count - a real window
+    # where two concurrent reviews for the same installation could both pass
+    # the check before either recorded anything. The fix reserves both caps
+    # atomically (reserve_flash_review_count/reserve_llm_spend) BEFORE the
+    # review starts, not after - see test_scan_worker_db.py's real-concurrency
+    # tests for proof the reservation itself is atomic under actual
+    # concurrent load. This test verifies the call ORDER: by the time
+    # review_diff runs, the reservation has already happened.
+    call_order = []
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
-    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
-    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _tracking_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+
+    def _reserve_flash_review_count(dsn, iid, limit):
+        call_order.append("reserve_count")
+        return True
+
+    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+        call_order.append("reserve_spend")
+        return True
+
+    def _review_diff(diff_text, file_context="", **kwargs):
+        call_order.append("review_diff")
+        return [{"file": "app.py", "line": 1, "issue": "x"}]
+
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", _reserve_flash_review_count)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
+    monkeypatch.setattr("scan_worker.jobs.review_diff", _review_diff)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert call_order == ["reserve_count", "reserve_spend", "review_diff"]
+
+
+def test_flash_review_job_releases_reservation_when_the_review_never_runs(monkeypatch):
+    # A reservation that never became a real review (every free-tier
+    # provider failed, or no provider keys were configured) must not
+    # permanently consume a slot/dollar the installation never actually
+    # used - see run_flash_review_job's finally block.
+    released = {"count": False, "spend": False}
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "scan_worker.jobs.release_flash_review_count_reservation",
+        lambda *a, **k: released.__setitem__("count", True),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.release_llm_spend_reservation",
+        lambda *a, **k: released.__setitem__("spend", True),
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+    # Free tier, no adapter chain built (no provider keys) - _run_flash_review
+    # returns False before ever calling review_diff.
+    monkeypatch.setattr("scan_worker.model_tiers.writing_adapter_chain_for_free_tier", lambda *a, **k: [])
+
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    # Free tier has no dollar reservation (reserved_spend stays 0.0), so
+    # only the count reservation should be released.
+    assert released == {"count": True, "spend": False}
+
+
+def test_flash_review_job_does_not_release_reservation_after_a_successful_review(monkeypatch):
+    released = {"count": False, "spend": False}
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "scan_worker.jobs.release_flash_review_count_reservation",
+        lambda *a, **k: released.__setitem__("count", True),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.release_llm_spend_reservation",
+        lambda *a, **k: released.__setitem__("spend", True),
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
@@ -1881,74 +2000,7 @@ def test_flash_review_job_records_spend_and_count_while_the_lock_is_still_held(m
         "scan_worker.jobs.review_diff",
         lambda diff_text, file_context="", **kwargs: [{"file": "app.py", "line": 1, "issue": "x"}],
     )
-
-    def _record_llm_spend(dsn, iid, cost, **kwargs):
-        lock_state["observed_during_record"] = lock_state["held"]
-
-    def _increment_flash_review_count(dsn, iid):
-        lock_state["observed_during_increment"] = lock_state["held"]
-
-    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", _increment_flash_review_count)
-    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
-
-    from scan_worker.jobs import run_flash_review_job
-
-    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
-
-    assert lock_state["observed_during_record"] is True
-    assert lock_state["observed_during_increment"] is True
-    assert lock_state["held"] is False  # released once the job actually finished
-
-
-def test_flash_review_job_releases_lock_during_the_review_itself(monkeypatch):
-    # Real production bug, found while opening 25 PRs on one installation
-    # in a benchmark run: the lock used to wrap the ENTIRE review (a real
-    # LLM call plus several GitHub API round-trips, measured up to 5m50s
-    # in production - see FLASH_REVIEW_JOB_TIMEOUT_SECONDS in
-    # app_server/webhooks/pull_request.py), not just the check-then-record
-    # spend bookkeeping it exists to protect (see installation_spend_lock's
-    # docstring). ADVISORY_LOCK_TIMEOUT is 5s, far shorter than a real
-    # review, so any review queued behind another for the same
-    # installation reliably failed with psycopg.errors.LockNotAvailable
-    # instead of just waiting its turn - confirmed in production logs.
-    # This asserts the lock is free during the expensive part, which the
-    # F25 test above doesn't check (it only checks record/increment).
-    from contextlib import contextmanager
-
-    lock_state = {"held": False, "observed_during_review": None}
-
-    @contextmanager
-    def _tracking_spend_lock(*args, **kwargs):
-        lock_state["held"] = True
-        try:
-            yield
-        finally:
-            lock_state["held"] = False
-
-    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
-    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
-    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
-    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
-    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
-    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
-    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
-    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _tracking_spend_lock)
-    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
-    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
-    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
-
-    def _review_diff(diff_text, file_context="", **kwargs):
-        lock_state["observed_during_review"] = lock_state["held"]
-        return [{"file": "app.py", "line": 1, "issue": "x"}]
-
-    monkeypatch.setattr("scan_worker.jobs.review_diff", _review_diff)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
 
@@ -1956,8 +2008,7 @@ def test_flash_review_job_releases_lock_during_the_review_itself(monkeypatch):
 
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
-    assert lock_state["observed_during_review"] is False
-    assert lock_state["held"] is False
+    assert released == {"count": False, "spend": False}
 
 
 def test_flash_review_job_posts_grounding_note_when_some_findings_are_dropped(monkeypatch):
@@ -1982,7 +2033,10 @@ def test_flash_review_job_posts_grounding_note_when_some_findings_are_dropped(mo
 
     monkeypatch.setattr("scan_worker.jobs.review_diff", fake_review_diff)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -2018,7 +2072,10 @@ def test_flash_review_job_reports_zero_grounded_distinctly_from_no_issues_found(
 
     monkeypatch.setattr("scan_worker.jobs.review_diff", fake_review_diff)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -2065,7 +2122,10 @@ def test_flash_review_job_discloses_files_it_never_reviewed(monkeypatch):
     )
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -2103,7 +2163,10 @@ def test_flash_review_job_adds_no_coverage_note_when_every_file_was_read(monkeyp
     )
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -2126,12 +2189,17 @@ def test_flash_review_job_posts_failure_comment_instead_of_raising(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
-    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
-    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    # The raised exception aborts the job before _run_flash_review reaches
+    # its normal completion, so run_flash_review_job's finally block must
+    # release both reservations - a review that never ran must not
+    # permanently consume a slot/dollar the installation never used.
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
 
     def _raise_diff_fetch(*a, **k):
@@ -2213,7 +2281,10 @@ def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkey
         lambda diff_text, file_context="", **kwargs: captured.update(kwargs) or [],
     )
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     from scan_worker.jobs import run_flash_review_job
@@ -2257,7 +2328,10 @@ def test_flash_review_job_passes_changed_file_contents_to_review_diff(monkeypatc
         lambda diff_text, file_context="", **kwargs: captured.update(kwargs) or [],
     )
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     from scan_worker.jobs import run_flash_review_job
@@ -2306,7 +2380,10 @@ def test_flash_review_job_never_sends_the_raw_file_context_blob_to_review_diff(m
         or [],
     )
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     from scan_worker.jobs import run_flash_review_job
@@ -2343,7 +2420,10 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
         ],
     )
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -2379,7 +2459,10 @@ def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch)
     monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", **kwargs: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.increment_flash_review_count", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     posted = {}
     monkeypatch.setattr(
@@ -4532,7 +4615,6 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: 0.0012)
@@ -4554,11 +4636,25 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
         adapter.on_usage(1, 1)
 
     monkeypatch.setattr("scan_worker.jobs._store_docs_generation_for_module", fake_store)
-    recorded_spend = []
-    monkeypatch.setattr(
-        "scan_worker.jobs.record_llm_spend",
-        lambda dsn, iid, cost, **k: recorded_spend.append(cost),
-    )
+    # In-memory stand-in for the real atomic reserve_llm_spend/record_llm_spend
+    # pair - see test_managed_audit_api_job_records_each_call_and_exposes_budget_stop
+    # for the full explanation of the shared running-total state and why the
+    # true-up delta (cost - next_call_reserve_usd) is negative here.
+    spend_state = {"total": 0.0}
+    recorded_deltas = []
+
+    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+        if spend_state["total"] + reserve_usd <= monthly_cap:
+            spend_state["total"] += reserve_usd
+            return True
+        return False
+
+    def _record_llm_spend(dsn, iid, delta, **k):
+        spend_state["total"] += delta
+        recorded_deltas.append(delta)
+
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
     status_calls = []
     monkeypatch.setattr(
         "scan_worker.jobs.set_docs_build_status",
@@ -4569,7 +4665,7 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
     run_live_docs_full_build_job(1, "octocat/hello-world")
 
     assert stored_for == ["m0.py"]
-    assert recorded_spend == [0.0006]
+    assert recorded_deltas == [pytest.approx(-0.0004)]
     assert status_calls[0][0] == "ready"
     assert "1/3 files processed" in status_calls[0][1]
     assert "spend cap" in status_calls[0][1]

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -51,6 +51,10 @@ from scan_worker.db import (
     record_llm_spend,
     record_sent_email,
     record_wiki_catchup_swept,
+    release_flash_review_count_reservation,
+    release_llm_spend_reservation,
+    reserve_flash_review_count,
+    reserve_llm_spend,
     set_last_reviewed_sha,
     upsert_docs_symbol,
     upsert_wiki_overview,
@@ -731,6 +735,113 @@ async def test_check_and_reserve_flash_review_attempt_allows_after_debounce_elap
         TEST_DATABASE_URL, 301, "a/repo1", 42, debounce_seconds=0
     )
     assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_reserve_flash_review_count_allows_up_to_limit_then_blocks(pool):
+    await _insert_installation(pool, 401, "a")
+    first = reserve_flash_review_count(TEST_DATABASE_URL, 401, limit=2)
+    second = reserve_flash_review_count(TEST_DATABASE_URL, 401, limit=2)
+    third = reserve_flash_review_count(TEST_DATABASE_URL, 401, limit=2)
+    assert (first, second, third) == (True, True, False)
+
+
+@pytest.mark.asyncio
+async def test_release_flash_review_count_reservation_frees_a_slot(pool):
+    await _insert_installation(pool, 402, "a")
+    reserve_flash_review_count(TEST_DATABASE_URL, 402, limit=1)
+    blocked = reserve_flash_review_count(TEST_DATABASE_URL, 402, limit=1)
+    assert blocked is False
+
+    release_flash_review_count_reservation(TEST_DATABASE_URL, 402)
+    allowed_again = reserve_flash_review_count(TEST_DATABASE_URL, 402, limit=1)
+    assert allowed_again is True
+
+
+@pytest.mark.asyncio
+async def test_release_flash_review_count_reservation_never_goes_negative(pool):
+    await _insert_installation(pool, 403, "a")
+    # Nothing reserved yet - a double-release (or a release with no matching
+    # reserve) must not underflow the count into negative territory.
+    release_flash_review_count_reservation(TEST_DATABASE_URL, 403)
+    release_flash_review_count_reservation(TEST_DATABASE_URL, 403)
+    allowed = reserve_flash_review_count(TEST_DATABASE_URL, 403, limit=1)
+    assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_reserve_flash_review_count_is_atomic_under_real_concurrency(pool):
+    # This is the actual regression test for the TOCTOU race
+    # run_flash_review_job used to have: many real, concurrent callers
+    # racing the same (installation_id, month) row, same as two Flash
+    # Reviews for one installation landing on different scan-worker
+    # replicas at once. A read-then-write check-then-act would let more
+    # than `limit` through under real thread-level concurrency; the atomic
+    # UPSERT...WHERE...RETURNING must not, no matter how many callers race
+    # it at once.
+    import concurrent.futures
+
+    await _insert_installation(pool, 404, "a")
+    limit = 20
+    attempts = 60
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=attempts) as pool_exec:
+        results = list(
+            pool_exec.map(
+                lambda _: reserve_flash_review_count(TEST_DATABASE_URL, 404, limit=limit),
+                range(attempts),
+            )
+        )
+
+    assert sum(results) == limit
+    assert results.count(False) == attempts - limit
+
+
+@pytest.mark.asyncio
+async def test_reserve_llm_spend_allows_up_to_cap_then_blocks(pool):
+    await _insert_installation(pool, 405, "a")
+    first = reserve_llm_spend(TEST_DATABASE_URL, 405, reserve_usd=0.5, monthly_cap=1.0)
+    second = reserve_llm_spend(TEST_DATABASE_URL, 405, reserve_usd=0.5, monthly_cap=1.0)
+    third = reserve_llm_spend(TEST_DATABASE_URL, 405, reserve_usd=0.5, monthly_cap=1.0)
+    assert (first, second, third) == (True, True, False)
+    assert get_llm_spend_this_month(TEST_DATABASE_URL, 405) == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_release_llm_spend_reservation_gives_back_the_reserved_amount(pool):
+    await _insert_installation(pool, 406, "a")
+    reserve_llm_spend(TEST_DATABASE_URL, 406, reserve_usd=0.5, monthly_cap=1.0)
+    release_llm_spend_reservation(TEST_DATABASE_URL, 406, reserve_usd=0.5)
+    assert get_llm_spend_this_month(TEST_DATABASE_URL, 406) == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_release_llm_spend_reservation_never_goes_negative(pool):
+    await _insert_installation(pool, 407, "a")
+    release_llm_spend_reservation(TEST_DATABASE_URL, 407, reserve_usd=0.5)
+    assert get_llm_spend_this_month(TEST_DATABASE_URL, 407) == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_reserve_llm_spend_is_atomic_under_real_concurrency(pool):
+    import concurrent.futures
+
+    await _insert_installation(pool, 408, "a")
+    reserve_usd = 0.5
+    cap = 5.0
+    max_successes = 10  # cap / reserve_usd
+    attempts = 30
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=attempts) as pool_exec:
+        results = list(
+            pool_exec.map(
+                lambda _: reserve_llm_spend(TEST_DATABASE_URL, 408, reserve_usd, cap),
+                range(attempts),
+            )
+        )
+
+    assert sum(results) == max_successes
+    assert get_llm_spend_this_month(TEST_DATABASE_URL, 408) == pytest.approx(max_successes * reserve_usd)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The single highest-priority finding from `before_launch_fixes.md`: the installation-level LLM spend cap (free-tier review-count cap, paid-tier dollar cap, and the AIRview/Docs/managed-audit incremental-budget variant) was check-then-act, not atomic. `installation_spend_lock` was acquired once to check the cap, released, the expensive review ran unlocked (up to 5m50s in production), then re-acquired separately just to record the cost — so two concurrent reviews for the same installation could both pass the cap check before either recorded anything, overshooting the cap by however many landed in that window. **Real financial exposure on every paid installation**, not a code-quality nit.

**Fix:** reserve atomically at check-time instead of locking only the read — the same approach `model_tiers._reserve_openai_free_tier_budget` already uses for the OpenAI daily-token cap.

- `scan_worker/db.py`: `reserve_flash_review_count`/`release_flash_review_count_reservation` and `reserve_llm_spend`/`release_llm_spend_reservation` — atomic `INSERT...ON CONFLICT...WHERE...RETURNING` reservations, the same shape as the pre-existing `check_and_reserve_flash_review_attempt`. Postgres's own row-level lock during the UPSERT serializes concurrent callers; no advisory lock needed.
- `scan_worker/jobs.py`: `run_flash_review_job` now reserves both caps atomically *before* `_run_flash_review` starts, not after it finishes. `_run_flash_review` returns whether a real review actually ran; a `finally` block releases the reservation when it didn't (free-tier fully exhausted, no provider keys configured, or any exception before completion) — this also closes a second finding (a fully-exhausted free-tier fallback used to still burn a monthly review slot). `_IncrementalSpendBudget` (managed audits, AIRview/Docs full builds and incremental updates) had the same root problem in a different shape — `can_start_next_call()` compared against a `current_spend` snapshot taken once per job, invisible to any other concurrent job spending against the same cap for the job's whole (sometimes minutes-long) duration. Now reserves per call atomically via the same primitive instead.

## Verification

Verified under genuine concurrent load, not just mocks: 60 real threads racing a count-cap reservation and 30 racing a dollar-cap reservation against an actual Postgres instance, both landing on exactly the right number of successes every time (`test_scan_worker_db.py`'s two `*_is_atomic_under_real_concurrency` tests).

The two stale tests that couldn't actually detect this race (`test_flash_review_job_records_spend_and_count_while_the_lock_is_still_held` / `test_flash_review_job_releases_lock_during_the_review_itself`) are replaced with tests that check reservation happens before the review runs and is released on failure.

## Test plan
- [x] `test_scan_worker_db.py`'s new atomic-reservation tests, including two real-concurrency tests — pass against a real Postgres instance
- [x] Full `test_jobs.py` suite (157 tests) — pass
- [x] Full `github-app` test suite (1,410 tests total) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj