### PR TITLE
fix: AIRview banner still claimed incremental updates use a fast model

### DIFF
--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1587,7 +1587,7 @@ async function loadWiki() {{
       ' Showing the last successful build below - it may be stale.</div>';
   }}
   let html = staleBanner +
-    '<div class="wiki-banner"><div class="wiki-banner-text"><b>Built once by a frontier model, kept current by a fast one.</b> Every diagram edge below is a real import in this repo, never inferred.</div></div>' +
+    '<div class="wiki-banner"><div class="wiki-banner-text"><b>Built and kept current by a frontier model.</b> Every diagram edge below is a real import in this repo, never inferred.</div></div>' +
     '<div class="diagram-wrap"><div class="mermaid" id="overview-diagram"></div></div>' +
     '<div class="subsystem-grid" id="subsystem-grid"></div>';
   body.innerHTML = html;

--- a/github-app/tests/test_frontend_js_syntax.py
+++ b/github-app/tests/test_frontend_js_syntax.py
@@ -73,3 +73,13 @@ def test_wiki_markdown_renders_untrusted_html_inert():
     )
     result = subprocess.run(["node", "-e", harness], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
+
+
+def test_wiki_banner_does_not_claim_a_separate_fast_model_for_incremental_updates():
+    """model_tiers.resolve_model() has routed both the full AIRview build and
+    every incremental update to the same model (Luna, whenever OPENAI_API_KEY
+    is configured) since the 2026-08-09 routing change - see
+    scan_worker/model_tiers.py's module docstring. The banner used to promise
+    a cheap/fast model for updates, which stopped being true that day."""
+    assert "kept current by a fast one" not in frontend.WIKI_HTML
+    assert "frontier model" in frontend.WIKI_HTML


### PR DESCRIPTION
## Summary
- The AIRview dashboard banner said "Built once by a frontier model, kept current by a fast one" — but `resolve_model()` has routed both the full build and every incremental update to the same model (Luna) since the 2026-08-09 routing change (see `model_tiers.py`'s module docstring).
- Paying customers were shown a stale, false description of what actually runs their updates.
- Found while auditing AIRview for gaps in the same style as PR #346. Reworded to not name a specific model, so it can't drift the same way again if routing changes further.

## Test plan
- [x] `test_wiki_banner_does_not_claim_a_separate_fast_model_for_incremental_updates` added, verified fail-without/pass-with via `git stash`
- [x] Full `github-app/tests/test_frontend_js_syntax.py` suite passes (11 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj