### PR TITLE
fix: audit's sponsor panel claimed nothing left the machine after sending evidence out

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -221,9 +221,13 @@ def _query_kinds_panel() -> Panel:
 
 
 def _sponsor_panel() -> Panel:
+    # Shown only after 'audit' (see the sole call site below), which always
+    # hands evidence to some external agent - an API Aletheore calls
+    # directly, or a CLI tool the user already authenticated. A "nothing
+    # leaves this machine" claim printed right after that would contradict
+    # the consent prompt (or the CLI-adapter invocation) from the same run.
     body = Text()
-    body.append("Aletheore is 100% open-source, local, and free.\n", style="bold")
-    body.append("No accounts, no tracking — nothing leaves this machine.\n\n")
+    body.append("Aletheore is 100% open-source and free.\n\n", style="bold")
     body.append("If it saved you time, consider supporting development:\n")
     body.append("https://github.com/sponsors/ArihantK15", style="cyan underline")
     return Panel(body, border_style="magenta", width=78)

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -731,6 +731,23 @@ def test_audit_shows_consent_prompt_for_api_based_adapter_and_proceeds_on_yes(tm
     fake_adapter.invoke.assert_called_once()
 
 
+def test_audit_sponsor_panel_does_not_claim_nothing_left_the_machine(tmp_path):
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+
+    fake_adapter = MagicMock()
+    fake_adapter.name = "openai"
+    fake_adapter.requires_consent = True
+    fake_adapter.invoke.return_value = "## Summary\n\nreport text"
+
+    with patch("aletheore.cli.select_adapter", return_value=fake_adapter):
+        with patch("builtins.input", return_value="y"):
+            result = runner.invoke(app, ["audit", str(repo)])
+
+    assert result.exit_code == 0
+    assert "nothing leaves this machine" not in result.output.lower()
+
+
 def test_audit_cancels_cleanly_when_consent_is_declined(tmp_path):
     repo = tmp_path
     (repo / "main.py").write_text("x = 1\n")


### PR DESCRIPTION
## Summary
- \`_sponsor_panel()\` printed "No accounts, no tracking — nothing leaves this machine" unconditionally after every \`audit\` run.
- Every \`audit\` adapter path sends evidence to some external agent — either a third-party API Aletheore calls directly (with the explicit consent prompt shown right before), or an already-authenticated local CLI tool the user selected.
- Found while auditing the CLI/MCP surface for gaps in the same style as PR #346 (a printed claim that doesn't match what the code actually did).

## Test plan
- [x] `test_audit_sponsor_panel_does_not_claim_nothing_left_the_machine` added, verified fail-without/pass-with via `git stash`
- [x] Full `src/tests/test_cli.py` suite passes (154 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj