### PR TITLE
fix: settings page card layout, webhook setup links, and a seat-purchase race

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -465,6 +465,30 @@ async def add_member(org: str, repo: str, request: Request, body: AddMemberReque
     return {"ok": True}
 
 
+# buy_extra_seat and remove_extra_seat each do a read-then-write against
+# Paddle's subscription (get_paddle_subscription, then a delta computed off
+# what it returned, then update_subscription_items) with no lock around it.
+# Two concurrent calls for the same installation - a double-click, or two
+# admins both clicking around the same time - can both read the same
+# starting quantity and each submit their own absolute (not relative) item
+# list, so the second write silently clobbers the first rather than
+# stacking: two "buy" clicks can net only +1 seat, with both requests
+# returning 200. The app server runs as a single uvicorn worker (see
+# Dockerfile.app-server's CMD, no --workers flag, and docker-compose.yml has
+# no replicas set for app-server), so - unlike a multi-replica service - a
+# plain in-process lock, keyed per installation, is sufficient to serialize
+# this without needing a cross-process Postgres advisory lock held open
+# across the Paddle network round-trip.
+_SEAT_ADJUSTMENT_LOCKS: dict[int, asyncio.Lock] = {}
+
+
+def _seat_adjustment_lock(installation_id: int) -> asyncio.Lock:
+    lock = _SEAT_ADJUSTMENT_LOCKS.get(installation_id)
+    if lock is None:
+        lock = _SEAT_ADJUSTMENT_LOCKS[installation_id] = asyncio.Lock()
+    return lock
+
+
 def _build_updated_seat_items(subscription_items: list[dict], delta: int) -> list[dict] | None:
     # Paddle requires the complete item list on every subscription update -
     # this rebuilds it with the extra-seat item's quantity adjusted by
@@ -515,9 +539,10 @@ async def buy_extra_seat(org: str, repo: str, request: Request):
 
     settings = get_settings()
     try:
-        await asyncio.to_thread(
-            _adjust_extra_seat_sync, settings.paddle_api_key, subscription_id, 1
-        )
+        async with _seat_adjustment_lock(installation["installation_id"]):
+            await asyncio.to_thread(
+                _adjust_extra_seat_sync, settings.paddle_api_key, subscription_id, 1
+            )
     except PaddleAPIError as exc:
         # exc's message includes the raw Paddle response (URL, status code,
         # docs link) - useful in a log, not something to hand an end user
@@ -554,9 +579,10 @@ async def remove_extra_seat(org: str, repo: str, request: Request):
 
     settings = get_settings()
     try:
-        items = await asyncio.to_thread(
-            _adjust_extra_seat_sync, settings.paddle_api_key, subscription_id, -1
-        )
+        async with _seat_adjustment_lock(installation["installation_id"]):
+            items = await asyncio.to_thread(
+                _adjust_extra_seat_sync, settings.paddle_api_key, subscription_id, -1
+            )
         if items is None:
             raise HTTPException(status_code=409, detail="no extra seats to remove")
     except PaddleAPIError as exc:

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -346,11 +346,15 @@ table.findings tr:last-child td { border-bottom: none; }
 .wiki-md-list li { font-size: 12.5px; color: var(--slate-600); line-height: 1.6; margin-bottom: 3px; }
 .wiki-md code { font-family: var(--font-mono); font-size: 11.5px; background: var(--slate-100); padding: 1px 4px; border-radius: 4px; overflow-wrap: anywhere; }
 
-.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; }
-.settings-block { margin-bottom: 18px; }
-.settings-block-label { font-size: 12px; font-weight: 500; margin-bottom: 7px; }
+.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }
+.settings-block { background: var(--paper); border: 1px solid var(--border); border-radius: 12px;
+  padding: 16px 18px; box-shadow: var(--shadow-card); margin-bottom: 16px; }
+.settings-block-label { font-size: 13px; font-weight: 600; margin-bottom: 9px; }
 .settings-block-hint { font-size: 11px; color: var(--slate-600); margin-top: 6px; }
-.danger-zone { margin-top: 24px; border: 1px solid var(--critical); border-radius: 6px; padding: 14px 16px; }
+.settings-help-links { display: flex; gap: 14px; margin-top: 8px; }
+.settings-help-links a { font-size: 11px; color: var(--accent-strong); text-decoration: none; font-weight: 500; }
+.settings-help-links a:hover { text-decoration: underline; }
+.danger-zone { margin-top: 16px; border: 1px solid var(--critical); border-radius: 12px; padding: 16px 18px; }
 .danger-zone .settings-block-label { color: var(--critical); }
 .danger-zone .btn-danger { background: var(--critical); border-color: var(--critical); color: #fff; }
 .danger-zone .btn-danger[disabled] { opacity: 0.5; cursor: not-allowed; }
@@ -2191,6 +2195,10 @@ async function loadSettings() {{
           '<input class="field" id="webhook-url-input" placeholder="Slack or Teams webhook URL" value="' + escapeHtml(installation.webhook_url || '') + '">' +
           '<div class="form-row"><button class="btn" onclick="saveWebhook()">Save</button><button class="btn" onclick="sendTestNotification()" style="margin-left:6px;">Send test</button><span id="webhook-status" class="settings-block-hint"></span></div>' +
           '<div class="settings-block-hint">New critical findings are posted here shortly after a scan finishes. Paste a Slack incoming-webhook URL or a Teams workflow webhook URL - both are auto-detected.</div>' +
+          '<div class="settings-help-links">' +
+            '<a href="https://api.slack.com/messaging/webhooks" target="_blank" rel="noopener">Get a Slack webhook &rarr;</a>' +
+            '<a href="https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498" target="_blank" rel="noopener">Get a Teams webhook &rarr;</a>' +
+          '</div>' +
         '</div>' +
         '<div class="settings-block">' +
           '<div class="settings-block-label">Managed audit content</div>' +

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -1,6 +1,9 @@
+import asyncio
 import socket
+import threading
+import time
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -15,6 +18,7 @@ from app_server.admin import (
 )
 from app_server.auth import decrypt_access_token, encrypt_access_token, sign_session_id
 from app_server.url_validation import UnsafeURLError
+from app_server import admin
 from app_server.db import (
     add_paddle_ids_to_installation,
     create_session,
@@ -1001,6 +1005,77 @@ async def test_buy_extra_seat_reports_paddle_api_failure(pool, monkeypatch):
         response = await client.post("/admin/octocat/hello-world/seats/buy")
 
     assert response.status_code == 502
+
+
+def test_concurrent_buy_extra_seat_calls_do_not_lose_an_update():
+    # _adjust_extra_seat_sync does a read-then-write against Paddle's
+    # subscription: get_paddle_subscription, then a delta computed off
+    # whatever it returned, then update_subscription_items. Two concurrent
+    # calls for the same installation can both read the same starting
+    # quantity before either write lands, so the second write silently
+    # clobbers the first instead of stacking - two "buy" clicks net only +1
+    # seat, both requests still reporting success.
+    #
+    # This calls the real buy_extra_seat route function directly (auth,
+    # session and DB-logging dependencies mocked out) rather than
+    # reimplementing its body, so it actually verifies the endpoint wires
+    # _seat_adjustment_lock around the critical section - not just that the
+    # lock helper works in isolation. Asserts peak concurrent entry into the
+    # fake Paddle rather than only the final quantity, since that's a
+    # direct, deterministic measurement of serialization rather than
+    # something that depends on exact read/write interleaving to go wrong
+    # in a specific way. Confirmed this reproduces the bug: temporarily
+    # removing the "async with _seat_adjustment_lock(...)" wrapper from
+    # buy_extra_seat makes this fail with peak_concurrency == 2.
+    fake_paddle_state = {"quantity": 0}
+    concurrency = {"current": 0, "peak": 0}
+    concurrency_lock = threading.Lock()
+
+    def fake_get(api_key, sub_id):
+        with concurrency_lock:
+            concurrency["current"] += 1
+            concurrency["peak"] = max(concurrency["peak"], concurrency["current"])
+        time.sleep(0.3)
+        v = fake_paddle_state["quantity"]
+        with concurrency_lock:
+            concurrency["current"] -= 1
+        return {"items": [{"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": v}]}
+
+    def fake_update(api_key, sub_id, items, proration_billing_mode):
+        fake_paddle_state["quantity"] = items[0]["quantity"]
+        return {}
+
+    fake_installation = {"installation_id": 100, "paddle_subscription_id": "sub_test_seat"}
+
+    async def fake_require_admin_installation(request, org, repo):
+        return fake_installation
+
+    async def fake_get_current_session(request):
+        return {"github_login": "octocat"}
+
+    async def fake_record_admin_action(*args, **kwargs):
+        return None
+
+    with patch("app_server.admin.get_paddle_subscription", fake_get), \
+         patch("app_server.admin.update_paddle_subscription_items", fake_update), \
+         patch("app_server.admin._require_admin_installation", fake_require_admin_installation), \
+         patch("app_server.admin.get_current_session", fake_get_current_session), \
+         patch("app_server.admin.record_admin_action", fake_record_admin_action), \
+         patch("app_server.admin.get_settings", lambda: MagicMock(paddle_api_key="fake-api-key")):
+
+        async def main():
+            fake_request = MagicMock()
+            responses = await asyncio.gather(
+                admin.buy_extra_seat("octocat", "hello-world", fake_request),
+                admin.buy_extra_seat("octocat", "hello-world", fake_request),
+            )
+            return responses
+
+        responses = asyncio.run(main())
+
+    assert responses == [{"ok": True}, {"ok": True}]
+    assert concurrency["peak"] == 1
+    assert fake_paddle_state["quantity"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Settings page**: `.settings-block` rendered as a bare div (no border/background/shadow), so every section read as one continuous wall of text. Gives each section real card styling and more breathing room between columns.
- **Webhook setup**: the "Slack or Teams webhook URL" field gave no indication of how to actually get one. Added direct links to Slack's and Microsoft's own current webhook-setup docs.
- **Seat purchase race** (real bug): `buy_extra_seat`/`remove_extra_seat` read Paddle's current subscription, computed a new quantity, and wrote it back with no lock. Two concurrent calls for the same installation could both read the same starting quantity and each submit their own item list — the second write silently clobbers the first, so two "buy" clicks can net only +1 seat with both requests reporting success. Fixed with a per-installation `asyncio.Lock` (confirmed the app server is genuinely single-process, so this is sufficient without a cross-process DB lock).

## Test plan
- [x] Added `test_concurrent_buy_extra_seat_calls_do_not_lose_an_update` — calls the real `buy_extra_seat` endpoint directly, measures peak concurrent entry into a fake Paddle. Verified: fails reliably (5/5) with the lock removed, passes reliably (5/5) with it.
- [x] `pytest tests/test_admin.py` — 73 passed
- [x] `pytest tests/test_frontend_js_syntax.py` — passed
- [x] Verified the settings-page card redesign visually against a local mock built from the real CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)