### PR TITLE
test: fix flaky wall-clock threshold in live_wiki batch-overlap test

### DIFF
--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -821,11 +821,28 @@ def test_generate_file_pages_overlaps_writing_calls_instead_of_serializing():
     # Batching (FILE_PAGE_WRITE_BATCH_SIZE=5) makes the unit of concurrency
     # the batch, not the individual file, so this needs more than one
     # batch's worth of paths to prove batches still overlap each other.
+    #
+    # Asserts on the recorded call windows actually overlapping, not a
+    # tight total-wall-clock threshold - a fixed cutoff like "elapsed <
+    # 0.28" is a condition-based check in disguise (did the batches run
+    # concurrently?) expressed as an arbitrary timing number instead, and
+    # CI-runner scheduling noise can push even genuinely-overlapped calls
+    # past a tight bound (observed 0.33-0.36s here against a 0.28s cutoff,
+    # still nowhere near the ~450ms fully-serial floor). Checking overlap
+    # directly proves the real property without being sensitive to how
+    # loaded the runner happens to be.
     evidence = _n_cluster_evidence(12)
     paths = [f"pkg{i}/mod.py" for i in range(12)]
 
+    call_windows: list[tuple[float, float]] = []
+    windows_lock = threading.Lock()
+
     def _slow_response(_system_prompt, user_prompt, cwd):
+        call_start = time.monotonic()
         time.sleep(0.15)
+        call_end = time.monotonic()
+        with windows_lock:
+            call_windows.append((call_start, call_end))
         items = json.loads(user_prompt)
         return json.dumps({item["id"]: {"detail": f"## Overview\nSee {item['path']}:1."} for item in items})
 
@@ -836,8 +853,21 @@ def test_generate_file_pages_overlaps_writing_calls_instead_of_serializing():
     pages = generate_file_pages(evidence, writing_adapter, paths=paths)
     elapsed = time.monotonic() - started
 
-    # 3 batches (5, 5, 2) at 150ms each, overlapped: well under serial ~450ms.
-    assert elapsed < 0.28
+    # 3 batches (5, 5, 2) at 150ms each - real proof of concurrency: at
+    # least two calls' [start, end) windows genuinely intersect. A fully
+    # serial implementation could never produce this, regardless of how
+    # loaded the machine running the test is.
+    assert len(call_windows) == 3
+    overlapping_pairs = [
+        (a, b)
+        for i, a in enumerate(call_windows)
+        for b in call_windows[i + 1:]
+        if a[0] < b[1] and b[0] < a[1]
+    ]
+    assert overlapping_pairs, f"no overlapping call windows found: {call_windows}"
+    # Loose backstop against genuine full serialization (~450ms) - not the
+    # primary assertion, just a sanity net with real margin over CI noise.
+    assert elapsed < 0.4
     assert set(pages) == set(paths)
 
 


### PR DESCRIPTION
## Summary
- `test_generate_file_pages_overlaps_writing_calls_instead_of_serializing` (`github-app/tests/test_live_wiki.py`) asserted total elapsed time < 0.28s to prove batches ran concurrently - failed twice in a row on PR #315's CI with elapsed=0.362 and 0.329, both far under the ~450ms fully-serial floor (real behavior intact) but above the tight bound. CI-runner scheduling noise, not a regression.
- Replaced the wall-clock assertion with a direct check: record each mocked call's `[start, end)` window and assert at least two genuinely overlap - the actual property being tested, immune to how loaded the runner is. Kept a loose `elapsed < 0.4s` backstop against real full serialization.

## Test plan
- [x] Ran the fixed test 5x locally, no flakes
- [x] Full `test_live_wiki.py` suite (60 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)