### PR TITLE
fix: diff-marker collision unfixed in three sibling parsers

### DIFF
--- a/benchmarks/pr-review-benchmark/scripts/evaluate_semantic_checks.py
+++ b/benchmarks/pr-review-benchmark/scripts/evaluate_semantic_checks.py
@@ -58,6 +58,15 @@ def git_diff_to_review_format(raw_diff: str) -> str:
     parts: list[str] = []
     current_filename: str | None = None
     body_lines: list[str] = []
+    # Real git-diff header lines (index/---/+++) only ever appear between a
+    # `diff --git` marker and that file's first `@@` hunk - never inside a
+    # hunk body. Filtering on prefix alone, with no positional guard, also
+    # matches a genuine removed/added source line shaped like "--- old
+    # constant" (a deleted comment: "-- old constant" renders as "---  old
+    # constant" once diffed) and silently drops it from body_lines,
+    # indistinguishable from a real "--- a/path" header. seen_first_hunk
+    # scopes the filter to only the real header region.
+    seen_first_hunk = False
 
     def flush() -> None:
         if current_filename is not None and body_lines:
@@ -69,9 +78,12 @@ def git_diff_to_review_format(raw_diff: str) -> str:
             flush()
             current_filename = match.group(2)
             body_lines = []
+            seen_first_hunk = False
             continue
-        if line.startswith(("index ", "--- ", "+++ ")):
+        if not seen_first_hunk and line.startswith(("index ", "--- ", "+++ ")):
             continue
+        if line.startswith("@@"):
+            seen_first_hunk = True
         if current_filename is not None:
             body_lines.append(line)
     flush()

--- a/benchmarks/pr-review-benchmark/tests/test_evaluate_semantic_checks.py
+++ b/benchmarks/pr-review-benchmark/tests/test_evaluate_semantic_checks.py
@@ -1,0 +1,54 @@
+from scripts.evaluate_semantic_checks import git_diff_to_review_format
+
+
+def test_git_diff_to_review_format_survives_a_removed_line_shaped_like_a_real_diff_header():
+    # A removed source line reading "-- old value ---" renders, once
+    # diffed, as the raw line "--- old value ---" - indistinguishable from
+    # a real "--- a/path" header line without a positional guard. Real
+    # headers (index/---/+++) only ever appear between "diff --git" and
+    # that file's first "@@" hunk, never inside a hunk body -
+    # seen_first_hunk scopes the filter so a hunk-body line matching that
+    # same shape is kept instead of silently dropped, which is exactly
+    # what happened before this fix: the removed line's content vanished
+    # from the converted diff entirely, indistinguishable from it never
+    # having existed.
+    raw_diff = (
+        "diff --git a/caller.py b/caller.py\n"
+        "index abc123..def456 100644\n"
+        "--- a/caller.py\n"
+        "+++ b/caller.py\n"
+        "@@ -1,3 +1,2 @@\n"
+        "-shared_call()\n"
+        "--- old value ---\n"
+        "+shared_call()\n"
+    )
+
+    result = git_diff_to_review_format(raw_diff)
+
+    assert "--- caller.py ---" in result
+    assert "--- old value ---" in result
+    assert "-shared_call()" in result
+    assert "+shared_call()" in result
+
+
+def test_git_diff_to_review_format_still_strips_real_header_lines():
+    # Regression guard the other way: seen_first_hunk must not swallow the
+    # real index/---/+++ header lines that legitimately precede the first
+    # hunk - only content that appears after it should ever be kept.
+    raw_diff = (
+        "diff --git a/caller.py b/caller.py\n"
+        "index abc123..def456 100644\n"
+        "--- a/caller.py\n"
+        "+++ b/caller.py\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-old()\n"
+        "+new()\n"
+    )
+
+    result = git_diff_to_review_format(raw_diff)
+
+    assert "index abc123..def456 100644" not in result
+    assert "--- a/caller.py" not in result
+    assert "+++ b/caller.py" not in result
+    assert "-old()" in result
+    assert "+new()" in result

--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -369,12 +369,26 @@ def build_change_impact_context(diff_text: str) -> str:
     removed_by_file: dict[str, set[str]] = {}
     added_by_file: dict[str, set[str]] = {}
 
+    # Same file-marker collision _diff_valid_lines guards against, just
+    # unguarded here: a removed/added source line shaped like "--- text ---"
+    # (e.g. a deleted comment) is indistinguishable from a real file
+    # separator without requiring it to follow a blank line. Without this,
+    # such a line flips current_file mid-parse and misattributes every
+    # subsequent removed/added line and change-impact-pattern match to the
+    # wrong file.
+    prev_blank = True  # start-of-text counts as a boundary
     for raw_line in diff_text.splitlines():
-        if raw_line.startswith("--- ") and raw_line.endswith(" ---"):
+        if raw_line.startswith("--- ") and raw_line.endswith(" ---") and prev_blank:
             current_file = raw_line[4:-4]
+            prev_blank = False
             continue
-        if raw_line.startswith(("@@", "+++")) or not raw_line:
+        if raw_line.startswith(("@@", "+++")):
+            prev_blank = False
             continue
+        if not raw_line:
+            prev_blank = True
+            continue
+        prev_blank = False
         prefix = raw_line[0] if raw_line[0] in "+- " else " "
         code = raw_line[1:] if prefix in "+- " else raw_line
         if prefix == "-":

--- a/github-app/scan_worker/semantic_checks.py
+++ b/github-app/scan_worker/semantic_checks.py
@@ -85,11 +85,22 @@ def _diff_hunks_by_file(diff_text: str) -> dict[str, list[_Hunk]]:
     hunks: dict[str, list[_Hunk]] = {}
     current_file = ""
     current_hunk: _Hunk | None = None
+    # A removed/added source line that happens to read exactly like a file
+    # marker (e.g. a deleted comment "-- text ---", which renders as the raw
+    # line "--- text ---" once diffed) is indistinguishable from a real
+    # "--- {file} ---" separator without a positional guard - the real
+    # separator only ever appears after a blank line (or at the very start
+    # of the diff text). Matches flash_review.py's _diff_valid_lines fix for
+    # the identical collision; without this, a matching line here resets
+    # current_file/current_hunk mid-parse, silently misattributing every
+    # subsequent removed/added line to the wrong file.
+    prev_blank = True  # start-of-text counts as a boundary
     for line in diff_text.splitlines():
         file_match = _FILE_MARKER_RE.match(line)
-        if file_match:
+        if file_match and prev_blank:
             current_file = file_match.group(1)
             current_hunk = None
+            prev_blank = False
             continue
         hunk_match = _HUNK_HEADER_RE.match(line)
         if hunk_match:
@@ -101,7 +112,12 @@ def _diff_hunks_by_file(diff_text: str) -> dict[str, list[_Hunk]]:
             # flash_review.py's _diff_valid_lines for the same shape.
             current_hunk = _Hunk(new_start, new_start + max(new_count, 1) - 1)
             hunks.setdefault(current_file, []).append(current_hunk)
+            prev_blank = False
             continue
+        if line == "":
+            prev_blank = True
+            continue
+        prev_blank = False
         if current_hunk is None or not current_file:
             continue
         if line.startswith("-") and not line.startswith("---"):

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -967,6 +967,28 @@ def test_build_change_impact_context_surfaces_behavioral_change_signals():
     assert "iterator consumption:" in context
 
 
+def test_build_change_impact_context_survives_a_removed_line_shaped_like_a_file_marker():
+    # A removed source line reading "-- old value ---" renders, once
+    # diffed, as the raw line "--- old value ---" (the "-" diff-prefix plus
+    # the line's own leading "--") - indistinguishable from a real
+    # "--- {file} ---" separator without the prev_blank boundary guard
+    # _diff_valid_lines already uses for the identical collision. Without
+    # it, this line flips current_file mid-hunk and every subsequent
+    # removed/added line in the hunk gets misattributed to the wrong file.
+    diff_text = (
+        "--- caller.py ---\n"
+        "@@ -1,3 +1,3 @@\n"
+        "-shared_call()\n"
+        "--- old value ---\n"
+        "+shared_call()\n"
+    )
+
+    context = build_change_impact_context(diff_text)
+
+    assert "caller.py" in context
+    assert "call/order movement" in context
+
+
 def test_build_referenced_symbol_context_adds_observable_contract_signals():
     evidence = _evidence_with_two_modules()
     diff_text = "--- dashboard.py ---\n@@ -1,1 +1,1 @@\n+_github_http_client()\n"
@@ -987,6 +1009,28 @@ def test_build_referenced_symbol_context_adds_observable_contract_signals():
 def test_semantic_checker_finds_removed_exception_handler():
     diff = (
         "--- caller.py ---\n@@ -1,3 +1,2 @@\n"
+        "-except ErrorA:\n"
+        "+    value = op_one(key, store)\n"
+    )
+    refs = "--- referenced definition (not part of this diff): callee.py:op_one ---\nraise ErrorA()"
+    findings = find_semantic_regressions(
+        diff, {"caller.py": "def handler():\n    value = op_one(key, store)"}, refs
+    )
+    assert findings[0]["file"] == "caller.py"
+    assert "removed its exception handler" in findings[0]["issue"]
+
+
+def test_semantic_checker_survives_a_removed_line_shaped_like_a_file_marker():
+    # Same collision _diff_valid_lines (flash_review.py) already guards
+    # against: a removed source line reading "-- old note ---" renders as
+    # the raw line "--- old note ---" once diffed - indistinguishable from
+    # a real "--- {file} ---" marker without the prev_blank boundary guard.
+    # Without it, this line mid-hunk resets current_file/current_hunk to a
+    # fabricated "old note" file with no hunk of its own, and the real
+    # regression on the next line is silently dropped rather than found.
+    diff = (
+        "--- caller.py ---\n@@ -1,3 +1,2 @@\n"
+        "--- old note ---\n"
         "-except ErrorA:\n"
         "+    value = op_one(key, store)\n"
     )


### PR DESCRIPTION
## Summary

PR #283 fixed a real file-marker collision in `flash_review.py`'s `_diff_valid_lines` — a removed/added source line that happens to read `--- text ---` once diffed (e.g. a deleted comment `-- text ---`, prefixed with `-`) is indistinguishable from a real `--- {file} ---` separator without a positional guard, and silently misattributes everything downstream to the wrong file. The fix landed in one of four call sites that needed it.

**Unfixed instances found and fixed here:**

- **`scan_worker/semantic_checks.py`'s `_diff_hunks_by_file`** — unconditional `_FILE_MARKER_RE` match, no guard at all. A colliding line mid-hunk reset `current_file`/`current_hunk`, dropping every subsequent finding for that hunk (confirmed: a removed exception handler a few lines after a colliding line was never found at all, not just misattributed).
- **`scan_worker/flash_review.py`'s own `build_change_impact_context`** — same unguarded pattern, in the same file as the fix. Misattributes removed/added lines and change-impact-pattern matches to the wrong file in the deterministic signals block shown to the reviewing model.
- **`benchmarks/pr-review-benchmark/scripts/evaluate_semantic_checks.py`'s `git_diff_to_review_format`** — a different shape (filtering real git-diff header lines by prefix, not matching the internal marker format) but the same root cause: real `index`/`---`/`+++` headers only ever appear between `diff --git` and a file's first `@@` hunk, never inside a hunk body, so a colliding hunk-body line was silently dropped rather than misattributed.

**Fix:** the first two got the identical `prev_blank` boundary guard `_diff_valid_lines` already uses (a marker only counts right after a blank line or at start-of-text). The third got an equivalent `seen_first_hunk` positional guard, since it needed to scope a prefix filter rather than gate a marker match.

Each fix ships with a regression test demonstrating the real failure mode, not just that the guard exists.

## Test plan
- [x] `test_flash_review.py` (135 tests, covers both the semantic-checker and `build_change_impact_context` fixes) — pass
- [x] New `benchmarks/pr-review-benchmark/tests/test_evaluate_semantic_checks.py` — pass
- [x] Full benchmark harness suite (64 tests) — pass
- [x] Rest of the github-app suite (1,249 passed, 8 skipped, excluding the already-verified `test_jobs.py` which this PR doesn't touch) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj