### PR TITLE
fix: three retrieval-quality regressions in search_index.py

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -249,6 +249,29 @@ def _truncate_for_embedding(text: str) -> str:
     return text[:MAX_EMBEDDING_CHARS] + "\n... (truncated for embedding)"
 
 
+_DOTNET_TEST_SUFFIX_RE = re.compile(r"Tests?$")
+
+
+def _has_dotnet_test_suffix(raw_part: str) -> bool:
+    """Whether a path segment ends in a .NET-style test-project name -
+    "Tests"/"Test" as its own trailing word, not a bare suffix.
+
+    Must run on the segment's original case, before it's lowered: the
+    signal that separates a real .NET test-project name from an ordinary
+    English word ending in the same five letters ("Contests", "Protests",
+    "Attests") is either a preceding "."/"-"/"_" separator
+    (AutoMapper.DI.Tests) or a lower-to-upper case transition
+    (UnitTests) - both destroyed by lowercasing first.
+    """
+    match = _DOTNET_TEST_SUFFIX_RE.search(raw_part)
+    if match is None:
+        return False
+    prefix = raw_part[: match.start()]
+    if not prefix:
+        return True
+    return prefix[-1] in "._-" or prefix[-1].islower()
+
+
 def _is_test_path(module_path: str) -> bool:
     """Whether a path is test code rather than the implementation.
 
@@ -259,7 +282,8 @@ def _is_test_path(module_path: str) -> bool:
     excluded. Someone asking how something works wants the implementation;
     if they want the test, they ask for the test by name and grep finds it.
     """
-    parts = [part.lower() for part in module_path.split("/")]
+    raw_parts = module_path.split("/")
+    parts = [part.lower() for part in raw_parts]
     if any(part in {"tests", "test", "spec", "__tests__", "testing"} for part in parts):
         return True
     # .NET names test projects after the assembly they cover - "UnitTests",
@@ -268,10 +292,18 @@ def _is_test_path(module_path: str) -> bool:
     # Measured on AutoMapper/AutoMapper: every one of 15 questions returned
     # src/UnitTests/ files ahead of the implementation, for 0.0% top-1.
     #
-    # Matched on the "tests" plural only. "test" as a suffix would swallow
-    # ordinary words - "latest" ends with "test" - while no English word this
-    # matters for ends with "tests".
-    if any(part.endswith("tests") or part.endswith(".test") for part in parts):
+    # Checked against the ORIGINAL-case segment (raw_parts), not the
+    # lowered `parts` above: a bare endswith("tests") on already-lowercased
+    # text can't tell "UnitTests" apart from an ordinary word that merely
+    # ends in the same five letters - "Contests", "Protests", "Attests" -
+    # a real false-positive class, and this is a hard exclusion (file
+    # dropped from the index entirely), not a rank penalty. Matched on the
+    # "Tests"/"Test" plural or singular as its own trailing word, signalled
+    # by a preceding "."/"-"/"_" separator or a lower-to-upper case
+    # transition (AutoMapper.DI.Tests, UnitTests) - not a bare suffix.
+    if any(_has_dotnet_test_suffix(part) for part in raw_parts):
+        return True
+    if any(part.endswith(".test") for part in parts):
         return True
     name = parts[-1]
     stem = name.rsplit(".", 1)[0]
@@ -291,8 +323,14 @@ _INTERFACE_DIR_MARKERS = frozenset({"interfaces", "contracts"})
 
 _PHP_INTERFACE_DECL = re.compile(r"^\s*interface\s+\w", re.MULTILINE)
 _JAVA_CSHARP_INTERFACE_DECL = re.compile(r"^\s*(?:public\s+|internal\s+)?interface\s+\w", re.MULTILINE)
+# "abstract" deliberately excluded from the modifier alternation: this
+# regex is used to decide whether a Java/C# file has a *concrete* class
+# alongside its interface (see _is_declaration_only_file below), and an
+# abstract class has no instantiable implementation of its own - a file
+# with only an interface plus an abstract class is functionally still
+# pure contract, same as interface-only.
 _JAVA_CSHARP_CLASS_DECL = re.compile(
-    r"^\s*(?:public\s+|internal\s+|private\s+|protected\s+|sealed\s+|abstract\s+|static\s+|partial\s+|final\s+)*class\s+\w",
+    r"^\s*(?:public\s+|internal\s+|private\s+|protected\s+|sealed\s+|static\s+|partial\s+|final\s+)*class\s+\w",
     re.MULTILINE,
 )
 _RUST_TRAIT_DECL = re.compile(r"^\s*(?:pub\s+)?trait\s+\w", re.MULTILINE)
@@ -1306,7 +1344,13 @@ _LANGUAGE_CUE = r"(?:library|implementation|impl|module|package|code|side|bindin
 _CUED_QUERY_LANGUAGES = (
     (rf"\bgo\s+{_LANGUAGE_CUE}\b|\bin\s+go\b", "go"),
     (rf"\bjava\s+{_LANGUAGE_CUE}\b|\bin\s+java\b", "java"),
-    (rf"\bc\s+{_LANGUAGE_CUE}\b|\bin\s+c\b", "c"),
+    # (?![+#]) after the bare-"c" match: \b is satisfied by any non-word
+    # character, "+" and "#" included, so \bin\s+c\b alone also matched
+    # inside "in C++"/"in C#" - colliding with the already-correct
+    # unambiguous cpp/csharp match above and tripping the two-languages
+    # decline guard on the exact plain phrasing ("...implemented in C++?")
+    # this feature exists to handle.
+    (rf"\bc\s+{_LANGUAGE_CUE}\b|\bin\s+c\b(?![+#])", "c"),
 )
 
 

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -618,6 +618,23 @@ def test_is_declaration_only_file_does_not_flag_a_csharp_file_mixing_interface_a
     )
 
 
+def test_is_declaration_only_file_still_flags_an_interface_paired_only_with_an_abstract_class():
+    # Batch 5 finding 9: _JAVA_CSHARP_CLASS_DECL's modifier alternation
+    # included "abstract", so an interface-plus-abstract-class file (no
+    # concrete/instantiable implementation at all - functionally still pure
+    # contract) was treated identically to a file with a genuine concrete
+    # class, contradicting this fix's own stated intent: "demote a Java/C#
+    # file only when it has no CONCRETE class alongside its interface."
+    assert _is_declaration_only_file(
+        "Shape.java", "java",
+        "public interface Shape {\n    double area();\n}\n"
+        "public abstract class AbstractShape implements Shape {\n"
+        "    public abstract double area();\n"
+        "    public String describe() { return \"shape\"; }\n"
+        "}\n",
+    )
+
+
 def test_is_declaration_only_file_detects_path_under_an_interfaces_directory():
     # Path-level signal alone, regardless of language or content - a PHP,
     # Java, or C# codebase commonly puts every interface under one of these
@@ -1709,6 +1726,23 @@ def test_is_test_path_does_not_swallow_ordinary_words_ending_in_test():
     assert not _is_test_path("src/AutoMapper/Mapper.cs")
 
 
+def test_is_test_path_does_not_exclude_ordinary_words_ending_in_tests():
+    # Batch 5 finding 5: the .NET-suffix fix's endswith("tests") ran against
+    # already-lowercased path segments, so it couldn't tell "UnitTests" (a
+    # real .NET test-project name, signalled by the Unit->Tests case
+    # transition) apart from an ordinary word that merely ends in the same
+    # five letters - "Contests", "Protests", "Attests" - which have no such
+    # boundary. This was a hard exclusion (file dropped from the index
+    # entirely), not a rank penalty.
+    assert not _is_test_path("src/Contests/ContestController.cs")
+    assert not _is_test_path("src/Protests/ProtestTracker.java")
+    assert not _is_test_path("src/Attests/Foo.cs")
+    # The real .NET conventions this fix exists for must still be excluded.
+    assert _is_test_path("src/UnitTests/ForAllMembers.cs")
+    assert _is_test_path("src/AutoMapper.DI.Tests/Profiles.cs")
+    assert _is_test_path("src/IntegrationTests/Foo.java")
+
+
 def test_detect_query_language_reads_an_explicit_language_mention():
     """apache/thrift implements TBinaryProtocol in seven languages, so a question
     naming one has a single correct answer and six near-identical wrong ones."""
@@ -1735,6 +1769,21 @@ def test_detect_query_language_declines_when_two_languages_are_named():
 
 def test_detect_query_language_does_not_confuse_java_with_javascript():
     assert _detect_query_language("Where is the JavaScript adapter?") == "javascript"
+
+
+def test_detect_query_language_reads_the_plain_in_cpp_and_in_csharp_phrasing():
+    # Batch 5 finding 6: \bin\s+c\b (meant to catch a bare "C" reference)
+    # also matched inside "in C++"/"in C#", since \b is satisfied by any
+    # non-word character - "+" and "#" both qualify. That collided with the
+    # already-correct unambiguous cpp/csharp match, populating `found` with
+    # two entries ({"cpp", "c"} / {"csharp", "c"}) and tripping the
+    # two-languages-named decline guard - on the exact plain phrasing
+    # ("...implemented in C++?") this feature was built to handle, not a
+    # contrived edge case.
+    assert _detect_query_language("Where is this implemented in C#") == "csharp"
+    assert _detect_query_language("Where is TBinaryProtocol implemented in C++") == "cpp"
+    # The bare-"C" cued match this pattern exists for must still work.
+    assert _detect_query_language("Where is this implemented in C") == "c"
 
 
 def test_hosted_batches_bound_a_request_by_characters_not_just_count():


### PR DESCRIPTION
## Summary
Batch 5 findings 5, 6, 9 (`before_launch_fixes.md`) - three independent bugs in `search_index.py`, each undoing part of the fix it shipped with:

- **Finding 5**: `_is_test_path`'s `.NET`-suffix exclusion checked `endswith("tests")` against already-lowercased path segments, so it hard-excluded ordinary words like `Contests`/`Protests`/`Attests` from the index.
- **Finding 6**: `_detect_query_language`'s cued "in C" pattern matched inside "in C++"/"in C#" too (regex `\b` is satisfied by `+`/`#`), tripping the two-languages-named decline guard on the exact plain phrasing the feature was built to handle.
- **Finding 9**: `_JAVA_CSHARP_CLASS_DECL` included `abstract` in its modifier alternation, so an interface-plus-abstract-class file wasn't demoted, contradicting the fix's own stated "no concrete class" intent.

## Test plan
- [x] One failing test per finding, confirmed failing against unfixed code
- [x] Fixes applied, all 3 new tests + full `test_search_index.py` (103+ tests) pass
- [x] Full `src/` suite (1317 tests) green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)