### PR TITLE
fix: search index detects an embedder swap even when dimensions match

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -959,8 +959,16 @@ def _embed_in_batches(
     repo_id: str | None = None,
     allow_hosted: bool = True,
     on_progress: Callable[[int, int], None] | None = None,
-) -> list[list[float]]:
+) -> tuple[list[list[float]], str]:
     """Embed everything, preferring Aletheore's endpoint when entitled.
+
+    Returns (vectors, embedder). embedder labels which provider actually
+    produced them - "hosted:<model>" or "local:<model>" - so a caller can
+    stamp it into the index and later detect a provider swap even when the
+    old and new dimensions happen to match (see IndexDimensionMismatchError:
+    Ollama's nomic-embed-text and the hosted jina-embeddings-v2-base-code
+    both embed to 768 dimensions from unrelated vector spaces, so dimension
+    alone cannot tell them apart).
 
     Hosted first, then local, and never the reverse: someone paying for
     hosted embeddings should not silently have their code sent to their own
@@ -1001,6 +1009,11 @@ def _embed_in_batches(
             file=sys.stderr,
         )
     vectors: list[list[float]] = []
+    # Default for the zero-batch case (empty texts): no embedding call ever
+    # runs, so this label is never actually observed against a real vector -
+    # a caller with reusable vectors to compare against always has at least
+    # one chunk to probe first (see build_index).
+    embedder = f"local:{DEFAULT_EMBEDDING_MODEL}"
     total = len(texts)
 
     # Recomputed when the provider changes: the hosted spans are character-
@@ -1017,6 +1030,7 @@ def _embed_in_batches(
         if use_hosted:
             try:
                 vectors.extend(embed_texts_hosted(batch, token, repo_id=repo_id))
+                embedder = f"hosted:{HOSTED_EMBEDDING_MODEL}"
                 if on_progress is not None:
                     on_progress(len(vectors), total)
                 continue
@@ -1040,10 +1054,11 @@ def _embed_in_batches(
                 spans = [(s, min(s + batch_size, len(texts))) for s in range(end, len(texts), batch_size)]
                 span_index = 0
         vectors.extend(embed_texts(batch))
+        embedder = f"local:{DEFAULT_EMBEDDING_MODEL}"
         if on_progress is not None:
             on_progress(len(vectors), total)
 
-    return vectors
+    return vectors, embedder
 
 
 def _index_path(repo_path: Path) -> Path:
@@ -1062,24 +1077,27 @@ def _chunk_hash(text: str) -> str:
     return hashlib.blake2b(text.encode("utf-8"), digest_size=16).hexdigest()
 
 
-def _reusable_vectors(index_path: Path) -> dict[str, list[float]]:
-    """chunk_hash -> vector, from the existing index if there is one.
+def _reusable_vectors(index_path: Path) -> tuple[dict[str, list[float]], str | None]:
+    """chunk_hash -> vector, plus the embedder that produced them, from the
+    existing index if there is one.
+
+    The embedder is None for an index written before that column existed -
+    the caller cannot verify it against anything, so it re-embeds rather
+    than guessing, the same conservative default as an unreadable index.
 
     Best-effort: any failure to read the previous index (missing, corrupt,
     or written before chunk_hash existed) just means everything is embedded
     fresh, which is the old behavior rather than an error.
     """
     if not index_path.exists():
-        return {}
+        return {}, None
     try:
-        table = lancedb.connect(str(index_path)).open_table(TABLE_NAME)
-        return {
-            row["chunk_hash"]: row["vector"]
-            for row in table.to_arrow().to_pylist()
-            if row.get("chunk_hash")
-        }
+        rows = lancedb.connect(str(index_path)).open_table(TABLE_NAME).to_arrow().to_pylist()
+        vectors = {row["chunk_hash"]: row["vector"] for row in rows if row.get("chunk_hash")}
+        embedder = next((row["embedder"] for row in rows if row.get("embedder")), None)
+        return vectors, embedder
     except Exception:  # noqa: BLE001
-        return {}
+        return {}, None
 
 
 def _embed_stale_by_hash(
@@ -1087,16 +1105,16 @@ def _embed_stale_by_hash(
     repo_id: str | None = None,
     allow_hosted: bool = True,
     on_progress: Callable[[int, int], None] | None = None,
-) -> dict[str, list[float]]:
+) -> tuple[dict[str, list[float]], str]:
     stale_by_hash = {chunk["chunk_hash"]: chunk["text"] for chunk in stale}
     stale_hashes = list(stale_by_hash)
-    fresh_vectors = _embed_in_batches(
+    fresh_vectors, embedder = _embed_in_batches(
         [stale_by_hash[chunk_hash] for chunk_hash in stale_hashes],
         repo_id=repo_id,
         allow_hosted=allow_hosted,
         on_progress=on_progress,
     )
-    return dict(zip(stale_hashes, fresh_vectors))
+    return dict(zip(stale_hashes, fresh_vectors)), embedder
 
 
 def build_index(
@@ -1123,10 +1141,12 @@ def build_index(
     # free, where an upsert would leave a deleted function searchable
     # forever.
     index_path = _index_path(repo_path)
-    reusable = _reusable_vectors(index_path)
+    reusable, reusable_embedder = _reusable_vectors(index_path)
     stale = [chunk for chunk in chunks if chunk["chunk_hash"] not in reusable]
     repo = _repo_id(repo_path)
-    fresh = _embed_stale_by_hash(stale, repo_id=repo, allow_hosted=allow_hosted, on_progress=on_progress)
+    fresh, current_embedder = _embed_stale_by_hash(
+        stale, repo_id=repo, allow_hosted=allow_hosted, on_progress=on_progress
+    )
     fresh_vectors = list(fresh.values())
 
     # Vectors from two different embedding models cannot share an index -
@@ -1140,11 +1160,13 @@ def build_index(
     # not comparable to the new ones, so keeping them would return nonsense
     # rankings even if the write succeeded.
     #
-    # Keyed on dimension rather than model name because the dimension is
-    # observable from what embed_texts actually returned, and embed_texts
-    # chooses its provider internally. Two distinct models with matching
-    # dimensions would not be caught; that costs stale-but-valid vectors,
-    # not a crash or a schema error.
+    # Checked on both dimension AND embedder identity. Dimension alone is
+    # not sufficient: Ollama's nomic-embed-text and the hosted
+    # jina-embeddings-v2-base-code both produce 768-dim vectors from
+    # unrelated vector spaces, so a repo indexed locally and then rebuilt
+    # against the hosted provider (or the reverse) passed the old
+    # dimension-only check and silently kept comparing incompatible
+    # vectors - reproduced directly, see this file's git history.
     #
     # This has to run even when stale is empty. If every chunk's hash
     # already matches the previous index, that's the "rebuild with no
@@ -1152,25 +1174,33 @@ def build_index(
     # 0.2s - but the provider can still have changed underneath it with zero
     # code changes in between (this is precisely "index with Ollama, lose
     # Ollama": nothing edited, only the available provider). With
-    # fresh_vectors empty there's nothing to compare reusable's dimension
-    # against, so a one-item probe embed establishes it. Reproduced without
-    # this: the table silently kept 768-dim rows, and the next search()
-    # crashed on the mismatch between the table and the freshly-embedded
-    # 1536-dim query vector instead of degrading.
+    # fresh_vectors empty there's nothing to compare reusable's dimension or
+    # embedder against, so a one-item probe embed establishes both.
+    # Reproduced without this: the table silently kept 768-dim rows, and the
+    # next search() crashed on the mismatch between the table and the
+    # freshly-embedded 1536-dim query vector instead of degrading.
     if reusable:
-        current_dimension = (
-            len(fresh_vectors[0])
-            if fresh_vectors
-            else len(_embed_in_batches([chunks[0]["text"]], repo_id=repo, allow_hosted=allow_hosted)[0])
-        )
+        if fresh_vectors:
+            current_dimension = len(fresh_vectors[0])
+        else:
+            probe_vectors, current_embedder = _embed_in_batches(
+                [chunks[0]["text"]], repo_id=repo, allow_hosted=allow_hosted
+            )
+            current_dimension = len(probe_vectors[0])
         reused_dimensions = {len(vector) for vector in reusable.values()}
-        if reused_dimensions != {current_dimension}:
+        if reused_dimensions != {current_dimension} or reusable_embedder != current_embedder:
             reusable = {}
             stale = chunks
-            fresh = _embed_stale_by_hash(stale, repo_id=repo, allow_hosted=allow_hosted, on_progress=on_progress)
+            fresh, current_embedder = _embed_stale_by_hash(
+                stale, repo_id=repo, allow_hosted=allow_hosted, on_progress=on_progress
+            )
 
     rows = [
-        {**chunk, "vector": reusable.get(chunk["chunk_hash"]) or fresh[chunk["chunk_hash"]]}
+        {
+            **chunk,
+            "vector": reusable.get(chunk["chunk_hash"]) or fresh[chunk["chunk_hash"]],
+            "embedder": current_embedder,
+        }
         for chunk in chunks
     ]
 
@@ -1382,6 +1412,25 @@ def _detect_query_language(query_text: str) -> str | None:
     return found.pop()
 
 
+def _table_embedder(table) -> str | None:
+    """The embedder identity stamped into this index's rows, or None.
+
+    None both for an index written before the "embedder" column existed and
+    for anything that fails to answer this cheaply (a missing column raises
+    inside LanceDB itself) - either way the caller falls back to the
+    dimension-only check, exactly as before this check existed. Read via a
+    single-row select rather than to_arrow() over the whole table: this
+    runs on every query, and materializing the full index here would undo
+    the in-process speed this path exists for.
+    """
+    try:
+        rows = table.search().select(["embedder"]).limit(1).to_list()
+        value = rows[0].get("embedder") if rows else None
+        return value if isinstance(value, str) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def search_index(
     repo_path: Path,
     query_text: str,
@@ -1405,9 +1454,10 @@ def search_index(
     # then returned nonsense ranked against the wrong vector space, with no
     # error at all. Matching the same provider choice at query time removes
     # the coincidence the guard was accidentally relying on.
-    query_vector = _embed_in_batches(
+    query_vectors, query_embedder = _embed_in_batches(
         [query_text], repo_id=_repo_id(repo_path), allow_hosted=allow_hosted
-    )[0]
+    )
+    query_vector = query_vectors[0]
 
     # The index and the query must come from the same embedding model - see
     # build_index's dimension-drift handling for the mechanism that keeps
@@ -1430,6 +1480,25 @@ def search_index(
             "embedding provider available now differs from the one used to build this "
             f"index. Re-run 'aletheore index {repo_path}' to rebuild it with the "
             "provider currently available"
+        )
+
+    # The dimension check above cannot catch two distinct models that
+    # happen to produce the same-sized vectors - exactly what let a
+    # hosted-jina-built index get silently searched with a local-nomic
+    # query vector (both 768-dim) and return coherent-looking but wrong
+    # results with no error at all. None on either side means "can't
+    # verify" (an index built before this column existed, or a table this
+    # check otherwise can't read) and falls through to trusting the
+    # dimension check alone, unchanged from before this existed.
+    table_embedder = _table_embedder(table)
+    if table_embedder is not None and table_embedder != query_embedder:
+        raise IndexDimensionMismatchError(
+            f"the index at {_index_path(repo_path)} was built with '{table_embedder}' "
+            f"embeddings but this query embedded with '{query_embedder}' - both happen "
+            f"to produce {table_dimension}-dimension vectors, so without this check the "
+            "search would silently rank against an unrelated vector space instead of "
+            f"failing loudly. Re-run 'aletheore index {repo_path}' to rebuild it with "
+            "the provider currently available"
         )
 
     # Over-fetch, then thin by file: the chunks displaced by the per-file cap

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -478,7 +478,7 @@ def test_embed_in_batches_splits_large_inputs():
         return [[0.0]] * len(texts)
 
     with patch("aletheore.search_index.embed_texts", side_effect=fake_embed):
-        vectors = _embed_in_batches([f"t{i}" for i in range(450)], batch_size=200)
+        vectors, _ = _embed_in_batches([f"t{i}" for i in range(450)], batch_size=200)
 
     assert calls == [200, 200, 50]
     assert len(vectors) == 450
@@ -510,7 +510,7 @@ def test_embed_in_batches_on_progress_defaults_to_silent():
         return [[0.0]] * len(texts)
 
     with patch("aletheore.search_index.embed_texts", side_effect=fake_embed):
-        vectors = _embed_in_batches([f"t{i}" for i in range(10)], batch_size=200)
+        vectors, _ = _embed_in_batches([f"t{i}" for i in range(10)], batch_size=200)
 
     assert len(vectors) == 10
 
@@ -1235,7 +1235,7 @@ def test_build_index_drops_chunks_that_no_longer_exist(tmp_path):
 def test_reusable_vectors_survives_an_unreadable_previous_index(tmp_path):
     """An index missing, corrupt, or written before chunk_hash existed must
     degrade to embedding everything - the old behavior - not raise."""
-    assert _reusable_vectors(tmp_path / "nope.lancedb") == {}
+    assert _reusable_vectors(tmp_path / "nope.lancedb") == ({}, None)
 
 
 def test_switching_embedding_provider_rebuilds_instead_of_crashing(tmp_path):
@@ -1303,6 +1303,85 @@ def test_switching_embedding_provider_rebuilds_even_when_nothing_else_changed(tm
     assert calls, "a probe embed must run to detect the provider change"
     rows = open_index(tmp_path).to_arrow().to_pylist()
     assert {len(row["vector"]) for row in rows} == {1536}
+
+
+def test_build_index_does_not_reuse_vectors_from_a_different_embedder_even_when_dimensions_match(tmp_path):
+    """Matching dimension is not proof of a matching vector space: Ollama's
+    nomic-embed-text and the hosted jina-embeddings-v2-base-code both embed
+    to 768 dimensions from unrelated vector spaces. The existing
+    dimension-only reuse guard would happily reuse the local vectors below
+    under a hosted rebuild, since both are 768-dim - this proves the
+    embedder identity itself blocks the reuse, not just the dimension."""
+    (tmp_path / "a.py").write_text("def f():\n    return 1\n")
+    evidence = _evidence_with_module("a.py", [{"name": "f", "start_line": 1, "end_line": 2}])
+
+    with patch("aletheore.search_index.embed_texts", side_effect=lambda t: [[0.1] * 768] * len(t)):
+        build_index(tmp_path, evidence)
+
+    rows_before = open_index(tmp_path).to_arrow().to_pylist()
+    assert rows_before[0]["vector"] == pytest.approx([0.1] * 768)
+
+    http = MagicMock()
+    http.post.return_value = _hosted_response(200, {"vectors": [[0.9] * 768]})
+    with patch("aletheore.search_index.get_api_key", return_value="tok"), \
+         patch("aletheore.search_index.httpx.Client", return_value=http):
+        # Same content, same chunk_hash, same dimension - only the provider
+        # available underneath it changed.
+        build_index(tmp_path, evidence)
+
+    rows_after = open_index(tmp_path).to_arrow().to_pylist()
+    assert rows_after[0]["vector"] == pytest.approx([0.9] * 768)
+    assert rows_after[0]["embedder"] == "hosted:jina-embeddings-v2-base-code"
+
+
+def test_reusable_vectors_returns_the_embedder_identity_stamped_in_the_index(tmp_path):
+    from aletheore.search_index import _index_path
+
+    (tmp_path / "a.py").write_text("def f():\n    return 1\n")
+    evidence = _evidence_with_module("a.py", [{"name": "f", "start_line": 1, "end_line": 2}])
+    with patch("aletheore.search_index.embed_texts", side_effect=lambda t: [[0.1] * 768] * len(t)):
+        build_index(tmp_path, evidence)
+
+    _, embedder = _reusable_vectors(_index_path(tmp_path))
+    assert embedder == "local:nomic-embed-text"
+
+
+def test_search_index_raises_when_query_embedder_differs_from_the_indexs_despite_matching_dimension(tmp_path):
+    """A hosted-built index (jina, 768-dim) queried by the local embedder
+    (nomic, also 768-dim) must fail loudly, not silently rank against an
+    unrelated vector space - the dimension-only check above cannot catch
+    this because the two providers happen to share a dimension."""
+    from aletheore.search_index import IndexDimensionMismatchError, TABLE_NAME, _index_path
+    import lancedb
+
+    repo = tmp_path
+    index_path = _index_path(repo)
+    index_path.parent.mkdir(parents=True)
+    db = lancedb.connect(str(index_path))
+    db.create_table(
+        TABLE_NAME,
+        data=[
+            {
+                "module_path": "a.py",
+                "symbol_name": "foo",
+                "start_line": 1,
+                "end_line": 2,
+                "language": "python",
+                "imports": [],
+                "text": "def foo(): pass",
+                "chunk_hash": "abc",
+                "vector": [0.1] * 768,
+                "embedder": "hosted:jina-embeddings-v2-base-code",
+            }
+        ],
+    )
+
+    with patch("aletheore.search_index.get_api_key", return_value=None), \
+         patch("aletheore.search_index.embed_texts", return_value=[[0.0] * 768]):
+        with pytest.raises(
+            IndexDimensionMismatchError, match="hosted:jina.*local:nomic|local:nomic.*hosted:jina"
+        ):
+            search_index(repo, "where is foo")
 
 
 def _hosted_response(status: int, payload: dict | None = None):
@@ -1444,7 +1523,7 @@ def test_hosted_embeddings_are_preferred_when_a_token_exists():
     with patch("aletheore.search_index.get_api_key", return_value="tok"), \
          patch("aletheore.search_index.httpx.Client", return_value=http), \
          patch("aletheore.search_index.embed_texts") as local:
-        vectors = _embed_in_batches(["chunk"])
+        vectors, _ = _embed_in_batches(["chunk"])
 
     assert len(vectors[0]) == 1536
     local.assert_not_called()
@@ -1460,7 +1539,7 @@ def test_a_402_falls_back_to_local_and_says_why(capsys):
     with patch("aletheore.search_index.get_api_key", return_value="tok"), \
          patch("aletheore.search_index.httpx.Client", return_value=http), \
          patch("aletheore.search_index.embed_texts", side_effect=lambda t: [[0.0] * 768] * len(t)):
-        vectors = _embed_in_batches(["chunk"])
+        vectors, _ = _embed_in_batches(["chunk"])
 
     # One vector for one input text - not two. The local fallback for the
     # batch that just failed on hosted used to also get re-queued as
@@ -1494,7 +1573,7 @@ def test_hosted_failure_on_the_first_of_several_batches_does_not_duplicate_it():
     with patch("aletheore.search_index.get_api_key", return_value="tok"), \
          patch("aletheore.search_index.httpx.Client", return_value=http), \
          patch("aletheore.search_index.embed_texts", side_effect=fake_local_embed):
-        vectors = _embed_in_batches(texts, batch_size=5)
+        vectors, _ = _embed_in_batches(texts, batch_size=5)
 
     assert len(vectors) == 10
     # Every input text embedded exactly once, not twice - flattening
@@ -1538,7 +1617,7 @@ def test_allow_hosted_false_skips_hosted_call_even_with_a_token(capsys):
     with patch("aletheore.search_index.get_api_key", return_value="tok"), \
          patch("aletheore.search_index.httpx.Client", return_value=http), \
          patch("aletheore.search_index.embed_texts", side_effect=lambda t: [[0.0] * 768] * len(t)):
-        vectors = _embed_in_batches(["chunk"], allow_hosted=False)
+        vectors, _ = _embed_in_batches(["chunk"], allow_hosted=False)
 
     http.post.assert_not_called()
     assert len(vectors[0]) == 768
@@ -1550,7 +1629,7 @@ def test_allow_hosted_true_is_the_default_and_preserves_existing_behavior():
     http.post.return_value = _hosted_response(200, {"vectors": [[0.1] * 1536]})
     with patch("aletheore.search_index.get_api_key", return_value="tok"), \
          patch("aletheore.search_index.httpx.Client", return_value=http):
-        vectors = _embed_in_batches(["chunk"])  # no allow_hosted kwarg at all
+        vectors, _ = _embed_in_batches(["chunk"])  # no allow_hosted kwarg at all
 
     http.post.assert_called_once()
     assert len(vectors[0]) == 1536


### PR DESCRIPTION
## Summary
- `search_index()` already caught a *dimension* mismatch between a query vector and an index, but Ollama's `nomic-embed-text` and Aletheore's hosted `jina-embeddings-v2-base-code` both produce 768-dim vectors from unrelated vector spaces - so a repo indexed under one and searched (or rebuilt) under the other passed the dimension guard silently and returned coherent-looking but wrong rankings, with no error.
- Found live during this session's retrieval-latency benchmark re-verification: a hosted-built index queried with a local vector (both 768-dim) returned 25% top-1 accuracy instead of ~72-75%, with zero error signal.
- `_embed_in_batches`/`_embed_stale_by_hash`/`_reusable_vectors` now also report which embedder actually produced a set of vectors, stamped into every index row. `build_index`'s reuse guard and `search_index`'s mismatch check now compare embedder identity in addition to dimension.
- An index built before this column existed falls through safely to the old dimension-only behavior (no false positives, no crash) - self-healing on the next rebuild, same pattern as PR #343's embedding-cache identity fix.

## Test plan
- [x] New TDD tests (`test_build_index_does_not_reuse_vectors_from_a_different_embedder_even_when_dimensions_match`, `test_search_index_raises_when_query_embedder_differs_from_the_indexs_despite_matching_dimension`, `test_reusable_vectors_returns_the_embedder_identity_stamped_in_the_index`) confirmed failing against the unfixed code, passing after
- [x] Full `src/` suite green: 1329 passed
- [x] Real end-to-end smoke test against local Ollama + a real Aletheore hosted build: embedder column stamped correctly, self-consistent search still succeeds normally (no false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)