### PR TITLE
fix: flash review similarity cache retained raw PR diffs indefinitely

### DIFF
--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -1372,6 +1372,25 @@ def record_flash_review_cache_hit(dsn: str, row_id: int) -> None:
         conn.commit()
 
 
+def delete_expired_flash_review_cache(dsn: str, retention_days: int = 30) -> int:
+    """Bounds how long a real PR diff (source code, not derived evidence)
+    sits in this table - previously unbounded, since the only thing
+    limiting a lookup's read was list_recent_flash_review_cache_rows'
+    LIMIT 200, which caps what one query returns, not what the table
+    retains. A near-duplicate-diff hit also gets less useful the older the
+    stored diff is, so this doesn't trade away the cache's actual purpose."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM flash_review_cache "
+                "WHERE created_at < now() - make_interval(days => %s)",
+                (retention_days,),
+            )
+            deleted = cur.rowcount
+        conn.commit()
+    return deleted
+
+
 def email_already_sent(dsn: str, dedupe_key: str) -> bool:
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -60,6 +60,7 @@ from scan_worker.db import (
     delete_docs_symbols_not_in,
     get_docs_symbol_hashes,
     delete_expired_endpoint_health,
+    delete_expired_flash_review_cache,
     delete_expired_sessions,
     delete_expired_webhook_deliveries,
     delete_wiki_subsystems_not_in,
@@ -2543,6 +2544,25 @@ def run_endpoint_health_cleanup_job() -> None:
     deleted = delete_expired_endpoint_health(dsn, ENDPOINT_HEALTH_RETENTION_DAYS)
     logging.getLogger("scan_worker.jobs").info(
         "endpoint health cleanup completed", extra={"deleted_count": deleted}
+    )
+
+
+# flash_review_cache stores a real PR diff (source code, not derived
+# evidence) per row - unlike every other cleanup job here, this one bounds
+# retention of raw customer source code, not just operational metadata. 30
+# days matches ENDPOINT_HEALTH_RETENTION_DAYS's existing convention and
+# comfortably covers the cache's actual purpose (catching a near-duplicate
+# diff reviewed recently) without indefinitely accumulating source code
+# with no further use once that window has passed.
+FLASH_REVIEW_CACHE_RETENTION_DAYS = 30
+
+
+@log_job
+def run_flash_review_cache_cleanup_job() -> None:
+    dsn = get_settings().database_url
+    deleted = delete_expired_flash_review_cache(dsn, FLASH_REVIEW_CACHE_RETENTION_DAYS)
+    logging.getLogger("scan_worker.jobs").info(
+        "flash review cache cleanup completed", extra={"deleted_count": deleted}
     )
 
 

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -27,6 +27,9 @@ WEBHOOK_DELIVERY_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # sweep over direct children only.
 JOB_TEMP_DIR_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 ENDPOINT_HEALTH_CLEANUP_JOB_TIMEOUT_SECONDS = 60
+# Same shape as the endpoint health cleanup: one range DELETE over an
+# index on flash_review_cache.created_at.
+FLASH_REVIEW_CACHE_CLEANUP_JOB_TIMEOUT_SECONDS = 60
 # The sweep itself only calls run_live_docs_full_build_job for repos that
 # list_paid_repos_due_for_docs_catchup already filtered to "genuinely due"
 # (48h+ since last sweep, real activity since then) - most ticks this
@@ -93,6 +96,10 @@ def run_forever(
         scans_queue.enqueue(
             "scan_worker.jobs.run_endpoint_health_cleanup_job",
             job_timeout=ENDPOINT_HEALTH_CLEANUP_JOB_TIMEOUT_SECONDS,
+        )
+        scans_queue.enqueue(
+            "scan_worker.jobs.run_flash_review_cache_cleanup_job",
+            job_timeout=FLASH_REVIEW_CACHE_CLEANUP_JOB_TIMEOUT_SECONDS,
         )
         scans_queue.enqueue(
             "scan_worker.jobs.run_live_docs_catchup_sweep_job",

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -547,6 +547,24 @@ def test_run_endpoint_health_cleanup_job_removes_only_old_rows(monkeypatch):
     assert deleted == [("dsn", ENDPOINT_HEALTH_RETENTION_DAYS)]
 
 
+def test_run_flash_review_cache_cleanup_job_removes_only_old_rows(monkeypatch):
+    from scan_worker.jobs import FLASH_REVIEW_CACHE_RETENTION_DAYS, run_flash_review_cache_cleanup_job
+
+    deleted = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_settings",
+        lambda: type("Settings", (), {"database_url": "dsn"})(),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.delete_expired_flash_review_cache",
+        lambda dsn, retention_days: deleted.append((dsn, retention_days)) or 7,
+    )
+
+    run_flash_review_cache_cleanup_job()
+
+    assert deleted == [("dsn", FLASH_REVIEW_CACHE_RETENTION_DAYS)]
+
+
 def test_clone_failure_posts_failure_comment_and_cleans_up(monkeypatch):
     import scan_worker.jobs as jobs_module
 

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -348,6 +348,37 @@ async def test_delete_expired_endpoint_health_keeps_rows_inside_the_window(pool)
 
 
 @pytest.mark.asyncio
+async def test_delete_expired_flash_review_cache_keeps_rows_inside_the_window(pool):
+    # flash_review_cache stores a real PR diff (source code) per row, unlike
+    # every other table this cleanup pattern already covers - a real
+    # retention limit, not just an operational-metadata one.
+    await _insert_installation(pool, 415, "cache-retention-org")
+    now = datetime.now(timezone.utc)
+    await pool.execute(
+        """
+        INSERT INTO flash_review_cache
+            (installation_id, repo_full_name, content_hash, embedding,
+             diff_text, findings, model_used, created_at)
+        VALUES
+            (415, 'cache-retention-org/repo', 'old-hash', '{0.1}',
+             'old diff', '[]', 'deepseek-v4-flash', $1),
+            (415, 'cache-retention-org/repo', 'recent-hash', '{0.2}',
+             'recent diff', '[]', 'deepseek-v4-flash', $2)
+        """,
+        now - timedelta(days=31),
+        now - timedelta(days=29),
+    )
+
+    from scan_worker.db import delete_expired_flash_review_cache
+
+    deleted = delete_expired_flash_review_cache(TEST_DATABASE_URL, 30)
+
+    assert deleted == 1
+    remaining = await pool.fetch("SELECT content_hash FROM flash_review_cache")
+    assert {row["content_hash"] for row in remaining} == {"recent-hash"}
+
+
+@pytest.mark.asyncio
 async def test_get_latest_evidence_returns_most_recent(pool):
     await _insert_installation(pool, 301, "a")
     # Version-stamped because get_latest_evidence now refuses evidence written

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from scan_worker.scheduler import (
     DOCS_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS,
     ENDPOINT_HEALTH_CLEANUP_JOB_TIMEOUT_SECONDS,
+    FLASH_REVIEW_CACHE_CLEANUP_JOB_TIMEOUT_SECONDS,
     HEALTH_QUEUE_NAME,
     HEALTH_SWEEP_JOB_TIMEOUT_SECONDS,
     HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS,
@@ -58,7 +59,7 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
 
-    assert scans_queue.enqueue.call_count == 27
+    assert scans_queue.enqueue.call_count == 30
     session_cleanup_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
@@ -91,6 +92,10 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_endpoint_health_cleanup_job",)
     ]
+    flash_review_cache_cleanup_calls = [
+        c for c in scans_queue.enqueue.call_args_list
+        if c.args == ("scan_worker.jobs.run_flash_review_cache_cleanup_job",)
+    ]
     ops_monitor_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_ops_monitor_job",)
@@ -103,9 +108,12 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
     assert len(webhook_cleanup_calls) == 3
     assert len(job_temp_dir_cleanup_calls) == 3
     assert len(endpoint_health_cleanup_calls) == 3
+    assert len(flash_review_cache_cleanup_calls) == 3
     assert len(ops_monitor_calls) == 3
     for call in endpoint_health_cleanup_calls:
         assert call.kwargs == {"job_timeout": ENDPOINT_HEALTH_CLEANUP_JOB_TIMEOUT_SECONDS}
+    for call in flash_review_cache_cleanup_calls:
+        assert call.kwargs == {"job_timeout": FLASH_REVIEW_CACHE_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in session_cleanup_calls:
         assert call.kwargs == {"job_timeout": SESSION_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in docs_catchup_calls:

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -64,7 +64,11 @@
           <li>
             <strong>Flash review</strong> (automated pull request review) sends
             <strong>the pull request's diff</strong> - that is your source code, for the changed
-            lines - along with limited surrounding file context.
+            lines - along with limited surrounding file context. For paid installations, that diff
+            is also kept for up to 30 days in a short-lived cache, so a near-identical diff doesn't
+            get re-reviewed from scratch; it is deleted automatically once that window passes, or
+            immediately on uninstall. Free-tier reviews are never cached - nothing about them is
+            retained beyond the request itself.
           </li>
           <li>
             <strong>Managed audits</strong> and <strong>AIRview</strong> send derived evidence, not


### PR DESCRIPTION
## Summary
- `flash_review_cache` stores a real PR diff (source code, not derived evidence) per row, for paid installations' Flash Review similarity cache. Nothing ever expired a row — the only bound was `list_recent_flash_review_cache_rows`' `LIMIT 200`, which caps what one lookup reads, not what the table retains.
- The privacy policy said "what is stored long-term is derived evidence," which this table directly contradicted — no disclosure that raw diffs were cached at all.
- Adds `delete_expired_flash_review_cache` (30-day window, matching `ENDPOINT_HEALTH_RETENTION_DAYS`'s existing convention) and wires a scheduled cleanup job into the same loop every other retention job already runs on.
- Free-tier Flash Review was already never cached (`is_free_tier` gates `cache_lookup`/`cache_write` to `None`), so this only affects paid installations — which is also the only place the raw diff was ever stored.
- Updates the privacy policy to accurately disclose the cache: what it is, that it's paid-only, the 30-day window, and that uninstalling deletes it immediately (already true via `ON DELETE CASCADE`, unchanged here).

## Test plan
- [x] New DB-level test inserts an old and a recent row and asserts only the old one is deleted; verified via `git stash` that it fails (ImportError) without the fix and passes with it.
- [x] New job-level test asserts the cleanup job calls the delete function with the right retention constant.
- [x] Updated scheduler tests for the new enqueue call (call count 27 → 30).
- [x] Full `github-app` suite green (1465 passed, 8 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj