### PR TITLE
fix: two sequential blocking Redis calls inside an async request handler

### DIFF
--- a/github-app/app_server/embeddings_api.py
+++ b/github-app/app_server/embeddings_api.py
@@ -178,14 +178,24 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
         else f"ratelimit:embeddings:{installation_id}"
     )
     try:
-        rate_limited = is_rate_limited(
+        # is_rate_limited uses the synchronous redis-py client and blocks on
+        # pipe.execute() - run off the event loop (asyncio.to_thread, same
+        # as the actual embedding call below) so one request's Redis
+        # round-trip doesn't stall every other concurrent request on this
+        # worker. Kept sequential (not pipelined into one round-trip):
+        # skipping the second, repo-scoped check when the installation-wide
+        # one already trips the limit is a real short-circuit worth keeping,
+        # not just an artifact of the two calls being adjacent.
+        rate_limited = await asyncio.to_thread(
+            is_rate_limited,
             get_redis_client(),
             installation_rate_limit_key,
             RATE_LIMIT_REQUESTS,
             RATE_LIMIT_WINDOW_SECONDS,
         )
         if not rate_limited and body.repo_id:
-            rate_limited = is_rate_limited(
+            rate_limited = await asyncio.to_thread(
+                is_rate_limited,
                 get_redis_client(),
                 rate_limit_key,
                 RATE_LIMIT_REQUESTS,

--- a/github-app/tests/test_embeddings_api.py
+++ b/github-app/tests/test_embeddings_api.py
@@ -5,7 +5,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app_server.db import create_api_token, set_installation_plan, upsert_installation
-from app_server.embeddings_api import EMBEDDING_MODEL, MAX_CHARS_PER_TEXT, get_jina_client
+from app_server.embeddings_api import EMBEDDING_MODEL, MAX_CHARS_PER_TEXT, get_jina_client, is_rate_limited
 from app_server.main import app
 
 
@@ -102,9 +102,19 @@ async def test_embedding_route_uses_cached_jina_client_factory(pool):
 
 @pytest.mark.asyncio
 async def test_embedding_provider_call_is_offloaded_to_thread(pool):
+    # The rate-limit checks now also go through asyncio.to_thread (see
+    # test_rate_limit_checks_are_offloaded_to_thread below), so this mock
+    # dispatches by which callable it's given rather than assuming it's
+    # only ever called once, for the Jina POST.
     await _installation_with_token(pool, 9012, "air", "thread-token")
     client = _fake_jina(count=2)
-    offloaded = AsyncMock(return_value=client.post.return_value)
+
+    async def _dispatch(func, *args, **kwargs):
+        if func is client.post:
+            return client.post.return_value
+        return func(*args, **kwargs)
+
+    offloaded = AsyncMock(side_effect=_dispatch)
 
     with patch("app_server.embeddings_api.get_jina_client", return_value=client), \
          patch("app_server.embeddings_api.asyncio.to_thread", offloaded), \
@@ -112,10 +122,36 @@ async def test_embedding_provider_call_is_offloaded_to_thread(pool):
         response = await _post(pool, "thread-token", ["a", "b"])
 
     assert response.status_code == 200
-    offloaded.assert_awaited_once()
-    call = offloaded.await_args
+    jina_calls = [c for c in offloaded.await_args_list if c.args and c.args[0] is client.post]
+    assert len(jina_calls) == 1
+    call = jina_calls[0]
     assert call.args == (client.post, "/embed_batch")
     assert call.kwargs == {"json": {"texts": ["a", "b"]}}
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_checks_are_offloaded_to_thread(pool):
+    # Real regression this guards: is_rate_limited uses the synchronous
+    # redis-py client and blocks on pipe.execute() - called directly inside
+    # an async def handler, each check stalls the whole event loop (every
+    # other concurrent request on this worker) for its full duration.
+    await _installation_with_token(pool, 9013, "air", "rl-thread-token")
+    client = _fake_jina()
+
+    offloaded_funcs = []
+
+    async def _dispatch(func, *args, **kwargs):
+        offloaded_funcs.append(func)
+        return func(*args, **kwargs)
+
+    with patch("app_server.embeddings_api.get_jina_client", return_value=client), \
+         patch("app_server.embeddings_api.asyncio.to_thread", side_effect=_dispatch):
+        response = await _post(pool, "rl-thread-token", ["x"], repo_id="acme/widgets")
+
+    assert response.status_code == 200
+    # Both the installation-wide and repo-scoped checks went through
+    # asyncio.to_thread, not a direct blocking call.
+    assert offloaded_funcs.count(is_rate_limited) == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
From the ongoing PR-history audit (\`before_launch_fixes.md\` Batch 3 #7): \`is_rate_limited\` uses the synchronous redis-py client and blocks via \`pipe.execute()\` - called directly (not awaited) inside \`create_embeddings\`' \`async def\` handler, both the installation-wide and repo-scoped checks stalled the whole asyncio event loop (every other concurrent request on this worker) for their full duration, back-to-back, with no data dependency forcing that order.

## Fix
Wrapped both calls in \`asyncio.to_thread\`, matching the pattern this same file already uses for the actual Jina embedding call. Kept them sequential rather than pipelining into one Redis round-trip: skipping the second, repo-scoped check when the installation-wide one already trips the limit is a real short-circuit worth keeping, not just an artifact of the two calls being adjacent.

## Test plan
- [x] Regression test confirmed 0 of 2 expected \`asyncio.to_thread\` calls without the fix and 2 with it
- [x] Updated an existing test (\`test_embedding_provider_call_is_offloaded_to_thread\`) to dispatch by which function it's given rather than assume it's the only \`asyncio.to_thread\` call in the request - not a functional regression, just a stale assumption from before this fix
- [x] Full \`test_embeddings_api.py\`: 20 passed
- [x] Full \`github-app\` suite: 1,453 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj