### PR TITLE
fix: ops-alert cooldown keyed on source alone conflated three different backup-freshness conditions

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2839,11 +2839,20 @@ def _latest_backup_age_seconds(backup_dir: Path, now: float) -> float | None:
 
 
 def _check_backup_freshness(redis_conn, now: float) -> None:
+    # Each condition below gets its own source suffix, not a shared
+    # "ops_monitor.backup_freshness" - both _send_ops_alert's Redis
+    # cooldown and send_error_alert's own independent in-memory cooldown
+    # key on source alone, so three genuinely different, differently-
+    # severe conditions sharing one source meant whichever fired first
+    # silently suppressed the other two for the next 15 minutes (e.g. a
+    # stale-backup alert firing, then the backup dir going fully
+    # unavailable five minutes later - a worse condition - with on-call
+    # never hearing about it until the first alert's cooldown expired).
     backup_dir = Path(os.environ.get(OPS_BACKUP_DIR_ENV, OPS_DEFAULT_BACKUP_DIR))
     if not backup_dir.is_dir():
         _send_ops_alert(
             redis_conn,
-            "ops_monitor.backup_freshness",
+            "ops_monitor.backup_freshness.missing_dir",
             "PostgreSQL backup directory is not available",
             f"backup_dir={backup_dir}",
         )
@@ -2853,7 +2862,7 @@ def _check_backup_freshness(redis_conn, now: float) -> None:
     if age_seconds is None:
         _send_ops_alert(
             redis_conn,
-            "ops_monitor.backup_freshness",
+            "ops_monitor.backup_freshness.no_dump",
             "no PostgreSQL backup dump found",
             f"backup_dir={backup_dir} stale_after={OPS_BACKUP_STALE_SECONDS}s",
         )
@@ -2864,7 +2873,7 @@ def _check_backup_freshness(redis_conn, now: float) -> None:
 
     _send_ops_alert(
         redis_conn,
-        "ops_monitor.backup_freshness",
+        "ops_monitor.backup_freshness.stale",
         "latest PostgreSQL backup is stale",
         f"backup_dir={backup_dir} age_seconds={age_seconds:.0f} "
         f"stale_after={OPS_BACKUP_STALE_SECONDS}s",

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -5404,8 +5404,40 @@ def test_run_ops_monitor_job_alerts_when_backup_missing(monkeypatch, tmp_path):
     run_ops_monitor_job()
 
     assert len(alerts) == 1
-    assert alerts[0][0][0] == "ops_monitor.backup_freshness"
+    assert alerts[0][0][0] == "ops_monitor.backup_freshness.missing_dir"
     assert str(missing_dir) in alerts[0][0][2]
+
+
+def test_check_backup_freshness_missing_dir_and_stale_backup_both_alert_within_cooldown(monkeypatch, tmp_path):
+    # Real regression this guards: all three backup-freshness conditions
+    # used to share one source ("ops_monitor.backup_freshness"), so
+    # whichever fired first silently suppressed the other two for
+    # OPS_ALERT_COOLDOWN_SECONDS - a stale-backup alert firing, then the
+    # backup dir going fully unavailable minutes later (a worse condition),
+    # with on-call never hearing about the second, worse one. Each
+    # condition now has its own source suffix, so both alert.
+    from scan_worker.jobs import OPS_BACKUP_STALE_SECONDS, _check_backup_freshness
+
+    redis_conn = _FakeRedis()
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append(a[0]))
+
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    stale_dump = backup_dir / "aletheore_app_20260101.dump"
+    stale_dump.write_text("x")
+    now = OPS_BACKUP_STALE_SECONDS + 10_000
+    os.utime(stale_dump, (0, 0))
+    monkeypatch.setenv("ALETHEORE_BACKUP_DIR", str(backup_dir))
+
+    _check_backup_freshness(redis_conn, now)  # stale backup: first alert
+
+    stale_dump.unlink()
+    backup_dir.rmdir()  # now the whole directory is gone: worse condition
+
+    _check_backup_freshness(redis_conn, now)  # missing dir: must still alert
+
+    assert alerts == ["ops_monitor.backup_freshness.stale", "ops_monitor.backup_freshness.missing_dir"]
 
 
 def test_run_git_scrubs_credentialed_url_from_a_failed_clone_error(tmp_path):


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (\`before_launch_fixes.md\` Batch 2 #8): \`_check_backup_freshness\` calls \`_send_ops_alert\` three times for three genuinely different, differently-severe conditions (backup directory missing, no dump found, latest backup stale), all sharing the identical \`source="ops_monitor.backup_freshness"\`. Because the cooldown key is \`source\` alone, whichever condition fired first silently suppressed the other two for the next 15 minutes - e.g. a stale-backup alert firing, then the backup dir going fully unavailable five minutes later (a worse condition), with on-call never hearing about it until the first alert's cooldown expired.

## Fix
Gave each condition its own \`source\` suffix (\`.missing_dir\`, \`.no_dump\`, \`.stale\`) rather than adding a separate \`variant\` param that only affected the Redis cooldown key: \`send_error_alert\` (\`app_server/error_alerts.py\`) has its own independent in-memory cooldown also keyed on \`source\` alone, so a \`variant\`-only fix would have left that second cooldown still conflating the three conditions.

## Test plan
- [x] Regression test confirmed only 1 of 2 alerts fired without the fix (second silently suppressed) and both fire with it
- [x] Full \`github-app\` suite: 1,453 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj