### PR TITLE
fix: FastAPI implicit router mount lost its unprefixed endpoint

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -120,13 +120,29 @@ def _collect_fastapi_include_prefixes(
             None,
         )
         if prefix_arg is None:
-            continue
-        value = prefix_arg.child_by_field_name("value")
-        if value is None or value.type != "string":
-            continue
+            # No prefix= at all - an ordinary FastAPI pattern for mounting a
+            # router unprefixed alongside also mounting it elsewhere under a
+            # versioned/admin prefix. Recorded as an explicit empty-string
+            # mount rather than skipped: skipping it left this router's
+            # mounts list empty for this call, and if the same router also
+            # had one explicitly-prefixed mount elsewhere, that non-empty
+            # list silently suppressed the fan-out branch that would have
+            # emitted the implicit mount's own unprefixed path - a real,
+            # reachable endpoint dropped from the map entirely. compose()
+            # below already treats an empty-string mount_prefix as "nothing
+            # to join", so recording it here is enough to fix the fan-out.
+            prefix_text = ""
+        else:
+            value = prefix_arg.child_by_field_name("value")
+            if value is None or value.type != "string":
+                # prefix= given but not a literal string (a variable,
+                # f-string, ...) - can't resolve it statically, so skip only
+                # this mount rather than guessing at its value.
+                continue
+            prefix_text = _string_literal_text(value, source)
         router = source[positional[0].start_byte:positional[0].end_byte].decode()
         defining_file = _resolve_router_definition_file(root, source, router, repo_path, path, source_roots)
-        prefixes.setdefault((defining_file, router), []).append(_string_literal_text(value, source))
+        prefixes.setdefault((defining_file, router), []).append(prefix_text)
     return prefixes
 
 

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -204,6 +204,34 @@ def test_map_api_endpoints_fans_out_a_router_mounted_at_multiple_prefixes(tmp_pa
     assert paths == {"/api/{user_id}", "/admin/{user_id}"}
 
 
+def test_map_api_endpoints_keeps_an_implicit_mount_alongside_a_prefixed_one(tmp_path):
+    # Batch 5 finding 4: _collect_fastapi_include_prefixes only recorded a
+    # mount when include_router(...) carried an explicit prefix= kwarg - a
+    # prefix-less app.include_router(router) call (an ordinary FastAPI
+    # pattern for mounting a router unprefixed alongside also mounting it
+    # under a versioned/admin prefix) contributed nothing to the mounts
+    # list, so when the *same* router also had one explicitly-prefixed
+    # mount, the truthy mounts list from that other call suppressed the
+    # fan-out branch that would have emitted the unprefixed path - silently
+    # dropping a real, reachable endpoint from the map.
+    (tmp_path / "users.py").write_text(
+        'router = APIRouter()\n'
+        '@router.get("/{user_id}")\n'
+        'def get_user(user_id: int):\n    pass\n'
+    )
+    (tmp_path / "main.py").write_text(
+        "from users import router\n"
+        "app.include_router(router)\n"
+        'app.include_router(router, prefix="/admin")\n'
+    )
+
+    result = map_api_endpoints(tmp_path)
+
+    routes = [e for e in result["endpoints"] if e["file"] == "users.py"]
+    paths = {route["path"] for route in routes}
+    assert paths == {"/{user_id}", "/admin/{user_id}"}
+
+
 def test_map_api_endpoints_does_not_cross_contaminate_same_named_routers_in_different_files(tmp_path):
     # Regression test: "router" is the idiomatic FastAPI variable name, so
     # two different files' routers, each imported into a different mounting


### PR DESCRIPTION
## Summary
Batch 5 finding 4 (`before_launch_fixes.md`) - `_collect_fastapi_include_prefixes` only recorded a router mount when `include_router(...)` carried an explicit `prefix=` kwarg. `app.include_router(router)` (no prefix at all - an ordinary FastAPI pattern for mounting a router unprefixed alongside also mounting it elsewhere under a versioned/admin prefix) contributed nothing to that router's mounts list. If the same router also had one explicitly-prefixed mount elsewhere, the resulting non-empty list silently suppressed the fan-out branch that would have emitted the implicit mount's own unprefixed path.

For a product whose job is enumerating reachable API surface for security review, a real, reachable, unauthenticated-by-default endpoint silently missing from the map is a meaningful gap.

**Fix:** record an explicit empty-string mount for a prefix-less call instead of skipping it. `compose()`'s existing `if mount_prefix:` check already treats an empty string as "nothing to join," so this alone fixes the fan-out without touching the consumer side.

## Test plan
- [x] Test written first, confirmed it fails against unfixed code
- [x] Fix applied, test passes; full `test_endpoints.py` (59 tests) green
- [x] Full `src/` test suite (1312 tests) green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)