### PR TITLE
docs: record the 2026-08-22 deploy

### DIFF
--- a/docs/operations/DEPLOYMENT-VERIFICATION.md
+++ b/docs/operations/DEPLOYMENT-VERIFICATION.md
@@ -4,8 +4,8 @@
 **Status:** Active baseline
 **Owner:** Arihant Kaul
 **Related Documents:** [README.md](README.md), [INCIDENT-RESPONSE.md](INCIDENT-RESPONSE.md), [../../github-app/README.md](../../github-app/README.md)
-**Last Updated:** 2026-08-10
-**Snapshot Freshness:** CURRENT as of 2026-08-10 - production was redeployed to `master` (commit `1659182`) and re-verified live via SSH the same day.
+**Last Updated:** 2026-08-22
+**Snapshot Freshness:** CURRENT as of 2026-08-22 - production was redeployed to `master` (commit `291819d`) and re-verified live via SSH the same day.
 
 ## Purpose
 
@@ -30,28 +30,22 @@ Before claiming a hardening change is live, verify:
 
 ## Current Server Snapshot
 
-As of 2026-08-10, following a redeploy to `master` (`git reset --hard origin/master` + `docker compose build app-server scan-worker health-worker scheduler` + `docker compose up -d --no-deps` for those four), live inspection found:
+As of 2026-08-22, following a redeploy to `master` (`git reset --hard origin/master` + `docker compose build app-server scan-worker health-worker scheduler` + `docker compose up -d --no-deps` for those four), live inspection found:
 
-- Host: `srv1675832`.
+- Host: `srv1675832` (`root@187.127.169.89`).
 - Deployment path: `/root/aletheore`.
 - Remote: `https://github.com/Aletheore/Aletheore.git`.
 - Branch: `master`.
-- Commit: `1659182c146601a0817059b09d1d70cd99b25889`.
-- Working tree: clean, no local diffs or stashes.
-- Services running: `app-server`, `scan-worker`, `health-worker`, `scheduler`, `autoheal`, `demo-scan-worker`, `demo-sandbox-runner`, `postgres`, `redis`, `caddy`, `ollama` - all `Up`; `app-server`, `scan-worker`, `health-worker`, `scheduler`, `autoheal`, and `postgres` reporting Docker-healthcheck `healthy`. All four rebuilt services show `RestartCount: 0` since redeploy.
-- App server starts via `python scripts/migrate.py && exec uvicorn ...`; this redeploy carried 5 pending migrations (`035_data_deletion_log.sql` through `039_telemetry_retention_index.sql`), all applied cleanly on startup with no errors (`applied 5 migration(s)` in logs). Confirmed live in Postgres afterward: `data_deletion_log`, `webhook_deliveries`, and `installation_access_log` tables exist; `cli_telemetry_events_occurred_at_idx` index exists; `installations.llm_suggestions_enabled` column exists.
-- This redeploy shipped: self-serve data deletion (Settings -> Delete all data, and identically on uninstall) with a plan-independent purge that covers free-plan installations, not just paid seats; AIR evidence schema validation; webhook replay/duplicate protection for GitHub and Paddle; an MCP consent boundary (`ALETHEORE_MCP_ALLOW`) gating tools that transmit repository evidence externally; and body-size/rate-limit/retention controls on the two ingestion endpoints (`/v1/telemetry`, `/v1/runtime-events`).
-- The two new abuse controls were verified live against the public endpoint post-deploy, not just via test suite: an oversized `/v1/telemetry` POST returned `413`; a chunked request with no `Content-Length` returned `411`; a valid small request returned `200` and inserted normally.
-- The data-deletion fix (purging PII for free-plan installations, not just paid seats) was verified pre-deploy via the test suite and a red/green check against a local test database, not re-exercised against a real production installation - deleting a live customer's data to prove the code path would be destructive and out of proportion to what the test suite already demonstrates.
-- `demo-scan-worker` has **no** Docker socket mount (`docker inspect` confirms empty `Mounts`); `demo-sandbox-runner` is the sole holder of `/var/run/docker.sock`, publishes no host ports (internal-only on the Compose network) - unchanged this pass, not re-verified with a fresh TCP connect since neither service nor its Dockerfile was touched by this redeploy.
-- `app-server` and `scan-worker` run as the non-root `aletheore` user (re-confirmed live via `docker compose exec ... whoami`); `demo-sandbox-runner` runs as `root` (required to reach the Docker socket - the one service designed to need it, unchanged).
-- CPU/mem limits present and re-confirmed via `docker inspect`: `app-server` 768MiB, `scan-worker` 1GiB. `demo-scan-worker`/`demo-sandbox-runner` limits not re-checked this pass - neither was touched by this redeploy.
-- `scripts/backup-postgres.sh` present at the expected path, **and its cron schedule (`0 3 * * *` in root's crontab) is now confirmed to actually fire successfully** - previously the crontab entry existed but had never once executed since being installed (no `/var/log/aletheore-backup.log`, no cron-log line for it, both existing `.dump` files were manual runs). Verified 2026-08-10 by adding a temporary `*/2 * * * *` entry, confirming it produced a clean dump under cron's real minimal environment (not just an interactive SSH shell), then removing the temporary entry. "A crontab entry exists" and "the job actually runs" are different claims - re-verify this specific gap (dump file freshness `<24h`, no stale `/var/log/aletheore-backup.log`) after any host-level change (OS upgrade, cron package change, PATH-affecting change), not just after app-level redeploys.
-- `app-server`/`scan-worker` base image digest-pinning not re-verified this pass - neither Dockerfile changed in this redeploy's diff (confirmed via `git diff` against the prior deployed commit), so the prior verification stands.
-- Restore drill target database availability was **not** re-verified this pass - out of scope for a routine redeploy; still needs an explicit check per its own runbook item.
+- Commit: `291819d32d1968646b3604f4ee2b785cd7092d21`.
+- Working tree: clean aside from an untracked `github-app/backups/` directory (expected - backup script output, not repo content), no local diffs or stashes.
+- 24 commits had accumulated unreleased since the prior deploy tag (`github-app-deploy-2026-08-21`) and shipped together in this one - see `github-app/CHANGELOG.md`'s 2026-08-22 entry for the full list. Notably this includes a spend-cap check-and-record race fix (#331, #332) that had been sitting fixed in code since 2026-08-20 but not yet live, and the AIRview deepseek-writer switch (#352) + architecture-clustering test-file fix (#353) from the same-day benchmark re-verification.
+- Services running: `app-server`, `scan-worker` (2 replicas), `health-worker`, `scheduler`, `autoheal`, `demo-scan-worker`, `demo-sandbox-runner`, `postgres`, `redis`, `caddy`, `jina-embed` - all `Up`; `app-server`, both `scan-worker` replicas, `health-worker`, `scheduler`, `autoheal`, `jina-embed`, and `postgres` reporting Docker-healthcheck `healthy`.
+- `docker compose up -d --no-deps scan-worker` recreated only the first replica (`scan-worker-1`); the second replica needed an explicit `--scale scan-worker=2` to be recreated, and doing so left an orphaned old-image container running alongside the new one under a different name (`scan-worker-2-1` vs the new `scan-worker-2`) until it was manually stopped and removed. Re-check both replica names after any future `--no-deps` restart of a scaled service - the plain service-name form does not reliably recreate every replica.
+- App server starts via `python scripts/migrate.py && exec uvicorn ...`; this redeploy carried 1 pending migration (`054_cache_embedder_identity.sql`), applied cleanly on startup with no errors (`applied 1 migration(s)` in logs).
+- Post-deploy, verified live inside `scan-worker-1` (not just that the deploy succeeded) that the two headline fixes are actually present in the running code: `model_tiers.writing_adapter_for_airview` exists and `scan_worker.jobs` calls it; `aletheore.architecture.build_clusters` references `_is_test_path`.
 - Health checks: internal `http://127.0.0.1:8000/healthz` and public `https://app.aletheore.com/healthz` both return `200 {"status":"ok","checks":{"database":"ok","redis":"ok"}}`.
-- No errors, tracebacks, or exceptions in `app-server`, `scan-worker`, `health-worker`, or `scheduler` logs since restart.
-- Disk: 129G available of 193G (34% used).
+- No errors, tracebacks, or exceptions found in `app-server` logs after restart (targeted grep for `error|traceback|exception`); the same grep across `scan-worker-1`, `scan-worker-2`, `health-worker`, and `scheduler` logs also came back clean.
+- Not re-verified this pass (out of scope for this redeploy, no relevant Dockerfile/script changes in the diff): Docker socket mount absence on `demo-scan-worker`, non-root user on `app-server`/`scan-worker`, CPU/mem limits, backup cron execution, base-image digest pinning, restore-drill target availability, disk space. Each was last directly verified in the 2026-08-10 deploy (see `git log -p` on this file, or the `github-app-deploy-2026-08-10` tag) - re-check if any host-level or Dockerfile change touches them.
 
 ## Paddle Webhook Destination (live account config, not in git)
 

--- a/github-app/CHANGELOG.md
+++ b/github-app/CHANGELOG.md
@@ -12,6 +12,50 @@ re-verified snapshot of exactly what's running in production right now, see
 [`docs/operations/DEPLOYMENT-VERIFICATION.md`](docs/operations/DEPLOYMENT-VERIFICATION.md) — this
 file is the history; that one is the current state.
 
+## 2026-08-22
+
+24 commits accumulated since the 8/21 deploy tag and shipped together in this one:
+
+- **AIRview writing surface now always uses deepseek-v4-flash, never GPT-5.6 Luna**, regardless of
+  `OPENAI_API_KEY` availability - a benchmark re-run (5 language corpora, blind judge) found
+  DeepSeek beats Luna specifically for this comprehension-writing surface, the opposite of what
+  holds for PR review and coding benchmarks elsewhere, so the switch is scoped narrowly to AIRview
+  via a new `writing_adapter_for_airview` (#352).
+- **Architecture clustering no longer counts test files as subsystems.** Reproduced on
+  AutoMapper/AutoMapper: 82% of the dependency graph was test files, fragmenting what should have
+  been a handful of subsystems into 119 near-singleton clusters. Fixed by excluding test paths
+  before clustering, the same filter already used for retrieval (#353).
+- Spend-cap check-and-record was two separate lock acquisitions for both fix-suggestion and
+  AIRview live-wiki spend budgets - a race that could let concurrent calls both pass the cap
+  check before either recorded usage. Fixed via atomic reservation (#331, #332).
+- AIRview banner still claimed incremental updates use a fast model after that had changed (#350).
+- Healthcheck sweep exited 0 and printed no summary even when every endpoint was unreachable
+  (#349); CI never actually booted the app-server/scan-worker images before this - the same class
+  of gap that caused the #246 crash-loop incident could have shipped silently again (#342).
+  Real end-to-end integration test added for the health-check sweep (#351).
+- Audit's sponsor panel claimed nothing left the machine after evidence was actually sent out
+  (#348).
+- Local search index now detects an embedder swap even when the new embedder happens to produce
+  the same dimensionality (#347); three other retrieval-quality regressions in `search_index.py`
+  fixed (#340); embedding-cache rows now carry the embedder identity that produced them, closing
+  the gap the above fix needed (#343, migration `049_purge_cache_for_embedder_switch.sql`).
+- Flash review similarity cache retained raw PR diffs indefinitely instead of expiring them
+  (#344).
+- Three CLI UX gaps found while auditing for more issues like the update-notice one (#346); bare
+  CLI invocation now surfaces an available update (#345); `mcp-install` prints a copyable
+  `claude mcp add` command for Claude Code (#341).
+- FastAPI router mounted implicitly alongside a prefixed mount lost its own unprefixed endpoint
+  (#339); router-mount prefixes could cross-contaminate between files (#333).
+- Schema-mapper silently corrupted on ordinary SQL comments (#338).
+- Secret scanner missed dotted-attribute credential assignments (#334).
+- Java/C# pre-parsed trees stayed pinned in memory for the whole scan instead of being released
+  (#337).
+- Module-overview chunk boundary used the wrong "first" symbol (#336).
+- Unpinned marker-qualified PEP 508 dependency was silently dropped (#335).
+- Benchmark numbers on the public site updated to the current, re-verified figures: 40.5ms mean
+  retrieval latency (was 125ms) vs RepoWise's 52.5ms, and 2.00 vs 1.77 average comprehension score
+  across 5 language corpora (#354).
+
 ## 2026-08-19
 
 - **AIRview and Docs generation cut down to a fraction of their prior LLM call volume.**


### PR DESCRIPTION
## Summary
- Records the 2026-08-22 production deploy in `github-app/CHANGELOG.md` and `docs/operations/DEPLOYMENT-VERIFICATION.md`.
- 24 commits had accumulated unreleased since the 8/21 deploy tag, including the spend-cap check-and-record race fix (#331/#332, fixed in code 8/20 but not yet live), and the same-day AIRview deepseek-writer switch (#352) + architecture clustering test-file fix (#353).
- Deploy itself already happened and was verified live (health checks, migration output, log scan, and direct in-container confirmation that `writing_adapter_for_airview` and `_is_test_path`-based clustering are present in the running code). This PR is documentation only.

## Test plan
- [x] Internal `/healthz` and public `https://app.aletheore.com/healthz` both returned 200 post-deploy
- [x] No errors/tracebacks in app-server, scan-worker (both replicas), health-worker, scheduler logs
- [x] Migration `054_cache_embedder_identity.sql` applied cleanly
- [x] Verified live in `scan-worker-1`: `model_tiers.writing_adapter_for_airview` exists and is called from `jobs.py`; `build_clusters` references `_is_test_path`
- No code changes in this PR — docs only, standard CI applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)