### PR TITLE
feat: bare CLI invocation now surfaces an available update

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -591,6 +591,29 @@ def _check_for_update(installed_version: str, http_client: httpx.Client | None =
     return f"update available: {latest_version}"
 
 
+def _print_update_notice_if_available() -> None:
+    # Only on the bare invocation - previously the only way to learn a
+    # newer version existed was to already know to run 'aletheore status'.
+    # Deliberately not added to scan/audit/query/diff/verify/mcp/etc.: the
+    # privacy policy promises 'aletheore scan' makes no network calls of
+    # its own, and the same reasoning extends to every other command whose
+    # job is local evidence work, not talking to Aletheore's own infra.
+    # Silent on "up to date" or a failed check - this is a friendly nudge,
+    # not something worth cluttering the banner over when there's nothing
+    # to report.
+    import importlib.metadata
+
+    installed_version = importlib.metadata.version("aletheore")
+    version_note = _check_for_update(installed_version)
+    if not version_note.startswith("update available: "):
+        return
+    latest_version = version_note.removeprefix("update available: ")
+    console.print(
+        f"\n[bold yellow]Update available:[/bold yellow] {installed_version} → {latest_version}. "
+        "Run [cyan]pipx upgrade aletheore[/cyan] (or [cyan]pip install --upgrade aletheore[/cyan])."
+    )
+
+
 def _fetch_whoami(
     token: str,
     api_base_url: str = "https://app.aletheore.com",
@@ -1256,6 +1279,7 @@ def _main_callback(
 ) -> None:
     if ctx.invoked_subcommand is None:
         console.print(_banner_panel())
+        _print_update_notice_if_available()
         raise typer.Exit(code=0)
 
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -158,11 +158,36 @@ def test_run_reasoning_phase_does_not_clobber_report_the_agent_wrote_itself(tmp_
 
 
 def test_main_with_no_command_shows_banner_and_exits_cleanly():
-    result = runner.invoke(app, [])
+    with patch("aletheore.cli._check_for_update", return_value="up to date"):
+        result = runner.invoke(app, [])
 
     assert result.exit_code == 0
     assert "ALETHEORE" in result.output
     assert "scan" in result.output and "audit" in result.output
+
+
+def test_main_with_no_command_prints_update_notice_when_available():
+    with patch("aletheore.cli._check_for_update", return_value="update available: 9.9.9"):
+        result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Update available" in result.output
+    assert "9.9.9" in result.output
+    assert "pipx upgrade aletheore" in result.output
+
+
+def test_main_with_no_command_omits_update_notice_when_up_to_date():
+    with patch("aletheore.cli._check_for_update", return_value="up to date"):
+        result = runner.invoke(app, [])
+
+    assert "Update available" not in result.output
+
+
+def test_main_with_no_command_omits_update_notice_when_check_fails():
+    with patch("aletheore.cli._check_for_update", return_value="couldn't check for updates"):
+        result = runner.invoke(app, [])
+
+    assert "Update available" not in result.output
 
 
 def test_version_flag_prints_version_and_exits():


### PR DESCRIPTION
## Summary
- `_check_for_update` already existed and worked, but the only place it ever ran was `aletheore status` — unless a user already knew to run that specific command, there was no indication a newer version existed at all.
- Prints an "Update available: X → Y" notice (with the upgrade command) after the banner on a bare `aletheore` invocation, when one is actually available — silent on "up to date" or a failed check.
- Deliberately **not** added to `scan`/`audit`/`query`/`diff`/`verify`/`mcp`/`mcp-install`/`dashboard`/`watch`: the privacy policy promises `aletheore scan` makes no network calls of its own, and the same reasoning extends to every other command whose job is local evidence work rather than talking to Aletheore's own infrastructure. The bare invocation isn't covered by that promise and is also the most common "first thing run" moment.

## Test plan
- [x] New regression tests cover the notice appearing when an update exists, and staying silent on both "up to date" and a failed check.
- [x] Verified via `git stash` that the "prints when available" test fails without this fix and passes with it.
- [x] Fixed the one pre-existing bare-invocation test that would otherwise now make a real network call during test runs.
- [x] Manually verified against real PyPI end-to-end.
- [x] Full `src` suite green (1322 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj