### PR TITLE
fix: unpinned marker-qualified PEP 508 dependency was silently dropped

### DIFF
--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -40,7 +40,6 @@ def _clean_range_version(version: str) -> str | None:
 
 
 def _parse_pep508_dependency(dependency: str) -> tuple[str, str, str] | None:
-    has_marker = ";" in dependency
     dependency = dependency.split(";", 1)[0].strip()
     name_match = re.match(r"^([A-Za-z0-9_.-]+)(?:\[[^\]]+\])?", dependency)
     if not name_match:
@@ -49,10 +48,14 @@ def _parse_pep508_dependency(dependency: str) -> tuple[str, str, str] | None:
     specifiers = dependency[name_match.end():]
     version_match = re.search(r"(?:==|>=|~=)\s*([0-9][^,\s]*)", specifiers)
     # A lower bound is the most useful stable approximation for a range. Keep
-    # unpinned declarations too: downstream checks can query the package as a
-    # whole instead of silently pretending the dependency was absent.
-    if version_match is None and has_marker:
-        return None
+    # unpinned declarations too, marker-qualified or not: downstream checks
+    # can query the package as a whole instead of silently pretending the
+    # dependency was absent. A prior version of this function dropped
+    # unpinned dependencies that also carried an environment marker (e.g.
+    # `typing_extensions; python_version < "3.10"`, an idiomatic and common
+    # PEP 508 shape) - directly contradicting this comment for exactly that
+    # case, and making any marker-qualified unpinned dependency invisible to
+    # CVE scanning, license checking, and unused-dependency detection.
     version = version_match.group(1) if version_match else "*"
     return (name, version, "PyPI")
 

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -434,7 +434,14 @@ def test_parse_pip_pins_reads_pep621_pyproject_dependencies(tmp_path):
 
     assert ("asgiref", "3.12.1", "PyPI") in pins
     assert ("sqlparse", "0.5.0", "PyPI") in pins
-    assert not any(pin[0] == "tzdata" for pin in pins)
+    # An unpinned, marker-qualified dependency is kept like any other
+    # unpinned dependency (queried by name only, see _query_batch) rather
+    # than dropped - this test used to assert the opposite, predating #230's
+    # explicit "keep unpinned declarations too" fix and left un-reconciled
+    # with it. Dropping it would make this exact conditional-platform
+    # dependency shape invisible to CVE scanning, license checking, and
+    # unused-dependency detection alike.
+    assert ("tzdata", "*", "PyPI") in pins
 
 
 def test_parse_pip_pins_keeps_compound_compatible_and_unpinned_pep508_dependencies(tmp_path):
@@ -456,6 +463,25 @@ def test_parse_pip_pins_keeps_compound_compatible_and_unpinned_pep508_dependenci
     assert ("tree-sitter", "0.24.0", "PyPI") in pins
     assert ("openai", "1.0.0", "PyPI") in pins
     assert ("rich", "*", "PyPI") in pins
+
+
+def test_parse_pep508_dependency_keeps_unpinned_marker_qualified_dependency():
+    # Regression: an unpinned dependency that also carries an environment
+    # marker (e.g. `typing_extensions; python_version < "3.10"` - an
+    # idiomatic and common PEP 508 shape) used to be silently dropped
+    # entirely, directly contradicting this function's own comment that
+    # unpinned declarations are kept rather than treated as absent. This
+    # made any marker-qualified unpinned dependency invisible to CVE
+    # scanning, license checking, and unused-dependency detection.
+    from aletheore.vulnerabilities import _parse_pep508_dependency
+
+    assert _parse_pep508_dependency("typing_extensions") == ("typing-extensions", "*", "PyPI")
+    assert _parse_pep508_dependency(
+        'typing_extensions; python_version < "3.10"'
+    ) == ("typing-extensions", "*", "PyPI")
+    assert _parse_pep508_dependency(
+        'requests>=2.0; python_version < "3.10"'
+    ) == ("requests", "2.0", "PyPI")
 
 
 def test_parse_pip_pins_reads_poetry_dependencies(tmp_path):


### PR DESCRIPTION
## Summary
- `_parse_pep508_dependency` dropped an unpinned dependency whenever it also carried a PEP 508 environment marker (e.g. `typing_extensions; python_version < "3.10"` — an idiomatic and common shape), directly contradicting the function's own adjacent comment ("Keep unpinned declarations too"). This made any marker-qualified unpinned dependency invisible to CVE scanning, license checking, and unused-dependency detection — all three share this one parser.
- Confirmed via git history this was a real regression against PR #230's own stated intent, not an intentional carve-out: #230's commit message explicitly lists "or no version at all" as now being kept rather than dropped, with no marker exception mentioned.
- Caught mid-implementation that a pre-existing test (predating #230) asserted the *opposite* — that `tzdata; sys_platform == 'win32'` should be dropped. The full `src` suite surfaced this as a real failure, not a false positive. Verified via `git log` this test predates #230 and was never reconciled with #230's later fix; updated it to assert `tzdata` is now kept too, consistent with every other unpinned dependency.

## Test plan
- [x] New regression test `test_parse_pep508_dependency_keeps_unpinned_marker_qualified_dependency` covers both the marker-qualified-unpinned and marker-qualified-pinned cases.
- [x] Verified via `git stash` that the new test fails without the fix and passes with it.
- [x] Updated the pre-existing `tzdata` test to match the reconciled, correct behavior.
- [x] Full `src` suite green (1306 passed).
- [x] Full `github-app` suite green (1459 passed, 8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj