### PR TITLE
marketing: clarify free-tier PR reviews use the same compact prompt as AIR

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -55,7 +55,7 @@
       "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, DeepSeek, Ollama)",
       "GitHub App: automatic PR comments and branch-protection check runs",
       "AI-powered managed audit reports on pull requests, written by an OpenAI frontier model",
-      "Automatic Flash reviews on every pull request push, grounded with an OpenAI frontier model",
+      "Automatic Flash reviews on every pull request push: one model writes the review, a second independent model re-checks every finding against the diff before it's shown (AIR)",
       "Slack/Teams alerts on new findings",
       "Live API endpoint health monitoring across multiple targets, with a public status API",
       "AIRview: an AI-generated, always-current map of your repo's architecture with dependency diagrams",
@@ -173,7 +173,7 @@
         <article class="pillar-card">
           <span class="pillar-index">01</span>
           <h3>Code Review</h3>
-          <p>Automatic PR comments, Flash reviews, managed audits, and branch-protection checks that cite the changed file and line.</p>
+          <p>Automatic PR comments, Flash reviews independently re-checked by a second model before you see them, managed audits, and branch-protection checks that cite the changed file and line.</p>
           <ul>
             <li>Review only what changed</li>
             <li>Catch secrets before merge</li>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -89,7 +89,7 @@
         Install it on your GitHub account or organization, then hit Subscribe above to activate AIR on that installation. The public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find and install it today.
       </p>
       <p class="cta-note">
-        <sup>*</sup><strong>Free AI Reviews:</strong> AI-powered PR reviews are available for free during the early access period. Usage is globally rate-limited and subject to availability. Free AI access may be modified, restricted, or revoked at any time.
+        <sup>*</sup><strong>Free AI Reviews:</strong> AI-powered PR reviews are available for free during the early access period, built on the same evidence-only (compact) prompt as AIR - see the <a href="benchmarks.html">Benchmarks page</a> for the methodology. They don't include AIR's independent second-model verification pass. Usage is globally rate-limited and subject to availability. Free AI access may be modified, restricted, or revoked at any time.
       </p>
       <div class="pricing-proof">
         <span>Source-grounded PR reviews</span>


### PR DESCRIPTION
## Summary
- Free-tier Flash Review runs the same evidence-only (compact) prompt as AIR - confirmed unconditional in `jobs.py` (not plan-gated). What's actually AIR-exclusive is the independent second-model verification pass.
- Updates `pricing.html`'s free-tier footnote and `index.html`'s JSON-LD `featureList`/Code Review pillar copy to state that distinction accurately.

## Test plan
- [x] Verified locally in browser preview (both pages render, JSON-LD still parses as valid JSON)
- Static marketing copy only, no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)