### PR TITLE
fix: healthcheck exits 0 and prints no summary even when every endpoint is unreachable

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -979,14 +979,24 @@ def _healthcheck(repo_path: str, base_url: str) -> int:
         return 1
     save_healthcheck(result, repo)
 
+    checked = 0
+    reachable = 0
     for entry in result["results"]:
         method = entry.get("method") or "?"
         if entry.get("skipped"):
             print(f"{method:6} {entry['path']:40} SKIPPED ({entry['reason']})")
-        else:
-            status = entry["status_code"] if entry["reachable"] else "UNREACHABLE"
-            note = f" ({entry['note']})" if entry.get("note") else ""
-            print(f"{method:6} {entry['path']:40} {status} {entry['latency_ms']}ms{note}")
+            continue
+        checked += 1
+        if entry["reachable"]:
+            reachable += 1
+        status = entry["status_code"] if entry["reachable"] else "UNREACHABLE"
+        note = f" ({entry['note']})" if entry.get("note") else ""
+        print(f"{method:6} {entry['path']:40} {status} {entry['latency_ms']}ms{note}")
+
+    if checked:
+        print(f"\n{reachable} of {checked} endpoint(s) reachable.")
+        if reachable == 0:
+            return 1
 
     return 0
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import time
 import tomllib
+import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1253,6 +1254,23 @@ def test_main_healthcheck_reports_results(tmp_path):
     assert result.exit_code == 0
     assert "/health" in result.output
     assert "200" in result.output
+
+
+def test_main_healthcheck_fails_when_every_endpoint_is_unreachable(tmp_path):
+    repo = tmp_path
+    (repo / "app.py").write_text('@app.route("/health")\ndef health():\n    pass\n')
+    runner.invoke(app, ["scan", str(repo)])
+
+    with patch(
+        "aletheore.healthcheck._NO_REDIRECT_OPENER.open",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        result = runner.invoke(
+            app, ["healthcheck", str(repo), "--base-url", "http://localhost:5000"]
+        )
+
+    assert result.exit_code == 1
+    assert "0 of 1 endpoint(s) reachable" in result.output
 
 
 def test_main_healthcheck_without_evidence_errors_clearly(tmp_path):


### PR DESCRIPTION
## Summary
- \`aletheore healthcheck\` always returned exit code 0, and printed no aggregate count — every endpoint could be UNREACHABLE and the process still exited clean.
- Found while auditing endpoint monitoring for gaps in the same style as PR #346.
- Now prints a "N of M endpoint(s) reachable" summary line, and exits 1 when every checked (non-skipped) endpoint is unreachable.

## Test plan
- [x] `test_main_healthcheck_fails_when_every_endpoint_is_unreachable` added, verified fail-without/pass-with via `git stash`
- [x] Full `src/tests/test_cli.py` suite passes (154 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj