### PR TITLE
fix: marketplace webhook's one-time build isn't retry-safe

### DIFF
--- a/github-app/app_server/webhooks/marketplace.py
+++ b/github-app/app_server/webhooks/marketplace.py
@@ -3,6 +3,7 @@ import logging
 from app_server.db import (
     add_installation_member,
     claim_free_to_paid_plan,
+    claim_paid_setup,
     get_installation_by_account_login,
     set_extra_seats,
     set_installation_plan,
@@ -78,7 +79,20 @@ async def handle_marketplace_event(payload: dict, pool, redis_url: str, queue=No
         # One-time Live Wiki build, tier-independent - fires exactly once,
         # on the free -> paid transition. A paid-to-paid plan change (e.g.
         # Team -> Growth) must not re-trigger it.
-        if transitioned_to_paid:
+        #
+        # Deliberately gated on claim_paid_setup, not transitioned_to_paid:
+        # if the handler crashes after claim_free_to_paid_plan's write
+        # commits but before the enqueue below runs, GitHub retries the
+        # same delivery (this handler re-raises on exception specifically
+        # so it will), but claim_free_to_paid_plan now finds plan already
+        # non-free and correctly returns False - so gating on it directly
+        # would skip the initial build forever. claim_paid_setup is an
+        # independent claim that still returns True on that retry, mirroring
+        # the fix already applied to the Paddle webhook path (paddle.py).
+        should_run_paid_setup = new_plan != "free" and await claim_paid_setup(
+            pool, installation_id
+        )
+        if should_run_paid_setup:
             if queue is None:
                 from redis import Redis
                 from rq import Queue

--- a/github-app/tests/test_marketplace_webhook.py
+++ b/github-app/tests/test_marketplace_webhook.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app_server.db import (
+    claim_free_to_paid_plan,
     get_installation,
     get_extra_seats,
     is_installation_member,
@@ -165,6 +166,35 @@ async def test_cancellation_does_not_trigger_live_wiki_build(pool):
     )
 
     fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_crash_after_plan_write_still_runs_setup_on_retry(pool):
+    """Simulates a process death between the plan write committing and
+    setup (wiki/docs build) running: claim_free_to_paid_plan already
+    flipped the plan to 'air' and reset paid_setup_completed_at to NULL (a
+    real free->paid transition happened), but nothing past that point ran -
+    as if the handler crashed right there, e.g. inside add_installation_member
+    a few lines later. GitHub retries the same delivery on the handler's
+    exception. Gating the build on transitioned_to_paid (claim_free_to_paid_plan's
+    own return value) would find plan already non-free on the retry and
+    silently skip the initial build forever; gating on the independent
+    claim_paid_setup claim instead means the retry still runs it exactly
+    once, mirroring the fix already in the Paddle webhook path."""
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 777, "octocat")  # defaults to plan='free'
+    assert await claim_free_to_paid_plan(pool, 777, "air") is True  # the crashed attempt
+
+    await handle_marketplace_event(
+        _payload("purchased", 999011, "octocat"), pool, "redis://unused", queue=fake_queue
+    )
+
+    assert fake_queue.enqueue.call_count == 2
+    job_names = {call.args[0] for call in fake_queue.enqueue.call_args_list}
+    assert job_names == {
+        "scan_worker.jobs.run_live_wiki_full_build_for_installation_job",
+        "scan_worker.jobs.run_live_docs_full_build_for_installation_job",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (`before_launch_fixes.md` Batch 3 #5): the GitHub Marketplace webhook gated its one-time Live Wiki/Docs build on `transitioned_to_paid` (`claim_free_to_paid_plan`'s own return value), unlike the Paddle webhook path, which was already hardened to gate the same one-time build on an independent `claim_paid_setup` claim.

If the handler crashed after the plan-transition write committed but before the build enqueue ran (e.g. inside `add_installation_member` a few lines later), GitHub retries the same delivery - but `claim_free_to_paid_plan` now finds the plan already non-free and correctly returns `False`, so gating on it directly meant the retry permanently skipped the installation's initial build.

## Fix
Gave the Marketplace path the same independent `claim_paid_setup` gate the Paddle path already has.

## Test plan
- [x] `test_marketplace_webhook.py`'s `test_crash_after_plan_write_still_runs_setup_on_retry` (mirrors `test_webhooks_paddle.py`'s equivalent) - confirmed it fails without the fix (0 enqueues instead of 2) and passes with it
- [x] Full `github-app` suite: 1,417 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj