### PR TITLE
fix: architecture clustering no longer counts test files toward subsystems

### DIFF
--- a/src/aletheore/architecture.py
+++ b/src/aletheore/architecture.py
@@ -5,7 +5,6 @@ import networkx as nx
 from networkx.algorithms.community import greedy_modularity_communities
 
 from aletheore.repo_config import load_repo_config
-from aletheore.search_index import _is_test_path
 
 
 def load_architecture_config(repo_path: Path) -> dict | None:
@@ -67,6 +66,11 @@ def build_clusters(dependency_graph: dict, resolution: float = 1.0) -> tuple[lis
     (AIRview subsystems, the dashboard's dependency graph, aletheore_cluster)
     wants architecture, not a test suite's own internal structure.
     """
+    # Deferred: search_index.py pulls in lancedb/openai, which cli.py's
+    # import-time footprint must not carry for every command - see
+    # test_importing_cli_does_not_eagerly_load_heavy_dependencies.
+    from aletheore.search_index import _is_test_path
+
     nodes = [n for n in dependency_graph["nodes"] if not _is_test_path(n)]
     kept = set(nodes)
     edges = [

--- a/src/aletheore/architecture.py
+++ b/src/aletheore/architecture.py
@@ -5,6 +5,7 @@ import networkx as nx
 from networkx.algorithms.community import greedy_modularity_communities
 
 from aletheore.repo_config import load_repo_config
+from aletheore.search_index import _is_test_path
 
 
 def load_architecture_config(repo_path: Path) -> dict | None:
@@ -52,9 +53,29 @@ LAYER_FOLDER_MARKERS = {
 
 
 def build_clusters(dependency_graph: dict, resolution: float = 1.0) -> tuple[list[dict], list[dict]]:
+    """Group dependency_graph's modules into communities by import density.
+
+    Test files are excluded before clustering, not after: they pollute
+    architecture grouping the same way they polluted retrieval accuracy
+    (see search_index._is_test_path's own measurement). Reproduced directly
+    on AutoMapper/AutoMapper - 420 of 513 dependency-graph nodes (82%) are
+    test files, and clustering them alongside real source produced 119
+    subsystems for 512 files instead of a handful of meaningful ones,
+    because modularity clustering has no notion of "this node doesn't count
+    toward the architecture" - every test file becomes its own small
+    community or drags a real one apart. Every consumer of these clusters
+    (AIRview subsystems, the dashboard's dependency graph, aletheore_cluster)
+    wants architecture, not a test suite's own internal structure.
+    """
+    nodes = [n for n in dependency_graph["nodes"] if not _is_test_path(n)]
+    kept = set(nodes)
+    edges = [
+        (a, b) for a, b in dependency_graph["edges"] if a in kept and b in kept
+    ]
+
     graph = nx.Graph()
-    graph.add_nodes_from(dependency_graph["nodes"])
-    graph.add_edges_from(dependency_graph["edges"])
+    graph.add_nodes_from(nodes)
+    graph.add_edges_from(edges)
 
     communities = list(greedy_modularity_communities(graph, resolution=resolution))
 
@@ -66,12 +87,12 @@ def build_clusters(dependency_graph: dict, resolution: float = 1.0) -> tuple[lis
             cluster_of[module] = cluster_id
         clusters.append({"id": cluster_id, "modules": modules, "internal_edges": 0})
 
-    for a, b in dependency_graph["edges"]:
+    for a, b in edges:
         if cluster_of.get(a) is not None and cluster_of.get(a) == cluster_of.get(b):
             clusters[cluster_of[a]]["internal_edges"] += 1
 
     cross_pairs: dict[tuple[int, int], list[list[str]]] = {}
-    for a, b in dependency_graph["edges"]:
+    for a, b in edges:
         ca, cb = cluster_of.get(a), cluster_of.get(b)
         if ca is None or cb is None or ca == cb:
             continue

--- a/src/tests/test_architecture.py
+++ b/src/tests/test_architecture.py
@@ -39,6 +39,31 @@ def test_build_clusters_finds_two_clusters_with_a_thin_bridge():
     assert bridge["edges"] == [["a.py", "x.py"]]
 
 
+def test_build_clusters_excludes_test_files():
+    """Test files pollute clustering the same way they polluted retrieval -
+    see search_index._is_test_path's own comment. Reproduced directly on
+    AutoMapper/AutoMapper: 420 of 513 dependency-graph nodes (82%) were test
+    files, and clustering produced 119 subsystems for 512 files instead of a
+    handful of real ones - see aletheore-benchmarks, AIRVIEW_GAP.md."""
+    dependency_graph = {
+        "nodes": ["a.py", "b.py", "tests/test_a.py", "UnitTests/MapperTest.cs"],
+        "edges": [
+            ["a.py", "b.py"],
+            ["b.py", "a.py"],
+            ["tests/test_a.py", "a.py"],
+            ["a.py", "tests/test_a.py"],
+        ],
+    }
+
+    clusters, cross_cluster_edges = build_clusters(dependency_graph)
+
+    all_modules = [m for c in clusters for m in c["modules"]]
+    assert "tests/test_a.py" not in all_modules
+    assert "UnitTests/MapperTest.cs" not in all_modules
+    assert set(all_modules) == {"a.py", "b.py"}
+    assert cross_cluster_edges == []
+
+
 def test_build_clusters_handles_isolated_nodes_without_crashing():
     dependency_graph = {"nodes": ["a.py", "b.py", "c.py"], "edges": []}
 


### PR DESCRIPTION
## Summary
- Surfaced by an AIRview-vs-RepoWise comprehension benchmark: AutoMapper/AutoMapper scored 0.38/3 against RepoWise's 2.29 - a 72/72 judge sweep - while every other corpus tested (Python, JS, C++, C) tied or won. Not a model-quality problem.
- Root cause: `build_clusters` (`architecture.py`) had no concept of "this node doesn't count toward the architecture." AutoMapper's dependency graph is 82% test files by node count (420 of 513 - `UnitTests`, `IntegrationTests`, `AutoMapper.DI.Tests`), and modularity clustering fragmented the repo into 119 tiny subsystems (3.9 files/subsystem) instead of a handful of meaningful ones.
- Confirmed directly: filtering to only the 85 real `AutoMapper/*.cs` library files and re-clustering the same real dependency graph drops it from 119 clusters to 8, with two substantial real subsystems (38 and 30 modules).
- Fix: `build_clusters` now excludes test paths before clustering using the same `_is_test_path` `search_index.py` already applies to retrieval, for the identical reason. Single source of truth, no duplicated test-detection logic.

## Test plan
- [x] New test (`test_build_clusters_excludes_test_files`) confirmed failing against the unfixed code, passing after
- [x] Full `src/` suite green (1332 passed)
- [x] `github-app` tests referencing clusters (`test_live_wiki.py`, `test_live_wiki_e2e.py`, `test_demo_scan.py`) green (75 passed, 7 pre-existing skips)
- [x] Verified empirically against the real AutoMapper corpus: 119 clusters → 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)