### PR TITLE
fix: blast-radius context couldn't receive the exact per-file line mapping already computed and available

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -251,6 +251,7 @@ def build_blast_radius_context(
     changed_files: list[str],
     diff_text: str,
     fetch_file_content: Callable[[str], str | None],
+    diff_patches: tuple[tuple[str, str], ...] | None = None,
 ) -> str:
     """For each symbol this diff actually touches, who else in the repo
     calls it - confirmed by both a real import relationship (evidence's
@@ -270,7 +271,7 @@ def build_blast_radius_context(
         return ""
     modules = evidence.get("repository", {}).get("modules", [])
     by_path = {m["path"]: m for m in modules if m.get("path")}
-    valid_lines = _diff_valid_lines(diff_text)
+    valid_lines = _diff_valid_lines(diff_text, diff_patches)
 
     lines: list[str] = []
     symbols_analyzed = 0

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1600,7 +1600,9 @@ def _run_flash_review(
             )
 
         blast_radius_context = build_blast_radius_context(
-            evidence, changed_files, diff_text, lambda p: fetch_file_content(client, token, repo_full_name, p, head_sha)
+            evidence, changed_files, diff_text,
+            lambda p: fetch_file_content(client, token, repo_full_name, p, head_sha),
+            diff_patches=diff_patches,
         )
         if blast_radius_context:
             code_evidence_context = "\n\n".join(

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -2134,6 +2134,53 @@ def test_build_blast_radius_context_finds_real_confirmed_caller():
     assert "caller.py" in context
 
 
+def test_build_blast_radius_context_forwards_diff_patches_to_valid_lines_computation(monkeypatch):
+    # Real regression this guards: build_blast_radius_context had no
+    # diff_patches parameter at all, forcing the less-precise text-parsing
+    # fallback path even though jobs.py already computes diff_patches once
+    # and threads it into review_diff at both of its call sites - blast-
+    # radius citation-line computation was strictly less accurate than the
+    # rest of the same review pipeline for no reason other than the
+    # parameter not being threaded through.
+    from scan_worker import flash_review
+
+    captured = {}
+    real_diff_valid_lines = flash_review._diff_valid_lines
+
+    def spy(diff_text, patches=None):
+        captured["patches"] = patches
+        return real_diff_valid_lines(diff_text, patches)
+
+    monkeypatch.setattr(flash_review, "_diff_valid_lines", spy)
+
+    evidence = {
+        "repository": {
+            "modules": [
+                {
+                    "path": "a.py",
+                    "imported_by": ["caller.py"],
+                    "symbols": {
+                        "functions": [{"name": "handler", "start_line": 1, "end_line": 10}],
+                        "classes": [],
+                    },
+                }
+            ]
+        }
+    }
+    diff_text = "--- a.py ---\n@@ -1,10 +1,10 @@\n def handler():\n     pass\n"
+    diff_patches = (("a.py", "@@ -1,10 +1,10 @@\n def handler():\n     pass\n"),)
+
+    def fake_fetch_file_content(candidate_path: str) -> str | None:
+        return "def call_handler():\n    handler()\n" if candidate_path == "caller.py" else None
+
+    context = flash_review.build_blast_radius_context(
+        evidence, ["a.py"], diff_text, fake_fetch_file_content, diff_patches=diff_patches
+    )
+
+    assert captured["patches"] == diff_patches
+    assert "caller.py" in context
+
+
 def test_build_blast_radius_context_omits_symbol_with_no_confirmed_callers():
     """A symbol with imported_by present, but the fake fetcher never returns
     content containing the call shape -> context omitted entirely ("")."""

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1521,7 +1521,7 @@ def test_flash_review_job_routes_free_tier_to_free_tier_path(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.build_code_evidence_context", lambda *a: "")
     monkeypatch.setattr("scan_worker.jobs.build_dependency_impact_context", lambda *a: "")
     monkeypatch.setattr("scan_worker.jobs.build_change_impact_context", lambda *a: "")
-    monkeypatch.setattr("scan_worker.jobs.build_blast_radius_context", lambda *a: "")
+    monkeypatch.setattr("scan_worker.jobs.build_blast_radius_context", lambda *a, **k: "")
     monkeypatch.setattr("scan_worker.jobs.build_referenced_symbol_context", lambda *a: "")
 
     cost_for_usage_calls = []
@@ -1676,7 +1676,7 @@ def test_flash_review_job_alerts_ops_when_all_free_tier_providers_fail(monkeypat
     monkeypatch.setattr("scan_worker.jobs.build_code_evidence_context", lambda *a: "")
     monkeypatch.setattr("scan_worker.jobs.build_dependency_impact_context", lambda *a: "")
     monkeypatch.setattr("scan_worker.jobs.build_change_impact_context", lambda *a: "")
-    monkeypatch.setattr("scan_worker.jobs.build_blast_radius_context", lambda *a: "")
+    monkeypatch.setattr("scan_worker.jobs.build_blast_radius_context", lambda *a, **k: "")
     monkeypatch.setattr("scan_worker.jobs.build_referenced_symbol_context", lambda *a: "")
     monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a: 999.0)
     monkeypatch.setattr("scan_worker.jobs.lookup_cached_flash_review_result", lambda *a: None)
@@ -2465,7 +2465,7 @@ def test_flash_review_job_does_not_request_second_model_verification_on_free_tie
     monkeypatch.setattr("scan_worker.jobs.build_code_evidence_context", lambda *a: "")
     monkeypatch.setattr("scan_worker.jobs.build_dependency_impact_context", lambda *a: "")
     monkeypatch.setattr("scan_worker.jobs.build_change_impact_context", lambda *a: "")
-    monkeypatch.setattr("scan_worker.jobs.build_blast_radius_context", lambda *a: "")
+    monkeypatch.setattr("scan_worker.jobs.build_blast_radius_context", lambda *a, **k: "")
     monkeypatch.setattr("scan_worker.jobs.build_referenced_symbol_context", lambda *a: "")
     captured = {}
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (\`before_launch_fixes.md\` Batch 2 #9): \`build_blast_radius_context\` had no \`diff_patches\` parameter, forcing the less-precise text-parsing fallback path even though \`jobs.py\` already computes \`diff_patches\` once (line 1535) and threads it into \`review_diff\` at both of its call sites - the \`build_blast_radius_context\` call had no way to forward it, since the function's signature didn't accept it.

## Fix
Added a \`diff_patches\` parameter, forwarded to \`_diff_valid_lines(diff_text, diff_patches)\`, which already supported an optional \`patches\` argument - just never received one from this call site.

## Test plan
- [x] Regression test spies on \`_diff_valid_lines\` to confirm \`diff_patches\` is actually forwarded; confirmed it fails without the fix (\`TypeError: unexpected keyword argument\`) and passes with it
- [x] Updated 3 existing \`test_jobs.py\` mocks of \`build_blast_radius_context\` from \`lambda *a: ""\` to \`lambda *a, **k: ""\` - they broke because the call site now passes \`diff_patches\` as a keyword argument, not because of any functional regression (confirmed: all 3 pass once the mock accepts the new kwarg)
- [x] Full \`test_flash_review.py\`: 156 passed
- [x] Full \`github-app\` suite: 1,453 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj