### PR TITLE
fix: _looks_like_test_file reimplements an existing, weaker-in-both-directions utility

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 
+from aletheore.dead_code import is_test_file
 from aletheore.evidence_resolution import (
     attach_dependency_evidence,
     attach_risk_evidence,
@@ -152,7 +153,7 @@ def fetch_review_file_context(
         encoded_len = len(content.encode("utf-8"))
         if total_bytes + encoded_len > MAX_CONTEXT_TOTAL_BYTES:
             break
-        label = "test file content" if _looks_like_test_file(path) else "full content"
+        label = "test file content" if is_test_file(path) else "full content"
         parts.append(f"--- {label}: {path} ---\n{content}")
         total_bytes += encoded_len
     file_context = "\n\n".join(parts)
@@ -351,15 +352,6 @@ _CHANGE_IMPACT_PATTERNS = {
         r"\b(?:thread|threads|Thread|Executor|Pool|async|await|lock|mutex|concurrent|parallel)\b"
     ),
 }
-
-
-def _looks_like_test_file(path: str) -> bool:
-    lowered = path.lower()
-    return (
-        "/test" in lowered
-        or lowered.startswith("test_")
-        or lowered.endswith(("_test.py", ".test.js", ".spec.js", ".test.ts", ".spec.ts"))
-    )
 
 
 def build_change_impact_context(diff_text: str) -> str:

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -1734,6 +1734,38 @@ def test_fetch_review_file_context_stops_context_at_total_byte_budget(monkeypatc
     assert file_contents == {"a.py": "0123456789", "b.py": "0123456789", "c.py": "0123456789"}
 
 
+def test_fetch_review_file_context_does_not_mislabel_a_production_file_starting_with_test(monkeypatch):
+    # Real regression: the old unanchored "/test" in path.lower() substring
+    # check false-positived on any production file whose path segment
+    # merely starts with "test" - src/testing_utils.py is not a test file.
+    from scan_worker import flash_review
+
+    monkeypatch.setattr(flash_review, "fetch_file_content", lambda client, token, repo, path, ref: "content")
+
+    file_context, _ = flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["src/testing_utils.py"], "sha"
+    )
+
+    assert "full content: src/testing_utils.py" in file_context
+    assert "test file content: src/testing_utils.py" not in file_context
+
+
+def test_fetch_review_file_context_labels_a_tests_directory_jsx_spec_file_correctly(monkeypatch):
+    # Real regression: __tests__/Button.spec.tsx was missed entirely by the
+    # old check - no literal "/test" substring (it's "__tests__/"), and
+    # .tsx isn't in the old endswith(...) tuple, which only covered
+    # .js/.ts.
+    from scan_worker import flash_review
+
+    monkeypatch.setattr(flash_review, "fetch_file_content", lambda client, token, repo, path, ref: "content")
+
+    file_context, _ = flash_review.fetch_review_file_context(
+        None, "tok", "o/r", ["__tests__/Button.spec.tsx"], "sha"
+    )
+
+    assert "test file content: __tests__/Button.spec.tsx" in file_context
+
+
 def test_fetch_review_file_context_returns_path_to_content_mapping(monkeypatch):
     from scan_worker import flash_review
 


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (\`before_launch_fixes.md\` Batch 2 #7): \`_looks_like_test_file\`'s unanchored \`"/test" in path.lower()\` substring check false-positived on any production file whose path segment merely starts with "test" (e.g. \`src/testing_utils.py\`), and its \`endswith(...)\` tuple only covered \`.js\`/\`.ts\`, missing \`.tsx\`/\`.jsx\` spec/test files and anything under a \`__tests__/\` directory (no literal "/test" substring).

## Fix
\`aletheore.dead_code.is_test_file\` already handles all of this correctly via anchored regexes, and is already imported by this file's neighbor (\`jobs.py\`). Deleted \`_looks_like_test_file\`, called \`is_test_file\` instead.

## Test plan
- [x] Regression tests cover both directions: a production file that no longer false-positives, and a \`__tests__/\` \`.spec.tsx\` file that's now correctly detected
- [x] Full \`test_flash_review.py\`: 155 passed
- [x] Full \`github-app\` suite: 1,452 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj