### PR TITLE
fix: embedding-batch duplication, MCP answer consent bypass, affiliate audit-trail bug

### DIFF
--- a/github-app/app_server/affiliates.py
+++ b/github-app/app_server/affiliates.py
@@ -134,8 +134,17 @@ async def mark_commissions_paid(pool: asyncpg.Pool, affiliate_id: int) -> int:
     after the admin has sent that amount manually outside the app. Returns
     the number of rows updated, for the route to confirm back to the
     caller."""
+    # AND NOT reversed, matching list_affiliates_with_totals's own
+    # total_owed_usd/total_paid_usd queries - without it, a commission
+    # reversed via the Paddle refund/chargeback webhook path (correctly
+    # already excluded from total_owed_usd) could still be matched here and
+    # flipped to paid=true, after which it's also excluded from
+    # total_paid_usd (same NOT reversed filter). The row would silently
+    # disappear from both totals while sitting in the database marked
+    # paid - a commission never actually paid out, with no trace in either
+    # report.
     result = await pool.execute(
-        "UPDATE affiliate_commissions SET paid = true WHERE affiliate_id = $1 AND NOT paid",
+        "UPDATE affiliate_commissions SET paid = true WHERE affiliate_id = $1 AND NOT paid AND NOT reversed",
         affiliate_id,
     )
     return int(result.split()[-1])

--- a/github-app/tests/test_affiliates.py
+++ b/github-app/tests/test_affiliates.py
@@ -178,6 +178,50 @@ async def test_mark_commissions_paid_does_not_touch_other_affiliates(pool):
 
 
 @pytest.mark.asyncio
+async def test_mark_commissions_paid_does_not_touch_a_reversed_commission(pool):
+    # Regression test: a commission reversed via the Paddle
+    # refund/chargeback webhook path (reverse_commission) was already
+    # correctly excluded from total_owed_usd, but mark_commissions_paid's
+    # UPDATE had no NOT reversed filter, so an admin's "mark everything
+    # paid" click could still flip it to paid=true - after which it's ALSO
+    # excluded from total_paid_usd (same NOT reversed filter on that
+    # query), silently vanishing from both totals while sitting in the
+    # database marked paid. A commission never actually paid out, with no
+    # trace in either report.
+    affiliate = await create_affiliate(pool, "NIA10", "dsc_nia", "Nia")
+    await upsert_installation(pool, 910, "acme")
+    await record_referral(pool, 910, affiliate["id"])
+    now = datetime.now(timezone.utc)
+    await record_commission(pool, affiliate["id"], 910, "txn_reversed", Decimal("4.00"), now)
+    await reverse_commission(pool, "txn_reversed")
+
+    marked = await mark_commissions_paid(pool, affiliate["id"])
+
+    assert marked == 0
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("0")
+    assert totals[affiliate["id"]]["total_paid_usd"] == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_mark_commissions_paid_still_pays_unreversed_commissions_alongside_a_reversed_one(pool):
+    affiliate = await create_affiliate(pool, "OWEN10", "dsc_owen", "Owen")
+    await upsert_installation(pool, 911, "acme")
+    await record_referral(pool, 911, affiliate["id"])
+    now = datetime.now(timezone.utc)
+    await record_commission(pool, affiliate["id"], 911, "txn_good", Decimal("5.00"), now)
+    await record_commission(pool, affiliate["id"], 911, "txn_bad", Decimal("4.00"), now)
+    await reverse_commission(pool, "txn_bad")
+
+    marked = await mark_commissions_paid(pool, affiliate["id"])
+
+    assert marked == 1
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_paid_usd"] == Decimal("5.00")
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("0")
+
+
+@pytest.mark.asyncio
 async def test_totals_are_not_multiplied_by_referral_count(pool):
     """Regression for a real bug: joining affiliate_referrals and
     affiliate_commissions onto affiliates in one query is a cartesian

--- a/src/aletheore/answer.py
+++ b/src/aletheore/answer.py
@@ -23,8 +23,17 @@ def answer_question(
     adapter: AgentAdapter,
     k: int = 5,
     confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+    allow_hosted: bool = True,
 ) -> dict:
-    results = search_index(repo_path, question, k=k)
+    # Forwarded to search_index (and transitively _embed_in_batches) rather
+    # than left to default True unconditionally - mcp_server.py's
+    # aletheore_answer tool passes this through from the caller's actual
+    # EFFECT_EXTERNAL consent, the same way aletheore_search_codebase and
+    # aletheore_index already do for their own hosted-embedding calls.
+    # Without it, declining hosted-transmission consent for this specific
+    # tool had no effect: the question (and retrieved chunks) still went to
+    # Aletheore's hosted embedding endpoint whenever a token was configured.
+    results = search_index(repo_path, question, k=k, allow_hosted=allow_hosted)
 
     if not results or results[0]["score"] > confidence_threshold:
         return {

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -631,11 +631,13 @@ def _register_search_codebase_tool(
 
 
 def _register_answer_tool(
-    mcp_instance: MCPServer, repo_path: Path, answer_adapter: AgentAdapter
+    mcp_instance: MCPServer, repo_path: Path, answer_adapter: AgentAdapter, effects: frozenset[str]
 ) -> None:
     @mcp_instance.tool(
         name="aletheore_answer",
-        # Sends retrieved code chunks to the configured LLM adapter.
+        # Sends retrieved code chunks to the configured LLM adapter, and -
+        # same as aletheore_search_codebase - embeds the question text
+        # through the configured provider, so it can reach the network too.
         annotations=ToolAnnotations(
             readOnlyHint=True, destructiveHint=False, idempotentHint=False, openWorldHint=True
         ),
@@ -643,7 +645,11 @@ def _register_answer_tool(
     def aletheore_answer(question: str, k: int = 5) -> str:
         """Answer a natural-language question about this repository from the semantic index."""
         try:
-            return _toon_result(answer_question(repo_path, question, answer_adapter, k=k))
+            return _toon_result(
+                answer_question(
+                    repo_path, question, answer_adapter, k=k, allow_hosted=EFFECT_EXTERNAL in effects
+                )
+            )
         except IndexNotFoundError:
             return _toon_result(_NO_INDEX_ERROR)
         except IndexDimensionMismatchError as exc:
@@ -738,7 +744,7 @@ def build_server(
     if permitted("aletheore_managed_audit"):
         _register_managed_audit_tool(mcp_instance, repo_path)
     if answer_adapter is not None and permitted("aletheore_answer"):
-        _register_answer_tool(mcp_instance, repo_path, answer_adapter)
+        _register_answer_tool(mcp_instance, repo_path, answer_adapter, effects)
 
     if withheld:
         # stderr, not stdout: stdout is the MCP transport. The operator is the

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -979,7 +979,16 @@ def _embed_in_batches(
                 # changed, which the user needs to see.
                 print(f"aletheore: hosted embeddings unavailable ({exc}); using local provider")
                 use_hosted = False
-                spans = [(s, min(s + batch_size, len(texts))) for s in range(start, len(texts), batch_size)]
+                # range(end, ...), not range(start, ...): the current batch
+                # (texts[start:end]) is about to be embedded locally by the
+                # fallthrough below - rebuilding remaining spans from `start`
+                # put that same batch back at the front of the queue, so the
+                # next loop iteration embedded it a second time via the local
+                # path. Confirmed: 10 texts, batch_size=5, hosted fails on the
+                # first batch -> 15 vectors returned for 10 input texts, with
+                # _embed_stale_by_hash's zip(stale_hashes, fresh_vectors)
+                # silently misaligning every hash after the duplicate.
+                spans = [(s, min(s + batch_size, len(texts))) for s in range(end, len(texts), batch_size)]
                 span_index = 0
         vectors.extend(embed_texts(batch))
         if on_progress is not None:

--- a/src/tests/test_answer.py
+++ b/src/tests/test_answer.py
@@ -59,3 +59,32 @@ def test_answer_question_gates_when_nothing_retrieved(mock_search_index, tmp_pat
 
     assert result["confidence_gated"] is True
     adapter.simple_completion.assert_not_called()
+
+
+@patch("aletheore.answer.search_index")
+def test_answer_question_forwards_allow_hosted_to_search_index(mock_search_index, tmp_path):
+    # Regression test: answer_question used to call search_index with no
+    # allow_hosted argument at all, so search_index's (and transitively
+    # _embed_in_batches's) default of True applied regardless of what the
+    # caller actually consented to - mcp_server.py's aletheore_answer tool
+    # forwards the operator's real EFFECT_EXTERNAL decision here, the same
+    # way aletheore_search_codebase and aletheore_index already do for
+    # their own hosted-embedding calls.
+    mock_search_index.return_value = []
+    adapter = MagicMock()
+
+    answer_question(tmp_path, "how does login work", adapter, allow_hosted=False)
+
+    assert mock_search_index.call_args.kwargs["allow_hosted"] is False
+
+
+@patch("aletheore.answer.search_index")
+def test_answer_question_allow_hosted_defaults_to_true(mock_search_index, tmp_path):
+    # Preserves existing callers' behavior (the CLI's own interactive use)
+    # that never passed allow_hosted at all.
+    mock_search_index.return_value = []
+    adapter = MagicMock()
+
+    answer_question(tmp_path, "how does login work", adapter)
+
+    assert mock_search_index.call_args.kwargs["allow_hosted"] is True

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -410,6 +410,36 @@ async def test_aletheore_answer_returns_friendly_error_on_dimension_mismatch(tmp
 
 
 @pytest.mark.asyncio
+async def test_aletheore_answer_tool_forbids_hosted_embeddings_by_default(tmp_path):
+    # Regression test: aletheore_answer used to call answer_question with no
+    # allow_hosted argument at all, so the question (and retrieved chunks)
+    # still reached Aletheore's hosted embedding endpoint whenever a token
+    # was configured, regardless of the operator's actual EFFECT_EXTERNAL
+    # grant - unlike aletheore_index/aletheore_search_codebase, which this
+    # same default-posture test already covers for their own hosted calls.
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo, answer_adapter=MagicMock())  # default effects, no `allow=` override
+
+    with patch("aletheore.mcp_server.answer_question", return_value={"answer": "", "cited_chunks": [], "confidence_gated": True}) as mock_answer:
+        await server.call_tool("aletheore_answer", {"question": "what does foo do"})
+
+    assert mock_answer.call_args.kwargs["allow_hosted"] is False
+
+
+@pytest.mark.asyncio
+async def test_aletheore_answer_tool_permits_hosted_embeddings_when_external_is_allowed(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(
+        repo, answer_adapter=MagicMock(), allow=frozenset({"write", "network", "external"})
+    )
+
+    with patch("aletheore.mcp_server.answer_question", return_value={"answer": "", "cited_chunks": [], "confidence_gated": True}) as mock_answer:
+        await server.call_tool("aletheore_answer", {"question": "what does foo do"})
+
+    assert mock_answer.call_args.kwargs["allow_hosted"] is True
+
+
+@pytest.mark.asyncio
 async def test_aletheore_index_tool_builds_the_search_index(tmp_path):
     # Before this fix, aletheore_search_codebase/aletheore_answer required
     # .aletheore/index.lancedb, buildable only via the CLI's `aletheore

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -1412,8 +1412,45 @@ def test_a_402_falls_back_to_local_and_says_why(capsys):
          patch("aletheore.search_index.embed_texts", side_effect=lambda t: [[0.0] * 768] * len(t)):
         vectors = _embed_in_batches(["chunk"])
 
+    # One vector for one input text - not two. The local fallback for the
+    # batch that just failed on hosted used to also get re-queued as
+    # "remaining work", so it was embedded locally a second time.
+    assert len(vectors) == 1
     assert len(vectors[0]) == 768
     assert "requires a paid plan" in capsys.readouterr().out
+
+
+def test_hosted_failure_on_the_first_of_several_batches_does_not_duplicate_it():
+    """Real bug: the local fallback for a batch that just failed on hosted
+    rebuilt the remaining-spans list starting from that same batch's own
+    start index instead of its end index, re-queuing a batch that had
+    already been embedded (by the immediate local fallthrough) as if it
+    were still pending. Confirmed: 10 texts, batch_size=5, hosted fails on
+    the first batch -> 15 vectors returned for 10 input texts, with
+    _embed_stale_by_hash's zip(stale_hashes, fresh_vectors) then silently
+    misaligning every hash after the duplicate - a search index built from
+    this run would return plausible-looking but wrong results for an
+    unknown subset of chunks, with nothing in the logs to indicate it
+    happened."""
+    http = MagicMock()
+    http.post.return_value = _hosted_response(402, {"detail": "requires a paid plan"})
+    texts = [f"t{i}" for i in range(10)]
+    local_calls = []
+
+    def fake_local_embed(batch):
+        local_calls.append(list(batch))
+        return [[0.0] * 768] * len(batch)
+
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http), \
+         patch("aletheore.search_index.embed_texts", side_effect=fake_local_embed):
+        vectors = _embed_in_batches(texts, batch_size=5)
+
+    assert len(vectors) == 10
+    # Every input text embedded exactly once, not twice - flattening
+    # local_calls (list of batches) must reproduce the original input with
+    # no repeats.
+    assert [t for batch in local_calls for t in batch] == texts
 
 
 def test_hosted_failure_partway_through_raises_rather_than_mixing_providers():


### PR DESCRIPTION
## Summary
Three independent findings from the ongoing PR-history audit (`before_launch_fixes.md` Batch 3 #2/#3/#4):

- **`search_index.py`'s `_embed_in_batches`** rebuilt its remaining-work spans from the *start* of a failed hosted batch instead of its *end*, so a hosted-embedding failure on the first batch caused that batch to be embedded locally a second time. The resulting vector count no longer matched the input text count, silently misaligning `_embed_stale_by_hash`'s hash-to-vector zip downstream — a search index built from such a run would return plausible-looking but wrong results for an unknown subset of chunks, with nothing in the logs to indicate it happened.
- **`mcp_server.py`'s `aletheore_answer` tool** never forwarded the operator's `EFFECT_EXTERNAL` consent decision to its embedding call, unlike its sibling tools (`aletheore_search_codebase`, `aletheore_index`). An operator who withheld consent to transmit repository content externally had that consent silently ignored for this one tool. `answer_question` now takes `allow_hosted` (default `True`, preserving existing callers), and the MCP handler threads `EFFECT_EXTERNAL in effects` through to it.
- **`affiliates.py`'s `mark_commissions_paid`** had no `NOT reversed` filter on its UPDATE, unlike both `total_owed_usd`/`total_paid_usd` queries in `list_affiliates_with_totals`. A commission reversed via the Paddle refund/chargeback webhook path could still be marked paid by an admin's bulk action, after which it disappeared from both totals while sitting in the database flagged as paid out.

## Test plan
- [x] `src/tests/test_search_index.py`: strengthened `test_a_402_falls_back_to_local_and_says_why`, added `test_hosted_failure_on_the_first_of_several_batches_does_not_duplicate_it` (10 texts, batch_size=5, asserts exactly 10 vectors and no duplicate texts)
- [x] `src/tests/test_answer.py`: added `test_answer_question_forwards_allow_hosted_to_search_index`, `test_answer_question_allow_hosted_defaults_to_true`
- [x] `src/tests/test_mcp_server.py`: added `test_aletheore_answer_tool_forbids_hosted_embeddings_by_default`, `test_aletheore_answer_tool_permits_hosted_embeddings_when_external_is_allowed`
- [x] `github-app/tests/test_affiliates.py`: added `test_mark_commissions_paid_does_not_touch_a_reversed_commission`, `test_mark_commissions_paid_still_pays_unreversed_commissions_alongside_a_reversed_one`
- [x] Full `github-app` suite: 1,414 passed, 8 skipped
- [x] Full `src/tests` suite: 1,294 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj