### PR TITLE
fix: embedding-cache rows now carry the embedder that produced them

### DIFF
--- a/github-app/migrations/054_cache_embedder_identity.sql
+++ b/github-app/migrations/054_cache_embedder_identity.sql
@@ -1,0 +1,13 @@
+-- Batch 5 finding 8 (before_launch_fixes.md): neither cache table recorded
+-- which embedder produced its stored vector, so a wrong-embedder cache hit
+-- (e.g. mid-rollout during a future embedder switch) would pass the
+-- array-length check in _cosine_similarity and get compared against a
+-- different embedding space's query vectors - meaningless, but nothing
+-- caught it except deploy-time discipline (remembering to write a purge
+-- migration for the switch). NULL for every existing row (written before
+-- this column existed, under an embedder identity nobody recorded) -
+-- treated as a non-match at lookup time, same as a genuinely wrong
+-- embedder, so historical rows age out naturally instead of serving a hit
+-- nobody can verify.
+ALTER TABLE evidence_packet_cache ADD COLUMN IF NOT EXISTS embedder TEXT;
+ALTER TABLE flash_review_cache ADD COLUMN IF NOT EXISTS embedder TEXT;

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -1240,6 +1240,7 @@ def insert_evidence_packet_cache_row(
     packet: dict,
     model_output: dict,
     model_used: str,
+    embedder: str,
 ) -> None:
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
@@ -1247,8 +1248,8 @@ def insert_evidence_packet_cache_row(
                 """
                 INSERT INTO evidence_packet_cache
                     (installation_id, repo_full_name, content_hash, embedding,
-                     packet_json, model_output, model_used)
-                VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb, %s)
+                     packet_json, model_output, model_used, embedder)
+                VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s)
                 """,
                 (
                     installation_id,
@@ -1258,25 +1259,33 @@ def insert_evidence_packet_cache_row(
                     json.dumps(packet),
                     json.dumps(model_output),
                     model_used,
+                    embedder,
                 ),
             )
         conn.commit()
 
 
 def list_recent_evidence_packet_cache_rows(
-    dsn: str, installation_id: int, repo_full_name: str, limit: int = 200
+    dsn: str, installation_id: int, repo_full_name: str, embedder: str, limit: int = 200
 ) -> list[dict]:
+    # Filtered to the currently-configured embedder at the SQL level, not
+    # in Python after fetching: a row written under a different embedder
+    # (an old row from before a switch, or one written mid-rollout) is a
+    # different embedding space entirely, not just a lower-quality match -
+    # see before_launch_fixes.md Batch 5 finding 8. NULL (every row from
+    # before this column existed) never equals embedder in SQL, so those
+    # age out the same way, without a separate migration to purge them.
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
                 """
                 SELECT id, content_hash, embedding, packet_json, model_output, model_used, hit_count
                 FROM evidence_packet_cache
-                WHERE installation_id = %s AND repo_full_name = %s
+                WHERE installation_id = %s AND repo_full_name = %s AND embedder = %s
                 ORDER BY created_at DESC
                 LIMIT %s
                 """,
-                (installation_id, repo_full_name, limit),
+                (installation_id, repo_full_name, embedder, limit),
             )
             return cur.fetchall()
 
@@ -1304,6 +1313,7 @@ def insert_flash_review_cache_row(
     diff_text: str,
     findings: list[dict],
     model_used: str,
+    embedder: str,
 ) -> None:
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
@@ -1311,8 +1321,8 @@ def insert_flash_review_cache_row(
                 """
                 INSERT INTO flash_review_cache
                     (installation_id, repo_full_name, content_hash, embedding,
-                     diff_text, findings, model_used)
-                VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s)
+                     diff_text, findings, model_used, embedder)
+                VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s)
                 """,
                 (
                     installation_id,
@@ -1322,25 +1332,28 @@ def insert_flash_review_cache_row(
                     diff_text,
                     json.dumps(findings),
                     model_used,
+                    embedder,
                 ),
             )
         conn.commit()
 
 
 def list_recent_flash_review_cache_rows(
-    dsn: str, installation_id: int, repo_full_name: str, limit: int = 200
+    dsn: str, installation_id: int, repo_full_name: str, embedder: str, limit: int = 200
 ) -> list[dict]:
+    # See list_recent_evidence_packet_cache_rows's comment - same
+    # embedder-identity filter, same reasoning (Batch 5 finding 8).
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
                 """
                 SELECT id, content_hash, embedding, diff_text, findings, model_used, hit_count
                 FROM flash_review_cache
-                WHERE installation_id = %s AND repo_full_name = %s
+                WHERE installation_id = %s AND repo_full_name = %s AND embedder = %s
                 ORDER BY created_at DESC
                 LIMIT %s
                 """,
-                (installation_id, repo_full_name, limit),
+                (installation_id, repo_full_name, embedder, limit),
             )
             return cur.fetchall()
 

