### PR TITLE
fix: subsystem cache lookups became strictly sequential

### DIFF
--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -839,20 +839,31 @@ def generate_subsystems(
     # Cache lookups are cheap and per-cluster, so they run first, before any
     # decision about whether the remaining clusters get one call each or
     # (2+) a batched call - a cache hit never enters the write path at all.
-    records_by_id: dict[str, dict] = {}
-    targets: list[_SubsystemWriteTarget] = []
-    order: list[str] = []
-    for brief in briefs:
+    # Run concurrently, same as the write phase below: on a repo with
+    # 30-40 subsystem clusters, a plain sequential loop here added 30-40
+    # blocking round-trips to the front of every build - serialized latency
+    # ahead of the very calls this function exists to batch/parallelize.
+    def _lookup_one(brief: dict) -> tuple[dict, dict, str, dict | None] | None:
         cluster = clusters_by_id.get(brief["cluster_id"])
         if cluster is None:
-            continue
+            return None
         name = names[brief["cluster_id"]]
-        cluster_id_str = str(brief["cluster_id"])
-        order.append(cluster_id_str)
-
         cached_record = _cached_subsystem_record(
             evidence, cluster, brief, name, cache_lookup, model_used, fetch_line_count
         )
+        return brief, cluster, name, cached_record
+
+    lookup_results = _run_concurrently([lambda b=brief: _lookup_one(b) for brief in briefs])
+
+    records_by_id: dict[str, dict] = {}
+    targets: list[_SubsystemWriteTarget] = []
+    order: list[str] = []
+    for result in lookup_results:
+        if result is None:
+            continue
+        brief, cluster, name, cached_record = result
+        cluster_id_str = str(brief["cluster_id"])
+        order.append(cluster_id_str)
         if cached_record is not None:
             records_by_id[cluster_id_str] = cached_record
         else:

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -664,6 +664,43 @@ def test_generate_subsystems_overlaps_writing_calls_instead_of_serializing():
     assert len(records) == 12
 
 
+def test_generate_subsystems_overlaps_cache_lookups_instead_of_serializing():
+    # Real regression this guards: the cache-lookup phase used to be a
+    # plain sequential for loop, adding one blocking round-trip per
+    # cluster to the front of every build before the (already concurrent)
+    # write phase even started - on a repo with 30-40 subsystem clusters,
+    # 30-40 serialized lookups, working against the very "overlap calls"
+    # goal batching exists for. Every cluster here misses cache (the slow
+    # cache_lookup returns None), so the whole measured elapsed time is the
+    # lookup phase; the write phase's own adapter responds instantly, no
+    # sleep, so it can't be what makes this pass.
+    evidence = _n_cluster_evidence(12)
+    naming_adapter = _adapter(json.dumps({str(i): f"Sub{i}" for i in range(12)}))
+
+    def _fast_write_response(_system_prompt, user_prompt, cwd):
+        items = json.loads(user_prompt)
+        return json.dumps({item["id"]: {"description": "stuff.", "files": []} for item in items})
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _fast_write_response
+
+    def _slow_cache_lookup(packet):
+        time.sleep(0.15)
+        return None
+
+    started = time.monotonic()
+    records = generate_subsystems(
+        evidence, naming_adapter, writing_adapter, cache_lookup=_slow_cache_lookup
+    )
+    elapsed = time.monotonic() - started
+
+    # 12 lookups at 150ms each: serial would be ~1.8s. Overlapped
+    # (MAX_GENERATION_WORKERS=6), 2 rounds of 6 at once is ~300ms - generous
+    # margin above that, comfortably below the serial figure.
+    assert elapsed < 0.9
+    assert len(records) == 12
+
+
 def test_generate_subsystems_propagates_a_write_failure_instead_of_swallowing_it():
     # Matches the prior fully-serial behavior: one subsystem's LLM call
     # raising aborted the whole build rather than silently continuing to


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (`before_launch_fixes.md` Batch 1 #6): `generate_subsystems`' cache-lookup phase was a plain sequential for-loop, running to completion before the (already concurrent) write phase started. On a repo with 30-40 subsystem clusters, that's 30-40 blocking cache round-trips added to the front of every build - working against the stated goal of cutting call volume/build time.

## Fix
Cache lookups now run through `_run_concurrently`, the same bounded thread pool the write phase already uses. Order and failure-propagation semantics are unchanged: results are gathered in input order before partitioning into `records_by_id`/`targets`, and `_run_concurrently`'s own first-exception-cancels-the-rest behavior matches the prior fully-serial abort-on-failure behavior.

## Test plan
- [x] `test_generate_subsystems_overlaps_cache_lookups_instead_of_serializing` (12 clusters, 150ms simulated cache-lookup latency each) - confirmed it measures ~1.85s without the fix (fully sequential) and comfortably under 0.9s with it
- [x] Full `github-app` suite: 1,441 passed, 8 skipped (isolated run; an earlier concurrent run showed unrelated cross-session DB contention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj