### PR TITLE
fix: nothing alerted when a free-tier provider key went missing in production

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -21,6 +21,7 @@ from rq.registry import FailedJobRegistry
 from app_server.audit_signing import content_hash, public_key_hex_from_private, sign_report
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from aletheore.code_graph_diff import diff_endpoints, diff_modules
+from aletheore.credentials import has_api_key
 from aletheore.dead_code import is_test_file
 from aletheore.evidence import write_evidence
 from aletheore.git_intel.analyzer import analyze_git, compute_hotspots
@@ -2907,6 +2908,40 @@ def _check_backup_freshness(redis_conn, now: float) -> None:
     )
 
 
+# (env var, provider_name) pairs, matching writing_adapter_chain_for_free_tier's
+# own has_api_key calls exactly - keep in sync with that function, not
+# re-derived from it, since it builds adapters (a side effect this check must
+# never trigger) rather than exposing its provider list separately.
+FREE_TIER_PROVIDER_KEYS = (
+    ("GROQ_API_KEY", "Groq"),
+    ("GEMINI_API_KEY", "Gemini"),
+    ("OPENAI_FREE_TIER_API_KEY", "OpenAI-FreeTier"),
+    ("OPENROUTER_API_KEY", "OpenRouter"),
+)
+
+
+def _check_free_tier_provider_keys(redis_conn) -> None:
+    # Real incident: writing_adapter_chain_for_free_tier silently skips any
+    # provider whose key is missing (by design - never hard-fails free-tier
+    # Flash Review on missing infra) and logs nothing louder than an info
+    # line. All four keys were unset in production for weeks with nothing
+    # watching that log, so every free-tier Flash Review quietly no-op'ed
+    # the whole time - no user-facing error, no alert, no signal at all.
+    # Each provider gets its own alert source (same reasoning as
+    # _check_backup_freshness above) so two providers missing at once both
+    # get reported, not just whichever's alert fires first.
+    for env_var, provider_name in FREE_TIER_PROVIDER_KEYS:
+        if has_api_key(env_var, provider_name):
+            continue
+        _send_ops_alert(
+            redis_conn,
+            f"ops_monitor.free_tier_key.{provider_name.lower()}",
+            f"free-tier provider key missing: {provider_name}",
+            f"env_var={env_var} - free-tier Flash Review silently skips this "
+            "provider until it's set, with no other signal",
+        )
+
+
 @log_job
 def run_ops_monitor_job() -> None:
     """Small production-readiness checks that feed the existing ops email
@@ -2921,6 +2956,7 @@ def run_ops_monitor_job() -> None:
     )
     _check_queue_alerts(redis_conn, now)
     _check_backup_freshness(redis_conn, now)
+    _check_free_tier_provider_keys(redis_conn)
 
 
 # Each template function takes exactly one positional string arg

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -5755,6 +5755,7 @@ def test_run_ops_monitor_job_alerts_on_second_app_health_failure(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs._fetch_app_health", lambda url: (False, "broken"))
     monkeypatch.setattr("scan_worker.jobs._check_queue_alerts", lambda redis_conn, now: None)
     monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_free_tier_provider_keys", lambda redis_conn: None)
     monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
     monkeypatch.setenv("ALETHEORE_APP_HEALTH_URL", "http://bad-health.local/healthz")
 
@@ -5784,6 +5785,7 @@ def test_run_ops_monitor_job_broken_app_health_sends_ops_email(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs._fetch_app_health", lambda url: (False, "broken"))
     monkeypatch.setattr("scan_worker.jobs._check_queue_alerts", lambda redis_conn, now: None)
     monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_free_tier_provider_keys", lambda redis_conn: None)
     monkeypatch.setattr(
         error_alerts,
         "send_transactional_email",
@@ -5822,6 +5824,7 @@ def test_run_ops_monitor_job_alerts_when_queue_depth_stays_high(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
     monkeypatch.setattr("scan_worker.jobs._check_app_health", lambda redis_conn, url: None)
     monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_free_tier_provider_keys", lambda redis_conn: None)
     monkeypatch.setattr("scan_worker.jobs.Queue", FakeQueue)
     monkeypatch.setattr("scan_worker.jobs.FailedJobRegistry", FakeFailedRegistry)
     monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
@@ -5872,6 +5875,7 @@ def test_run_ops_monitor_job_does_not_repeat_alert_within_cooldown(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
     monkeypatch.setattr("scan_worker.jobs._check_app_health", lambda redis_conn, url: None)
     monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_free_tier_provider_keys", lambda redis_conn: None)
     monkeypatch.setattr("scan_worker.jobs.Queue", FakeQueue)
     monkeypatch.setattr("scan_worker.jobs.FailedJobRegistry", FakeFailedRegistry)
     monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
@@ -5925,6 +5929,7 @@ def test_run_ops_monitor_job_alerts_when_backup_missing(monkeypatch, tmp_path):
     monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
     monkeypatch.setattr("scan_worker.jobs._check_app_health", lambda redis_conn, url: None)
     monkeypatch.setattr("scan_worker.jobs._check_queue_alerts", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_free_tier_provider_keys", lambda redis_conn: None)
     monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
     monkeypatch.setenv("ALETHEORE_BACKUP_DIR", str(missing_dir))
 
@@ -5965,6 +5970,69 @@ def test_check_backup_freshness_missing_dir_and_stale_backup_both_alert_within_c
     _check_backup_freshness(redis_conn, now)  # missing dir: must still alert
 
     assert alerts == ["ops_monitor.backup_freshness.stale", "ops_monitor.backup_freshness.missing_dir"]
+
+
+def test_run_ops_monitor_job_alerts_when_a_free_tier_provider_key_is_missing(monkeypatch):
+    # Real incident this guards: writing_adapter_chain_for_free_tier silently
+    # skips (info-log only) any provider whose key isn't set, so all four
+    # free-tier keys sat unset in production for weeks with free-tier Flash
+    # Review quietly no-op'ing the whole time - no error, no alert. This is
+    # the check that would have caught it in minutes instead of weeks.
+    from scan_worker.jobs import run_ops_monitor_job
+
+    redis_conn = _FakeRedis()
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: redis_conn)
+    monkeypatch.setattr("scan_worker.jobs._check_app_health", lambda redis_conn, url: None)
+    monkeypatch.setattr("scan_worker.jobs._check_queue_alerts", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs._check_backup_freshness", lambda redis_conn, now: None)
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append((a, k)))
+
+    def fake_has_api_key(env_var, provider_name, **kwargs):
+        return provider_name != "Groq"
+
+    monkeypatch.setattr("scan_worker.jobs.has_api_key", fake_has_api_key)
+
+    run_ops_monitor_job()
+
+    assert len(alerts) == 1
+    assert alerts[0][0][0] == "ops_monitor.free_tier_key.groq"
+    assert "GROQ_API_KEY" in alerts[0][0][2]
+
+
+def test_check_free_tier_provider_keys_alerts_separately_for_each_missing_provider(monkeypatch):
+    # Same reasoning as the backup-freshness dual-condition test above: each
+    # provider needs its own alert source, or two providers going missing at
+    # once would have the second one silently suppressed by the first's
+    # cooldown.
+    from scan_worker.jobs import _check_free_tier_provider_keys
+
+    redis_conn = _FakeRedis()
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append(a[0]))
+    monkeypatch.setattr("scan_worker.jobs.has_api_key", lambda *a, **k: False)
+
+    _check_free_tier_provider_keys(redis_conn)
+
+    assert alerts == [
+        "ops_monitor.free_tier_key.groq",
+        "ops_monitor.free_tier_key.gemini",
+        "ops_monitor.free_tier_key.openai-freetier",
+        "ops_monitor.free_tier_key.openrouter",
+    ]
+
+
+def test_check_free_tier_provider_keys_sends_no_alert_when_all_keys_present(monkeypatch):
+    from scan_worker.jobs import _check_free_tier_provider_keys
+
+    redis_conn = _FakeRedis()
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append(a[0]))
+    monkeypatch.setattr("scan_worker.jobs.has_api_key", lambda *a, **k: True)
+
+    _check_free_tier_provider_keys(redis_conn)
+
+    assert alerts == []
 
 
 def test_run_git_scrubs_credentialed_url_from_a_failed_clone_error(tmp_path):


### PR DESCRIPTION
## Summary
- `writing_adapter_chain_for_free_tier` silently skips (info-log only) any free-tier provider whose key isn't configured — correct behavior for never hard-failing free-tier Flash Review on missing infra, but it meant all four keys sitting unset in production for weeks produced no signal beyond a log line nobody was watching (see #356, which recorded the incident and the fix to prod config).
- This closes the systemic gap: adds `_check_free_tier_provider_keys` to the existing `run_ops_monitor_job` sweep, checking each of the four providers (Groq, Gemini, OpenAI-FreeTier, OpenRouter) via the same `has_api_key()` calls the adapter chain itself uses, alerting per-provider (so two missing at once don't have the second masked by the first's cooldown) if any are absent.
- Runs on the existing ~3-minute ops-monitor cadence alongside app health, queue depth, and backup freshness — this class of incident now surfaces in minutes instead of weeks.

## Test plan
- [x] 3 new tests added, verified fail-without/pass-with via `git stash`
- [x] Updated 5 pre-existing `run_ops_monitor_job` tests to isolate the new check (matching how they already isolate every other check)
- [x] Full `test_jobs.py` suite passes (169 passed, real Postgres/Redis, 0 skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtiV9cPbw76F6WLA1iKQDj