### PR TITLE
fix: three crash/broken-feature bugs from the second-pass audit

### DIFF
--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -415,7 +415,7 @@ def _fetch_wiki_file_content_sync(
     settings = get_settings()
     app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
     token = get_installation_token(installation_id, app_jwt)
-    return fetch_file_content(get_github_api_client(), token, repo_full_name, path)
+    return fetch_file_content(_github_http_client(), token, repo_full_name, path)
 
 
 @dashboard_router.get("/app/{org}/{repo}/wiki/file/{file_path:path}")

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -1739,3 +1739,40 @@ async def test_dashboard_docs_export_sanitizes_unsafe_characters_in_filename(poo
 
     assert response.status_code == 200
     assert response.headers["content-disposition"] == 'attachment; filename="weird_repo-api-reference.md"'
+
+
+def test_fetch_wiki_file_content_sync_calls_a_function_that_actually_exists(monkeypatch):
+    # Regression test for docs/audits/Claude_Audit.md finding #23: the real
+    # function body called get_github_api_client(), which is never imported
+    # in dashboard.py (only _github_http_client is) - a pure NameError on
+    # every call. test_dashboard_wiki_file_fetches_unindexed_file_without_llm
+    # monkeypatches this whole function out, so it never exercised the real
+    # body and the bug shipped invisibly. This test calls the real function.
+    import httpx
+
+    from app_server import dashboard
+
+    monkeypatch.setattr(dashboard, "generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr(
+        dashboard, "get_installation_token", lambda installation_id, app_jwt, http_client=None: "fake-token"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/repos/octocat/hello-world/contents/config.toml"
+        return httpx.Response(
+            200,
+            json={
+                "encoding": "base64",
+                "content": "Q29uZmln",  # base64("Config")
+            },
+        )
+
+    monkeypatch.setattr(
+        dashboard,
+        "_github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+
+    result = dashboard._fetch_wiki_file_content_sync(608, "octocat/hello-world", "config.toml")
+
+    assert result == "Config"

--- a/src/aletheore/answer.py
+++ b/src/aletheore/answer.py
@@ -35,7 +35,12 @@ def answer_question(
     # Aletheore's hosted embedding endpoint whenever a token was configured.
     results = search_index(repo_path, question, k=k, allow_hosted=allow_hosted)
 
-    if not results or results[0]["score"] > confidence_threshold:
+    # A chunk found only by full-text search (never by the vector retriever)
+    # has no distance-based score at all - None means "no signal to gate
+    # on", not "reject": the text match is still real evidence, so it must
+    # not be treated the same as a low-confidence numeric score.
+    top_score = results[0]["score"] if results else None
+    if not results or (top_score is not None and top_score > confidence_threshold):
         return {
             "answer": "Not enough evidence in the indexed codebase to answer this confidently.",
             "cited_chunks": [],

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -136,7 +136,7 @@ def _params_text(source: bytes, enclosing_node: Node) -> str | None:
             params_node = declarator.child_by_field_name("parameters")
     if params_node is None:
         return None
-    raw = source[params_node.start_byte:params_node.end_byte].decode()
+    raw = source[params_node.start_byte:params_node.end_byte].decode(errors="ignore")
     return " ".join(raw.split())
 
 
@@ -249,7 +249,7 @@ def _symbol_entry(
     is_pure_declaration: bool = False,
 ) -> dict:
     return {
-        "name": source[name_node.start_byte:name_node.end_byte].decode(),
+        "name": source[name_node.start_byte:name_node.end_byte].decode(errors="ignore"),
         "start_line": enclosing_node.start_point[0] + 1,
         "end_line": enclosing_node.end_point[0] + 1,
         "params": _params_text(source, enclosing_node),
@@ -301,7 +301,7 @@ def _python_docstring(source: bytes, enclosing_node: Node) -> str | None:
     string_node = first.children[0]
     if string_node.type != "string":
         return None
-    raw = source[string_node.start_byte:string_node.end_byte].decode()
+    raw = source[string_node.start_byte:string_node.end_byte].decode(errors="ignore")
     return _strip_docstring_quotes(raw) or None
 
 
@@ -312,7 +312,7 @@ def _python_return_type(source: bytes, enclosing_node: Node) -> str | None:
     return_type_node = enclosing_node.child_by_field_name("return_type")
     if return_type_node is None:
         return None
-    return source[return_type_node.start_byte:return_type_node.end_byte].decode().strip()
+    return source[return_type_node.start_byte:return_type_node.end_byte].decode(errors="ignore").strip()
 
 
 def _extract_python(
@@ -346,7 +346,7 @@ def _extract_python(
             if n.type == "import_from_statement":
                 module_node = n.child_by_field_name("module_name")
                 module_name = (
-                    source[module_node.start_byte:module_node.end_byte].decode()
+                    source[module_node.start_byte:module_node.end_byte].decode(errors="ignore")
                     if module_node is not None
                     else ""
                 )
@@ -355,26 +355,26 @@ def _extract_python(
                     if child == module_node:
                         continue
                     if child.type in ("dotted_name", "identifier"):
-                        names.append(source[child.start_byte:child.end_byte].decode())
+                        names.append(source[child.start_byte:child.end_byte].decode(errors="ignore"))
                     elif child.type == "aliased_import":
                         name_node = child.child_by_field_name("name")
                         if name_node is not None:
-                            names.append(source[name_node.start_byte:name_node.end_byte].decode())
+                            names.append(source[name_node.start_byte:name_node.end_byte].decode(errors="ignore"))
                 from_imports.append((module_name, names))
             elif n.type == "import_statement":
                 for child in n.named_children:
                     if child.type == "dotted_name":
-                        plain_imports.append(source[child.start_byte:child.end_byte].decode())
+                        plain_imports.append(source[child.start_byte:child.end_byte].decode(errors="ignore"))
                     elif child.type == "aliased_import":
                         name_node = child.child_by_field_name("name")
                         if name_node is not None:
                             plain_imports.append(
-                                source[name_node.start_byte:name_node.end_byte].decode()
+                                source[name_node.start_byte:name_node.end_byte].decode(errors="ignore")
                             )
             elif n.type == "function_definition":
                 name_node = n.child_by_field_name("name")
                 if name_node is not None:
-                    name = source[name_node.start_byte:name_node.end_byte].decode()
+                    name = source[name_node.start_byte:name_node.end_byte].decode(errors="ignore")
                     functions.append(_symbol_entry(
                         source, name_node, n,
                         docstring=_python_docstring(source, n),
@@ -384,7 +384,7 @@ def _extract_python(
             elif n.type == "class_definition":
                 name_node = n.child_by_field_name("name")
                 if name_node is not None:
-                    name = source[name_node.start_byte:name_node.end_byte].decode()
+                    name = source[name_node.start_byte:name_node.end_byte].decode(errors="ignore")
                     classes.append(_symbol_entry(
                         source, name_node, n,
                         docstring=_python_docstring(source, n),
@@ -403,7 +403,7 @@ def _extract_python(
                     # is not a single identifier a reader could look up.
                     if target is None or target.type != "identifier":
                         continue
-                    name = source[target.start_byte:target.end_byte].decode()
+                    name = source[target.start_byte:target.end_byte].decode(errors="ignore")
                     constants.append(_symbol_entry(
                         source, target, n,
                         is_public=_is_public_symbol(name, "python"),
@@ -608,7 +608,7 @@ def _leading_block_comment(
         candidates.append(enclosing_node.parent.prev_sibling)
     for candidate in candidates:
         if candidate is not None and candidate.type == comment_type:
-            raw = source[candidate.start_byte:candidate.end_byte].decode()
+            raw = source[candidate.start_byte:candidate.end_byte].decode(errors="ignore")
             if raw.startswith(marker):
                 return raw
     return None
@@ -639,7 +639,7 @@ def _ts_return_type(source: bytes, enclosing_node: Node) -> str | None:
     node = enclosing_node.child_by_field_name("return_type")
     if node is None:
         return None
-    text = source[node.start_byte:node.end_byte].decode().strip()
+    text = source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
     return text[1:].strip() if text.startswith(":") else text
 
 
@@ -651,7 +651,7 @@ def _extract_javascript(node: Node, source: bytes) -> tuple[list[str], list[dict
     def string_literal(n: Node | None) -> str | None:
         if n is None or n.type != "string":
             return None
-        raw = source[n.start_byte:n.end_byte].decode()
+        raw = source[n.start_byte:n.end_byte].decode(errors="ignore")
         return raw[1:-1] if len(raw) >= 2 and raw[0] in "'\"" else None
 
     def walk(root: Node):
@@ -662,7 +662,7 @@ def _extract_javascript(node: Node, source: bytes) -> tuple[list[str], list[dict
             if n.type == "import_statement":
                 source_node = n.child_by_field_name("source")
                 if source_node is not None:
-                    raw = source[source_node.start_byte:source_node.end_byte].decode()
+                    raw = source[source_node.start_byte:source_node.end_byte].decode(errors="ignore")
                     imports.append(raw.strip("'\""))
             elif n.type == "export_statement":
                 # Re-export barrels ("export { x } from './x'", "export * from
@@ -695,7 +695,7 @@ def _extract_javascript(node: Node, source: bytes) -> tuple[list[str], list[dict
                     if args is not None:
                         for arg in args.named_children:
                             if arg.type == "string":
-                                spec = source[arg.start_byte:arg.end_byte].decode().strip("'\"`")
+                                spec = source[arg.start_byte:arg.end_byte].decode(errors="ignore").strip("'\"`")
                                 if spec:
                                     imports.append(spec)
                                 break
@@ -800,7 +800,7 @@ def _leading_go_doc_comment(source: bytes, enclosing_node: Node) -> str | None:
     lines: list[str] = []
     expected_end_row = anchor.start_point[0] - 1
     while node is not None and node.type == "comment" and node.end_point[0] == expected_end_row:
-        raw = source[node.start_byte:node.end_byte].decode().strip()
+        raw = source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
         if raw.startswith("//"):
             raw = raw[2:].strip()
         elif raw.startswith("/*") and raw.endswith("*/"):
@@ -824,7 +824,7 @@ def _extract_go(node: Node, source: bytes) -> tuple[list[str], list[dict], list[
     def string_content(n: Node) -> str | None:
         for child in n.children:
             if child.type == "interpreted_string_literal_content":
-                return source[child.start_byte:child.end_byte].decode()
+                return source[child.start_byte:child.end_byte].decode(errors="ignore")
         return None
 
     def walk(root: Node):
@@ -851,7 +851,7 @@ def _extract_go(node: Node, source: bytes) -> tuple[list[str], list[dict], list[
                             name_node = child
                             break
                 if name_node is not None:
-                    name = source[name_node.start_byte:name_node.end_byte].decode()
+                    name = source[name_node.start_byte:name_node.end_byte].decode(errors="ignore")
                     functions.append(_symbol_entry(
                         source, name_node, n,
                         docstring=_leading_go_doc_comment(source, n),
@@ -860,7 +860,7 @@ def _extract_go(node: Node, source: bytes) -> tuple[list[str], list[dict], list[
             elif n.type == "type_spec":
                 name_node = n.child_by_field_name("name")
                 if name_node is not None:
-                    name = source[name_node.start_byte:name_node.end_byte].decode()
+                    name = source[name_node.start_byte:name_node.end_byte].decode(errors="ignore")
                     types.append(_symbol_entry(
                         source, name_node, n,
                         docstring=_leading_go_doc_comment(source, n),
@@ -917,7 +917,7 @@ def _rust_use_paths(node: Node, source: bytes) -> list[str]:
     """
 
     def text(n: Node) -> str:
-        return source[n.start_byte:n.end_byte].decode()
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
 
     if node.type == "use_as_clause":
         # "crate::foo::Bar as MyBar" - only the path before "as" matters for
@@ -966,7 +966,7 @@ def _leading_rust_doc_comment(source: bytes, enclosing_node: Node) -> str | None
     node = enclosing_node.prev_sibling
     expected_end_row = enclosing_node.start_point[0]
     while node is not None and node.type == "line_comment" and node.end_point[0] == expected_end_row:
-        raw = source[node.start_byte:node.end_byte].decode().strip()
+        raw = source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
         if not raw.startswith("///"):
             break
         lines.append(raw[3:].strip())
@@ -1009,7 +1009,7 @@ def _extract_rust(node: Node, source: bytes) -> tuple[list[str], list[dict], lis
                 # possible on-disk shapes.
                 name_node = n.child_by_field_name("name")
                 if name_node is not None:
-                    name = source[name_node.start_byte:name_node.end_byte].decode()
+                    name = source[name_node.start_byte:name_node.end_byte].decode(errors="ignore")
                     if name:
                         imports.append(f"self::{name}")
             elif n.type in ("function_item", "function_signature_item"):
@@ -1020,7 +1020,7 @@ def _extract_rust(node: Node, source: bytes) -> tuple[list[str], list[dict], lis
                         source, name_node, n,
                         docstring=_leading_rust_doc_comment(source, n),
                         return_type=(
-                            source[return_type_node.start_byte:return_type_node.end_byte].decode().strip()
+                            source[return_type_node.start_byte:return_type_node.end_byte].decode(errors="ignore").strip()
                             if return_type_node is not None else None
                         ),
                         is_public=(
@@ -1179,7 +1179,7 @@ def _extract_java_package(node: Node, source: bytes) -> str | None:
         if child.type == "package_declaration":
             for grandchild in child.children:
                 if grandchild.type in ("scoped_identifier", "identifier"):
-                    return source[grandchild.start_byte:grandchild.end_byte].decode()
+                    return source[grandchild.start_byte:grandchild.end_byte].decode(errors="ignore")
             return None
     return None
 
@@ -1192,7 +1192,7 @@ def _java_return_type(source: bytes, enclosing_node: Node) -> str | None:
     node = enclosing_node.child_by_field_name("type")
     if node is None:
         return None
-    return source[node.start_byte:node.end_byte].decode().strip()
+    return source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
 
 
 def _java_is_public(node: Node) -> bool:
@@ -1242,7 +1242,7 @@ def _extract_java(
     types: list[dict] = []
 
     def text(n: Node) -> str:
-        return source[n.start_byte:n.end_byte].decode()
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
 
     def walk(root: Node):
         # Iterative, not recursive - see _extract_python's walk for why.
@@ -1377,7 +1377,7 @@ def _leading_ruby_doc_comment(source: bytes, enclosing_node: Node) -> str | None
     lines: list[str] = []
     expected_end_row = anchor.start_point[0] - 1
     while node is not None and node.type == "comment" and node.end_point[0] == expected_end_row:
-        raw = source[node.start_byte:node.end_byte].decode().strip()
+        raw = source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
         if raw.startswith("#"):
             raw = raw[1:].strip()
         lines.append(raw)
@@ -1397,7 +1397,7 @@ def _extract_ruby(node: Node, source: bytes) -> tuple[list[tuple[str, str]], lis
     types: list[dict] = []
 
     def text(n: Node) -> str:
-        return source[n.start_byte:n.end_byte].decode()
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
 
     def walk(root: Node):
         # Iterative, not recursive - see _extract_python's walk for why.
@@ -1468,7 +1468,7 @@ def _php_string_content(n: Node, source: bytes) -> str | None:
     # PHP string literals - both wrap their text in an identically-named child.
     for child in n.children:
         if child.type == "string_content":
-            return source[child.start_byte:child.end_byte].decode()
+            return source[child.start_byte:child.end_byte].decode(errors="ignore")
     return None
 
 
@@ -1499,7 +1499,7 @@ def _php_return_type(source: bytes, enclosing_node: Node) -> str | None:
     node = enclosing_node.child_by_field_name("return_type")
     if node is None:
         return None
-    return source[node.start_byte:node.end_byte].decode().strip()
+    return source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
 
 
 def _extract_php(node: Node, source: bytes) -> tuple[list[tuple[str, str]], list[dict], list[dict]]:
@@ -1509,7 +1509,7 @@ def _extract_php(node: Node, source: bytes) -> tuple[list[tuple[str, str]], list
     types: list[dict] = []
 
     def text(n: Node) -> str:
-        return source[n.start_byte:n.end_byte].decode()
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
 
     include_keywords = ("require", "require_once", "include", "include_once")
 
@@ -1632,7 +1632,7 @@ def _extract_c_family(node: Node, source: bytes) -> tuple[list[str], list[dict],
     types: list[dict] = []
 
     def text(n: Node) -> str:
-        return source[n.start_byte:n.end_byte].decode()
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
 
     def function_name(declarator: Node) -> str | None:
         # The name-bearing function_declarator can be wrapped in pointer_declarator
@@ -1734,7 +1734,7 @@ def _extract_csharp_namespace(node: Node, source: bytes) -> str | None:
         if child.type in ("namespace_declaration", "file_scoped_namespace_declaration"):
             for grandchild in child.children:
                 if grandchild.type in ("qualified_name", "identifier"):
-                    return source[grandchild.start_byte:grandchild.end_byte].decode()
+                    return source[grandchild.start_byte:grandchild.end_byte].decode(errors="ignore")
             return None
     return None
 
@@ -1757,7 +1757,7 @@ def _leading_csharp_xmldoc(source: bytes, enclosing_node: Node) -> str | None:
     node = enclosing_node.prev_sibling
     expected_end_row = enclosing_node.start_point[0] - 1
     while node is not None and node.type == "comment" and node.end_point[0] == expected_end_row:
-        raw = source[node.start_byte:node.end_byte].decode().strip()
+        raw = source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
         if not raw.startswith("///"):
             break
         lines.append(raw[3:].strip())
@@ -1785,7 +1785,7 @@ def _csharp_return_type(source: bytes, enclosing_node: Node) -> str | None:
     node = enclosing_node.child_by_field_name("returns")
     if node is None:
         return None
-    return source[node.start_byte:node.end_byte].decode().strip()
+    return source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
 
 
 def _extract_csharp(node: Node, source: bytes) -> tuple[list[str], list[dict], list[dict]]:
@@ -1794,7 +1794,7 @@ def _extract_csharp(node: Node, source: bytes) -> tuple[list[str], list[dict], l
     types: list[dict] = []
 
     def text(n: Node) -> str:
-        return source[n.start_byte:n.end_byte].decode()
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
 
     def walk(root: Node):
         # Iterative, not recursive - see _extract_python's walk for why.
@@ -1871,7 +1871,7 @@ def _csharp_declared_type_names(node: Node, source: bytes) -> list[str]:
         if n.type in _CSHARP_TYPE_DECLS:
             name_node = n.child_by_field_name("name")
             if name_node is not None:
-                names.append(source[name_node.start_byte:name_node.end_byte].decode())
+                names.append(source[name_node.start_byte:name_node.end_byte].decode(errors="ignore"))
         stack.extend(n.children)
     return names
 

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -1322,7 +1322,13 @@ def _rrf_fuse(vector_hits: list[dict], text_hits: list[dict]) -> list[dict]:
             if _is_auxiliary_path(hit.get("module_path") or ""):
                 effective_rank += _AUXILIARY_RANK_PENALTY
             scores[key] = scores.get(key, 0.0) + 1.0 / (_RRF_K + effective_rank + 1)
-            by_key[key] = hit
+            # Merge, don't overwrite: vector_hits carries _distance and
+            # text_hits carries _score, never both. A plain `by_key[key] =
+            # hit` on a dual-matched chunk left whichever retriever ran
+            # second (text_hits) clobbering the first, silently dropping
+            # _distance - the field search_index's final "score" is built
+            # from - for exactly the chunks both retrievers agree on.
+            by_key[key] = {**by_key.get(key, {}), **hit}
     return [by_key[key] for key, _ in sorted(scores.items(), key=lambda item: -item[1])]
 
 

--- a/src/tests/test_answer.py
+++ b/src/tests/test_answer.py
@@ -51,6 +51,37 @@ def test_answer_question_confidence_gate_skips_adapter_call(mock_search_index, t
 
 
 @patch("aletheore.answer.search_index")
+def test_answer_question_does_not_crash_when_top_result_has_no_score(mock_search_index, tmp_path):
+    """Regression test for docs/audits/Claude_Audit.md finding #18: a chunk
+    found only by full-text search (never by the vector retriever) has no
+    _distance at all, so search_index's "score" is None for it - and
+    `results[0]["score"] > confidence_threshold` used to crash with
+    `TypeError: '>' not supported between instances of 'NoneType' and
+    'float'` whenever that chunk ranked first. A missing distance-based
+    score means there's no signal to gate on, not that the match should be
+    rejected - the text match is real evidence either way."""
+    mock_search_index.return_value = [
+        {
+            "module_path": "auth.py",
+            "symbol_name": "login",
+            "start_line": 1,
+            "end_line": 3,
+            "language": "python",
+            "text": "auth.py::login\ndef login():\n    return True",
+            "score": None,
+        }
+    ]
+    adapter = MagicMock()
+    adapter.simple_completion.return_value = "Login is handled in auth.py::login."
+
+    result = answer_question(tmp_path, "how does login work", adapter)
+
+    assert result["confidence_gated"] is False
+    assert result["answer"] == "Login is handled in auth.py::login."
+    adapter.simple_completion.assert_called_once()
+
+
+@patch("aletheore.answer.search_index")
 def test_answer_question_gates_when_nothing_retrieved(mock_search_index, tmp_path):
     mock_search_index.return_value = []
     adapter = MagicMock()

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -17,6 +17,25 @@ def test_build_module_graph_records_oversized_source_without_parsing(tmp_path):
     assert unparseable == [{"path": "large.py", "reason": "file exceeds size limit"}]
 
 
+def test_build_module_graph_survives_invalid_utf8_in_one_file(tmp_path):
+    """Regression test for docs/audits/Claude_Audit.md finding #17: every
+    extractor decodes byte-slices with the plain .decode() (no errors=),
+    so one invalid-UTF-8 byte anywhere - an ordinary occurrence in real C/C++
+    code with non-English author names in a comment, since C predates UTF-8
+    - used to abort the entire repo scan with an unhandled
+    UnicodeDecodeError, taking down every other, unrelated file with it."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bad = b"/* Copyright \xe9 2019 Some Author */\nint foo(int x) {\n    return x;\n}\n"
+    (repo / "bad.c").write_bytes(bad)
+    (repo / "good.py").write_text("def ok():\n    return 1\n")
+
+    modules, _graph, _unparseable = build_module_graph(repo)
+
+    module_paths = {m["path"] for m in modules}
+    assert "good.py" in module_paths
+
+
 def make_python_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     app = repo / "app"

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -532,6 +532,28 @@ def test_rrf_fuse_ranks_a_chunk_found_by_both_retrievers_first():
     assert {c["module_path"] for c in fused} == {"shared.py", "vec_only.py", "fts_only.py"}
 
 
+def test_rrf_fuse_preserves_the_vector_distance_on_a_dual_matched_hit():
+    """Regression test for docs/audits/Claude_Audit.md finding #18: fusion
+    used to write by_key[key] = hit unconditionally, so a chunk found by
+    both retrievers ended up holding whichever retriever's dict was
+    processed last (text_hits, which carries _score but not _distance) -
+    silently losing the vector hit's _distance field entirely. search_index
+    then returned "score": None for exactly this case, and answer_question's
+    `results[0]["score"] > confidence_threshold` crashed with a TypeError on
+    its own best-case match. Fusion must preserve fields from both hits."""
+    def chunk(path, name, **extra):
+        return {"module_path": path, "symbol_name": name, "start_line": 1, **extra}
+
+    vector_hit = chunk("shared.py", "f", _distance=0.12)
+    text_hit = chunk("shared.py", "f", _score=8.5)
+
+    fused = _rrf_fuse([vector_hit], [text_hit])
+
+    assert len(fused) == 1
+    assert fused[0]["_distance"] == 0.12
+    assert fused[0]["_score"] == 8.5
+
+
 def test_rrf_fuse_demotes_a_declaration_only_hit_below_an_implementation():
     """A demotion, not an exclusion: slimphp/Slim's interfaces displaced the
     correct implementation on 4 of 6 misses by simply outranking it. Ranked


### PR DESCRIPTION
## Summary
Fixes findings #17, #18, #23 from `docs/audits/Claude_Audit.md`'s second pass - the three flagged as live-in-production priorities.

- **#17 (critical)**: any invalid-UTF-8 byte anywhere in a scanned repo aborted the *entire* scan. `scanner/graph.py` had 39 unguarded `.decode()` calls; all converted to `errors="ignore"`, matching the pattern the file already used at 2 of them.
- **#18 (high)**: `search_index`'s RRF fusion silently dropped the vector `_distance` field on any chunk found by both retrievers (overwritten by the text hit processed second), returning `score=None` for exactly its best-case match and crashing `answer_question` with a `TypeError`. Fixed the fusion to merge hit dicts instead of overwriting, plus an explicit `None`-guard in `answer_question` for the narrower remaining case (a text-only match genuinely has no distance-based score).
- **#23 (medium-high)**: AIRview's fallback for non-scanned files called `get_github_api_client()`, which is never imported in `dashboard.py` - pure `NameError`, silently caught, the feature 404'd on every call. One-line fix to the function that's actually imported (`_github_http_client`).

Each fix follows TDD: a failing test confirming the real bug first, then the minimal fix, then the full suite.

## Test plan
- [x] `test_fetch_wiki_file_content_sync_calls_a_function_that_actually_exists` - fails with the real `NameError` before the fix, passes after
- [x] `test_rrf_fuse_preserves_the_vector_distance_on_a_dual_matched_hit` - fails before, passes after
- [x] `test_answer_question_does_not_crash_when_top_result_has_no_score` - fails with the real `TypeError` before, passes after
- [x] `test_build_module_graph_survives_invalid_utf8_in_one_file` - fails with the real `UnicodeDecodeError` before, passes after
- [x] Full `src/` suite: 1335 passed, no regressions
- [x] `github-app/tests/test_dashboard.py`: 2 passed locally (rest skip without local Postgres/Redis, standard for this repo - CI runs them against real services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)