### PR TITLE
fix: secret scanner missed dotted-attribute credential assignments

### DIFF
--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -80,7 +80,13 @@ SECRET_PATTERNS = [
             # google_api_key shape above) - without it, GEMINI_API_KEY=AQ.Ab8R... matched
             # only the 2 characters before the dot, fell under the 16-char minimum, and
             # the whole credential silently went undetected rather than just unredacted.
-            r"(?i)(?:^|[\s_-])(PASSWORD|SECRET|API_KEY)\s*[:=]\s*"
+            #
+            # The left-boundary class includes "." too, alongside the pre-existing "_"
+            # and "-", so a dotted attribute assignment (self.PASSWORD=..., cfg.API_KEY=...
+            # - one of the most common hardcoded-credential shapes in object-oriented
+            # code) isn't silently invisible to this pattern the way a bare "." boundary
+            # was. MYPASSWORD= (no separator at all) still correctly does not match.
+            r"(?i)(?:^|[\s_.-])(PASSWORD|SECRET|API_KEY)\s*[:=]\s*"
             r"['\"]?([A-Za-z0-9+/=_.-]{16,})['\"]?(?=\s|$|[,#;)])"
         ),
         2,

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -141,6 +141,26 @@ def test_find_secrets_detects_credential_value_containing_a_dot(tmp_path):
     assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 1
 
 
+def test_find_secrets_detects_dotted_attribute_credential_assignment(tmp_path):
+    # Regression: the left-boundary class allowed whitespace, "_", and "-"
+    # before the keyword but not ".", so a dotted attribute assignment
+    # (self.PASSWORD=..., cfg.API_KEY=...) - one of the most common
+    # hardcoded-credential shapes in object-oriented code - was silently
+    # invisible to this pattern. MYPASSWORD= (no separator at all) must
+    # still not match.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "config.py").write_text(
+        "self.PASSWORD = 'Tr0ub4dor4NoSpecialChars'\n"
+        "cfg.API_KEY = 'abcdefghijklmnopqrstuvwx1234'\n"
+        "MYPASSWORD = 'shouldnotmatchatall1234567890'\n"
+    )
+
+    findings = find_secrets(repo)["findings"]
+
+    assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 2
+
+
 def test_find_secrets_detects_fine_grained_github_and_sts_aws_tokens(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- `generic_credential_assignment`'s left-boundary class allowed whitespace, `_`, and `-` before the keyword (PASSWORD/SECRET/API_KEY) but not `.`, so any dotted attribute-assignment credential (`self.PASSWORD=...`, `cfg.API_KEY=...` — one of the most common hardcoded-credential shapes in object-oriented Python/JS/Java code) was silently invisible to this scanner.
- Confirmed via direct regex testing this was a real regression, not an intentional trade-off: the boundary class already special-cases `_`/`-` to keep matching compound names like `MY_PASSWORD` while still rejecting `MYPASSWORD` (no separator at all) — `.` was simply omitted from that same class.
- Fixes it by adding `.` to the boundary class. Also tested and rejected an alternative fix (a negative lookbehind) after confirming it would regress the working `MY_PASSWORD=` case.

## Test plan
- [x] New regression test `test_find_secrets_detects_dotted_attribute_credential_assignment` covers the dotted-attribute cases plus the `MYPASSWORD=` negative case.
- [x] Verified via `git stash` that the new test fails without the fix and passes with it.
- [x] Full `src` suite green (1305 passed).
- [x] Full `github-app` suite green (1456 passed, 8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj