### PR TITLE
fix: AIRview live-wiki spend cap check and record were two separate locks

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -3100,23 +3100,27 @@ class _IncrementalSpendBudget:
 
 
 def _live_wiki_naming_adapter(
-    on_usage: Callable[[int, int], None] | None = None
+    on_usage: Callable[[int, int], None] | None = None,
+    before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
-    return writing_adapter_for(live_wiki.FLASH_MODEL, on_usage=on_usage)
+    return writing_adapter_for(live_wiki.FLASH_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
 
 
 def _live_wiki_full_build_writing_adapter(
-    plan: str, on_usage: Callable[[int, int], None] | None = None
+    plan: str,
+    on_usage: Callable[[int, int], None] | None = None,
+    before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter | AnthropicAdapter:
     # The one-time full build uses the same model as managed audits (see
     # model_tiers.py) - Luna (falling back to DeepSeek Pro), for every plan.
-    return writing_adapter_for_plan(plan, on_usage=on_usage)
+    return writing_adapter_for_plan(plan, on_usage=on_usage, before_llm_call=before_llm_call)
 
 
 def _live_wiki_update_writing_adapter(
-    on_usage: Callable[[int, int], None] | None = None
+    on_usage: Callable[[int, int], None] | None = None,
+    before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
-    return writing_adapter_for(live_wiki.UPDATE_MODEL, on_usage=on_usage)
+    return writing_adapter_for(live_wiki.UPDATE_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
 
 
 def _real_line_count_fetcher(
@@ -3276,8 +3280,14 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
     plan = installation["plan"] if installation is not None else "free"
     model_used = model_for_plan(plan)
 
-    with installation_spend_lock(dsn, installation_id):
-        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+    # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring;
+    # real enforcement is its can_start_next_call() reserving atomically per
+    # call below, wired into both adapters so it gates every real network
+    # call generate_subsystems/_attach_wiki_file_pages makes regardless of
+    # how many clusters get batched into one call (see live_wiki.py's
+    # _run_batched_with_retry) - a per-cluster loop check here couldn't do
+    # that cleanly the way Docs' per-module loop check can.
+    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
     if cap_reached:
         logging.getLogger("scan_worker.jobs").info(
             "live wiki full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
@@ -3289,19 +3299,17 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
         )
         return
 
-    spend_accumulator = {"total": 0.0}
-    spend_lock = threading.Lock()
-
-    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-        # Generation runs on a bounded thread pool, so usage callbacks can
-        # arrive concurrently and need a local accumulator lock.
-        cost = cost_for_usage(model_used, prompt_tokens, completion_tokens)
-        with spend_lock:
-            spend_accumulator["total"] += cost
+    spend_budget = _IncrementalSpendBudget(
+        dsn, installation_id, model_used, monthly_cap, feature="airview_full_build"
+    )
 
     try:
-        naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
-        writing_adapter = _live_wiki_full_build_writing_adapter(plan, on_usage=_on_usage)
+        naming_adapter = _live_wiki_naming_adapter(
+            on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
+        )
+        writing_adapter = _live_wiki_full_build_writing_adapter(
+            plan, on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
+        )
         fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
         records = live_wiki.generate_subsystems(
             evidence,
@@ -3316,11 +3324,6 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
             fetch_line_count=fetch_line_count,
         )
         _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count)
-        with installation_spend_lock(dsn, installation_id):
-            record_llm_spend(
-                dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap,
-                feature="airview_full_build",
-            )
         _store_wiki_generation(
             dsn, installation_id, repo_full_name, evidence, records, writing_adapter, None,
             fetch_line_count=fetch_line_count,
@@ -3416,8 +3419,9 @@ def _maybe_update_live_wiki(
 
     dsn = settings.database_url
     plan = installation["plan"]
-    with installation_spend_lock(dsn, installation_id):
-        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
+    # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring
+    # and run_live_wiki_full_build_job's identical comment above.
+    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
     if cap_reached:
         logging.getLogger("scan_worker.jobs").info(
             "live wiki incremental update skipped for installation=%s repo=%s - "
@@ -3431,17 +3435,17 @@ def _maybe_update_live_wiki(
         return
 
     update_model = resolve_model(live_wiki.UPDATE_MODEL)
-    spend_accumulator = {"total": 0.0}
-    spend_lock = threading.Lock()
-
-    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-        cost = cost_for_usage(update_model, prompt_tokens, completion_tokens)
-        with spend_lock:
-            spend_accumulator["total"] += cost
+    spend_budget = _IncrementalSpendBudget(
+        dsn, installation_id, update_model, monthly_cap, feature="airview_incremental"
+    )
 
     try:
-        naming_adapter = _live_wiki_naming_adapter(on_usage=_on_usage)
-        writing_adapter = _live_wiki_update_writing_adapter(on_usage=_on_usage)
+        naming_adapter = _live_wiki_naming_adapter(
+            on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
+        )
+        writing_adapter = _live_wiki_update_writing_adapter(
+            on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
+        )
         fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
         records = live_wiki.generate_subsystems(
             evidence,
@@ -3456,11 +3460,6 @@ def _maybe_update_live_wiki(
             fetch_line_count=fetch_line_count,
         )
         _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count)
-        with installation_spend_lock(dsn, installation_id):
-            record_llm_spend(
-                dsn, installation_id, spend_accumulator["total"], monthly_cap=monthly_cap,
-                feature="airview_incremental",
-            )
         _store_wiki_generation(
             dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
             fetch_line_count=fetch_line_count,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2672,9 +2672,13 @@ def test_run_live_wiki_full_build_job_skips_model_call_on_cache_hit(monkeypatch)
             return json.dumps({"0": "Auth"})
 
     monkeypatch.setattr(
-        "scan_worker.jobs._live_wiki_full_build_writing_adapter", lambda plan, on_usage=None: _SpyAdapter()
+        "scan_worker.jobs._live_wiki_full_build_writing_adapter",
+        lambda plan, on_usage=None, before_llm_call=None: _SpyAdapter(),
     )
-    monkeypatch.setattr("scan_worker.jobs._live_wiki_naming_adapter", lambda on_usage=None: _NamingAdapter())
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_wiki_naming_adapter",
+        lambda on_usage=None, before_llm_call=None: _NamingAdapter(),
+    )
     monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_wiki_build_status", lambda *a, **k: None)
 
@@ -3749,6 +3753,106 @@ def test_maybe_update_live_wiki_skips_llm_call_when_spend_cap_reached(monkeypatc
     assert "spend cap" in status_calls[0][1]
 
 
+def test_maybe_update_live_wiki_reserves_spend_atomically_against_concurrent_pushes(monkeypatch):
+    # Same regression as test_run_live_wiki_full_build_job_reserves_spend_atomically_against_concurrent_repos,
+    # for the incremental-update path: _maybe_update_live_wiki had the
+    # identical two-separate-lock-acquisitions shape. Two pushes landing
+    # close together for two different repos under the same paid
+    # installation used to be able to both pass the cap check before either
+    # recorded spend.
+    import threading
+
+    from scan_worker.jobs import DEFAULT_LLM_NEXT_CALL_RESERVE_USD, _maybe_update_live_wiki
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: (lambda path: None))
+
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr(
+        "scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: DEFAULT_LLM_NEXT_CALL_RESERVE_USD
+    )
+
+    spend_state = {"total": 0.0}
+    state_lock = threading.Lock()
+    cap_check_barrier = threading.Barrier(2)
+
+    def _get_llm_spend_this_month(dsn, iid):
+        cap_check_barrier.wait(timeout=5)
+        with state_lock:
+            value = spend_state["total"]
+        cap_check_barrier.wait(timeout=5)
+        return value
+
+    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+        with state_lock:
+            if spend_state["total"] + reserve_usd <= monthly_cap:
+                spend_state["total"] += reserve_usd
+                return True
+            return False
+
+    def _record_llm_spend(dsn, iid, delta, **k):
+        with state_lock:
+            spend_state["total"] += delta
+
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", _get_llm_spend_this_month)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
+    monkeypatch.setattr(
+        "scan_worker.jobs.cost_for_usage", lambda *a, **k: DEFAULT_LLM_NEXT_CALL_RESERVE_USD
+    )
+
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error_message=None: status_calls.append((repo, status, error_message)),
+    )
+
+    def _fake_generate_subsystems(evidence, naming_adapter, writing_adapter, **kwargs):
+        writing_adapter.simple_completion("system", "user", cwd=".")
+        return [{"subsystem_id": "0", "name": "Auth", "description": "d", "files": []}]
+
+    monkeypatch.setattr("scan_worker.jobs.live_wiki.generate_subsystems", _fake_generate_subsystems)
+    monkeypatch.setattr("scan_worker.jobs._attach_wiki_file_pages", lambda *a, **k: a[1])
+
+    class _FakeWikiAdapter:
+        def __init__(self, on_usage=None, before_llm_call=None, **k):
+            self._on_usage = on_usage
+            self._before_llm_call = before_llm_call
+
+        def simple_completion(self, *a, **k):
+            if self._before_llm_call is not None and not self._before_llm_call():
+                raise RuntimeError("monthly LLM spend cap would be exceeded")
+            if self._on_usage:
+                self._on_usage(10, 10)
+            return "some subsystem prose"
+
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_wiki_naming_adapter",
+        lambda on_usage=None, before_llm_call=None: _FakeWikiAdapter(on_usage, before_llm_call),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_wiki_update_writing_adapter",
+        lambda on_usage=None, before_llm_call=None: _FakeWikiAdapter(on_usage, before_llm_call),
+    )
+
+    def _call(repo):
+        _maybe_update_live_wiki(1, repo, _wiki_evidence(), ["auth/login.py"], "sha1")
+
+    threads = [
+        threading.Thread(target=_call, args=(repo,)) for repo in ("octocat/repo-a", "octocat/repo-b")
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    ready = [repo for repo, status, _ in status_calls if status == "ready"]
+    assert len(ready) == 1
+
+
 def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_with_two_commits, monkeypatch):
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
@@ -4191,6 +4295,125 @@ def test_run_live_wiki_full_build_job_skips_llm_call_when_spend_cap_reached(monk
     assert llm_called == []
     assert build_status_calls[0][0] == "failed"
     assert "spend cap" in build_status_calls[0][1]
+
+
+def test_run_live_wiki_full_build_job_reserves_spend_atomically_against_concurrent_repos(monkeypatch):
+    # Regression test for a check-then-act race: run_live_wiki_full_build_job
+    # used to check the cap and record spend under two SEPARATE
+    # installation_spend_lock acquisitions, with the real (potentially
+    # many-call) generate_subsystems/_attach_wiki_file_pages work happening
+    # fully unlocked in between - so two full builds for different repos
+    # under the SAME paid installation, landing close together (e.g. both
+    # due for the 48h catch-up sweep at the same tick), could each pass the
+    # cap check before either had recorded anything, both proceeding. The
+    # double-barrier below forces both threads' cap-check reads to land at
+    # the same instant - the exact window the old two-lock shape left open -
+    # so this only passes if the real gate is _IncrementalSpendBudget's
+    # can_start_next_call(), reserving atomically per call rather than
+    # reading a value that can go stale before it's acted on.
+    import threading
+
+    from scan_worker.jobs import DEFAULT_LLM_NEXT_CALL_RESERVE_USD, run_live_wiki_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
+    monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: (lambda path: None))
+
+    # Only one reservation of DEFAULT_LLM_NEXT_CALL_RESERVE_USD fits under
+    # this cap - the second concurrent repo's build must be rejected.
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr(
+        "scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: DEFAULT_LLM_NEXT_CALL_RESERVE_USD
+    )
+
+    # In-memory stand-in for the real atomic llm_spend row, shared across
+    # both threads the same way concurrent transactions against the same DB
+    # row would be.
+    spend_state = {"total": 0.0}
+    state_lock = threading.Lock()
+    cap_check_barrier = threading.Barrier(2)
+
+    def _get_llm_spend_this_month(dsn, iid):
+        # Two waits on the same (cyclic) barrier: the first forces both
+        # threads to arrive together, the second forces both to finish
+        # reading before either can return and proceed - see the identical
+        # technique in test_fix_suggestion_attachment_reserves_spend_atomically_against_concurrent_calls.
+        cap_check_barrier.wait(timeout=5)
+        with state_lock:
+            value = spend_state["total"]
+        cap_check_barrier.wait(timeout=5)
+        return value
+
+    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+        with state_lock:
+            if spend_state["total"] + reserve_usd <= monthly_cap:
+                spend_state["total"] += reserve_usd
+                return True
+            return False
+
+    def _record_llm_spend(dsn, iid, delta, **k):
+        with state_lock:
+            spend_state["total"] += delta
+
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", _get_llm_spend_this_month)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
+    # Real cost equal to the flat reservation, so record_usage's true-up
+    # delta is exactly 0 (a no-op) - isolates this test to the reservation
+    # race itself, same reasoning as the fix-suggestion regression test.
+    monkeypatch.setattr(
+        "scan_worker.jobs.cost_for_usage", lambda *a, **k: DEFAULT_LLM_NEXT_CALL_RESERVE_USD
+    )
+
+    build_status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_wiki_build_status",
+        lambda dsn, iid, repo, status, error=None: build_status_calls.append((repo, status, error)),
+    )
+
+    def _fake_generate_subsystems(evidence, naming_adapter, writing_adapter, **kwargs):
+        writing_adapter.simple_completion("system", "user", cwd=".")
+        return [{"subsystem_id": "0", "name": "Auth", "description": "d", "files": []}]
+
+    monkeypatch.setattr("scan_worker.jobs.live_wiki.generate_subsystems", _fake_generate_subsystems)
+    monkeypatch.setattr("scan_worker.jobs._attach_wiki_file_pages", lambda *a, **k: a[1])
+
+    class _FakeWikiAdapter:
+        def __init__(self, on_usage=None, before_llm_call=None, **k):
+            self._on_usage = on_usage
+            self._before_llm_call = before_llm_call
+
+        def simple_completion(self, *a, **k):
+            if self._before_llm_call is not None and not self._before_llm_call():
+                raise RuntimeError("monthly LLM spend cap would be exceeded")
+            if self._on_usage:
+                self._on_usage(10, 10)
+            return "some subsystem prose"
+
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_wiki_naming_adapter",
+        lambda on_usage=None, before_llm_call=None: _FakeWikiAdapter(on_usage, before_llm_call),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_wiki_full_build_writing_adapter",
+        lambda plan, on_usage=None, before_llm_call=None: _FakeWikiAdapter(on_usage, before_llm_call),
+    )
+
+    threads = [
+        threading.Thread(target=run_live_wiki_full_build_job, args=(1, repo))
+        for repo in ("octocat/repo-a", "octocat/repo-b")
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    ready = [repo for repo, status, _ in build_status_calls if status == "ready"]
+    assert len(ready) == 1
 
 
 def test_real_line_count_fetcher_returns_none_when_token_setup_fails(monkeypatch):


### PR DESCRIPTION
## Summary
- `run_live_wiki_full_build_job` and `_maybe_update_live_wiki` checked the monthly LLM spend cap under one `installation_spend_lock` acquisition, then ran the real (potentially many-call) `generate_subsystems`/`_attach_wiki_file_pages` work fully unlocked, then recorded spend under a **second, later** lock acquisition.
- Two full builds or incremental updates for different repos under the same paid installation, landing close together (e.g. both due for the 48h catch-up sweep at the same tick), could each pass the cap check before either recorded anything, both proceeding — overshooting the monthly cap.
- PR #304 migrated the sibling Docs paths onto the atomic `reserve_llm_spend`/`record_llm_spend` primitive but never touched these two Wiki functions.
- Migrates both onto `_IncrementalSpendBudget`. Unlike Docs (one LLM call per module, gated by a per-module loop check), Wiki batches multiple clusters into single LLM calls internally, so a loop check can't align with real network calls the way Docs' can — instead wires `before_llm_call=spend_budget.can_start_next_call` directly into the adapters (added a `before_llm_call` pass-through parameter to `_live_wiki_naming_adapter`, `_live_wiki_full_build_writing_adapter`, `_live_wiki_update_writing_adapter`). This gates every real call regardless of internal batching, and covers `_attach_wiki_file_pages`'s calls for free since it reuses the same `writing_adapter` instance.

## Test plan
- [x] Two new regression tests (`test_run_live_wiki_full_build_job_reserves_spend_atomically_against_concurrent_repos`, `test_maybe_update_live_wiki_reserves_spend_atomically_against_concurrent_pushes`) fire two concurrent builds for different repos under the same installation, with a cap that only fits one reservation, using a double-wait barrier to force both threads' cap-check reads to land at the same instant.
- [x] Verified via `git stash` that both new tests fail (2 succeed instead of 1) against the pre-fix code and pass against the fix.
- [x] Full `github-app` suite green (1458 passed, 8 skipped).
- [x] Full `src` suite green (1304 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj