### PR TITLE
fix: coarse installation-list membership let a read-only org member claim admin

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from app_server.affiliates import create_affiliate, list_affiliates_with_totals, mark_commissions_paid
 from app_server.auth import encrypt_access_token, get_current_session, refresh_github_access_token
 from app_server.config import get_settings
+from app_server.github_auth import generate_app_jwt, get_installation_token, get_repo_permission_for_user
 from app_server.github_pagination import fetch_paginated_github_collection
 from app_server.http_client import get_github_api_client
 from app_server.email_client import send_transactional_email
@@ -333,7 +334,42 @@ def _bearer_github_token(request: Request) -> str:
     return auth_header.removeprefix("Bearer ")
 
 
-async def _require_seat_if_paid(pool, installation: dict, github_login: str) -> None:
+def _fetch_repo_permission_sync(installation_id: int, github_login: str, repo_full_name: str) -> str:
+    settings = get_settings()
+    app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+    installation_token = get_installation_token(installation_id, app_jwt)
+    return get_repo_permission_for_user(repo_full_name, github_login, installation_token)
+
+
+async def _has_real_admin_permission(installation_id: int, github_login: str, repo_full_name: str) -> bool:
+    """A stronger check than membership in the coarse `/user/installations`
+    set (_administered_installation_ids draws from it) - GitHub documents
+    that endpoint as listing every installation the caller has explicit
+    *read*, write, or admin access to on any one repo it covers, so a
+    read-only org member passes it too, same as a real admin. This queries
+    GitHub's actual per-repo permission for the specific repo being
+    administered instead, and is reserved for the two places the coarse
+    set is too weak to trust on its own: claiming the first seat, and
+    reaching the billing portal before any seat exists.
+
+    Fails closed on any error (network, revoked token, GitHub outage) - an
+    inability to verify real admin rights must never be treated as having
+    them.
+    """
+    try:
+        permission = await asyncio.to_thread(
+            _fetch_repo_permission_sync, installation_id, github_login, repo_full_name
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "real admin permission check failed for installation=%s login=%s repo=%s (%s)",
+            installation_id, github_login, repo_full_name, exc,
+        )
+        return False
+    return permission == "admin"
+
+
+async def _require_seat_if_paid(pool, installation: dict, github_login: str, repo_full_name: str) -> None:
     """Paid installations gate on a seat, not just raw GitHub admin rights -
     GitHub's own "who can manage this installation" set is an org-side
     setting Aletheore doesn't control, and in many orgs is every Owner, so
@@ -343,14 +379,24 @@ async def _require_seat_if_paid(pool, installation: dict, github_login: str) -> 
 
     If nobody has ever been seated yet (a paid installation from before
     seats existed, or the purchase webhook hasn't landed), the first
-    verified GitHub admin to show up becomes seat one rather than every
-    such customer being locked out of their own account.
+    *verified* GitHub admin to show up becomes seat one rather than every
+    such customer being locked out of their own account - verified via
+    _has_real_admin_permission, not just presence in the coarse
+    administered-installations set, since that set alone would let any
+    read-only org member with access to one repo the app is installed on
+    claim the first seat and everything it unlocks (API tokens, team
+    management).
     """
     if installation["plan"] == "free":
         return
     installation_id = installation["installation_id"]
     if await is_installation_member(pool, installation_id, github_login):
         return
+    if not await _has_real_admin_permission(installation_id, github_login, repo_full_name):
+        raise HTTPException(
+            status_code=403,
+            detail="you do not have admin access to this repository on GitHub",
+        )
     if await add_initial_installation_member_if_empty(pool, installation_id, github_login, github_login):
         return
     raise HTTPException(
@@ -395,7 +441,7 @@ async def _require_admin_installation(request: Request, org: str, repo: str) -> 
     if installation["plan"] == "free":
         raise HTTPException(status_code=402, detail="this feature requires a paid plan")
     pool = request.app.state.db_pool
-    await _require_seat_if_paid(pool, installation, session["github_login"])
+    await _require_seat_if_paid(pool, installation, session["github_login"], f"{org}/{repo}")
     return installation
 
 
@@ -610,8 +656,27 @@ async def get_billing_portal_url(org: str, repo: str, request: Request):
     """Deliberately not behind _require_admin_installation's plan gate (see
     _require_authorized_installation) - a payment failure has already
     downgraded this installation to free by the time anyone would use this,
-    and that's exactly who needs to reach it."""
-    _, installation = await _require_authorized_installation(request, org, repo)
+    and that's exactly who needs to reach it.
+
+    _require_authorized_installation alone only proves membership in the
+    coarse administered-installations set, which GitHub documents as
+    including anyone with read access to a single repo the app covers -
+    not enough to trust with a session that can view or change a payment
+    method, or cancel the subscription outright. An already-seated member
+    is trusted outright (paid access was already vetted when they were
+    added); anyone else needs their real per-repo GitHub permission
+    verified via _has_real_admin_permission, same bar as claiming the
+    first seat.
+    """
+    session, installation = await _require_authorized_installation(request, org, repo)
+    installation_id = installation["installation_id"]
+    pool = request.app.state.db_pool
+    if not await is_installation_member(pool, installation_id, session["github_login"]):
+        if not await _has_real_admin_permission(installation_id, session["github_login"], f"{org}/{repo}"):
+            raise HTTPException(
+                status_code=403,
+                detail="you do not have admin access to this repository on GitHub",
+            )
     customer_id = installation.get("paddle_customer_id")
     if not customer_id:
         raise HTTPException(

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -200,7 +200,7 @@ async def _require_dashboard_installation(request: Request, org: str, repo: str)
     if installation is not None:
         if installation["plan"] == "free":
             raise HTTPException(status_code=402, detail="the managed dashboard requires a paid plan")
-        await _require_seat_if_paid(pool, installation, session["github_login"])
+        await _require_seat_if_paid(pool, installation, session["github_login"], f"{org}/{repo}")
 
     return session, installation_id
 

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -14,6 +14,7 @@ from app_server.admin import (
     _fetch_administered_installation_ids,
     _administered_installation_ids_for_session_or_401,
     _build_updated_seat_items,
+    _has_real_admin_permission,
     _repo_installation_id,
 )
 from app_server.auth import decrypt_access_token, encrypt_access_token, sign_session_id
@@ -25,6 +26,7 @@ from app_server.db import (
     get_max_tokens,
     get_session,
     insert_repo_history,
+    is_installation_member,
     record_llm_spend,
     set_installation_plan,
     upsert_installation,
@@ -70,11 +72,26 @@ async def _logged_in_client(pool, monkeypatch, installation_id=100, plan="air"):
         "app_server.url_validation.socket.getaddrinfo",
         lambda *a, **k: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))],
     )
+    # Default "logged in" represents a real GitHub admin on the repo -
+    # _has_real_admin_permission would otherwise attempt a live GitHub API
+    # call (via app_server.github_auth, a different client than the
+    # coarse-check mock above) and fail closed. Tests exercising the
+    # narrower, non-admin case override this back to _async_false after
+    # calling this fixture.
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_true)
 
     app.state.db_pool = pool
     signed = sign_session_id("sess-1", "test-session-secret")
     transport = ASGITransport(app=app)
     return AsyncClient(transport=transport, base_url="http://test", cookies={"session": signed})
+
+
+async def _async_true(*args, **kwargs) -> bool:
+    return True
+
+
+async def _async_false(*args, **kwargs) -> bool:
+    return False
 
 
 async def _mock_github_installations(monkeypatch, installation_ids: list[int]):
@@ -1140,6 +1157,7 @@ async def test_remove_extra_seat_updates_paddle_subscription(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_billing_portal_requires_billing_account_on_file(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_true)
     async with client:
         response = await client.get("/admin/octocat/hello-world/billing-portal")
     assert response.status_code == 400
@@ -1162,6 +1180,7 @@ async def test_billing_portal_accessible_on_free_plan(pool, monkeypatch):
             "urls": {"general": {"overview": "https://customer-portal.paddle.com/overview"}}
         },
     )
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_true)
 
     async with client:
         response = await client.get("/admin/octocat/hello-world/billing-portal")
@@ -1197,6 +1216,7 @@ async def test_billing_portal_returns_subscription_scoped_url(pool, monkeypatch)
         }
 
     monkeypatch.setattr("app_server.admin.create_portal_session", fake_create_portal_session)
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_true)
 
     async with client:
         response = await client.get("/admin/octocat/hello-world/billing-portal")
@@ -1219,6 +1239,7 @@ async def test_billing_portal_falls_back_to_general_url_without_subscription(poo
             "urls": {"general": {"overview": "https://customer-portal.paddle.com/overview"}}
         },
     )
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_true)
 
     async with client:
         response = await client.get("/admin/octocat/hello-world/billing-portal")
@@ -1237,11 +1258,94 @@ async def test_billing_portal_reports_paddle_api_failure(pool, monkeypatch):
         raise PaddleAPIError("could not create portal session")
 
     monkeypatch.setattr("app_server.admin.create_portal_session", _boom)
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_true)
 
     async with client:
         response = await client.get("/admin/octocat/hello-world/billing-portal")
 
     assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_billing_portal_denies_a_non_admin_in_the_coarse_installations_set(pool, monkeypatch):
+    # The gap this closes: GET /user/installations (the coarse set
+    # _require_authorized_installation checks) includes anyone with mere
+    # read access to one repo the app covers, per GitHub's own docs - not
+    # enough to trust with a session that can view/change a payment method
+    # or cancel the subscription. Real per-repo permission ("admin") must
+    # be verified before an unseated caller reaches this.
+    await upsert_installation(pool, 100, "octocat")
+    await add_paddle_ids_to_installation(pool, 100, "sub_test", "ctm_test")
+    client = await _logged_in_client(pool, monkeypatch)
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_false)
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/billing-portal")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_seat_claim_denied_for_a_non_admin_in_the_coarse_installations_set(pool, monkeypatch):
+    # Same gap as above, for the other place the coarse set was trusted
+    # alone: claiming the first seat on a paid installation with none yet -
+    # which would otherwise hand the claimant /admin/{org}/{repo} access
+    # (API tokens, team management), not just the billing portal.
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_false)
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world")
+
+    assert response.status_code == 403
+    assert "admin access" in response.json()["detail"]
+    assert await is_installation_member(pool, 100, "octocat") is False
+
+
+@pytest.mark.asyncio
+async def test_has_real_admin_permission_true_only_for_admin_level(monkeypatch):
+    monkeypatch.setattr("app_server.admin.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("app_server.admin.get_installation_token", lambda *a, **k: "fake-installation-token")
+    monkeypatch.setattr("app_server.admin.get_repo_permission_for_user", lambda *a, **k: "admin")
+
+    assert await _has_real_admin_permission(100, "octocat", "octocat/hello-world") is True
+
+
+@pytest.mark.asyncio
+async def test_has_real_admin_permission_false_for_read_or_write(monkeypatch):
+    monkeypatch.setattr("app_server.admin.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("app_server.admin.get_installation_token", lambda *a, **k: "fake-installation-token")
+    for permission in ("read", "write", "none"):
+        monkeypatch.setattr(
+            "app_server.admin.get_repo_permission_for_user", lambda *a, permission=permission, **k: permission
+        )
+        assert await _has_real_admin_permission(100, "octocat", "octocat/hello-world") is False
+
+
+@pytest.mark.asyncio
+async def test_has_real_admin_permission_fails_closed_on_a_github_error(monkeypatch):
+    monkeypatch.setattr("app_server.admin.generate_app_jwt", lambda *a, **k: "fake-jwt")
+
+    def _boom(*a, **k):
+        raise RuntimeError("GitHub API unavailable")
+
+    monkeypatch.setattr("app_server.admin.get_installation_token", _boom)
+
+    assert await _has_real_admin_permission(100, "octocat", "octocat/hello-world") is False
+
+
+@pytest.mark.asyncio
+async def test_seat_claim_still_succeeds_for_a_verified_real_admin(pool, monkeypatch):
+    # The legitimate path this must not break: a genuinely-admin caller
+    # with no seat yet (a paid installation from before seats existed, or
+    # the purchase webhook hasn't landed) still becomes seat one.
+    client = await _logged_in_client(pool, monkeypatch, plan="air")
+
+    async with client:
+        response = await client.get("/admin/octocat/hello-world")
+
+    assert response.status_code == 200
+    assert await is_installation_member(pool, 100, "octocat") is True
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -145,6 +145,10 @@ def _evidence_with_module(module_path: str, function_name: str, docstring: str |
     }
 
 
+async def _async_true(*args, **kwargs) -> bool:
+    return True
+
+
 async def _logged_in_client(pool, monkeypatch, administered_ids):
     monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
     await create_session(
@@ -169,6 +173,11 @@ async def _logged_in_client(pool, monkeypatch, administered_ids):
         "app_server.admin._github_http_client",
         lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
     )
+    # This fixture's "logged in" user represents a real GitHub admin on the
+    # repo - _has_real_admin_permission (app_server/admin.py) would otherwise
+    # attempt a live GitHub API call and fail closed. See test_admin.py's
+    # identical mock on its own _logged_in_client for the same reasoning.
+    monkeypatch.setattr("app_server.admin._has_real_admin_permission", _async_true)
 
     app.state.db_pool = pool
     signed = sign_session_id("sess-1", "test-session-secret")


### PR DESCRIPTION
## Summary
- Confirmed against GitHub's own docs: `GET /user/installations` (the set `_require_authorized_installation` checks) includes anyone with `read`/`write`/`admin` access to a single repo the app covers - not just admins.
- Two places trusted that coarse set alone: claiming the first seat on a paid installation with none yet (`_require_seat_if_paid`), and reaching the Paddle billing portal before a seat exists (`/admin/{org}/{repo}/billing-portal`). Either let a read-only org member escalate to real admin access (API tokens, team management) or reach a session that can view/change the payment method or cancel the subscription.
- Adds `_has_real_admin_permission`, reusing the same per-repo GitHub permission check (`get_repo_permission_for_user`) already used to gate the ChatOps audit trigger in `issue_comment.py`. Fails closed on any error, same discipline as the existing coarse check.

## Test plan
- [x] 3 new unit tests for `_has_real_admin_permission` (admin-only passes, read/write/none fail, fails closed on a GitHub error) - pass cleanly in isolation
- [x] New integration tests proving the gap is closed (non-admin denied on both paths) and the legitimate first-admin-claim flow still works
- [x] Verified via `git stash` comparison that the local Postgres/Redis-backed integration test failures I'm seeing right now reproduce identically on unmodified `master` - a pre-existing shared-resource contention issue on this machine, not something this diff introduces. Relying on CI's isolated service containers for the real integration signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)