### PR TITLE
perf: Java/C# pre-parsed trees stayed pinned in memory for the whole scan

### DIFF
--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -2296,9 +2296,21 @@ def build_module_graph(
             unparseable.append({"path": rel_path, "reason": "file exceeds size limit"})
             continue
         if language_name == "java" and path in java_pre_parsed:
-            source, tree = java_pre_parsed[path]
+            # pop, not a plain lookup: java_pre_parsed/csharp_pre_parsed hold
+            # the full (source, Tree) for every .java/.cs file simultaneously
+            # once the pre-pass above finishes - unavoidable, since the
+            # pre-pass needs every file's package/namespace before it can
+            # infer a source root at all. But nothing forces this loop to
+            # keep holding a file's entry once it's been consumed here -
+            # tree-sitter trees run roughly 37x their source size, so on a
+            # large Java/C# repo this loop's the rest of its run (every
+            # other-language file remaining) previously held every already-
+            # consumed tree alive for no reason. Popping lets each entry's
+            # memory free as soon as this loop passes it, instead of only
+            # when build_module_graph returns.
+            source, tree = java_pre_parsed.pop(path)
         elif language_name == "csharp" and path in csharp_pre_parsed:
-            source, tree = csharp_pre_parsed[path]
+            source, tree = csharp_pre_parsed.pop(path)
         else:
             parser.language = ts_language
             source = path.read_bytes()

--- a/src/tests/test_graph_csharp.py
+++ b/src/tests/test_graph_csharp.py
@@ -233,6 +233,49 @@ def test_build_module_graph_reuses_the_csharp_prepass_parse_in_the_main_loop(tmp
     assert all(count == 1 for count in read_counts.values())
 
 
+def test_build_module_graph_releases_a_csharp_prepass_tree_once_the_main_loop_consumes_it(tmp_path, monkeypatch):
+    # C# equivalent of the identically-named Java test in test_graph_java.py
+    # - see that test's comment for the full reasoning. csharp_pre_parsed
+    # has the same shape (dict[Path, tuple[bytes, Tree]]) and the same
+    # main-loop consumption site as java_pre_parsed.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "AFirst.cs").write_text("namespace Example { class AFirst {} }\n")
+    (repo / "ZLater.js").write_text("const x = 1;\n")
+
+    import sys
+
+    import tree_sitter
+
+    from aletheore.scanner import graph as graph_module
+
+    captured: dict[str, object] = {}
+    original_parse = tree_sitter.Parser.parse
+
+    def tracking_parse(self, source, *a, **k):
+        tree = original_parse(self, source, *a, **k)
+        if b"AFirst" in source:
+            captured["tree"] = tree
+        return tree
+
+    monkeypatch.setattr(tree_sitter.Parser, "parse", tracking_parse)
+
+    refcounts: dict[str, int] = {}
+    original_rel = graph_module._rel
+
+    def tracking_rel(repo_path, path):
+        if path.name == "ZLater.js" and "tree" in captured:
+            refcounts["value"] = sys.getrefcount(captured["tree"])
+        return original_rel(repo_path, path)
+
+    monkeypatch.setattr(graph_module, "_rel", tracking_rel)
+
+    graph_module.build_module_graph(repo)
+
+    assert "value" in refcounts
+    assert refcounts["value"] <= 3
+
+
 def test_csharp_extracts_summary_from_xmldoc(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -252,6 +252,68 @@ def test_build_module_graph_reuses_the_java_prepass_parse_in_the_main_loop(tmp_p
     assert all(count == 1 for count in read_counts.values())
 
 
+def test_build_module_graph_releases_a_java_prepass_tree_once_the_main_loop_consumes_it(tmp_path, monkeypatch):
+    # Real regression this guards: java_pre_parsed holds every .java file's
+    # (source, Tree) simultaneously once the pre-pass finishes - tree-sitter
+    # trees run ~37x their source size, so on a large Java repo this is real
+    # memory (measured independently at 82MB RSS on a 512-file C# repo, the
+    # same shape). The main loop used to keep each entry alive via a plain
+    # dict lookup even after consuming it, so the whole cache stayed pinned
+    # until build_module_graph returned - i.e. until every other file in the
+    # repo (every language, not just Java) had also been processed. Popping
+    # instead of indexing releases each entry's memory as soon as the main
+    # loop passes it.
+    #
+    # Refcount, not RSS: RSS is real but flaky/slow to assert on directly in
+    # a unit test. sys.getrefcount() on the specific Tree object is a direct,
+    # reliable proxy for "is java_pre_parsed still holding a reference to
+    # this" - verified by hand that reverting the pop() fix changes the
+    # count this asserts (4 without the fix, 3 with it).
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "AFirst.java").write_text("package com.example;\nclass AFirst {}\n")
+    (repo / "ZLater.js").write_text("const x = 1;\n")
+
+    import sys
+
+    import tree_sitter
+
+    from aletheore.scanner import graph as graph_module
+
+    captured: dict[str, object] = {}
+    original_parse = tree_sitter.Parser.parse
+
+    def tracking_parse(self, source, *a, **k):
+        tree = original_parse(self, source, *a, **k)
+        if b"AFirst" in source:
+            captured["tree"] = tree
+        return tree
+
+    monkeypatch.setattr(tree_sitter.Parser, "parse", tracking_parse)
+
+    refcounts: dict[str, int] = {}
+    original_rel = graph_module._rel
+
+    def tracking_rel(repo_path, path):
+        # _rel(repo_path, path) is the first thing the main loop does for
+        # each file - by the time it's called for ZLater.js, AFirst.java's
+        # own main-loop iteration (including the java_pre_parsed.pop()) has
+        # already completed.
+        if path.name == "ZLater.js" and "tree" in captured:
+            refcounts["value"] = sys.getrefcount(captured["tree"])
+        return original_rel(repo_path, path)
+
+    monkeypatch.setattr(graph_module, "_rel", tracking_rel)
+
+    graph_module.build_module_graph(repo)
+
+    assert "value" in refcounts
+    # Baseline references at this point: captured["tree"] itself, the local
+    # `tree` parameter inside sys.getrefcount()'s own call frame. Anything
+    # higher means java_pre_parsed is still holding a third reference alive.
+    assert refcounts["value"] <= 3
+
+
 def test_java_extracts_javadoc_and_return_type(tmp_path):
     repo = tmp_path / "repo"
     (repo / "src" / "main" / "java").mkdir(parents=True)


### PR DESCRIPTION
## Summary
- `build_module_graph`'s Java/C# pre-passes cache `dict[Path, tuple[bytes, Tree]]` for every file of that language simultaneously, so the main loop can reuse the parse instead of doing it twice (PR #330). Measured independently at 82MB RSS on a 512-file C# repo, extrapolating to ~1.6GB on 10,000 files (tree-sitter trees run ~37x their source size).
- The main loop consumed each entry via a plain dict lookup rather than releasing it, so the whole cache stayed alive until `build_module_graph` returned — i.e. until every other file in the repo, any language, had also been processed.
- Changes the lookup to `.pop(path)` for both `java_pre_parsed` and `csharp_pre_parsed`, releasing each entry's memory as soon as it's consumed. Does not reduce the pre-pass's own peak (structurally unavoidable — every file's declaration has to be seen before a source root can be inferred), only how long that peak persists afterward.
- From an independent re-verification of `Claude_Audit.md`/`immediate_issue_PRs.md` against current master — this was the one finding (of 16 + 4) still genuinely open; everything else was already fixed by earlier work.

## Test plan
- [x] New regression tests (`test_build_module_graph_releases_a_{java,csharp}_prepass_tree_once_the_main_loop_consumes_it`) use `sys.getrefcount()` on the specific `Tree` object as a proxy for "is the cache still holding a reference" (tree-sitter's `Tree` doesn't support weakref).
- [x] Verified via `git stash` that reverting the fix changes the asserted refcount (4 without, 3 with it) and both tests fail without the fix, pass with it.
- [x] Full `src` suite green (1310 passed).
- [x] Full `github-app` suite green (1459 passed, 8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj