### PR TITLE
fix: duplicated free-tier/cache wiring in _run_flash_review

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1699,61 +1699,37 @@ def _run_flash_review(
                 )
                 return False
 
-        if code_evidence_context:
-            findings = review_diff(
-                diff_text,
-                file_context=file_context,
-                code_evidence_context=code_evidence_context,
-                on_usage=_on_usage,
-                referenced_symbol_context=referenced_symbol_context,
-                pr_context=pr_context,
-                # The similarity cache is keyed only by (installation_id,
-                # repo_full_name) + diff similarity - it has no notion of
-                # which model produced a cached result. Free tier never
-                # reads or writes it, so a paid customer who upgraded from
-                # free mid-month can never be silently served a weaker
-                # free-tier-model result for a similar diff.
-                cache_lookup=None if is_free_tier else _cache_lookup,
-                cache_write=None if is_free_tier else _cache_write,
-                model_used=flash_review_model,
-                file_contents=file_contents,
-                on_grounding_result=_on_grounding_result,
-                diff_patches=diff_patches,
-                adapter_chain=free_tier_chain,
-                on_free_tier_exhausted=_on_free_tier_exhausted,
-                # Paid-tier only (see _on_verification_usage) - free tier's
-                # own generation quality/cost tradeoffs are a separate,
-                # already-pooled budget this doesn't touch.
-                verify_with_second_model=not is_free_tier,
-                on_verification_usage=_on_verification_usage,
-            )
-        else:
-            findings = review_diff(
-                diff_text,
-                file_context=file_context,
-                on_usage=_on_usage,
-                referenced_symbol_context=referenced_symbol_context,
-                pr_context=pr_context,
-                # The similarity cache is keyed only by (installation_id,
-                # repo_full_name) + diff similarity - it has no notion of
-                # which model produced a cached result. Free tier never
-                # reads or writes it, so a paid customer who upgraded from
-                # free mid-month can never be silently served a weaker
-                # free-tier-model result for a similar diff.
-                cache_lookup=None if is_free_tier else _cache_lookup,
-                cache_write=None if is_free_tier else _cache_write,
-                model_used=flash_review_model,
-                file_contents=file_contents,
-                on_grounding_result=_on_grounding_result,
-                diff_patches=diff_patches,
-                adapter_chain=free_tier_chain,
-                on_free_tier_exhausted=_on_free_tier_exhausted,
-                # Paid-tier only (see _on_verification_usage) - free tier's
-                # own generation quality/cost tradeoffs are a separate,
-                # already-pooled budget this doesn't touch.
-                verify_with_second_model=not is_free_tier,
-                on_verification_usage=_on_verification_usage,
-            )
+        # code_evidence_context defaults to "" in review_diff's own
+        # signature, so passing it unconditionally (even when this build
+        # produced none) is identical to omitting it - no need for the two
+        # near-duplicate call sites this used to be split into.
+        findings = review_diff(
+            diff_text,
+            file_context=file_context,
+            code_evidence_context=code_evidence_context,
+            on_usage=_on_usage,
+            referenced_symbol_context=referenced_symbol_context,
+            pr_context=pr_context,
+            # The similarity cache is keyed only by (installation_id,
+            # repo_full_name) + diff similarity - it has no notion of
+            # which model produced a cached result. Free tier never
+            # reads or writes it, so a paid customer who upgraded from
+            # free mid-month can never be silently served a weaker
+            # free-tier-model result for a similar diff.
+            cache_lookup=None if is_free_tier else _cache_lookup,
+            cache_write=None if is_free_tier else _cache_write,
+            model_used=flash_review_model,
+            file_contents=file_contents,
+            on_grounding_result=_on_grounding_result,
+            diff_patches=diff_patches,
+            adapter_chain=free_tier_chain,
+            on_free_tier_exhausted=_on_free_tier_exhausted,
+            # Paid-tier only (see _on_verification_usage) - free tier's
+            # own generation quality/cost tradeoffs are a separate,
+            # already-pooled budget this doesn't touch.
+            verify_with_second_model=not is_free_tier,
+            on_verification_usage=_on_verification_usage,
+        )
     # The review-count reservation already happened atomically up front (see
     # run_flash_review_job); nothing left to do for it here on the success
     # path. The dollar reservation was a conservative flat estimate, not the


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (`before_launch_fixes.md` Batch 1 #7): the two `review_diff()` call sites in `_run_flash_review` had grown to duplicate ~28 lines of identical free-tier chain / cache-lookup / cache-write / verification wiring, differing only in whether `code_evidence_context` was passed at all.

`review_diff`'s own signature already defaults `code_evidence_context` to `""` - passing the empty string explicitly is behaviorally identical to omitting it, so the `if/else` split had no real divergence left to justify it.

## Fix
Collapsed into a single unconditional call - simpler than a kwargs-dict extraction since there was nothing left to build a dict around.

## Test plan
- [x] Existing `tests/test_jobs.py -k "flash_review or review_diff"`: 26 passed, unchanged behavior (pure refactor, no new test needed)
- [x] Full `github-app` suite: 1,442 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj