### PR TITLE
fix: three CLI UX gaps found auditing for more issues like the update-notice one

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -125,12 +125,12 @@ MANUAL_DIR = str(Path(__file__).resolve().parent / "manual")
 console = Console()
 
 # Grouped rather than flat because this list is the CLI's only map of what
-# `query` can actually do - 23 kinds printed as one comma-separated run is
+# `query` can actually do - every kind printed as one comma-separated run is
 # unreadable, and a bare `aletheore query` previously got Typer's "Missing
 # argument 'KIND'" with no kinds named at all. The grouping is also the
 # answer to "why so few commands": every kind below reads the same air.json,
-# which is the point, so they belong under one verb rather than promoted to
-# 23 top-level commands.
+# which is the point, so they belong under one verb rather than each being
+# promoted to its own top-level command.
 QUERY_KIND_GROUPS: dict[str, list[str]] = {
     "Structure": [
         "imports",
@@ -1149,24 +1149,30 @@ def _mcp_install(path: str, targets: list[str]) -> int:
         # long text at the console width, which would corrupt the command if
         # pasted. Same reasoning as _print_result above.
         console.print(f"  claude mcp add aletheore -- {_aletheore_command()} mcp {repo_path}", soft_wrap=True)
-    console.print(
-        "\n[bold]PyCharm / other JetBrains IDEs:[/bold] not auto-configured - there's no single "
-        "stable, documented file format to script against yet. Instead: open Settings | Tools | "
-        "AI Assistant | Model Context Protocol, and use \"Import a Claude MCP config\", pointing "
-        "at the .mcp.json written above."
-    )
+    # Gated on the target that made each note true - these used to print
+    # unconditionally regardless of --target, so e.g. `--target cursor`
+    # claimed "wrote .codex/config.toml" and told the user to point PyCharm
+    # at "the .mcp.json written above" when neither file was ever written.
+    if "claude-code" in selected:
+        console.print(
+            "\n[bold]PyCharm / other JetBrains IDEs:[/bold] not auto-configured - there's no single "
+            "stable, documented file format to script against yet. Instead: open Settings | Tools | "
+            "AI Assistant | Model Context Protocol, and use \"Import a Claude MCP config\", pointing "
+            "at the .mcp.json written above."
+        )
     console.print(
         "[bold]vim / Neovim / Emacs / other terminal editors:[/bold] no native MCP client exists "
         "in any of them - support depends entirely on whichever AI plugin you have installed "
         "(e.g. avante.nvim, codecompanion.nvim). Point that plugin's own MCP config at: "
         f"aletheore mcp {repo_path}"
     )
-    console.print(
-        "[bold]OpenAI Codex CLI:[/bold] wrote .codex/config.toml, but Codex only reads "
-        "project-scoped MCP config for projects it already trusts - if the tools don't show up, "
-        "check Codex's own trust prompt for this directory. Also note: writing this file "
-        "reformats it - any hand-written comments in an existing config.toml are not preserved."
-    )
+    if "codex-cli" in selected:
+        console.print(
+            "[bold]OpenAI Codex CLI:[/bold] wrote .codex/config.toml, but Codex only reads "
+            "project-scoped MCP config for projects it already trusts - if the tools don't show up, "
+            "check Codex's own trust prompt for this directory. Also note: writing this file "
+            "reformats it - any hand-written comments in an existing config.toml are not preserved."
+        )
     return 0
 
 
@@ -1483,12 +1489,15 @@ def index(
 def query(
     # Optional rather than required: a bare `aletheore query` previously hit
     # Typer's "Missing argument 'KIND'", which names no kinds at all, leaving
-    # 23 capabilities discoverable only via --help. Defaulting to None turns
+    # every capability discoverable only via --help. Defaulting to None turns
     # the most likely first invocation into the listing the user was after.
     # Exit code stays 0 - asking what the kinds are is a successful question,
     # not a usage error. An *unknown* kind still exits 1, via _query.
     kind: Optional[str] = typer.Argument(
-        None, help="one of the 23 query kinds; omit to list them by category"
+        # Computed, not a hardcoded count in the help text itself - a
+        # hardcoded "23" here previously drifted to 24 real kinds the
+        # moment one more was added and nobody thought to grep for it.
+        None, help=f"one of the {len(QUERY_KIND_CHOICES)} query kinds; omit to list them by category"
     ),
     target: Optional[str] = typer.Argument(None, help="target for kinds that need one (a file path, branch name, ...)"),
     symbol: Optional[str] = typer.Argument(None, help="symbol name for 'symbol-source'"),
@@ -1630,7 +1639,7 @@ def healthcheck(
 
 @app.command(help="authenticate with GitHub via device flow and save a personal API token")
 def login() -> None:
-    from aletheore.credentials import save_api_token
+    from aletheore.credentials import DEFAULT_CREDENTIALS_PATH, has_api_key, save_api_token
     from aletheore.device_auth import (
         DeviceFlowError,
         mint_cli_token,
@@ -1638,6 +1647,16 @@ def login() -> None:
         request_device_code,
         resolve_installation,
     )
+
+    # A purely local check (no network round-trip, unlike status()'s whoami
+    # call) - just enough to tell the user up front that a token is already
+    # saved, before running the whole device flow. Previously this command
+    # gave no sign it knew a token already existed until after a brand new
+    # one had already been minted and saved.
+    if has_api_key(
+        "ALETHEORE_API_TOKEN", "aletheore-managed-audit", credentials_path=DEFAULT_CREDENTIALS_PATH
+    ):
+        console.print("A token is already saved locally - continuing will replace it.\n")
 
     try:
         code = request_device_code()

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -528,6 +528,29 @@ def test_mcp_install_omits_the_claude_mcp_add_command_when_claude_code_not_targe
     assert "claude mcp add" not in result.stdout
 
 
+def test_mcp_install_does_not_claim_files_it_never_wrote(tmp_path):
+    # Regression: PyCharm/Codex CLI guidance used to print unconditionally
+    # regardless of --target, so `--target cursor` alone still told the user
+    # "wrote .codex/config.toml" and to point PyCharm at "the .mcp.json
+    # written above" - neither file exists after a cursor-only run.
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "cursor"])
+
+    assert result.exit_code == 0
+    assert not (tmp_path / ".codex" / "config.toml").exists()
+    assert not (tmp_path / ".mcp.json").exists()
+    assert "PyCharm" not in result.stdout
+    assert ".codex/config.toml" not in result.stdout
+
+
+def test_mcp_install_codex_only_target_still_prints_its_own_guidance(tmp_path):
+    result = runner.invoke(app, ["mcp-install", str(tmp_path), "--target", "codex-cli"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / ".codex" / "config.toml").exists()
+    assert "wrote .codex/config.toml" in result.stdout
+    assert "PyCharm" not in result.stdout
+
+
 def test_progress_printer_prints_each_distinct_phase_on_its_own_line(capsys):
     report = _make_progress_printer(is_tty=False)
     report("Detecting languages, frameworks, and build tools")
@@ -1277,8 +1300,40 @@ def test_login_saves_token_when_installation_auto_resolved(tmp_path, monkeypatch
 
     assert result.exit_code == 0
     assert "acme" in result.output
+    assert "already saved" not in result.output.lower()
     saved = json.loads(creds_path.read_text())
     assert saved["aletheore-managed-audit"] == "aletheore-tok-xyz"
+
+
+def test_login_acknowledges_an_already_saved_token_before_replacing_it(tmp_path, monkeypatch):
+    # Regression: login() previously gave no sign it knew a token already
+    # existed until after a brand new one had already been minted and
+    # saved - running it while already logged in looked identical to
+    # running it for the first time.
+    import aletheore.credentials as credentials
+
+    creds_path = tmp_path / "creds.json"
+    monkeypatch.setattr(credentials, "DEFAULT_CREDENTIALS_PATH", creds_path)
+    credentials.save_api_token("aletheore-managed-audit", "old-token", creds_path)
+
+    with patch("aletheore.device_auth.request_device_code") as mock_request_code, \
+         patch("aletheore.device_auth.poll_for_access_token") as mock_poll, \
+         patch("aletheore.device_auth.resolve_installation") as mock_resolve, \
+         patch("aletheore.device_auth.mint_cli_token") as mock_mint:
+        mock_request_code.return_value = MagicMock(
+            verification_uri="https://github.com/login/device",
+            user_code="ABCD-1234",
+        )
+        mock_poll.return_value = "gho_faketoken"
+        mock_resolve.return_value = {"installation_id": 100, "account_login": "acme"}
+        mock_mint.return_value = "aletheore-tok-new"
+
+        result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 0
+    assert "already saved" in result.output.lower()
+    saved = json.loads(creds_path.read_text())
+    assert saved["aletheore-managed-audit"] == "aletheore-tok-new"
 
 
 def test_login_prompts_when_installation_ambiguous(tmp_path, monkeypatch):
@@ -1980,6 +2035,17 @@ def test_query_kind_groups_cover_every_dispatchable_kind():
     """The grouped listing is the only map of what `query` does, so a kind
     added to QUERY_FUNCTIONS without a group would vanish from it."""
     assert set(QUERY_FUNCTIONS) <= set(QUERY_KIND_CHOICES)
+
+
+def test_query_help_kind_count_matches_the_real_number_of_kinds():
+    # Regression: --help's kind count used to be a hardcoded "23" that
+    # drifted the moment a 24th kind was added and nobody thought to grep
+    # for the stale literal - it's computed from QUERY_KIND_CHOICES now, so
+    # this can't go stale again, but pins the count is still self-consistent.
+    result = runner.invoke(app, ["query", "--help"])
+
+    assert result.exit_code == 0
+    assert f"one of the {len(QUERY_KIND_CHOICES)} query kinds" in result.output
 
 
 def test_unknown_query_kind_suggests_the_closest_match():


### PR DESCRIPTION
## Summary
Three independently-verified gaps, found auditing the CLI for more of the same class of bug as the recent update-notice fix (#345): a mechanism already exists but users have no way to discover it, or its behavior silently doesn't match what it claims.

1. **`mcp-install` claimed to have written files it never touched.** `_mcp_install` printed its PyCharm and "OpenAI Codex CLI: wrote .codex/config.toml" guidance unconditionally, regardless of `--target`. `mcp-install . --target cursor` told the user a `.codex/config.toml` was written and to point PyCharm at "the .mcp.json written above" — neither file was ever created. Gated both notes on the target that actually makes them true, matching how the Claude Code note (added in #341) was already correctly gated.
2. **`aletheore login` never acknowledged an existing saved token.** Running it while already logged in looked identical to running it for the first time — no check against current credential state anywhere in the function, unlike `status()` right below it. Added a purely local `has_api_key` check (no extra network round-trip) that prints a notice before starting the device flow.
3. **`query --help` said "one of the 23 query kinds" — there are 24.** `QUERY_KIND_CHOICES` grew since that count was hardcoded into the help string (and two comments). The bare `aletheore query` panel already computed its count dynamically; the `--help` string now does too, so it can't go stale again.

## Test plan
- [x] New regression tests for all three, verified via `git stash` that each fails without its fix and passes with it.
- [x] Manually verified all three end-to-end against real CLI runs.
- [x] Full `src` suite green (1326 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj