### PR TITLE
feat: mcp-install prints a copyable 'claude mcp add' command for Claude Code

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -1115,6 +1115,17 @@ def _mcp_install(path: str, targets: list[str]) -> int:
         "\nRestart or reload your coding tool so it picks up the new MCP server - "
         "Aletheore's tools will then be available without running 'aletheore mcp' yourself."
     )
+    if "claude-code" in selected:
+        console.print(
+            "\n[bold]Claude Code:[/bold] .mcp.json above is picked up automatically on reload - "
+            "no extra step needed. Prefer registering it yourself instead (or want a command to "
+            "verify the same server), paste this:"
+        )
+        # soft_wrap: this is a copy-pasteable shell command containing a full
+        # repo path - Rich's default wrapping inserts a real newline into
+        # long text at the console width, which would corrupt the command if
+        # pasted. Same reasoning as _print_result above.
+        console.print(f"  claude mcp add aletheore -- {_aletheore_command()} mcp {repo_path}", soft_wrap=True)
     console.print(
         "\n[bold]PyCharm / other JetBrains IDEs:[/bold] not auto-configured - there's no single "
         "stable, documented file format to script against yet. Instead: open Settings | Tools | "

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -488,6 +488,21 @@ def test_mcp_install_prints_pycharm_and_terminal_editor_guidance(tmp_path):
     assert "avante.nvim" in result.stdout or "no native MCP" in result.stdout
 
 
+def test_mcp_install_prints_a_copyable_claude_mcp_add_command(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "claude-code"])
+
+    assert result.exit_code == 0
+    assert "claude mcp add aletheore -- " in result.stdout
+    assert f"mcp {tmp_path.resolve()}" in result.stdout
+
+
+def test_mcp_install_omits_the_claude_mcp_add_command_when_claude_code_not_targeted(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "cursor"])
+
+    assert result.exit_code == 0
+    assert "claude mcp add" not in result.stdout
+
+
 def test_progress_printer_prints_each_distinct_phase_on_its_own_line(capsys):
     report = _make_progress_printer(is_tty=False)
     report("Detecting languages, frameworks, and build tools")


### PR DESCRIPTION
## Summary
- `mcp-install` already writes `.mcp.json` for Claude Code automatically, but gave no way to register the server by hand — no copyable command, no "connector" snippet, just a silent file write.
- Now prints `claude mcp add aletheore -- <resolved aletheore path> mcp <repo_path>` whenever `claude-code` is among the selected targets, for people who prefer Claude Code's own CLI registration, or want a one-liner to verify the same server against what got written.
- Uses `soft_wrap=True` for the printed command, matching `_print_result`'s existing discipline for copyable long paths — Rich's default wrapping otherwise inserts a real newline into the text at the console width, which would corrupt a pasted shell command.

## Test plan
- [x] New regression tests: the command appears when `claude-code` is targeted, and is absent when it isn't.
- [x] Manually verified the printed output in a real terminal.
- [x] Full `src` suite green (1316 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj