### PR TITLE
feat: tell CLI users the first scan/index is slower, later ones are faster

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -680,6 +680,15 @@ def _index(repo_path: str) -> int:
         "Building semantic search index (embedding via local Ollama, "
         "falling back to OpenAI if unavailable)..."
     )
+    # Same reasoning as _scan's cache-hit message: only a chunk whose text
+    # actually changed gets re-embedded (see search_index.build_index), so a
+    # repeat index of a mostly-unchanged repo is much faster than the first
+    # one - said explicitly here so a fast rebuild reads as the cache
+    # working, not as something having been skipped.
+    console.print(
+        "[dim]Only chunks that changed since the last index are re-embedded - "
+        "the first index of a repo is the slow one.[/dim]"
+    )
     from aletheore.search_index import build_index
 
     report = _make_progress_printer()

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -419,6 +419,21 @@ def scan_repository(
     unchanged_modules, unchanged_endpoints = _load_unchanged_scan_cache()
     if not using_hosted_cache and not local_cache_disabled:
         unchanged_modules, unchanged_endpoints = _load_local_scan_cache(repo_path)
+        # Surfaced here, not left implicit: a CLI user who only ever sees
+        # "Scanning..." has no way to know a scan is cached at all, so a
+        # fast repeat scan reads as suspicious (did it actually check
+        # everything?) rather than as the cache working as intended.
+        if unchanged_modules:
+            report(
+                f"Reusing cached results for {len(unchanged_modules)} unchanged "
+                "file(s) from the last scan of this repo"
+            )
+        else:
+            report(
+                "No previous scan cache found for this repo - this first scan "
+                "will take longer. Results are cached automatically, so future "
+                "scans only re-parse files that actually changed."
+            )
 
     report("Building module dependency graph (parsing source with tree-sitter)")
     modules, dependency_graph, unparseable_files = build_module_graph(

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -987,6 +987,23 @@ def test_index_command_builds_index_from_existing_evidence(tmp_path):
     mock_build.assert_called_once()
 
 
+def test_index_command_explains_incremental_re_embedding(tmp_path):
+    # A user who only ever sees "Building semantic search index..." then a
+    # near-instant "Indexed N chunks" on a repeat run has no way to know
+    # that's the cache working as intended, not something skipped.
+    repo = tmp_path
+    (repo / "app.py").write_text("def greet():\n    return 'hi'\n")
+    result = runner.invoke(app, ["scan", str(repo)])
+    assert result.exit_code == 0
+
+    with patch("aletheore.search_index.build_index", return_value=3):
+        result = runner.invoke(app, ["index", str(repo)])
+
+    assert result.exit_code == 0
+    assert "re-embedded" in result.output
+    assert "first index" in result.output.lower()
+
+
 def test_index_command_fails_clearly_without_prior_scan(tmp_path):
     result = runner.invoke(app, ["index", str(tmp_path)])
     assert result.exit_code == 1

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -377,6 +377,50 @@ def test_scan_repository_reparses_a_file_that_changed_since_the_local_cache(tmp_
     assert "before" not in [f["name"] for f in by_path["changing.py"]["symbols"]["functions"]]
 
 
+def test_scan_repository_reports_no_cache_found_on_a_first_scan(tmp_path):
+    # A CLI user who only ever sees "Scanning..." has no way to know a scan
+    # is cached at all - a fast repeat scan would otherwise read as
+    # suspicious (did it actually check everything?) rather than as the
+    # cache working as intended.
+    repo = make_repo(tmp_path)
+    (repo / "main.py").write_text("x = 1\n")
+    run(repo, "add", "-A")
+    run(repo, "commit", "-q", "-m", "add main.py")
+
+    messages = []
+    with patch("aletheore.evidence.check_dependency_vulnerabilities") as mock_check:
+        mock_check.return_value = {"checked": True, "reason": None, "findings": []}
+        scan_repository(repo, check_licenses=False, progress=messages.append)
+
+    assert any("No previous scan cache found" in m for m in messages)
+    assert not any("Reusing cached results" in m for m in messages)
+
+
+def test_scan_repository_reports_reused_file_count_on_a_cached_scan(tmp_path):
+    repo = make_repo(tmp_path)
+    (repo / "unchanged.py").write_text("def cached():\n    pass\n")
+    run(repo, "add", "-A")
+    run(repo, "commit", "-q", "-m", "add unchanged.py")
+
+    with patch("aletheore.evidence.check_dependency_vulnerabilities") as mock_check:
+        mock_check.return_value = {"checked": True, "reason": None, "findings": []}
+        scan_repository(repo, check_licenses=False)
+
+    messages = []
+    with patch("aletheore.evidence.check_dependency_vulnerabilities") as mock_check:
+        mock_check.return_value = {"checked": True, "reason": None, "findings": []}
+        scan_repository(repo, check_licenses=False, progress=messages.append)
+
+    # make_repo's own main.py + requirements.txt fixture files are also
+    # unchanged on this second scan, so the count is >1, not exactly the 1
+    # file this test itself adds - assert the message shape, not the exact
+    # count, so this doesn't depend on make_repo's fixture contents.
+    assert any(
+        m.startswith("Reusing cached results for ") and "unchanged file" in m for m in messages
+    )
+    assert not any("No previous scan cache found" in m for m in messages)
+
+
 def test_scan_repository_ignores_local_cache_when_hosted_cache_env_var_is_set(tmp_path, monkeypatch):
     # The hosted worker's own cache must always take priority - a plain
     # local cache left over on the same machine (e.g. a developer testing


### PR DESCRIPTION
## Summary
Neither \`aletheore scan\` nor \`aletheore index\` said anything about the incremental caching both already do (content-hash-keyed scan cache, chunk-hash-keyed embedding reuse) - a user seeing a much faster repeat run had no way to know that was the cache working as intended rather than something having been silently skipped.

## Change
- \`scan_repository\` now reports whether a local scan cache was found and, when it was, how many files were reused unchanged.
- The \`index\` command now states up front that only changed chunks get re-embedded.

## Test plan
- [x] New regression tests for both messages (first-scan vs cached-scan, and the index command's static explainer)
- [x] Full \`src/tests\` suite: 1,300 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj