### PR TITLE
fix: health-fix cooldown reinvented a Postgres-backed primitive the codebase already has in Redis

### DIFF
--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -719,43 +719,6 @@ def get_last_endpoint_health(
             return result
 
 
-def was_recently_down(
-    dsn: str,
-    installation_id: int,
-    repo_full_name: str,
-    method: str,
-    path: str,
-    target_id: int | None,
-    since: datetime,
-) -> bool:
-    """Whether this exact endpoint (same target, not just same path - a
-    staging and a prod target sharing a path are different incidents) was
-    already recorded unreachable at least once since `since`. Called before
-    the current check's own row is inserted, so this only ever reflects
-    PRIOR checks - a flapping endpoint's second, third, fourth down-flip
-    inside the window reads as "already had a recent incident" rather than
-    a fresh one, which is what lets the fix-suggestion cooldown work.
-    """
-    with get_db_pool(dsn).connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT 1
-                FROM endpoint_health
-                WHERE installation_id = %s
-                  AND repo_full_name = %s
-                  AND endpoint_method = %s
-                  AND endpoint_path = %s
-                  AND target_id IS NOT DISTINCT FROM %s
-                  AND reachable = false
-                  AND checked_at >= %s
-                LIMIT 1
-                """,
-                (installation_id, repo_full_name, method, path, target_id, since),
-            )
-            return cur.fetchone() is not None
-
-
 def list_recent_endpoint_incidents(
     dsn: str,
     installation_id: int,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -78,7 +78,6 @@ from scan_worker.db import (
     get_seconds_since_last_health_check,
     insert_audit_report,
     insert_endpoint_health,
-    was_recently_down,
     insert_repo_history,
     installation_spend_lock,
     release_flash_review_count_reservation,
@@ -2223,6 +2222,7 @@ def run_runtime_event_job(
 def run_health_check_sweep_job() -> None:
     settings = get_settings()
     dsn = settings.database_url
+    redis_conn = get_redis_client()
     deadline = time.monotonic() + HEALTH_SWEEP_SOFT_DEADLINE_SECONDS
     targets = _rotated_health_check_targets(dsn)
 
@@ -2241,7 +2241,7 @@ def run_health_check_sweep_job() -> None:
 
         try:
             _run_health_check_sweep_for_target(
-                dsn, target, installation_id, repo_full_name, target_id, base_url, threshold_ms
+                dsn, redis_conn, target, installation_id, repo_full_name, target_id, base_url, threshold_ms
             )
         except Exception as exc:  # noqa: BLE001
             # One customer's dead webhook URL, an unreachable target, or any
@@ -2262,6 +2262,7 @@ def run_health_check_sweep_job() -> None:
 
 def _run_health_check_sweep_for_target(
     dsn: str,
+    redis_conn,
     target: dict,
     installation_id: int,
     repo_full_name: str,
@@ -2333,10 +2334,13 @@ def _run_health_check_sweep_for_target(
 
         if reachability_flipped:
             if not reachable and source_file:
-                recently_down = was_recently_down(
-                    dsn, installation_id, repo_full_name, method, path, target_id,
-                    datetime.now(timezone.utc) - timedelta(seconds=HEALTH_FIX_SUGGESTION_COOLDOWN_SECONDS),
+                recently_down = _recently_suggested_a_fix(
+                    redis_conn, installation_id, repo_full_name, method, path, target_id
                 )
+                if not recently_down:
+                    _mark_fix_suggestion_sent(
+                        redis_conn, installation_id, repo_full_name, method, path, target_id
+                    )
                 evidence_resolution = _attach_recent_commit_for_failure(
                     installation_id,
                     repo_full_name,
@@ -2420,6 +2424,7 @@ def _run_health_check_sweep_for_target(
 def run_health_check_down_retry_job(target: dict, entry: dict, attempt: int) -> None:
     settings = get_settings()
     dsn = settings.database_url
+    redis_conn = get_redis_client()
     installation_id = target["installation_id"]
     repo_full_name = target["repo_full_name"]
     target_id = target["target_id"]
@@ -2467,10 +2472,13 @@ def run_health_check_down_retry_job(target: dict, entry: dict, attempt: int) -> 
 
     if reachability_flipped:
         if not reachable and source_file:
-            recently_down = was_recently_down(
-                dsn, installation_id, repo_full_name, method, path, target_id,
-                datetime.now(timezone.utc) - timedelta(seconds=HEALTH_FIX_SUGGESTION_COOLDOWN_SECONDS),
+            recently_down = _recently_suggested_a_fix(
+                redis_conn, installation_id, repo_full_name, method, path, target_id
             )
+            if not recently_down:
+                _mark_fix_suggestion_sent(
+                    redis_conn, installation_id, repo_full_name, method, path, target_id
+                )
             evidence_resolution = _attach_recent_commit_for_failure(
                 installation_id,
                 repo_full_name,
@@ -2666,6 +2674,37 @@ def _set_with_expiry(redis_conn, key: str, value, ttl_seconds: int) -> None:
         redis_conn.set(key, value)
         if hasattr(redis_conn, "expire"):
             redis_conn.expire(key, ttl_seconds)
+
+
+def _health_fix_suggestion_cooldown_key(
+    installation_id: int, repo_full_name: str, method: str, path: str, target_id: int | None
+) -> str:
+    return f"health_fix_suggestion:cooldown:{installation_id}:{repo_full_name}:{method}:{path}:{target_id}"
+
+
+def _recently_suggested_a_fix(
+    redis_conn, installation_id: int, repo_full_name: str, method: str, path: str, target_id: int | None
+) -> bool:
+    """Same Redis key-+-TTL cooldown shape _send_ops_alert uses, not a
+    was_recently_down-style Postgres row-history query - a DB round-trip per
+    down-flip to answer "have we already suggested a fix for this exact
+    endpoint recently" was slower and functionally redundant with a
+    primitive this module already has for exactly this shape of question.
+    """
+    return redis_conn.get(_health_fix_suggestion_cooldown_key(
+        installation_id, repo_full_name, method, path, target_id
+    )) is not None
+
+
+def _mark_fix_suggestion_sent(
+    redis_conn, installation_id: int, repo_full_name: str, method: str, path: str, target_id: int | None
+) -> None:
+    _set_with_expiry(
+        redis_conn,
+        _health_fix_suggestion_cooldown_key(installation_id, repo_full_name, method, path, target_id),
+        "1",
+        HEALTH_FIX_SUGGESTION_COOLDOWN_SECONDS,
+    )
 
 
 def _fetch_app_health(url: str) -> tuple[bool, str]:

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2692,6 +2692,7 @@ def _patch_sweep(
     result_entry=None,
     evidence=None,
     retry_result_entry=None,
+    redis_conn=None,
 ):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.time.sleep", lambda *a, **k: None)
@@ -2741,7 +2742,8 @@ def _patch_sweep(
         "scan_worker.jobs.get_last_endpoint_health", lambda dsn, iid, repo, method, path, target_id=None: prior
     )
     monkeypatch.setattr("scan_worker.jobs.insert_endpoint_health", lambda *a, **k: None)
-    monkeypatch.setattr("scan_worker.jobs.was_recently_down", lambda *a, **k: False)
+    active_redis_conn = redis_conn if redis_conn is not None else _FakeRedis()
+    monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: active_redis_conn)
     sent = []
     monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: sent.append(msg))
     return sent
@@ -2929,6 +2931,17 @@ def test_sweep_skips_fix_suggestion_when_endpoint_was_recently_down(monkeypatch)
     # must not pay for a second LLM fix-suggestion call on this flip - the
     # alert (and its deterministic commit/owner attachments) still fires,
     # only the one expensive call is skipped.
+    from scan_worker.jobs import _health_fix_suggestion_cooldown_key
+
+    redis_conn = _FakeRedis()
+    # installation_id/repo_full_name/target_id here match _patch_sweep's own
+    # fixed target fixture (installation_id=1, repo_full_name=
+    # "octocat/hello-world", target_id=900) - pre-populating the exact
+    # cooldown key a real prior suggestion would have set is what actually
+    # exercises the Redis-backed cooldown, not a mocked function.
+    redis_conn.set(
+        _health_fix_suggestion_cooldown_key(1, "octocat/hello-world", "GET", "/x", 900), "1", ex=1800
+    )
     sent = _patch_sweep(
         monkeypatch,
         prior={"reachable": True, "latency_ms": 100.0},
@@ -2945,9 +2958,9 @@ def test_sweep_skips_fix_suggestion_when_endpoint_was_recently_down(monkeypatch)
             "method": "GET", "path": "/x", "reachable": False,
             "status_code": None, "latency_ms": 10.0, "response_shape": None,
         },
+        redis_conn=redis_conn,
     )
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
-    monkeypatch.setattr("scan_worker.jobs.was_recently_down", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._commit_attachment_from_graph", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._owner_attachment_from_graph", lambda *a, **k: None)
 


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (`before_launch_fixes.md` Batch 1 #9): `was_recently_down` gated the health-fix-suggestion LLM call with a bespoke Postgres query against `endpoint_health`'s row history - a DB round-trip per down-flip, and functionally redundant with the Redis key-+-TTL cooldown `_send_ops_alert` already implements for exactly this shape of question ("have we already acted on this condition recently").

## Fix
Added `_health_fix_suggestion_cooldown_key` / `_recently_suggested_a_fix` / `_mark_fix_suggestion_sent`, built on the existing `_set_with_expiry` primitive, and threaded `redis_conn` through both call sites (`_run_health_check_sweep_for_target`, `run_health_check_down_retry_job`). Deleted the now-unused `was_recently_down` from `db.py`.

## Test plan
- [x] Regression test updated to pre-populate the real cooldown key in a `_FakeRedis` instance instead of mocking a function that no longer exists, so it exercises the actual Redis-backed mechanism rather than just its plumbing
- [x] `tests/test_jobs.py -k "sweep or health"`: 31 passed
- [x] Full `github-app` suite: 1,449 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj