### PR TITLE
fix: schema-mapper silently corrupts on ordinary SQL comments

### DIFF
--- a/src/aletheore/schema_map.py
+++ b/src/aletheore/schema_map.py
@@ -78,6 +78,33 @@ class _Cursor:
                 return
 
 
+def _comment_end(text: str, index: int) -> int:
+    """If a `--` or `/* */` comment starts at `index`, the index just past
+    it - otherwise `index` unchanged.
+
+    Shared by every scanner below that walks a plain string (not a
+    _Cursor) rather than duplicating comment detection three times: a
+    `CREATE TABLE` body is read once via _read_parenthesised_body (a
+    _Cursor consumer, handled separately below) but then re-scanned as a
+    plain string by _split_top_level and _tokenize_column_definition, and
+    an inline `--`/`/* */` comment inside a column list is ordinary,
+    common SQL that all three must skip past identically or the comment
+    text gets parsed as if it were column-definition source. Callers are
+    responsible for having already established `index` is not inside a
+    string literal - `--`/`/*` are not comment starts inside a Postgres
+    string literal, but no caller here ever reaches this check from
+    inside one (the `'` branch above it always continues past the whole
+    literal first).
+    """
+    if text[index : index + 2] == "--":
+        newline = text.find("\n", index)
+        return len(text) if newline == -1 else newline
+    if text[index : index + 2] == "/*":
+        end = text.find("*/", index + 2)
+        return len(text) if end == -1 else end + 2
+    return index
+
+
 def _read_identifier(cursor: _Cursor) -> str:
     """A bare or double-quoted identifier, optionally schema-qualified.
 
@@ -134,6 +161,9 @@ def _skip_to_statement_end(cursor: _Cursor) -> None:
             cursor.advance()
             return
         elif char == "-" and cursor.peek(2) == "--":
+            cursor.skip_whitespace_and_comments()
+            continue
+        elif char == "/" and cursor.peek(2) == "/*":
             cursor.skip_whitespace_and_comments()
             continue
         cursor.advance()
@@ -198,6 +228,10 @@ def _split_top_level(body: str) -> list[str]:
             current.append(body[index : end + 1])
             index = end + 1
             continue
+        comment_end = _comment_end(body, index)
+        if comment_end != index:
+            index = comment_end
+            continue
         if char == "(":
             depth += 1
         elif char == ")":
@@ -240,6 +274,10 @@ def _tokenize_column_definition(text: str) -> list[str]:
                 end += 1
             current.append(text[index : end + 1])
             index = end + 1
+            continue
+        comment_end = _comment_end(text, index)
+        if comment_end != index:
+            index = comment_end
             continue
         if char == "(":
             depth += 1
@@ -417,6 +455,10 @@ def _read_parenthesised_body(cursor: _Cursor) -> str | None:
         char = cursor.text[cursor.pos]
         if char == "'":
             _skip_single_quoted(cursor)
+            continue
+        comment_end = _comment_end(cursor.text, cursor.pos)
+        if comment_end != cursor.pos:
+            cursor.advance(comment_end - cursor.pos)
             continue
         if char == "(":
             depth += 1

--- a/src/tests/test_schema_map.py
+++ b/src/tests/test_schema_map.py
@@ -239,6 +239,87 @@ def test_indexes_are_extracted(tmp_path):
     ]
 
 
+def test_a_comment_inside_a_column_list_does_not_swallow_the_next_column(tmp_path):
+    # Batch 5 finding 1: neither _split_top_level nor
+    # _tokenize_column_definition recognized -- or /* */ comments, so an
+    # ordinary inline comment inside a CREATE TABLE column list got scanned
+    # as if it were column-definition source - fusing the real column that
+    # follows into a bogus "--"-named column, dropping it from the schema
+    # with no trace in `unsupported`.
+    repo = write_migrations(
+        tmp_path,
+        {
+            "001.sql": """
+            CREATE TABLE things (
+                id BIGINT PRIMARY KEY,
+                -- deprecated
+                name TEXT
+            );
+            """
+        },
+    )
+    result = extract_schema(repo, ["migrations"])
+
+    assert [c["name"] for c in result["tables"][0]["columns"]] == ["id", "name"]
+
+
+def test_an_unbalanced_paren_inside_a_comment_does_not_swallow_the_next_table(tmp_path):
+    # Batch 5 finding 2: _read_parenthesised_body's depth-tracking scan had
+    # no comment awareness, so a stray "(" inside a comment (e.g. "see issue
+    # (#123") bumped depth with nothing to close it until the *next* real
+    # ")" in the file - which can belong to an entirely different, later
+    # CREATE TABLE statement's own column definition, silently merging two
+    # tables' worth of text into one and dropping the second table.
+    repo = write_migrations(
+        tmp_path,
+        {
+            "001.sql": """
+            CREATE TABLE users (
+                id BIGINT PRIMARY KEY,
+                -- see issue (#123 for context, not closed here
+                name TEXT NOT NULL
+            );
+
+            CREATE TABLE orders (
+                id BIGINT PRIMARY KEY,
+                user_id BIGINT REFERENCES users(id)
+            );
+            """
+        },
+    )
+    result = extract_schema(repo, ["migrations"])
+
+    table_names = [t["name"] for t in result["tables"]]
+    assert "orders" in table_names
+    assert [c["name"] for c in result["tables"][table_names.index("users")]["columns"]] == ["id", "name"]
+    assert {"from_table": "orders", "from_column": "user_id", "to_table": "users", "to_column": "id", "on_delete": None} in [
+        {k: v for k, v in r.items() if k != "file" and k != "line"} for r in result["relations"]
+    ]
+
+
+def test_a_semicolon_inside_a_block_comment_does_not_end_the_statement_early(tmp_path):
+    # Batch 5 finding 3: _skip_to_statement_end special-cased -- comments
+    # but had no branch for /* */ block comments, so a ; inside a block
+    # comment was treated as the real statement terminator - splitting one
+    # ALTER TABLE statement into garbage fragments and losing the real
+    # column change.
+    repo = write_migrations(
+        tmp_path,
+        {
+            "001.sql": """
+            CREATE TABLE widgets (id BIGINT PRIMARY KEY);
+            ALTER TABLE widgets ADD COLUMN status TEXT /* values: active; inactive; deleted */ DEFAULT 'active';
+            """
+        },
+    )
+    result = extract_schema(repo, ["migrations"])
+
+    columns = {c["name"]: c for c in result["tables"][0]["columns"]}
+    assert "status" in columns
+    assert columns["status"]["default"] == "'active'"
+    assert result["unsupported"] == []
+
+
 def test_symlinked_migrations_are_not_followed(tmp_path):
     repo = write_migrations(tmp_path, {"001.sql": "CREATE TABLE real (id BIGINT PRIMARY KEY);"})
     outside = tmp_path / "outside.sql"


### PR DESCRIPTION
## Summary
Batch 5 findings 1-3 (`before_launch_fixes.md`) - the schema-mapping/ER-diagram feature (#203) silently corrupts on ordinary, common SQL comment styles, with zero error trace:

- `_split_top_level`/`_tokenize_column_definition` had no comment awareness: an inline `-- comment` inside a `CREATE TABLE` column list fused the real column that follows into a bogus `"--"`-named column and dropped it entirely.
- `_read_parenthesised_body`'s paren-depth tracking had no comment awareness: a stray `(` inside a comment (e.g. `-- see issue (#123`) could swallow an entire subsequent table into the previous one.
- `_skip_to_statement_end` special-cased `--` comments but not `/* */` block comments, so a `;` inside one ended a statement early.

All three share one root cause (comment-skipping not consistently reused across the module's scanning helpers) - fixed with one shared `_comment_end()` helper.

## Test plan
- [x] Wrote a failing test reproducing each of the 3 bugs first, confirmed each fails against unfixed code
- [x] Applied the fix, confirmed all 3 new tests + full `test_schema_map.py` (20 tests) pass
- [x] Full `src/` test suite (1312 tests) green, no regressions
- [x] Independently re-reproduced the original bug scenarios via the real parser both before and after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)