### PR TITLE
fix: three deterministic-check hunk-scoping bugs in semantic_checks.py

### DIFF
--- a/github-app/scan_worker/semantic_checks.py
+++ b/github-app/scan_worker/semantic_checks.py
@@ -123,6 +123,32 @@ def _line_number(source: str, needle: str) -> int | None:
     return None
 
 
+def _line_number_near_hunk(source: str, needle: str, hunk: "_Hunk") -> int | None:
+    """Same as _line_number, but scoped to the window around one hunk
+    instead of a whole-file scan for the first match.
+
+    Every finding in this module cites a line via a substring search for
+    something like "{var} =" or "except {name}" - for a common name
+    (result, count, except ValueError), _line_number's whole-file scan
+    returns whichever occurrence happens to appear first in the file, which
+    is very often a different, unrelated one from the actual line inside
+    the hunk that triggered the check. Confirmed: a variable clamped-then-
+    reassigned in a diff hunk, with an earlier unrelated assignment to the
+    same name in a different function, cited that earlier line instead of
+    the real one. Scoping the search to the same DIFF_HUNK_TOLERANCE window
+    every proximity check in this module already uses makes a same-window
+    collision the only way to still get this wrong, instead of any same-
+    name occurrence anywhere in the file.
+    """
+    lines = source.splitlines()
+    start = max(0, hunk.new_start - 1 - DIFF_HUNK_TOLERANCE)
+    end = min(len(lines), hunk.new_end + DIFF_HUNK_TOLERANCE)
+    for offset, line in enumerate(lines[start:end]):
+        if needle in line:
+            return start + offset + 1
+    return None
+
+
 def _nearest_hunk(hunks: list[_Hunk], line: int) -> _Hunk | None:
     candidates = [hunk for hunk in hunks if hunk.near(line)]
     if not candidates:
@@ -169,23 +195,38 @@ def _check_reference_at_call(
         if wrong:
             return _finding(
                 file,
-                _line_number(source, f"except {wrong[0]}") or call_line,
+                _line_number_near_hunk(source, f"except {wrong[0]}", hunk) or call_line,
                 f"{name} raises {', '.join(raised)}, but the changed handler catches {wrong[0]} instead.",
                 f"Catch {raised[0]} or translate the dependency error before handling it.",
             )
 
     if "yield" in dependency:
-        assignments = re.findall(rf"\b(\w+)\s*=\s*{re.escape(name)}\s*\(", source)
+        # Scoped to the hunk's own nearby window, not the whole file - this
+        # docstring's own contract ("every condition below is checked
+        # against that hunk's own removed/added lines, never the whole
+        # file's") was being violated here specifically. A common variable
+        # name (e.g. "results") reused across two genuinely unrelated
+        # functions - one already consuming a one-shot iterator correctly
+        # elsewhere in the file, another touched by this diff and calling a
+        # different yield-based dependency - could trip the len(uses) >= 2
+        # whole-file count and fire a false "consumes the iterator twice"
+        # finding tied to unrelated code.
+        window = "\n".join(
+            source.splitlines()[
+                max(0, hunk.new_start - 1 - DIFF_HUNK_TOLERANCE) : hunk.new_end + DIFF_HUNK_TOLERANCE
+            ]
+        )
+        assignments = re.findall(rf"\b(\w+)\s*=\s*{re.escape(name)}\s*\(", window)
         for variable in assignments:
             uses = re.findall(
                 rf"\bfor\s+\w+\s+in\s+{re.escape(variable)}\b|"
                 rf"\b(?:sum|list|tuple|set)\([^\n]*\b{re.escape(variable)}\b",
-                source,
+                window,
             )
             if len(uses) >= 2 and any(name in line for line in added_lines):
                 return _finding(
                     file,
-                    _line_number(source, f"{variable} = {name}(") or call_line,
+                    _line_number_near_hunk(source, f"{variable} = {name}(", hunk) or call_line,
                     f"{name} returns a one-shot iterator that the changed code consumes more than once.",
                     f"Materialize {variable} once before performing multiple passes.",
                 )
@@ -251,7 +292,7 @@ def _moved_record_findings(
             if removed_line.strip() not in {line.strip() for line in hunk.added}:
                 continue
             moved = removed_line.strip()
-            moved_line = _line_number(source, moved)
+            moved_line = _line_number_near_hunk(source, moved, hunk)
             if moved_line is None:
                 continue
             for name, (_path, dependency) in references.items():
@@ -302,19 +343,30 @@ def _resource_leak_findings(file: str, source: str, hunks: list[_Hunk]) -> list[
             if any(re.search(rf"\b{re.escape(var)}\.[Cc]lose\s*\(", line) for line in nearby):
                 continue  # a close for this variable survives nearby
 
+            # Cite the hunk itself, not open_line - a resource is
+            # frequently opened near the top of a function and closed near
+            # the bottom, and the downstream grounding filter
+            # (flash_review.py's _validate_findings) drops any finding
+            # whose cited line lands more than DIFF_LINE_TOLERANCE (8)
+            # lines from a diff-touched line. hunk.new_start is always
+            # inside the diff by construction, so this survives grounding
+            # regardless of how far the open() call is from the removed
+            # Close(). Where the resource was opened is still useful
+            # context for a human - included in the issue text, just not
+            # used as the finding's own citation, and its lookup stays a
+            # whole-file search since the open call itself can legitimately
+            # be anywhere in the file.
             open_match = next(
                 (m for m in _RESOURCE_OPEN_RE.finditer(source) if m.group(1) == var), None
             )
             open_line = _line_number(source, open_match.group(0)) if open_match else None
-            if open_line is None:
-                continue
+            opened_at = f" ({var} was opened at line {open_line})" if open_line else ""
 
             findings.append(
                 _finding(
                     file,
-                    open_line,
-                    f"{var} is opened here, but the changed code removed its Close() call - "
-                    "this resource now leaks.",
+                    hunk.new_start,
+                    f"The changed code removed {var}'s Close() call{opened_at} - this resource now leaks.",
                     f"Restore closing {var} (e.g. `defer {var}.Close()`), including on early-return paths.",
                 )
             )
@@ -351,7 +403,7 @@ def _copy_to_alias_findings(file: str, source: str, hunks: list[_Hunk]) -> list[
         if re.search(r"\bcopy\s*\(|\.copy\s*\(|\bmake\s*\(", alias.group(0)):
             continue  # the replacement still copies - not the bug this guards
 
-        line = _line_number(source, f"{dest} ") or hunk.new_start
+        line = _line_number_near_hunk(source, f"{dest} ", hunk) or hunk.new_start
         findings.append(
             _finding(
                 file,
@@ -400,7 +452,7 @@ def _removed_bounds_clamp_findings(file: str, source: str, hunks: list[_Hunk]) -
             findings.append(
                 _finding(
                     file,
-                    _line_number(source, f"{var} =") or hunk.new_start,
+                    _line_number_near_hunk(source, f"{var} =", hunk) or hunk.new_start,
                     f"{var} used to be clamped to a bound; the changed code removed it, "
                     f"so {var} can now fall outside that bound.",
                     f"Restore the bound (e.g. `max(0, ...)`) around {var}'s assignment.",
@@ -448,7 +500,7 @@ def _off_by_one_loop_findings(file: str, source: str, hunks: list[_Hunk]) -> lis
         if not indexed:
             continue  # the loop bound is suspicious, but nothing in this hunk actually indexes with it
 
-        line = _line_number(source, match.group(0)) or hunk.new_start
+        line = _line_number_near_hunk(source, match.group(0), hunk) or hunk.new_start
         findings.append(
             _finding(
                 file,
@@ -492,7 +544,7 @@ def _sql_injection_findings(file: str, source: str, hunks: list[_Hunk]) -> list[
             findings.append(
                 _finding(
                     file,
-                    _line_number(source, added_line.strip()) or hunk.new_start,
+                    _line_number_near_hunk(source, added_line.strip(), hunk) or hunk.new_start,
                     "This builds a SQL query by concatenating a variable directly into the query "
                     "text - a SQL-injection risk if that value can be influenced by a caller.",
                     "Use a parameterized query (a placeholder plus a bound parameter) instead of "

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -1019,6 +1019,41 @@ def test_semantic_checker_finds_mutable_alias_and_iterator_regressions():
     assert "one-shot iterator" in issues
 
 
+def test_semantic_checker_does_not_flag_a_common_variable_name_used_correctly_elsewhere_in_the_file():
+    # False-positive guard for the iterator-reuse check's hunk-scoping fix:
+    # two genuinely unrelated functions each assign a common variable name
+    # ("items") from the same yield-based dependency and consume it exactly
+    # once - correct on its own in both places. A whole-file scan of "uses"
+    # used to sum both functions' single uses into a false "consumed
+    # twice" count; scoped to the hunk's own nearby window, only the
+    # touched function's own use counts.
+    filler = "\n".join(f"    pass  # filler{i}" for i in range(10))
+    source = (
+        "def unrelated_func():\n"
+        "    items = op_five(other_db)\n"
+        "    for x in items:\n"
+        "        pass\n"
+        f"{filler}\n"
+        "\n"
+        "def caller():\n"
+        "    items = op_five(db)\n"
+        "    for x in items:\n"
+        "        pass\n"
+    )
+    diff = (
+        "--- caller.py ---\n@@ -16,4 +16,4 @@\n"
+        " def caller():\n"
+        "-    items = old_call(db)\n"
+        "+    items = op_five(db)\n"
+        "     for x in items:\n"
+    )
+    refs = "--- referenced definition (not part of this diff): callee.py:op_five ---\nyield row\n"
+
+    findings = find_semantic_regressions(diff, {"caller.py": source}, refs)
+
+    assert findings == []
+
+
 def test_semantic_checker_finds_wrong_exception_type():
     findings = find_semantic_regressions(
         "--- caller.py ---\n@@ -1,2 +1,3 @@\n+try:\n+    value = op(key)\n+except ErrorB:\n+    return None\n",
@@ -1242,6 +1277,37 @@ def test_semantic_checker_finds_a_resource_leak_from_a_removed_close():
     assert len(findings) == 1
     assert "leaks" in findings[0]["issue"]
     assert findings[0]["file"] == "gin.go"
+
+
+def test_semantic_checker_cites_the_hunk_not_the_far_away_open_call_for_a_resource_leak():
+    # Real-world shape this check exists for: a resource opened near the
+    # top of a function, closed near the bottom - the open() and the
+    # removed close() can be much more than flash_review.py's
+    # DIFF_LINE_TOLERANCE (8) lines apart. Citing the open() line (line 2
+    # here) instead of the hunk (line 17) meant the downstream grounding
+    # filter dropped this exact, correct finding as "outside the diff" -
+    # the single most common real trigger for this check, silently
+    # defeating it.
+    source = (
+        "func handle(fd int) error {\n"
+        "\tf := os.NewFile(uintptr(fd), \"fd\")\n"
+        + "".join(f"\tstep{i}()\n" for i in range(15))
+        + "\treturn nil\n"
+        "}\n"
+    )
+    diff = (
+        "--- handler.go ---\n"
+        "@@ -17,3 +17,2 @@\n"
+        " \tstep14()\n"
+        "-\tf.close()\n"
+        " \treturn nil\n"
+    )
+
+    findings = find_semantic_regressions(diff, {"handler.go": source}, "")
+
+    assert len(findings) == 1
+    assert findings[0]["line"] == 17
+    assert "opened at line 2" in findings[0]["issue"]
 
 
 def test_semantic_checker_does_not_flag_a_close_moved_within_the_same_hunk():
@@ -1728,6 +1794,40 @@ def test_semantic_checker_finds_a_removed_bounds_clamp():
 
     assert len(findings) == 1
     assert "clamped to a bound" in findings[0]["issue"]
+
+
+def test_semantic_checker_cites_the_hunk_not_an_earlier_unrelated_assignment_for_a_removed_bounds_clamp():
+    # Regression test for a wrong-line citation bug: _line_number's
+    # whole-file scan for "{var} =" returned whichever occurrence came
+    # first in the file - for a common name like "loaded", that's very
+    # often a different, unrelated assignment in a different function, not
+    # the real one inside the hunk that triggered the check.
+    filler = "\n".join(f"  // filler{i}" for i in range(8))
+    source = (
+        "function unrelated() {\n"
+        "  const loaded = 999;\n"
+        "  return loaded;\n"
+        "}\n"
+        f"{filler}\n"
+        "\n"
+        "function reducer(e) {\n"
+        "  const loaded = total != null ? Math.min(rawLoaded, total) : rawLoaded;\n"
+        "  return loaded;\n"
+        "}\n"
+    )
+    diff = (
+        "--- progressEventReducer.js ---\n"
+        "@@ -14,3 +14,3 @@\n"
+        " function reducer(e) {\n"
+        "-  const loaded = Math.max(0, total != null ? Math.min(rawLoaded, total) : rawLoaded);\n"
+        "+  const loaded = total != null ? Math.min(rawLoaded, total) : rawLoaded;\n"
+        "   return loaded;\n"
+    )
+
+    findings = find_semantic_regressions(diff, {"progressEventReducer.js": source}, "")
+
+    assert len(findings) == 1
+    assert findings[0]["line"] == 15
 
 
 def test_semantic_checker_does_not_flag_a_clamp_that_only_moved_within_the_hunk():


### PR DESCRIPTION
## Summary

Three related bugs in `semantic_checks.py`, all a variant of the same theme: a check that's supposed to be scoped to the diff hunk near the call site, but wasn't.

- **Resource-leak findings cited the `open()` line instead of the removed `Close()` call.** `flash_review.py`'s grounding filter drops any finding whose cited line lands more than `DIFF_LINE_TOLERANCE` (8) lines from a diff-touched line — the single most common real shape of this bug (a resource opened near the top of a function, closed near the bottom) silently defeated the check. Now cites `hunk.new_start` (always inside the diff by construction); the `open()` location is still surfaced, in the issue text rather than as the citation.
- **The iterator double-consumption check matched its regexes against the whole file**, directly contradicting this module's own docstring: *"every condition below is checked against that hunk's own removed/added lines, never the whole file's."* A common variable name used correctly once each in two genuinely unrelated functions could sum into a false "consumed twice" finding. Now scoped to the same hunk-nearby window every other proximity check in this module already uses.
- **Added `_line_number_near_hunk`** and swapped it in at every citation call site in the file (8 total, not just the bounds-clamp one originally flagged in the audit) — `_line_number`'s whole-file scan for a needle like `"{var} ="` or `"except {name}"` returns whichever occurrence comes first in the file, which for a common name is very often a different, unrelated assignment than the one inside the hunk that actually triggered the check.

Each fix ships with a regression test demonstrating the real failure mode: a resource opened 15+ lines from its removed close (well outside grounding tolerance), a common variable name used correctly in an unrelated function, and an earlier unrelated assignment of the same variable name elsewhere in the file.

## Test plan
- [x] `test_flash_review.py` (136 tests, covers `semantic_checks.py`) — pass
- [x] Full github-app suite (1,249 passed, 8 skipped) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj