### PR TITLE
fix: subsystem and file-page batch-write-retry logic duplicated near-verbatim

### DIFF
--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -84,6 +84,52 @@ def _run_concurrently(thunks: list[Callable[[], _T]], max_workers: int = MAX_GEN
             raise first_exception
         return [f.result() for f in futures]
 
+
+_BatchTarget = TypeVar("_BatchTarget")
+_BatchResult = TypeVar("_BatchResult")
+
+
+def _run_batched_with_retry(
+    targets: list[_BatchTarget],
+    target_id: Callable[[_BatchTarget], str],
+    write_batch: Callable[[list[_BatchTarget]], dict[str, _BatchResult]],
+    on_round_result: Callable[[str, _BatchResult], None],
+    is_resolved: Callable[[_BatchResult], bool],
+    attempts: int,
+    batch_size: int,
+) -> list[_BatchTarget]:
+    """Shared shape behind both subsystem and file-page batch generation:
+    chunk `targets`, run chunks concurrently via `write_batch`, retry only
+    whatever didn't resolve - up to `attempts` rounds - then stop.
+
+    `on_round_result(target_id, result)` fires once per target per round it
+    has a result for (in `targets`' order, while that target is still
+    unresolved) - callers own how to accumulate across rounds, since that
+    differs by type: subsystem callers only ever want a first/only success,
+    file-page callers need to keep the *last* result with a usable detail
+    even across failed retries, for salvage. Returns the targets that never
+    satisfied `is_resolved` after the final attempt.
+    """
+    remaining = list(targets)
+    for _attempt in range(1, attempts + 1):
+        if not remaining:
+            break
+        chunks = _batches(remaining, batch_size)
+        chunk_results = _run_concurrently([lambda c=chunk: write_batch(c) for chunk in chunks])
+        merged: dict[str, _BatchResult] = {}
+        for chunk_result in chunk_results:
+            merged.update(chunk_result)
+        for t in remaining:
+            result = merged.get(target_id(t))
+            if result is not None:
+                on_round_result(target_id(t), result)
+        remaining = [
+            t for t in remaining
+            if (result := merged.get(target_id(t))) is None or not is_resolved(result)
+        ]
+    return remaining
+
+
 SUBSYSTEM_DESCRIPTION_UNAVAILABLE = (
     "_Description withheld: the generated summary for this subsystem cited code that "
     "could not be verified against the scan. The file list and diagram below come "
@@ -689,20 +735,18 @@ def _generate_subsystem_records_for_targets(
     """
     by_id = {t.cluster_id_str: t for t in targets}
     resolved: dict[str, tuple[dict, str]] = {}
-    remaining = list(targets)
-
-    for _attempt in range(1, SUBSYSTEM_WRITE_ATTEMPTS + 1):
-        if not remaining:
-            break
-        chunks = _batches(remaining, SUBSYSTEM_WRITE_BATCH_SIZE)
-
-        def _thunk(chunk: list[_SubsystemWriteTarget]) -> dict[str, tuple[dict, str]]:
-            return _write_subsystem_batch(evidence, chunk, writing_adapter, fetch_line_count)
-
-        chunk_results = _run_concurrently([lambda c=chunk: _thunk(c) for chunk in chunks])
-        for chunk_result in chunk_results:
-            resolved.update(chunk_result)
-        remaining = [t for t in remaining if t.cluster_id_str not in resolved]
+    _run_batched_with_retry(
+        targets,
+        target_id=lambda t: t.cluster_id_str,
+        write_batch=lambda chunk: _write_subsystem_batch(evidence, chunk, writing_adapter, fetch_line_count),
+        on_round_result=resolved.__setitem__,
+        # _write_subsystem_batch only ever returns an entry for a target
+        # whose citations verified - any presence in a round's result means
+        # resolved, nothing further to check.
+        is_resolved=lambda _result: True,
+        attempts=SUBSYSTEM_WRITE_ATTEMPTS,
+        batch_size=SUBSYSTEM_WRITE_BATCH_SIZE,
+    )
 
     records: dict[str, dict] = {}
     for cluster_id_str, target in by_id.items():
@@ -1195,30 +1239,26 @@ def _generate_file_pages_for_targets(
     """
     verified: dict[str, str] = {}
     last_attempt: dict[str, tuple[str, list[dict]]] = {}
-    remaining = list(targets)
 
-    for _attempt in range(1, SUBSYSTEM_WRITE_ATTEMPTS + 1):
-        if not remaining:
-            break
-        chunks = _batches(remaining, FILE_PAGE_WRITE_BATCH_SIZE)
-        chunk_results = _run_concurrently(
-            [lambda c=chunk: _write_file_page_batch(evidence, c, writing_adapter, fetch_line_count)
-             for chunk in chunks]
-        )
-        merged: dict[str, tuple[str, str | None, list[dict]]] = {}
-        for chunk_result in chunk_results:
-            merged.update(chunk_result)
+    def _on_result(path: str, result: tuple[str, str | None, list[dict]]) -> None:
+        status, detail, unverified = result
+        if status == "verified" and detail is not None:
+            verified[path] = detail
+        elif detail is not None:
+            # Only remember an attempt that actually produced usable prose -
+            # a later retry that fails outright (no detail at all) must not
+            # erase an earlier round's salvageable one.
+            last_attempt[path] = (detail, unverified)
 
-        next_remaining = []
-        for t in remaining:
-            status, detail, unverified = merged.get(t.path, ("failed", None, []))
-            if status == "verified" and detail is not None:
-                verified[t.path] = detail
-            else:
-                if detail is not None:
-                    last_attempt[t.path] = (detail, unverified)
-                next_remaining.append(t)
-        remaining = next_remaining
+    remaining = _run_batched_with_retry(
+        targets,
+        target_id=lambda t: t.path,
+        write_batch=lambda chunk: _write_file_page_batch(evidence, chunk, writing_adapter, fetch_line_count),
+        on_round_result=_on_result,
+        is_resolved=lambda result: result[0] == "verified",
+        attempts=SUBSYSTEM_WRITE_ATTEMPTS,
+        batch_size=FILE_PAGE_WRITE_BATCH_SIZE,
+    )
 
     for t in remaining:
         prior = last_attempt.get(t.path)

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -864,6 +864,42 @@ def test_generate_file_pages_keeps_path_to_detail_mapping_correct_under_concurre
     assert pages["billing/charge.py"] == "## Overview\nSee billing/charge.py:1."
 
 
+def test_generate_file_pages_batched_salvage_survives_a_later_detail_less_retry():
+    # Real regression this must not reintroduce (guards _run_batched_with_
+    # retry's on_round_result contract): a target's most recent USABLE
+    # detail from an earlier round must not be erased by a later retry that
+    # fails outright with no detail at all - only a retry that itself
+    # produces a (still-unverified) detail should replace it.
+    evidence = _two_cluster_evidence()
+    call_count = {"n": 0}
+
+    def _respond(_system_prompt, user_prompt, cwd):
+        call_count["n"] += 1
+        items = json.loads(user_prompt)
+        if call_count["n"] == 1:
+            return json.dumps({
+                item["id"]: (
+                    {"detail": "## Overview\nSee billing/charge.py:1."}
+                    if item["path"] == "billing/charge.py"
+                    else {"detail": "## Overview\nSee auth/login.py:10.\n- `ghost` (auth/nowhere.py:99): missing."}
+                )
+                for item in items
+            })
+        # Retry round: only auth/login.py is still remaining, and this
+        # attempt produces nothing usable at all - must not erase round 1's
+        # salvageable detail.
+        return json.dumps({item["id"]: {"detail": ""} for item in items})
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _respond
+
+    pages = generate_file_pages(evidence, writing_adapter, paths=["auth/login.py", "billing/charge.py"])
+
+    assert pages["billing/charge.py"] == "## Overview\nSee billing/charge.py:1."
+    assert "auth/nowhere.py:99" not in pages["auth/login.py"]
+    assert "auth/login.py:10" in pages["auth/login.py"]
+
+
 def test_run_concurrently_preserves_input_order_regardless_of_completion_order():
     def _slow():
         time.sleep(0.1)


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (`before_launch_fixes.md` Batch 1 #8): `_generate_subsystem_records_for_targets` and `_generate_file_pages_for_targets` implemented the identical shape - chunk remaining targets, run chunks concurrently, merge results by id, retry only what didn't resolve, up to N rounds - with separately-named batch-size/attempt handling and only the per-item payload/result type differing.

## Fix
Extracted a generic `_run_batched_with_retry` helper that owns the loop/chunk/concurrency/retry mechanics. The two callers' per-round accumulation genuinely differs though: subsystem only ever wants a first success, while file-pages must remember the *last* result with a usable detail across failed retries, for salvage - a later retry that fails outright with no detail must not erase an earlier round's salvageable one. Rather than forcing one accumulation policy on both (which would have silently broken file-pages' salvage semantics), the helper takes an `on_round_result(target_id, result)` callback and lets each caller own its own merge logic.

## Test plan
- [x] `test_generate_file_pages_batched_salvage_survives_a_later_detail_less_retry` - confirmed it fails when the "don't erase" guard is broken and passes with it
- [x] Full `test_live_wiki.py`: 61 passed
- [x] Full `github-app` suite: 1,443 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj