### PR TITLE
feat: AIRview writing surface now uses deepseek-v4-flash instead of Luna

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -19,7 +19,6 @@ from rq import Queue, get_current_job
 from rq.registry import FailedJobRegistry
 
 from app_server.audit_signing import content_hash, public_key_hex_from_private, sign_report
-from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from aletheore.code_graph_diff import diff_endpoints, diff_modules
 from aletheore.dead_code import is_test_file
@@ -151,6 +150,7 @@ from scan_worker.model_tiers import (
     model_for_plan,
     resolve_model,
     writing_adapter_for,
+    writing_adapter_for_airview,
     writing_adapter_for_plan,
 )
 from scan_worker.packet_cache import lookup_cached_result, store_result
@@ -3127,24 +3127,29 @@ def _live_wiki_naming_adapter(
     on_usage: Callable[[int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
-    return writing_adapter_for(live_wiki.FLASH_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
+    return writing_adapter_for_airview(live_wiki.FLASH_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
 
 
 def _live_wiki_full_build_writing_adapter(
-    plan: str,
     on_usage: Callable[[int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
-) -> OpenAICompatibleAdapter | AnthropicAdapter:
-    # The one-time full build uses the same model as managed audits (see
-    # model_tiers.py) - Luna (falling back to DeepSeek Pro), for every plan.
-    return writing_adapter_for_plan(plan, on_usage=on_usage, before_llm_call=before_llm_call)
+) -> OpenAICompatibleAdapter:
+    # AIRview's own comprehension benchmark (aletheore-benchmarks,
+    # AIRVIEW_GAP.md, re-measured 2026-08-22) found deepseek-v4-flash tied
+    # RepoWise here while gpt-5.6-luna lost decisively, same corpus, same
+    # day - see writing_adapter_for_airview's docstring for the numbers.
+    # No longer plan-dependent: every plan gets deepseek-v4-flash, not
+    # Luna-falling-back-to-DeepSeek-Pro as before.
+    return writing_adapter_for_airview(
+        live_wiki.FLASH_MODEL, on_usage=on_usage, before_llm_call=before_llm_call
+    )
 
 
 def _live_wiki_update_writing_adapter(
     on_usage: Callable[[int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
-    return writing_adapter_for(live_wiki.UPDATE_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
+    return writing_adapter_for_airview(live_wiki.UPDATE_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
 
 
 def _real_line_count_fetcher(
@@ -3302,7 +3307,8 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
 
     installation = get_installation_row(dsn, installation_id)
     plan = installation["plan"] if installation is not None else "free"
-    model_used = model_for_plan(plan)
+    # No longer plan-dependent - see _live_wiki_full_build_writing_adapter.
+    model_used = live_wiki.FLASH_MODEL
 
     # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring;
     # real enforcement is its can_start_next_call() reserving atomically per
@@ -3332,7 +3338,7 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
             on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
         )
         writing_adapter = _live_wiki_full_build_writing_adapter(
-            plan, on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
+            on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
         )
         fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, None)
         records = live_wiki.generate_subsystems(
@@ -3458,7 +3464,8 @@ def _maybe_update_live_wiki(
         )
         return
 
-    update_model = resolve_model(live_wiki.UPDATE_MODEL)
+    # No longer dynamic - see _live_wiki_update_writing_adapter.
+    update_model = live_wiki.UPDATE_MODEL
     spend_budget = _IncrementalSpendBudget(
         dsn, installation_id, update_model, monthly_cap, feature="airview_incremental"
     )

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -158,8 +158,9 @@ def writing_adapter_for(
     on_usage: Callable[[int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
     allow_partial_report: bool = False,
+    _prefer_luna: bool = True,
 ) -> OpenAICompatibleAdapter:
-    if _openai_available():
+    if _prefer_luna and _openai_available():
         return OpenAICompatibleAdapter(
             name="OpenAI",
             base_url="https://api.openai.com/v1",
@@ -170,9 +171,15 @@ def writing_adapter_for(
             before_llm_call=before_llm_call,
             allow_partial_report=allow_partial_report,
         )
-    logging.getLogger(__name__).warning(
-        "OPENAI_API_KEY not configured - falling back to DeepSeek (%s)", fallback_model
-    )
+    if not _prefer_luna:
+        logging.getLogger(__name__).info(
+            "using DeepSeek (%s) for this writing surface by explicit preference, "
+            "not an OpenAI fallback", fallback_model,
+        )
+    else:
+        logging.getLogger(__name__).warning(
+            "OPENAI_API_KEY not configured - falling back to DeepSeek (%s)", fallback_model
+        )
     return OpenAICompatibleAdapter(
         name="DeepSeek",
         base_url="https://api.deepseek.com",
@@ -187,6 +194,32 @@ def writing_adapter_for(
         on_usage=on_usage,
         before_llm_call=before_llm_call,
         allow_partial_report=allow_partial_report,
+    )
+
+
+def writing_adapter_for_airview(
+    fallback_model: str,
+    on_usage: Callable[[int, int], None] | None = None,
+    before_llm_call: Callable[[], bool] | None = None,
+) -> OpenAICompatibleAdapter:
+    """Always DeepSeek for AIRview specifically - never Luna, regardless of
+    OPENAI_API_KEY availability.
+
+    Every other writing surface prefers Luna over DeepSeek when available
+    (writing_adapter_for above) because Luna measured better on real-world
+    coding/PR-review benchmarks - that is still true and unchanged here.
+    AIRview's own comprehension benchmark (aletheore-benchmarks,
+    AIRVIEW_GAP.md) measured the opposite for this one surface: the full
+    12-question architecture set, 3 judge repeats, deepseek-v4-flash scored
+    1.88 against RepoWise's 1.99 (a statistical tie, inside the judge's own
+    noise floor) while gpt-5.6-luna scored 1.53 against RepoWise's 2.08 (a
+    real loss, outside it) - same corpus, same day, same rubric. Scoped
+    narrowly to AIRview because that is exactly what was measured; PR
+    review and managed audits were not re-tested and stay on Luna via
+    writing_adapter_for/writing_adapter_for_plan.
+    """
+    return writing_adapter_for(
+        fallback_model, on_usage=on_usage, before_llm_call=before_llm_call, _prefer_luna=False
     )
 
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2691,7 +2691,7 @@ def test_run_live_wiki_full_build_job_skips_model_call_on_cache_hit(monkeypatch)
 
     monkeypatch.setattr(
         "scan_worker.jobs._live_wiki_full_build_writing_adapter",
-        lambda plan, on_usage=None, before_llm_call=None: _SpyAdapter(),
+        lambda on_usage=None, before_llm_call=None: _SpyAdapter(),
     )
     monkeypatch.setattr(
         "scan_worker.jobs._live_wiki_naming_adapter",
@@ -4562,7 +4562,7 @@ def test_run_live_wiki_full_build_job_reserves_spend_atomically_against_concurre
     )
     monkeypatch.setattr(
         "scan_worker.jobs._live_wiki_full_build_writing_adapter",
-        lambda plan, on_usage=None, before_llm_call=None: _FakeWikiAdapter(on_usage, before_llm_call),
+        lambda on_usage=None, before_llm_call=None: _FakeWikiAdapter(on_usage, before_llm_call),
     )
 
     threads = [
@@ -4840,21 +4840,31 @@ def test_run_live_wiki_full_build_for_installation_job_enqueues_per_repo(monkeyp
     assert repo_names == {"octocat/repo1", "octocat/repo2"}
 
 
-def test_full_build_writing_adapter_uses_the_tier_model_for_the_plan(monkeypatch):
-    # Model-selection logic itself is covered by test_model_tiers.py - this
-    # just checks jobs.py's wrapper actually delegates plan through.
+def test_full_build_writing_adapter_always_uses_deepseek_flash_even_with_openai_key_configured(monkeypatch):
+    # AIRview's own comprehension benchmark (aletheore-benchmarks,
+    # AIRVIEW_GAP.md, re-measured 2026-08-22) found deepseek-v4-flash tied
+    # RepoWise here while gpt-5.6-luna lost decisively - see
+    # writing_adapter_for_airview's docstring. No longer plan-dependent
+    # (was Luna falling back to deepseek-v4-pro per plan).
     from scan_worker.jobs import _live_wiki_full_build_writing_adapter
+    from scan_worker import live_wiki
 
-    adapter = _live_wiki_full_build_writing_adapter("pro")
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+
+    adapter = _live_wiki_full_build_writing_adapter()
     assert adapter.name == "DeepSeek"
-    assert adapter._model == "deepseek-v4-pro"
+    assert adapter._model == live_wiki.FLASH_MODEL
 
 
-def test_full_build_writing_adapter_indie_stays_on_deepseek(monkeypatch):
+def test_full_build_writing_adapter_uses_deepseek_flash_without_openai_key_too(monkeypatch):
     from scan_worker.jobs import _live_wiki_full_build_writing_adapter
+    from scan_worker import live_wiki
 
-    adapter = _live_wiki_full_build_writing_adapter("indie")
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+
+    adapter = _live_wiki_full_build_writing_adapter()
     assert adapter.name == "DeepSeek"
+    assert adapter._model == live_wiki.FLASH_MODEL
 
 
 def _docs_module(path="a.py", functions=None, classes=None) -> dict:
@@ -5582,15 +5592,21 @@ def test_health_fix_suggestion_adapter_falls_back_to_deepseek_pro(monkeypatch):
     assert adapter._model == "deepseek-v4-pro"
 
 
-def test_live_wiki_naming_adapter_uses_luna_when_openai_key_configured(monkeypatch):
+def test_live_wiki_naming_adapter_never_uses_luna_even_when_openai_key_configured(monkeypatch):
+    # AIRview is the one writing surface that must not prefer Luna - see
+    # writing_adapter_for_airview's docstring for the benchmark that
+    # justifies the exception (deepseek-v4-flash tied RepoWise, Luna lost).
     from scan_worker.jobs import _live_wiki_naming_adapter
+    from scan_worker import live_wiki
 
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
 
-    assert _live_wiki_naming_adapter().name == "OpenAI"
+    adapter = _live_wiki_naming_adapter()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == live_wiki.FLASH_MODEL
 
 
-def test_live_wiki_naming_adapter_falls_back_to_deepseek_flash(monkeypatch):
+def test_live_wiki_naming_adapter_uses_deepseek_flash_without_openai_key_too(monkeypatch):
     from scan_worker.jobs import _live_wiki_naming_adapter
     from scan_worker import live_wiki
 
@@ -5601,15 +5617,18 @@ def test_live_wiki_naming_adapter_falls_back_to_deepseek_flash(monkeypatch):
     assert adapter._model == live_wiki.FLASH_MODEL
 
 
-def test_live_wiki_update_writing_adapter_uses_luna_when_openai_key_configured(monkeypatch):
+def test_live_wiki_update_writing_adapter_never_uses_luna_even_when_openai_key_configured(monkeypatch):
     from scan_worker.jobs import _live_wiki_update_writing_adapter
+    from scan_worker import live_wiki
 
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
 
-    assert _live_wiki_update_writing_adapter().name == "OpenAI"
+    adapter = _live_wiki_update_writing_adapter()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == live_wiki.UPDATE_MODEL
 
 
-def test_live_wiki_update_writing_adapter_falls_back_to_deepseek_flash(monkeypatch):
+def test_live_wiki_update_writing_adapter_uses_deepseek_flash_without_openai_key_too(monkeypatch):
     from scan_worker.jobs import _live_wiki_update_writing_adapter
     from scan_worker import live_wiki
 

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -16,6 +16,7 @@ from scan_worker.model_tiers import (
     verification_adapter,
     writing_adapter_chain_for_free_tier,
     writing_adapter_for,
+    writing_adapter_for_airview,
     writing_adapter_for_plan,
 )
 
@@ -87,6 +88,44 @@ def test_writing_adapter_for_threads_on_usage_through_either_branch(monkeypatch)
         adapter = writing_adapter_for("deepseek-v4-flash", on_usage=lambda p, c: received.append((p, c)))
         adapter._on_usage(10, 20)
         assert received == [(10, 20)], key_configured
+
+
+def test_writing_adapter_for_airview_never_uses_luna_even_when_openai_is_configured(monkeypatch):
+    # AIRview's own comprehension benchmark (aletheore-benchmarks,
+    # AIRVIEW_GAP.md, re-measured 2026-08-22, full 12-question architecture
+    # set, 3 judge repeats) found deepseek-v4-flash tied RepoWise (1.88 vs
+    # 1.99, inside the judge's own noise floor) while gpt-5.6-luna lost
+    # decisively (1.53 vs 2.08, outside it) - same corpus, same day, same
+    # rubric. Unlike writing_adapter_for, this must not switch to Luna just
+    # because OPENAI_API_KEY is configured.
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    adapter = writing_adapter_for_airview("deepseek-v4-flash")
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == "deepseek-v4-flash"
+    assert adapter._base_url == "https://api.deepseek.com"
+    assert adapter._api_key_env_var == "DEEPSEEK_API_KEY"
+
+
+def test_writing_adapter_for_airview_still_uses_deepseek_when_openai_is_not_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+    adapter = writing_adapter_for_airview("deepseek-v4-flash")
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == "deepseek-v4-flash"
+
+
+def test_writing_adapter_for_airview_threads_on_usage_and_before_llm_call(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    received = []
+    calls_allowed = []
+    adapter = writing_adapter_for_airview(
+        "deepseek-v4-flash",
+        on_usage=lambda p, c: received.append((p, c)),
+        before_llm_call=lambda: calls_allowed.append(True) or True,
+    )
+    adapter._on_usage(7, 3)
+    assert received == [(7, 3)]
+    assert adapter._before_llm_call() is True
+    assert calls_allowed == [True]
 
 
 def test_verification_adapter_always_uses_deepseek_even_when_openai_is_configured(monkeypatch):


### PR DESCRIPTION
## Summary
- Every other writing surface (PR review, managed audits, Docs) prefers `gpt-5.6-luna` over DeepSeek when available, because Luna measured better on real-world coding/PR-review benchmarks - that's unchanged.
- AIRview's own comprehension benchmark measured the opposite for this one surface. Re-run across 5 corpora (Python, C#, JavaScript, C++, C), full 12-question architecture set, 3 judge repeats per question (see [`aletheore-benchmarks`](https://github.com/Aletheore/aletheore-benchmarks), `AIRVIEW_GAP.md`):

| corpus | deepseek-v4-flash | RepoWise | verdict |
|---|---|---|---|
| flask (Python) | 1.88 | 1.99 | tie |
| automapper (C#) | 0.38 | 2.29 | severe loss - clustering-fragmentation bug, not a model issue (see AIRVIEW_GAP.md) |
| axios (JS) | 2.28 | 1.61 | clear win |
| fmt (C++) | 2.04 | 1.64 | win |
| jq (C) | 1.93 | 1.76 | tie/lean win |

  Excluding automapper's confirmed clustering outlier: **deepseek-v4-flash averages 2.03 vs RepoWise's 1.75** across four languages. Luna measured 1.53 vs RepoWise's 2.08 on the one corpus tested against it - a real loss.

- `writing_adapter_for` gains a `_prefer_luna` flag (default `True`, unchanged everywhere else) and a new `writing_adapter_for_airview` wrapper that always sets it `False`. Wired into all three AIRview writing surfaces in `jobs.py`. The full-build path is no longer plan-dependent (was Luna falling back to `deepseek-v4-pro`, untested here) - every plan now gets the specific model that was actually benchmarked.
- PR review, managed audits, and Docs are untouched.

## Test plan
- [x] `test_model_tiers.py`: 35 passed, including 3 new tests for `writing_adapter_for_airview`
- [x] `test_jobs.py`: 199 passed, 1 pre-existing skip, including updated/new tests confirming AIRview never selects Luna even when `OPENAI_API_KEY` is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)