--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -21,6 +21,16 @@ import httpx
 # regardless of how it was found.
 MAX_EMBEDDING_CHARS = 5000
 
+# Identifies which embedder produced a vector, recorded alongside every
+# similarity-cache row (packet_cache.py, flash_review_cache.py) so a
+# future embedder switch can't silently compare vectors from two
+# different embedding spaces - see before_launch_fixes.md Batch 5 finding
+# 8. Update this whenever the model or serving backend actually changes,
+# in the same change that points JINA_EMBED_BASE_URL (or its replacement)
+# at the new service - it's what makes an old row's cached vector
+# correctly stop matching new queries the moment the embedder does.
+CURRENT_EMBEDDER = "jina-embed:jina-embeddings-v2-base-code"
+
 logger = logging.getLogger(__name__)
 
 

--- a/github-app/scan_worker/flash_review_cache.py
+++ b/github-app/scan_worker/flash_review_cache.py
@@ -14,7 +14,7 @@ from scan_worker.db import (
     list_recent_flash_review_cache_rows,
     record_flash_review_cache_hit,
 )
-from scan_worker.embedding_client import embed_text
+from scan_worker.embedding_client import CURRENT_EMBEDDER, embed_text
 
 SIMILARITY_THRESHOLD = 0.92
 
@@ -44,7 +44,7 @@ def lookup_cached_result(
         if vector is None:
             return None
 
-        rows = list_recent_flash_review_cache_rows(dsn, installation_id, repo_full_name)
+        rows = list_recent_flash_review_cache_rows(dsn, installation_id, repo_full_name, CURRENT_EMBEDDER)
         if not rows:
             return None
 
@@ -89,6 +89,7 @@ def store_result(
             diff_text,
             findings,
             model_used,
+            CURRENT_EMBEDDER,
         )
     except Exception as exc:
         logger.warning("flash review cache write failed (%s); continuing without cache", type(exc).__name__)

--- a/github-app/scan_worker/packet_cache.py
+++ b/github-app/scan_worker/packet_cache.py
@@ -14,7 +14,7 @@ from scan_worker.db import (
     list_recent_evidence_packet_cache_rows,
     record_evidence_packet_cache_hit,
 )
-from scan_worker.embedding_client import embed_text
+from scan_worker.embedding_client import CURRENT_EMBEDDER, embed_text
 
 SIMILARITY_THRESHOLD = 0.92
 
@@ -54,7 +54,7 @@ def lookup_cached_result(
         if vector is None:
             return None
 
-        rows = list_recent_evidence_packet_cache_rows(dsn, installation_id, repo_full_name)
+        rows = list_recent_evidence_packet_cache_rows(dsn, installation_id, repo_full_name, CURRENT_EMBEDDER)
         if not rows:
             return None
 
@@ -103,6 +103,7 @@ def store_result(
             packet,
             raw_model_output,
             model_used,
+            CURRENT_EMBEDDER,
         )
     except Exception as exc:
         logger.warning("evidence packet cache write failed (%s); continuing without cache", type(exc).__name__)

--- a/github-app/tests/test_flash_review_cache.py
+++ b/github-app/tests/test_flash_review_cache.py
@@ -1,5 +1,6 @@
 import pytest
 
+from scan_worker.embedding_client import CURRENT_EMBEDDER
 from scan_worker.flash_review_cache import lookup_cached_result, store_result
 
 
@@ -75,7 +76,7 @@ def test_lookup_fails_open_when_db_lookup_raises(monkeypatch):
 def test_store_result_writes_a_row(monkeypatch):
     written = {}
 
-    def fake_insert(dsn, installation_id, repo_full_name, content_hash, embedding, diff_text, findings, model_used):
+    def fake_insert(dsn, installation_id, repo_full_name, content_hash, embedding, diff_text, findings, model_used, embedder):
         written.update(
             installation_id=installation_id,
             repo_full_name=repo_full_name,
@@ -84,6 +85,7 @@ def test_store_result_writes_a_row(monkeypatch):
             diff_text=diff_text,
             findings=findings,
             model_used=model_used,
+            embedder=embedder,
         )
 
     monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [0.5, 0.5])
@@ -103,6 +105,24 @@ def test_store_result_writes_a_row(monkeypatch):
     assert written["embedding"] == [0.5, 0.5]
     assert written["findings"] == [{"file": "a.py", "line": 1, "issue": "fresh finding"}]
     assert written["model_used"] == "deepseek-v4-flash"
+    # Batch 5 finding 8: every write must be tagged with the embedder that
+    # produced the vector.
+    assert written["embedder"] == CURRENT_EMBEDDER
+
+
+def test_lookup_filters_by_the_current_embedder(monkeypatch):
+    captured = {}
+
+    def fake_list(dsn, installation_id, repo_full_name, embedder, limit=200):
+        captured["embedder"] = embedder
+        return []
+
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [1.0, 0.0])
+    monkeypatch.setattr("scan_worker.flash_review_cache.list_recent_flash_review_cache_rows", fake_list)
+
+    lookup_cached_result("postgresql://unused", 1, "org/repo", "some diff")
+
+    assert captured["embedder"] == CURRENT_EMBEDDER
 
 
 def test_store_result_is_noop_when_embedding_unavailable(monkeypatch):
@@ -155,5 +175,34 @@ async def test_lookup_never_returns_a_different_installations_row(pool, monkeypa
     )
 
     result = lookup_cached_result(TEST_DATABASE_URL, 602, "org-b/repo", "diff for org-a")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_never_matches_a_row_written_under_a_different_embedder(pool, monkeypatch):
+    # Batch 5 finding 8, proven against a real Postgres instance - see
+    # test_packet_cache.py's equivalent test for the full reasoning.
+    from conftest import TEST_DATABASE_URL
+
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login) VALUES ($1, $2)",
+        603,
+        "org-c",
+    )
+
+    monkeypatch.setattr("scan_worker.flash_review_cache.embed_text", lambda text: [1.0, 0.0])
+    monkeypatch.setattr("scan_worker.flash_review_cache.CURRENT_EMBEDDER", "old-embedder:v1")
+    store_result(
+        TEST_DATABASE_URL,
+        603,
+        "org-c/repo",
+        "diff cached under the old embedder",
+        [{"file": "a.py", "line": 1, "issue": "old-embedder finding"}],
+        "deepseek-v4-flash",
+    )
+
+    monkeypatch.setattr("scan_worker.flash_review_cache.CURRENT_EMBEDDER", "new-embedder:v2")
+    result = lookup_cached_result(TEST_DATABASE_URL, 603, "org-c/repo", "diff cached under the old embedder")
 
     assert result is None

--- a/github-app/tests/test_packet_cache.py
+++ b/github-app/tests/test_packet_cache.py
@@ -1,5 +1,6 @@
 import pytest
 
+from scan_worker.embedding_client import CURRENT_EMBEDDER
 from scan_worker.packet_cache import lookup_cached_result, store_result
 
 
@@ -68,7 +69,7 @@ def test_lookup_returns_match_above_threshold_and_records_hit(monkeypatch):
 def test_store_result_writes_a_row(monkeypatch):
     written = {}
 
-    def fake_insert(dsn, installation_id, repo_full_name, content_hash, embedding, packet, model_output, model_used):
+    def fake_insert(dsn, installation_id, repo_full_name, content_hash, embedding, packet, model_output, model_used, embedder):
         written.update(
             installation_id=installation_id,
             repo_full_name=repo_full_name,
@@ -77,6 +78,7 @@ def test_store_result_writes_a_row(monkeypatch):
             packet=packet,
             model_output=model_output,
             model_used=model_used,
+            embedder=embedder,
         )
 
     monkeypatch.setattr("scan_worker.packet_cache.embed_text", lambda text: [0.5, 0.5])
@@ -89,6 +91,30 @@ def test_store_result_writes_a_row(monkeypatch):
     assert written["embedding"] == [0.5, 0.5]
     assert written["model_output"] == {"description": "fresh"}
     assert written["model_used"] == "deepseek-v4-pro"
+    # Batch 5 finding 8: every write must be tagged with the embedder that
+    # produced the vector, so a future embedder switch can filter out
+    # mismatched rows at lookup time instead of comparing across two
+    # different embedding spaces.
+    assert written["embedder"] == CURRENT_EMBEDDER
+
+
+def test_lookup_filters_by_the_current_embedder(monkeypatch):
+    # Batch 5 finding 8: the lookup must ask the DB layer for rows tagged
+    # with the currently-configured embedder specifically, not "any row
+    # for this installation/repo" - a row written under a different
+    # embedder is a different embedding space, not just a worse match.
+    captured = {}
+
+    def fake_list(dsn, installation_id, repo_full_name, embedder, limit=200):
+        captured["embedder"] = embedder
+        return []
+
+    monkeypatch.setattr("scan_worker.packet_cache.embed_text", lambda text: [1.0, 0.0])
+    monkeypatch.setattr("scan_worker.packet_cache.list_recent_evidence_packet_cache_rows", fake_list)
+
+    lookup_cached_result("postgresql://unused", 1, "org/repo", _packet())
+
+    assert captured["embedder"] == CURRENT_EMBEDDER
 
 
 def test_store_result_is_noop_when_embedding_unavailable(monkeypatch):
@@ -130,5 +156,40 @@ async def test_lookup_never_returns_a_different_installations_row(pool, monkeypa
     result = lookup_cached_result(
         TEST_DATABASE_URL, 502, "org-b/repo", {"changed_files": ["a.py"], "cache_eligible": True}
     )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_never_matches_a_row_written_under_a_different_embedder(pool, monkeypatch):
+    # Batch 5 finding 8, proven against a real Postgres instance: a row
+    # written under a different embedder (an old row from before a switch,
+    # or one written mid-rollout) must never be served as a hit, even
+    # though its vector has the identical dimension and would otherwise
+    # pass _cosine_similarity's only check - comparing across two
+    # different embedding spaces is meaningless, not just a worse match.
+    from conftest import TEST_DATABASE_URL
+
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login) VALUES ($1, $2)",
+        503,
+        "org-c",
+    )
+
+    monkeypatch.setattr("scan_worker.packet_cache.embed_text", lambda text: [1.0, 0.0])
+    monkeypatch.setattr("scan_worker.packet_cache.CURRENT_EMBEDDER", "old-embedder:v1")
+    store_result(
+        TEST_DATABASE_URL,
+        503,
+        "org-c/repo",
+        _packet(),
+        {"description": "cached under the old embedder"},
+        "deepseek-v4-pro",
+    )
+
+    # Same repo, same near-identical embedding, but the currently-configured
+    # embedder has moved on - the old-embedder row must not be served.
+    monkeypatch.setattr("scan_worker.packet_cache.CURRENT_EMBEDDER", "new-embedder:v2")
+    result = lookup_cached_result(TEST_DATABASE_URL, 503, "org-c/repo", _packet())
 
     assert result is None

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -150,9 +150,10 @@ async def test_insert_and_list_evidence_packet_cache_rows(pool):
         {"changed_files": ["a.py"]},
         {"description": "does a thing"},
         "deepseek-v4-pro",
+        "test-embedder",
     )
 
-    rows = list_recent_evidence_packet_cache_rows(TEST_DATABASE_URL, 401, "cache-org/repo")
+    rows = list_recent_evidence_packet_cache_rows(TEST_DATABASE_URL, 401, "cache-org/repo", "test-embedder")
 
     assert len(rows) == 1
     assert rows[0]["content_hash"] == "hash-1"
@@ -170,13 +171,13 @@ async def test_list_evidence_packet_cache_rows_never_crosses_installations(pool)
     from scan_worker.db import insert_evidence_packet_cache_row, list_recent_evidence_packet_cache_rows
 
     insert_evidence_packet_cache_row(
-        TEST_DATABASE_URL, 402, "org-a/repo", "hash-a", [1.0], {}, {"description": "a"}, "deepseek-v4-pro"
+        TEST_DATABASE_URL, 402, "org-a/repo", "hash-a", [1.0], {}, {"description": "a"}, "deepseek-v4-pro", "test-embedder"
     )
     insert_evidence_packet_cache_row(
-        TEST_DATABASE_URL, 403, "org-b/repo", "hash-b", [1.0], {}, {"description": "b"}, "deepseek-v4-pro"
+        TEST_DATABASE_URL, 403, "org-b/repo", "hash-b", [1.0], {}, {"description": "b"}, "deepseek-v4-pro", "test-embedder"
     )
 
-    rows = list_recent_evidence_packet_cache_rows(TEST_DATABASE_URL, 402, "org-a/repo")
+    rows = list_recent_evidence_packet_cache_rows(TEST_DATABASE_URL, 402, "org-a/repo", "test-embedder")
 
     assert len(rows) == 1
     assert rows[0]["content_hash"] == "hash-a"
@@ -197,9 +198,10 @@ async def test_insert_and_list_flash_review_cache_rows(pool):
         "--- a.py ---\n@@ -1,1 +1,1 @@\n+x = 1",
         [{"file": "a.py", "line": 1, "issue": "unused variable"}],
         "deepseek-v4-flash",
+        "test-embedder",
     )
 
-    rows = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 411, "flash-org/repo")
+    rows = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 411, "flash-org/repo", "test-embedder")
 
     assert len(rows) == 1
     assert rows[0]["content_hash"] == "hash-1"
@@ -217,13 +219,13 @@ async def test_list_flash_review_cache_rows_never_crosses_installations(pool):
     from scan_worker.db import insert_flash_review_cache_row, list_recent_flash_review_cache_rows
 
     insert_flash_review_cache_row(
-        TEST_DATABASE_URL, 412, "org-a/repo", "hash-a", [1.0], "diff a", [], "deepseek-v4-flash"
+        TEST_DATABASE_URL, 412, "org-a/repo", "hash-a", [1.0], "diff a", [], "deepseek-v4-flash", "test-embedder"
     )
     insert_flash_review_cache_row(
-        TEST_DATABASE_URL, 413, "org-b/repo", "hash-b", [1.0], "diff b", [], "deepseek-v4-flash"
+        TEST_DATABASE_URL, 413, "org-b/repo", "hash-b", [1.0], "diff b", [], "deepseek-v4-flash", "test-embedder"
     )
 
-    rows = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 412, "org-a/repo")
+    rows = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 412, "org-a/repo", "test-embedder")
 
     assert len(rows) == 1
     assert rows[0]["content_hash"] == "hash-a"
@@ -240,9 +242,9 @@ async def test_record_flash_review_cache_hit_updates_hit_count_and_last_hit_at(p
     )
 
     insert_flash_review_cache_row(
-        TEST_DATABASE_URL, 414, "hit-org/repo", "hash-1", [1.0], "diff", [], "deepseek-v4-flash"
+        TEST_DATABASE_URL, 414, "hit-org/repo", "hash-1", [1.0], "diff", [], "deepseek-v4-flash", "test-embedder"
     )
-    row_id = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 414, "hit-org/repo")[0]["id"]
+    row_id = list_recent_flash_review_cache_rows(TEST_DATABASE_URL, 414, "hit-org/repo", "test-embedder")[0]["id"]
 
     record_flash_review_cache_hit(TEST_DATABASE_URL, row_id)
 


### PR DESCRIPTION
## Summary
Batch 5 finding 8 (`before_launch_fixes.md`). Neither cache table recorded which embedder produced its stored vector, so a wrong-embedder cache hit (mid-rollout during a future embedder switch, or a stale row from before one) would pass `_cosine_similarity`'s only check - vector-length equality - and get compared against a different embedding space's query vectors entirely. The only real protection was deploy-time discipline (remembering to write a purge migration), with zero code-level enforcement.

**Fix:** a `model`/`embedder` column on both cache tables and a `CURRENT_EMBEDDER` constant in `embedding_client.py` (the single place a real embedder switch already has to touch), tagged on every write, filtered at the SQL level on every lookup. Makes the cache self-healing on the next switch without needing a purge migration at all.

## Test plan
- [x] Mocked test per cache module confirming the current embedder is threaded through on read and write
- [x] Real-Postgres integration test per cache module proving a row written under one embedder never matches a lookup under a different one
- [x] Updated all existing direct-call tests in `test_scan_worker_db.py` for the new signature
- [x] Full `github-app` suite (1456 tests) green, including `test_jobs.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)