### PR TITLE
fix: module-overview chunk boundary used the wrong "first" symbol

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -497,7 +497,18 @@ def build_chunks(evidence: dict, repo_path: Path) -> list[dict]:
         # The head of a file is where a docstring, imports and top-level
         # constants live, so it is both the best summary available and the
         # part symbol extraction structurally cannot reach.
-        head_end = min(symbols[0]["start_line"] - 1, MODULE_CHUNK_MAX_LINES)
+        #
+        # `functions` and `classes` are two independently file-ordered lists
+        # concatenated above (code_symbols), not merged/sorted by
+        # start_line - symbols[0] is only "the first symbol in the file" when
+        # a function happens to come first. Whenever a class precedes the
+        # first function (confirmed on this repo's own
+        # github-app/app_server/url_validation.py: UnsafeURLError at line 6,
+        # _is_disallowed_ip at line 13), symbols[0] resolved to the function,
+        # and the "head" chunk swallowed the class's own declaration and body
+        # - content already separately indexed as its own chunk - instead of
+        # stopping where symbol extraction actually starts.
+        head_end = min(min(s["start_line"] for s in symbols) - 1, MODULE_CHUNK_MAX_LINES)
         if head_end > 0:
             head = "\n".join(lines[:head_end]).strip()
             if head:

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -71,6 +71,39 @@ def test_build_chunks_slices_real_source_per_symbol(tmp_path):
     assert "def greet():" in chunk["text"]
 
 
+def test_build_chunks_module_head_stops_at_a_class_that_precedes_the_first_function(tmp_path):
+    # Regression: code_symbols concatenates functions then classes - two
+    # independently file-ordered lists, not merged/sorted by start_line - so
+    # symbols[0] is only "the file's true first symbol" when a function
+    # happens to come first textually. Real case: url_validation.py has
+    # `class UnsafeURLError` before its first function - symbols[0] resolved
+    # to the function, and the module-overview "head" chunk swallowed the
+    # whole class declaration and body, content already separately indexed
+    # as its own chunk.
+    (tmp_path / "app.py").write_text(
+        '"""Module docstring."""\n'
+        "\n"
+        "class UnsafeURLError(ValueError):\n"
+        "    pass\n"
+        "\n"
+        "\n"
+        "def is_disallowed_ip(ip):\n"
+        "    return False\n"
+    )
+    evidence = _evidence_with_module(
+        "app.py",
+        functions=[{"name": "is_disallowed_ip", "start_line": 7, "end_line": 8}],
+        classes=[{"name": "UnsafeURLError", "start_line": 3, "end_line": 4}],
+    )
+
+    chunks = build_chunks(evidence, tmp_path)
+
+    module_chunk = next(c for c in chunks if c["symbol_name"] is None)
+    assert module_chunk["end_line"] == 2
+    assert "class UnsafeURLError" not in module_chunk["text"]
+    assert "Module docstring" in module_chunk["text"]
+
+
 def test_build_chunks_falls_back_to_whole_file_when_no_symbols(tmp_path):
     (tmp_path / "config.py").write_text("SETTING = 1\n")
     evidence = _evidence_with_module("config.py", [])


### PR DESCRIPTION
## Summary
- `build_chunks` computed `head_end` (the module-overview chunk's end line) from `symbols[0]["start_line"]`, where `symbols = code_symbols + constants` and `code_symbols = functions + classes` — two independently file-ordered lists concatenated, not merged/sorted by `start_line`. `symbols[0]` is only "the file's true first symbol" when a function happens to come first textually.
- Whenever a class precedes the first function (confirmed on this repo's own `github-app/app_server/url_validation.py`: `class UnsafeURLError` at line 6, first function `_is_disallowed_ip` at line 13), `symbols[0]` resolved to the function, and the head chunk swallowed the entire class declaration and body — content already separately indexed as its own class chunk — directly contradicting the adjacent comment's claim that the head only covers what "symbol extraction structurally cannot reach."
- Fixes it by computing `head_end` from `min(s["start_line"] for s in symbols)` instead of assuming positional order.

## Test plan
- [x] New regression test `test_build_chunks_module_head_stops_at_a_class_that_precedes_the_first_function` reproduces the real trigger shape and asserts the head chunk stops before the class.
- [x] Verified via `git stash` that the new test fails without the fix (head chunk swallowed the class) and passes with it.
- [x] Full `src` suite green (1307 passed).
- [x] Full `github-app` suite green (1459 passed, 8 skipped).

This is the last of the 7 Batch 4 audit findings — closes that batch out at 7/7 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj