### PR TITLE
fix: _first_commit_at's epoch fallback poisoned repo age for the whole repo, not just the bad commit

### DIFF
--- a/src/aletheore/git_intel/analyzer.py
+++ b/src/aletheore/git_intel/analyzer.py
@@ -6,6 +6,7 @@ from aletheore.git_intel.graph_store import GraphSnapshot, RepoGraphStore
 from aletheore.git_intel.incremental import (
     CO_CHANGE_PARTNERS_RETURNED,
     GitLogStreamError,
+    _EPOCH_UTC,
     compute_repo_key,
     parse_commit_date,
     stream_commit_touches,
@@ -324,7 +325,20 @@ def _first_commit_at(repo_path: Path) -> datetime:
     for sha in root_shas:
         date_result = _run_git_or_raise(repo_path, "log", "-1", "--format=%ad", "--date=iso-strict", sha)
         dates.append(parse_commit_date(date_result.stdout.strip()))
-    return min(dates)
+    # parse_commit_date's own epoch fallback is deliberately "very old" so a
+    # malformed date never skews a *most-recent* ranking as if it just
+    # happened (see incremental.py's _EPOCH_UTC comment) - but that same
+    # "very old" value is exactly wrong to feed into this min(), where it's
+    # the *oldest* value that wins. A repo with several root commits (a
+    # merged unrelated history) had a single malformed one silently set the
+    # whole repo's founding date to 1970-01-01, reporting it as ~56 years
+    # old, regardless of what every other root commit's real date said.
+    # Excluding epoch-fallback dates here means one bad commit no longer
+    # poisons a min() across otherwise-good ones; only degrades back to the
+    # epoch value in the genuinely-unrecoverable case where every root
+    # commit's date is unparseable.
+    real_dates = [d for d in dates if d != _EPOCH_UTC]
+    return min(real_dates) if real_dates else min(dates)
 
 
 def analyze_git(

--- a/src/tests/test_git_intel.py
+++ b/src/tests/test_git_intel.py
@@ -365,6 +365,66 @@ def test_analyze_git_repo_age_uses_oldest_of_multiple_root_commits(tmp_path):
     ).days
 
 
+def test_analyze_git_repo_age_excludes_a_root_commit_with_a_malformed_date(tmp_path):
+    # Real regression this guards: parse_commit_date's own epoch fallback
+    # (1970-01-01) is deliberately "very old" so a malformed date never
+    # skews a *most-recent* ranking as if it just happened - but that same
+    # value is exactly wrong fed into _first_commit_at's min(), where it's
+    # the *oldest* value that wins. One root commit with a malformed date
+    # (a corrupted local clock at authorship time - the real #281 case)
+    # among several good ones used to silently set the whole repo's
+    # founding date to 1970-01-01 (reporting it as ~56 years old)
+    # regardless of what the other root commits' real dates said.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(repo, "init", "-b", "main")
+    run(repo, "config", "user.email", "a@example.com")
+    run(repo, "config", "user.name", "Alice")
+    (repo / "a.txt").write_text("1")
+    run(repo, "add", "a.txt")
+    commit(repo, "main root", "2026-06-01T00:00:00+00:00")
+
+    run(repo, "checkout", "--orphan", "grafted")
+    run(repo, "reset", "--hard")
+    (repo / "b.txt").write_text("1")
+    run(repo, "add", "b.txt")
+    commit(repo, "older independent root, corrupted clock", "2026-01-01T00:00:00+00:00")
+    malformed_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    run(repo, "checkout", "main")
+    run(repo, "merge", "--allow-unrelated-histories", "-m", "merge", "grafted")
+
+    from aletheore.git_intel import analyzer
+
+    real_run_git_or_raise = analyzer._run_git_or_raise
+
+    def fake_run_git_or_raise(repo_path, *args):
+        result = real_run_git_or_raise(repo_path, *args)
+        if (
+            args[:4] == ("log", "-1", "--format=%ad", "--date=iso-strict")
+            and len(args) == 5
+            and args[4] == malformed_sha
+        ):
+            # Genuinely unparseable, not just a malformed offset (a bad
+            # offset like '+518:00' recovers via parse_commit_date's own
+            # second-tier 19-char-prefix fallback - see incremental.py -
+            # and never reaches the epoch case this test needs to trigger).
+            result = subprocess.CompletedProcess(
+                result.args, result.returncode, "garbage\n", result.stderr
+            )
+        return result
+
+    with patch("aletheore.git_intel.analyzer._run_git_or_raise", side_effect=fake_run_git_or_raise):
+        result = analyze_git(repo, now=datetime(2026, 7, 14, tzinfo=timezone.utc))
+
+    # Falls back to the remaining good (June) root, not epoch (~56 years).
+    assert result["repo_age_days"] == (
+        datetime(2026, 7, 14, tzinfo=timezone.utc) - datetime(2026, 6, 1, tzinfo=timezone.utc)
+    ).days
+
+
 def test_analyze_git_ignores_remote_head_symbolic_ref(tmp_path):
     repo = make_git_repo(tmp_path)
     remote = tmp_path / "remote.git"


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (\`before_launch_fixes.md\` Batch 2 #10): \`parse_commit_date\`'s epoch fallback (1970-01-01) is deliberately "very old" so a malformed commit date never skews a most-recent ranking as if it just happened (see \`incremental.py\`'s \`_EPOCH_UTC\` comment) - but that same "very old" value is exactly wrong fed into \`_first_commit_at\`'s \`min()\` across root commits, where it's the *oldest* value that wins. A repo with several root commits (a merged unrelated history) had a single malformed one silently set the whole repo's founding date to 1970-01-01 - reporting it as ~56 years old - regardless of what every other root commit's real date said.

## Fix
\`_first_commit_at\` now filters out epoch-fallback dates before taking \`min()\`, only falling back to the epoch value in the genuinely-unrecoverable case where every root commit's date is unparseable.

## Test plan
- [x] Regression test confirmed \`repo_age_days=20648\` (~56.5 years, matching the bug exactly) without the fix and the correct 43 days (from the remaining real root commit) with it
- [x] Full \`test_git_intel.py\`: 25 passed
- [x] Full \`src/tests\` suite: 1,301 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj