### PR TITLE
fix: patch util-linux CVEs blocking Trivy image-scan gate repo-wide

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -17,24 +17,3 @@
 # for a caller to supply a different model to load.
 CVE-2026-4372
 CVE-2026-5241
-
-# CVE-2026-53615 (bsdutils/libblkid1/liblastlog2-2/libmount1/libsmartcols1/
-# libuuid1/login/mount/util-linux - every image, base OS packages, not an
-# app dependency): integer overflow in libblkid's partition-table parser
-# (dos.c). Fixed version is 2.41.5-0+deb13u1, but not yet published:
-# pulled and scanned the current `python:3.12-slim` tag directly (not just
-# our pinned digest) on 2026-08-17 and it carries the identical vulnerable
-# 2.41-5 build - there is nothing newer to pin to yet, so bumping the
-# digest would not close this.
-#
-# Accepted temporarily because none of these images ever parse a
-# partition table: they're FastAPI/uvicorn services (app-server,
-# jina-embed, scan-worker, demo-scan-worker, demo-sandbox(-runner)) that
-# never mount a filesystem, read a raw block device, or invoke
-# mount/blkid/lsblk as part of any request-handling code path - libblkid
-# is pulled in transitively by util-linux as a base Debian package, not
-# something this application code calls. Revisit once Debian actually
-# ships the patched package - bump the pinned digest and remove this
-# entry then, don't leave it here longer than the fix is actually
-# unavailable.
-CVE-2026-53615

--- a/github-app/Dockerfile.app-server
+++ b/github-app/Dockerfile.app-server
@@ -15,6 +15,7 @@ COPY github-app/scripts ./scripts
 COPY github-app/migrations ./migrations
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/github-app/Dockerfile.jina-embed
+++ b/github-app/Dockerfile.jina-embed
@@ -33,6 +33,7 @@ FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd
 # at all with "libgomp.so.1: cannot open shared object file", not a
 # degraded-but-working fallback.
 RUN apt-get update -qq \
+    && apt-get upgrade -y -qq \
     && apt-get install -y -qq --no-install-recommends libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/github-app/Dockerfile.scan-worker
+++ b/github-app/Dockerfile.scan-worker
@@ -13,6 +13,7 @@ COPY github-app/app_server ./app_server
 COPY github-app/scan_worker ./scan_worker
 
 RUN apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Urgent - unblocks every open PR

CVE-2026-53612/53613/53614 (util-linux TOCTOU/SUID-mount issues) newly published against the `util-linux 2.41-5` baked into our pinned `python:3.12-slim` base image - failing "Enforce image scan" on all three images (app-server, scan-worker, jina-embed) on every PR, unrelated to any PR's own diff.

## What I verified before touching anything
- Pulled the current `python:3.12-slim` tag directly - still ships vulnerable `2.41-5`, so bumping the pinned digest wouldn't close this (nothing newer published yet).
- Confirmed via `apt-cache policy` inside the pinned base image that Debian's `trixie-security` apt repo already has the fixed `2.41.5-0+deb13u1` candidate available at build time.
- Added `apt-get upgrade -y` to each Dockerfile's existing apt block (jina-embed: the runtime stage, not the discarded builder stage).
- Built all three real images and ran the exact CI enforcement scan (`trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1`) against each locally - all pass.
- Before/after comparison: all 27 flagged findings present in the original image, zero in the fixed one.
- This same upgrade also resolves `CVE-2026-53615`, which this repo's `.trivyignore` already carried with a note anticipating exactly this fix once Debian shipped it - removed that now-obsolete entry per its own stated intent.
- Smoke-tested all three images still import/boot correctly (jina-embed even fully loaded its model).

## Test plan
- [x] Local build + exact CI-equivalent Trivy scan, all three images, exit code 0
- [x] Before/after CVE comparison confirms the fix and rules out regression
- [x] Smoke test: all three images import/boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)