### PR TITLE
fix: fix-suggestion spend cap check and record were two separate locks

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2060,18 +2060,35 @@ def _fix_suggestion_attachment(
     # Spend-gated like every other LLM call site in this service (F7): this
     # one is reachable up to RUNTIME_EVENT_RATE_LIMIT times/hour per
     # installation via POST /v1/runtime-events, so without a cap check it
-    # bills Aletheore's own key uncapped. installation_spend_lock also
-    # covers a free-plan installation reaching this path (its cap is
-    # $0, so the very first check blocks it) without a separate plan gate.
+    # bills Aletheore's own key uncapped. A free-plan installation reaching
+    # this path has a $0 cap, so can_start_next_call()'s very first
+    # reservation attempt blocks it, without a separate plan gate.
+    #
+    # Reserved atomically via _IncrementalSpendBudget rather than a held
+    # installation_spend_lock spanning the GitHub fetch and the real LLM
+    # call below - the same fix run_flash_review_job's cap check already
+    # applies (see its comment on ADVISORY_LOCK_TIMEOUT): a lock that wide
+    # can't stay held across real network round-trips, and a check-then-
+    # later-record split across two separate lock acquisitions (the
+    # previous shape here) leaves the exact race those two reservations
+    # exist to close - two concurrent runtime events for the same
+    # installation could each pass the cap check before either recorded
+    # spend, both proceeding.
     try:
         settings = get_settings()
         dsn = settings.database_url
         installation = get_installation_row(dsn, installation_id)
         plan = installation["plan"] if installation is not None else "free"
 
-        with installation_spend_lock(dsn, installation_id):
-            cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
         if cap_reached:
+            return None
+
+        fix_suggestion_model = model_for_plan(plan)
+        spend_budget = _IncrementalSpendBudget(
+            dsn, installation_id, fix_suggestion_model, monthly_cap, feature="health_fix_suggestion"
+        )
+        if not spend_budget.can_start_next_call():
             return None
 
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
@@ -2094,22 +2111,10 @@ def _fix_suggestion_attachment(
                 "code_context": snippet,
             }
         )
-        fix_suggestion_model = model_for_plan(plan)
-        spend_accumulator = {"total": 0.0}
 
-        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-            spend_accumulator["total"] += cost_for_usage(
-                fix_suggestion_model, prompt_tokens, completion_tokens
-            )
-
-        raw = _health_fix_suggestion_adapter(on_usage=_on_usage).simple_completion(
+        raw = _health_fix_suggestion_adapter(on_usage=spend_budget.record_usage).simple_completion(
             FIX_SUGGESTION_SYSTEM_PROMPT, user_prompt, cwd="."
         )
-        with installation_spend_lock(dsn, installation_id):
-            record_llm_spend(
-                dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap,
-                feature="health_fix_suggestion",
-            )
         suggestion = raw.strip()
     except Exception as exc:  # noqa: BLE001
         logging.getLogger("scan_worker.jobs").warning(
@@ -3023,17 +3028,16 @@ def run_weekly_digest_sweep_job() -> None:
 
 
 def _llm_spend_cap_reached(dsn: str, installation_id: int, plan: str) -> tuple[bool, float]:
-    """(cap_reached, monthly_cap) - a plain read, no lock required. For a
-    caller that goes on to gate every real LLM call through an
-    _IncrementalSpendBudget, this is a fast-fail hint only (skip setup work
-    if the cap is obviously already blown); real enforcement is that
-    budget's can_start_next_call() reserving atomically per call. A caller
-    with no such budget (a single LLM call, or none at all downstream)
-    should still treat this as its real enforcement and keep locking around
-    it - see run_flash_review_job's fix-suggestion attachment for that
-    shape. Factored out because AIRview/Docs builds have several call sites
-    needing the identical cap computation, where every existing caller only
-    ever needed it once.
+    """(cap_reached, monthly_cap) - a plain read, no lock required. For
+    every caller, real enforcement is an _IncrementalSpendBudget's
+    can_start_next_call() reserving atomically per call (see
+    _fix_suggestion_attachment for the single-call shape, AIRview/Docs
+    builds for the several-sequential-calls shape) - this is a fast-fail
+    hint only, letting a caller skip setup work (a GitHub fetch, a clone)
+    when the cap is obviously already blown before it even tries to
+    reserve. Factored out because AIRview/Docs builds have several call
+    sites needing the identical cap computation, where every existing
+    caller only ever needed it once.
     """
     extra_seats = get_extra_seats(dsn, installation_id)
     monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)

--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -6,6 +6,7 @@ import pytest
 
 from aletheore.evidence_resolution import normalize_resolution
 from scan_worker.jobs import (
+    DEFAULT_LLM_NEXT_CALL_RESERVE_USD,
     GRAPH_BRANCH,
     _attach_recent_commit_for_failure,
     _commit_attachment_from_graph,
@@ -271,10 +272,20 @@ def _patch_fix_suggestion_spend_gate(monkeypatch, plan: str = "air") -> None:
     # F7: _fix_suggestion_attachment now checks and records against the
     # installation's monthly LLM spend cap like every other LLM call site -
     # these were previously the only mocks these tests needed.
+    #
+    # reserve_llm_spend is the real gate now (via _IncrementalSpendBudget,
+    # replacing the old check-under-one-lock/record-under-another-lock
+    # shape - see before_launch_fixes.md finding #2) - default it to
+    # succeed so these tests exercise the same happy path they did before
+    # that migration; test_fix_suggestion_attachment_skips_the_llm_call_when_spend_cap_reached
+    # below still gets its cap-reached behavior from get_llm_spend_this_month,
+    # since _llm_spend_cap_reached's fast-fail hint runs before reserve_llm_spend
+    # is ever attempted.
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": plan})
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
 
 
@@ -374,7 +385,10 @@ def test_fix_suggestion_attachment_records_spend_when_model_succeeds(monkeypatch
     result = _fix_suggestion_attachment(901, "org/repo", "app/handler.py", 15, "GET", "/v1/users", 500, None)
 
     assert result is not None
-    assert recorded == [pytest.approx(0.0017)]
+    # record_llm_spend now receives the true-up delta from the flat
+    # DEFAULT_LLM_NEXT_CALL_RESERVE_USD reservation already made by
+    # can_start_next_call(), not the raw cost - see _IncrementalSpendBudget.record_usage.
+    assert recorded == [pytest.approx(0.0017 - DEFAULT_LLM_NEXT_CALL_RESERVE_USD)]
 
 
 def test_fix_suggestion_attachment_degrades_gracefully_on_any_failure(monkeypatch):

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -5052,6 +5052,129 @@ def test_maybe_sync_docs_to_repo_swallows_github_api_errors(monkeypatch):
     _maybe_sync_docs_to_repo("dsn", 1, "octocat/hello-world")
 
 
+def test_fix_suggestion_attachment_reserves_spend_atomically_against_concurrent_calls(monkeypatch):
+    # Regression test for a check-then-act race: _fix_suggestion_attachment
+    # used to check the cap and record spend under two SEPARATE
+    # installation_spend_lock acquisitions, with the real GitHub fetch and
+    # LLM call happening fully unlocked in between - so two concurrent
+    # runtime events for the same installation (this path is reachable up
+    # to RUNTIME_EVENT_RATE_LIMIT times/hour via POST /v1/runtime-events)
+    # could each pass the cap check before either had recorded anything,
+    # both proceeding and overshooting the cap. The barrier below forces
+    # both threads to complete their cap-check read at the same instant -
+    # the exact window the old two-lock shape left open - so this only
+    # passes if the real gate is _IncrementalSpendBudget's
+    # can_start_next_call(), which reserves atomically in one statement
+    # rather than reading a value that can go stale before it's acted on.
+    import threading
+
+    from scan_worker.jobs import DEFAULT_LLM_NEXT_CALL_RESERVE_USD, _fix_suggestion_attachment
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_settings",
+        lambda: type(
+            "Settings",
+            (),
+            {
+                "database_url": "postgresql://unused",
+                "github_app_id": "1",
+                "github_app_private_key": "fake-key",
+            },
+        )(),
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.get_github_api_client", lambda: object())
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_file_content", lambda *a, **k: "def handler():\n    pass\n"
+    )
+    monkeypatch.setattr("scan_worker.jobs.model_for_plan", lambda *a, **k: "gpt-5.6-luna")
+
+    # Only one reservation of DEFAULT_LLM_NEXT_CALL_RESERVE_USD fits under
+    # this cap - the second concurrent call must be rejected.
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr(
+        "scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: DEFAULT_LLM_NEXT_CALL_RESERVE_USD
+    )
+
+    # In-memory stand-in for the real atomic llm_spend row, sharing running-
+    # total state the same way concurrent transactions against the same DB
+    # row would - reserve_llm_spend's own lock models the atomicity a real
+    # UPSERT gets from Postgres row-level locking.
+    spend_state = {"total": 0.0}
+    state_lock = threading.Lock()
+    cap_check_barrier = threading.Barrier(2)
+
+    def _get_llm_spend_this_month(dsn, iid):
+        # Two waits on the same (cyclic) barrier: the first forces both
+        # threads to arrive together, the second forces both to finish
+        # reading before either can return and proceed - so neither thread
+        # can complete a full check-then-record cycle before the other has
+        # even done its read. That's the exact check-then-act window the
+        # old two-lock shape left open; without it, GIL scheduling alone
+        # tends to let one thread race through check-unlocked_work-record
+        # before the other's read is even attempted, hiding the bug.
+        cap_check_barrier.wait(timeout=5)
+        with state_lock:
+            value = spend_state["total"]
+        cap_check_barrier.wait(timeout=5)
+        return value
+
+    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+        with state_lock:
+            if spend_state["total"] + reserve_usd <= monthly_cap:
+                spend_state["total"] += reserve_usd
+                return True
+            return False
+
+    def _record_llm_spend(dsn, iid, delta, **k):
+        with state_lock:
+            spend_state["total"] += delta
+
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", _get_llm_spend_this_month)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
+    # Real cost equal to the flat reservation, so record_usage's true-up
+    # delta is exactly 0 (a no-op) - isolates this test to the reservation
+    # race itself, instead of a coincidental true-up masking it.
+    monkeypatch.setattr(
+        "scan_worker.jobs.cost_for_usage", lambda *a, **k: DEFAULT_LLM_NEXT_CALL_RESERVE_USD
+    )
+
+    class _FakeAdapter:
+        def __init__(self, on_usage):
+            self._on_usage = on_usage
+
+        def simple_completion(self, *a, **k):
+            if self._on_usage:
+                self._on_usage(10, 10)
+            return "Wrap the call in a try/except and log the failure."
+
+    monkeypatch.setattr(
+        "scan_worker.jobs._health_fix_suggestion_adapter",
+        lambda on_usage=None: _FakeAdapter(on_usage),
+    )
+
+    results: list[dict | None] = [None, None]
+
+    def _call(idx):
+        results[idx] = _fix_suggestion_attachment(
+            1, "octocat/hello-world", "app.py", 10, "GET", "/x", 500, None,
+        )
+
+    threads = [threading.Thread(target=_call, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    succeeded = [r for r in results if r is not None]
+    assert len(succeeded) == 1
+
+
 def test_health_fix_suggestion_adapter_uses_luna_when_openai_key_configured(monkeypatch):
     from scan_worker.jobs import _health_fix_suggestion_adapter
 


### PR DESCRIPTION
## Summary
- `_fix_suggestion_attachment` checked the monthly LLM spend cap under one `installation_spend_lock` acquisition, then ran the real GitHub fetch and LLM call fully unlocked, then recorded spend under a **second, later** lock acquisition — the exact check-then-act race PR #220 originally closed for this call site, reopened by PR #258's lock-contention split.
- This path is reachable up to `RUNTIME_EVENT_RATE_LIMIT` times/hour per installation via `POST /v1/runtime-events`, so two concurrent runtime events could each pass the cap check before either recorded anything, both proceeding and overshooting the monthly cap.
- Migrates the call site onto `_IncrementalSpendBudget` (the same primitive AIRview/Docs full builds already use): `can_start_next_call()` reserves atomically before any real work starts, `record_usage` trues the flat reservation up to the real cost afterward.
- Updated `_llm_spend_cap_reached`'s docstring, which previously named this function as the reference example of the now-removed "keep locking around it" shape.

## Test plan
- [x] New regression test `test_fix_suggestion_attachment_reserves_spend_atomically_against_concurrent_calls` fires two concurrent calls under a cap that only fits one reservation, using a barrier to force both threads' cap-check reads to land at the same instant.
- [x] Verified via `git stash` that the new test fails (2 succeed instead of 1) against the pre-fix code and passes against the fix.
- [x] Updated two pre-existing `test_correlation.py` tests whose mocks predated this migration (`_patch_fix_suggestion_spend_gate` now mocks `reserve_llm_spend`; `test_fix_suggestion_attachment_records_spend_when_model_succeeds` now expects the true-up delta, not the raw cost).
- [x] Full `github-app` suite green (1457 passed, 8 skipped).
- [x] Full `src` suite green (1304 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj