### PR TITLE
fix: OpenAI free-tier daily token reservation leaks on a failed call

### DIFF
--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -292,6 +292,15 @@ def writing_adapter_chain_for_free_tier(
             extra_body={"reasoning_effort": "minimal"},
             on_usage=_on_openai_free_tier_usage,
             before_llm_call=lambda: _reserve_openai_free_tier_budget(redis_conn),
+            # Releases the reservation before_llm_call just made when the
+            # real call then fails (rate limit, auth error, timeout) -
+            # on_usage never fires on a failed call, so without this the
+            # reservation is permanently stuck against a call that used zero
+            # real tokens. See openai_compatible.OpenAICompatibleAdapter's
+            # on_call_failed for why this can't just reuse on_usage(0, 0):
+            # that would misrepresent a failed call as a completed one to
+            # any other on_usage consumer.
+            on_call_failed=lambda: _true_up_openai_free_tier_reservation(redis_conn, 0),
         ))
     else:
         logger.info("free-tier: OPENAI_FREE_TIER_API_KEY not configured, skipping OpenAI free-tier")

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -1,6 +1,8 @@
 import logging
 import threading
 
+import pytest
+
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from scan_worker.model_tiers import (
     LUNA_MODEL,
@@ -365,6 +367,57 @@ def test_openai_free_tier_usage_still_forwards_to_the_shared_on_usage(monkeypatc
     openai_adapter._on_usage(10, 20)
 
     assert received == [(10, 20)]
+
+
+def test_openai_free_tier_on_call_failed_releases_the_reservation(monkeypatch):
+    # Real regression this guards: on_usage only fires on a completed call -
+    # a failed call (rotated key, outage, transient error exhausted its
+    # retries) never reaches it, so without on_call_failed the reservation
+    # before_llm_call already made stays stuck forever against zero real
+    # tokens. ~18 such failures in a day (18 x 130k ~= 2.34M against the
+    # 2.4M daily cap) would silently exhaust the counter and exclude
+    # OpenAI-FreeTier from the fallback chain for the rest of the day, even
+    # though every failed review still succeeded via the next provider in
+    # the chain (Groq/Gemini tried first, OpenRouter last) - the bug is
+    # invisible in review outcomes, only visible in the day's shrinking
+    # free-tier capacity.
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    from scan_worker.model_tiers import _openai_free_tier_token_key
+
+    redis_conn = _FakeRedis()
+    chain = writing_adapter_chain_for_free_tier(redis_conn)
+    openai_adapter = next(a for a in chain if a.name == "OpenAI-FreeTier")
+
+    assert openai_adapter._before_llm_call() is True  # reserves 130,000
+    assert redis_conn.data[_openai_free_tier_token_key()] == 130_000
+    openai_adapter._on_call_failed()  # the real call then failed outright
+
+    assert redis_conn.data[_openai_free_tier_token_key()] == 0
+
+
+def test_openai_free_tier_simple_completion_releases_reservation_on_a_failed_call(monkeypatch):
+    # End-to-end version of the test above, through the real
+    # simple_completion exception path rather than calling the hook
+    # directly.
+    from unittest.mock import MagicMock, patch
+
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    from scan_worker.model_tiers import _openai_free_tier_token_key
+
+    redis_conn = _FakeRedis()
+    chain = writing_adapter_chain_for_free_tier(redis_conn)
+    openai_adapter = next(a for a in chain if a.name == "OpenAI-FreeTier")
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError("boom")
+    with (
+        patch("aletheore.adapters.openai_compatible.OpenAI", return_value=mock_client),
+        patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"),
+    ):
+        with pytest.raises(Exception):
+            openai_adapter.simple_completion("system", "user", cwd="/repo")
+
+    assert redis_conn.data[_openai_free_tier_token_key()] == 0
 
 
 # ── cascading fallback tests ────────────────────────────────────────────

--- a/src/aletheore/adapters/openai_compatible.py
+++ b/src/aletheore/adapters/openai_compatible.py
@@ -273,6 +273,7 @@ class OpenAICompatibleAdapter(AgentAdapter):
         credentials_path: Path | None = None,
         on_usage: Callable[[int, int], None] | None = None,
         before_llm_call: Callable[[], bool] | None = None,
+        on_call_failed: Callable[[], None] | None = None,
         allow_partial_report: bool = False,
         extra_body: dict | None = None,
     ) -> None:
@@ -295,6 +296,7 @@ class OpenAICompatibleAdapter(AgentAdapter):
         self._credentials_path = credentials_path or DEFAULT_CREDENTIALS_PATH
         self._on_usage = on_usage
         self._before_llm_call = before_llm_call
+        self._on_call_failed = on_call_failed
         self._allow_partial_report = allow_partial_report
 
     def is_available(self) -> bool:
@@ -324,6 +326,16 @@ class OpenAICompatibleAdapter(AgentAdapter):
                 )
             )
         except Exception as exc:
+            # _ensure_budget_for_next_call above already reserved real budget
+            # for this attempt (e.g. the OpenAI free-tier daily token
+            # counter) - a failed call still needs that reservation released,
+            # or a run of failures (rotated key, outage) silently exhausts
+            # the counter against zero real usage. Only fires here, not when
+            # _ensure_budget_for_next_call itself raised: a declined
+            # reservation already released itself before this try block was
+            # ever entered.
+            if self._on_call_failed is not None:
+                self._on_call_failed()
             raise AdapterInvocationError(
                 f"{self.name} invocation failed: {type(exc).__name__}"
             ) from exc

--- a/src/tests/test_openai_compatible_adapter.py
+++ b/src/tests/test_openai_compatible_adapter.py
@@ -340,6 +340,68 @@ def test_simple_completion_retries_a_transient_rate_limit_error(mock_openai_clas
 
 
 @patch("aletheore.adapters.openai_compatible.OpenAI")
+def test_simple_completion_calls_on_call_failed_when_the_call_fails(mock_openai_class, tmp_path):
+    # Real regression: a caller that reserves real budget before a call
+    # (before_llm_call) needs a way to release it when the call itself then
+    # fails - without this, on_usage never fires (the call never completed)
+    # and the reservation is stuck forever against a call that used zero
+    # real tokens.
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.chat.completions.create.side_effect = _openai_error(
+        openai.BadRequestError, status_code=400
+    )
+
+    failed_calls = []
+    adapter = _adapter(tmp_path, on_call_failed=lambda: failed_calls.append(1))
+    with patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"):
+        with pytest.raises(AdapterInvocationError):
+            adapter.simple_completion("system", "user", cwd=str(tmp_path))
+
+    assert failed_calls == [1]
+
+
+@patch("aletheore.adapters.openai_compatible.OpenAI")
+def test_simple_completion_does_not_call_on_call_failed_on_success(mock_openai_class, tmp_path):
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_message = MagicMock()
+    mock_message.content = "ok"
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=mock_message)]
+    mock_response.usage = None
+    mock_client.chat.completions.create.return_value = mock_response
+
+    failed_calls = []
+    adapter = _adapter(tmp_path, on_call_failed=lambda: failed_calls.append(1))
+    with patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"):
+        adapter.simple_completion("system", "user", cwd=str(tmp_path))
+
+    assert failed_calls == []
+
+
+def test_simple_completion_does_not_call_on_call_failed_when_budget_is_declined_up_front():
+    # _ensure_budget_for_next_call raises before the try block that
+    # on_call_failed lives in is ever entered - before_llm_call declining is
+    # a distinct, already-self-releasing path (see
+    # model_tiers._reserve_openai_free_tier_budget), not a call failure.
+    failed_calls = []
+    adapter = OpenAICompatibleAdapter(
+        name="testprovider",
+        base_url="https://example.test/v1",
+        api_key_env_var="TESTPROVIDER_API_KEY",
+        model="test-model",
+        before_llm_call=lambda: False,
+        on_call_failed=lambda: failed_calls.append(1),
+    )
+
+    with pytest.raises(AdapterInvocationError):
+        adapter.simple_completion("system", "user", cwd="/repo")
+
+    assert failed_calls == []
+
+
+@patch("aletheore.adapters.openai_compatible.OpenAI")
 def test_read_evidence_section_tool_returns_wrapped_data(mock_openai_class, tmp_path):
     repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": [{"path": "app.py"}]}})
     mock_client = MagicMock()


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (`before_launch_fixes.md` Batch 1 #2): `simple_completion` reserves `OPENAI_FREE_TIER_RESERVATION_TOKENS` (130,000) against the daily counter before every real OpenAI-FreeTier attempt, but `on_usage` - the only thing that trues that reservation up to the real total - only fires after a successful response. Any exception during the call left the reservation permanently stuck against zero real tokens used.

The free-tier fallback chain itself isn't the problem here: `run_with_free_tier_fallback` already correctly moves on to the next provider (Groq → Gemini → OpenAI-FreeTier → OpenRouter, in that order) when an attempt fails, so no individual review actually fails from this. The leak is narrower and quieter: after ~18 real failures in a day (18 × 130k ≈ 2.34M against the 2.4M daily cap), OpenAI-FreeTier silently drops out of the fallback chain for the rest of the day against zero real usage - a rotated/expired key or an outage produces exactly this pattern.

## Fix
Added an `on_call_failed` hook to `OpenAICompatibleAdapter`, invoked in `simple_completion`'s `except` branch (not when `_ensure_budget_for_next_call` itself declines up front - that path already self-releases). Wired it to release the OpenAI-FreeTier reservation specifically. Deliberately a dedicated hook rather than reusing `on_usage(0, 0)`, which would misrepresent a failed call as a completed one to any other `on_usage` consumer.

## Test plan
- [x] `src/tests/test_openai_compatible_adapter.py`: `test_simple_completion_calls_on_call_failed_when_the_call_fails`, `test_simple_completion_does_not_call_on_call_failed_on_success`, `test_simple_completion_does_not_call_on_call_failed_when_budget_is_declined_up_front`
- [x] `github-app/tests/test_model_tiers.py`: `test_openai_free_tier_on_call_failed_releases_the_reservation`, `test_openai_free_tier_simple_completion_releases_reservation_on_a_failed_call`
- [x] Confirmed all 5 new tests fail without the fix and pass with it
- [x] Full `src/tests` suite: 1,297 passed
- [x] Full `github-app` suite: 1,441 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj