### PR TITLE
fix: AIRview/Docs incremental updates timing out mid-flight on large repos

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -175,7 +175,15 @@ FLASH_REVIEW_MARKER = "<!-- aletheore-flash-review -->"
 # subsystem plus the overview, deliberately the most expensive step in
 # the whole Live Wiki pipeline - see scan_worker/live_wiki.py.
 LIVE_WIKI_FULL_BUILD_JOB_TIMEOUT_SECONDS = 1800
-LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS = 300
+# Real production incidents (Aug 2026) showed the incremental update - real
+# LLM calls, with retries, riding along inside run_pr_scan_job/
+# run_push_scan_job's own 300s job_timeout - getting killed mid-flight on a
+# large repo, losing the whole update with no partial result. This constant
+# existed but was never actually wired to its own job/enqueue call until
+# that was fixed - twice the old shared budget, dedicated solely to this
+# step now that it's decoupled from the scan job's critical path.
+LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS = 600
+LIVE_DOCS_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS = 600
 HEALTH_CHECK_DOWN_RETRY_ATTEMPTS = 2
 HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS = 2.0
 # A flapping endpoint (down -> up -> down -> ...) re-triggers
@@ -927,24 +935,39 @@ def run_pr_scan_job(
         except Exception:  # noqa: BLE001
             changed_files = None
         if changed_files is not None:
+            # Enqueued as their own jobs rather than called inline - see
+            # run_live_wiki_incremental_update_job's docstring for why: real
+            # LLM calls here could push total time past this scan job's own
+            # 300s job_timeout on a large repo, and RQ would kill this whole
+            # job mid-flight when that happened, losing the update with no
+            # partial result. The PR diff comment above (this job's primary
+            # deliverable) is already posted by this point regardless.
             try:
-                _maybe_update_live_wiki(installation_id, repo_full_name, new, changed_files, head_sha)
+                _scans_queue(settings.redis_url).enqueue(
+                    "scan_worker.jobs.run_live_wiki_incremental_update_job",
+                    job_timeout=LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
+                    installation_id=installation_id,
+                    repo_full_name=repo_full_name,
+                    changed_files=changed_files,
+                    head_sha=head_sha,
+                )
             except Exception as exc:  # noqa: BLE001
-                # _maybe_update_live_wiki already records failures to
-                # wiki_build_status itself; this only catches something
-                # failing before that handling could run (e.g. get_settings).
                 logging.getLogger("scan_worker.jobs").warning(
-                    "live wiki incremental update failed for installation=%s repo=%s (%s)",
+                    "could not enqueue live wiki incremental update for installation=%s repo=%s (%s)",
                     installation_id, repo_full_name, exc,
                 )
             try:
-                _maybe_update_live_docs(installation_id, repo_full_name, new, changed_files, head_sha)
+                _scans_queue(settings.redis_url).enqueue(
+                    "scan_worker.jobs.run_live_docs_incremental_update_job",
+                    job_timeout=LIVE_DOCS_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
+                    installation_id=installation_id,
+                    repo_full_name=repo_full_name,
+                    changed_files=changed_files,
+                    head_sha=head_sha,
+                )
             except Exception as exc:  # noqa: BLE001
-                # _maybe_update_live_docs already records failures to
-                # docs_build_status itself; this only catches something
-                # failing before that handling could run (e.g. get_settings).
                 logging.getLogger("scan_worker.jobs").warning(
-                    "live docs incremental update failed for installation=%s repo=%s (%s)",
+                    "could not enqueue live docs incremental update for installation=%s repo=%s (%s)",
                     installation_id, repo_full_name, exc,
                 )
             try:
@@ -1094,18 +1117,34 @@ def run_push_scan_job(
         _insert_history(installation_id, repo_full_name, evidence)
 
         if installation is not None and installation["plan"] != "free":
+            # Enqueued as their own jobs, not called inline - see
+            # run_live_wiki_incremental_update_job's docstring.
             try:
-                _maybe_update_live_wiki(installation_id, repo_full_name, evidence, changed_files, head_sha)
+                _scans_queue(settings.redis_url).enqueue(
+                    "scan_worker.jobs.run_live_wiki_incremental_update_job",
+                    job_timeout=LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
+                    installation_id=installation_id,
+                    repo_full_name=repo_full_name,
+                    changed_files=changed_files,
+                    head_sha=head_sha,
+                )
             except Exception as exc:  # noqa: BLE001
                 logging.getLogger("scan_worker.jobs").warning(
-                    "live wiki reconciliation after push failed for installation=%s repo=%s (%s)",
+                    "could not enqueue live wiki reconciliation after push for installation=%s repo=%s (%s)",
                     installation_id, repo_full_name, exc,
                 )
             try:
-                _maybe_update_live_docs(installation_id, repo_full_name, evidence, changed_files, head_sha)
+                _scans_queue(settings.redis_url).enqueue(
+                    "scan_worker.jobs.run_live_docs_incremental_update_job",
+                    job_timeout=LIVE_DOCS_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
+                    installation_id=installation_id,
+                    repo_full_name=repo_full_name,
+                    changed_files=changed_files,
+                    head_sha=head_sha,
+                )
             except Exception as exc:  # noqa: BLE001
                 logging.getLogger("scan_worker.jobs").warning(
-                    "live docs reconciliation after push failed for installation=%s repo=%s (%s)",
+                    "could not enqueue live docs reconciliation after push for installation=%s repo=%s (%s)",
                     installation_id, repo_full_name, exc,
                 )
     except Exception as exc:  # noqa: BLE001
@@ -3978,3 +4017,50 @@ def _maybe_update_live_docs(
         if last_error is not None else None,
     )
     _maybe_sync_docs_to_repo(dsn, installation_id, repo_full_name)
+
+
+@log_job
+def run_live_wiki_incremental_update_job(
+    installation_id: int, repo_full_name: str, changed_files: list[str], head_sha: str
+) -> None:
+    """_maybe_update_live_wiki as its own job, enqueued by run_pr_scan_job/
+    run_push_scan_job instead of called inline.
+
+    Real production incidents traced a class of "Work-horse terminated
+    unexpectedly" scan-job failures to this exact call: AIRview's real LLM
+    calls (with retries) riding along inside the scan job's own 300s
+    job_timeout could push total time past that budget on a large repo,
+    and RQ kills the whole scan job mid-flight when that happens - losing
+    the wiki update entirely, with no partial result and no signal to the
+    customer about why. The scan job's own primary deliverable (the PR diff
+    comment) is already posted before this point regardless, so decoupling
+    this into its own job with its own, more generous timeout
+    (LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS) doesn't change what
+    a customer sees for the PR review itself - only what happens to the
+    wiki update when it runs long.
+
+    Evidence isn't passed through the queue - the calling scan job already
+    persisted this exact evidence via _insert_history before enqueueing
+    this job, so it's reloaded from repo_history here instead, keeping the
+    job payload small regardless of repo size."""
+    dsn = get_settings().database_url
+    evidence = get_latest_evidence(dsn, installation_id, repo_full_name)
+    if evidence is None:
+        return  # nothing scanned for this repo yet - nothing to update from
+    _maybe_update_live_wiki(installation_id, repo_full_name, evidence, changed_files, head_sha)
+
+
+@log_job
+def run_live_docs_incremental_update_job(
+    installation_id: int, repo_full_name: str, changed_files: list[str], head_sha: str
+) -> None:
+    """See run_live_wiki_incremental_update_job's docstring - same
+    reasoning, the live docs path. A separate job (not bundled with the
+    wiki one above) so one's own timeout or failure doesn't affect the
+    other, matching how their full-build counterparts are already separate
+    jobs."""
+    dsn = get_settings().database_url
+    evidence = get_latest_evidence(dsn, installation_id, repo_full_name)
+    if evidence is None:
+        return
+    _maybe_update_live_docs(installation_id, repo_full_name, evidence, changed_files, head_sha)

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -8,6 +8,8 @@ import pytest
 
 from scan_worker.jobs import (
     FLASH_REVIEW_SPEND_RESERVE_USD,
+    LIVE_DOCS_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
+    LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
     MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH,
     run_pr_scan_job,
 )
@@ -4015,7 +4017,121 @@ def test_maybe_update_live_wiki_reserves_spend_atomically_against_concurrent_pus
     assert len(ready) == 1
 
 
-def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_with_two_commits, monkeypatch):
+def test_run_live_wiki_incremental_update_job_reloads_evidence_and_delegates(monkeypatch):
+    """run_live_wiki_incremental_update_job is the new, separately-timed job
+    that run_pr_scan_job/run_push_scan_job now enqueue instead of calling
+    _maybe_update_live_wiki inline. It doesn't receive evidence directly -
+    the calling scan job already persisted it via _insert_history before
+    enqueueing this job, so this reloads it from repo_history instead of
+    needing the (potentially large) evidence blob passed through the queue."""
+    from scan_worker.jobs import run_live_wiki_incremental_update_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    evidence = _wiki_evidence()
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda dsn, iid, repo: evidence)
+    called = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs._maybe_update_live_wiki",
+        lambda installation_id, repo_full_name, ev, changed_files, head_sha: called.update(
+            installation_id=installation_id, repo_full_name=repo_full_name,
+            evidence=ev, changed_files=changed_files, head_sha=head_sha,
+        ),
+    )
+
+    run_live_wiki_incremental_update_job(
+        installation_id=1, repo_full_name="octocat/hello-world",
+        changed_files=["auth/login.py"], head_sha="sha1",
+    )
+
+    assert called["installation_id"] == 1
+    assert called["repo_full_name"] == "octocat/hello-world"
+    assert called["evidence"] is evidence
+    assert called["changed_files"] == ["auth/login.py"]
+    assert called["head_sha"] == "sha1"
+
+
+def test_run_live_wiki_incremental_update_job_noop_when_no_evidence_yet(monkeypatch):
+    from scan_worker.jobs import run_live_wiki_incremental_update_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda dsn, iid, repo: None)
+    called = []
+    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: called.append(True))
+
+    run_live_wiki_incremental_update_job(
+        installation_id=1, repo_full_name="octocat/hello-world",
+        changed_files=["auth/login.py"], head_sha="sha1",
+    )
+
+    assert called == []
+
+
+def test_run_live_docs_incremental_update_job_reloads_evidence_and_delegates(monkeypatch):
+    from scan_worker.jobs import run_live_docs_incremental_update_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    evidence = _wiki_evidence()
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda dsn, iid, repo: evidence)
+    called = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs._maybe_update_live_docs",
+        lambda installation_id, repo_full_name, ev, changed_files, head_sha: called.update(
+            installation_id=installation_id, repo_full_name=repo_full_name,
+            evidence=ev, changed_files=changed_files, head_sha=head_sha,
+        ),
+    )
+
+    run_live_docs_incremental_update_job(
+        installation_id=1, repo_full_name="octocat/hello-world",
+        changed_files=["auth/login.py"], head_sha="sha1",
+    )
+
+    assert called["installation_id"] == 1
+    assert called["repo_full_name"] == "octocat/hello-world"
+    assert called["evidence"] is evidence
+    assert called["changed_files"] == ["auth/login.py"]
+    assert called["head_sha"] == "sha1"
+
+
+def test_run_live_docs_incremental_update_job_noop_when_no_evidence_yet(monkeypatch):
+    from scan_worker.jobs import run_live_docs_incremental_update_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda dsn, iid, repo: None)
+    called = []
+    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_docs", lambda *a, **k: called.append(True))
+
+    run_live_docs_incremental_update_job(
+        installation_id=1, repo_full_name="octocat/hello-world",
+        changed_files=["auth/login.py"], head_sha="sha1",
+    )
+
+    assert called == []
+
+
+class _FakeScansQueue:
+    """Records enqueue() calls instead of touching real Redis - see
+    test_run_pr_scan_job_enqueues_live_wiki_and_docs_update_jobs for why
+    this replaced monkeypatching _maybe_update_live_wiki directly."""
+
+    def __init__(self):
+        self.enqueued = []
+
+    def enqueue(self, func_name, **kwargs):
+        self.enqueued.append({"func_name": func_name, **kwargs})
+
+
+def test_run_pr_scan_job_enqueues_live_wiki_and_docs_update_jobs(bare_repo_with_two_commits, monkeypatch):
+    """Regression test for docs/audits history: run_pr_scan_job used to call
+    _maybe_update_live_wiki/_maybe_update_live_docs inline, sharing the
+    scan job's own 300s job_timeout - real production incidents showed
+    AIRview's real LLM calls (with retries) on a large repo pushing total
+    time past that budget, and RQ killing the whole job mid-flight
+    ("Work-horse terminated unexpectedly"), losing the wiki/docs update
+    entirely with no partial result and no signal to the customer. Now
+    enqueued as their own jobs with their own, more generous timeout,
+    decoupled from the scan job's critical path (which has already posted
+    the PR diff comment - its primary deliverable - by this point)."""
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
@@ -4033,16 +4149,15 @@ def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_wit
     monkeypatch.setattr(
         "scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"]
     )
-    called = {}
+    direct_calls = []
     monkeypatch.setattr(
-        "scan_worker.jobs._maybe_update_live_wiki",
-        lambda installation_id, repo_full_name, evidence, changed_files, head_sha: called.update(
-            installation_id=installation_id,
-            repo_full_name=repo_full_name,
-            changed_files=changed_files,
-            head_sha=head_sha,
-        ),
+        "scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: direct_calls.append("wiki")
     )
+    monkeypatch.setattr(
+        "scan_worker.jobs._maybe_update_live_docs", lambda *a, **k: direct_calls.append("docs")
+    )
+    fake_queue = _FakeScansQueue()
+    monkeypatch.setattr("scan_worker.jobs._scans_queue", lambda redis_url: fake_queue)
 
     run_pr_scan_job(
         installation_id=1,
@@ -4052,10 +4167,26 @@ def test_run_pr_scan_job_wires_changed_files_into_live_wiki_update(bare_repo_wit
         head_sha=head_sha,
     )
 
-    assert called["installation_id"] == 1
-    assert called["repo_full_name"] == "octocat/hello-world"
-    assert called["changed_files"] == ["app.py"]
-    assert called["head_sha"] == head_sha
+    # Never called inline - only as separately-enqueued jobs.
+    assert direct_calls == []
+
+    wiki_job = next(e for e in fake_queue.enqueued if "live_wiki_incremental" in e["func_name"])
+    assert wiki_job["func_name"] == "scan_worker.jobs.run_live_wiki_incremental_update_job"
+    assert wiki_job["installation_id"] == 1
+    assert wiki_job["repo_full_name"] == "octocat/hello-world"
+    assert wiki_job["changed_files"] == ["app.py"]
+    assert wiki_job["head_sha"] == head_sha
+    assert wiki_job["job_timeout"] == LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS
+    assert wiki_job["job_timeout"] > 300  # strictly more headroom than the scan job's own budget
+
+    docs_job = next(e for e in fake_queue.enqueued if "live_docs_incremental" in e["func_name"])
+    assert docs_job["func_name"] == "scan_worker.jobs.run_live_docs_incremental_update_job"
+    assert docs_job["installation_id"] == 1
+    assert docs_job["repo_full_name"] == "octocat/hello-world"
+    assert docs_job["changed_files"] == ["app.py"]
+    assert docs_job["head_sha"] == head_sha
+    assert docs_job["job_timeout"] == LIVE_DOCS_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS
+    assert docs_job["job_timeout"] > 300
 
 
 def test_run_pr_scan_job_logs_slack_alert_failure_instead_of_swallowing_it(
@@ -4098,7 +4229,9 @@ def test_run_pr_scan_job_logs_slack_alert_failure_instead_of_swallowing_it(
     )
 
 
-def test_run_push_scan_job_scans_and_reconciles_wiki(bare_repo_with_two_commits, monkeypatch):
+def test_run_push_scan_job_enqueues_live_wiki_and_docs_update_jobs(bare_repo_with_two_commits, monkeypatch):
+    """See test_run_pr_scan_job_enqueues_live_wiki_and_docs_update_jobs -
+    same fix, same reasoning, the push-scan path."""
     from scan_worker.jobs import run_push_scan_job
 
     bare_path, _base_sha, head_sha = bare_repo_with_two_commits
@@ -4109,17 +4242,15 @@ def test_run_push_scan_job_scans_and_reconciles_wiki(bare_repo_with_two_commits,
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
-
-    called = {}
+    direct_calls = []
     monkeypatch.setattr(
-        "scan_worker.jobs._maybe_update_live_wiki",
-        lambda installation_id, repo_full_name, evidence, changed_files, head_sha: called.update(
-            installation_id=installation_id,
-            repo_full_name=repo_full_name,
-            changed_files=changed_files,
-            head_sha=head_sha,
-        ),
+        "scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: direct_calls.append("wiki")
     )
+    monkeypatch.setattr(
+        "scan_worker.jobs._maybe_update_live_docs", lambda *a, **k: direct_calls.append("docs")
+    )
+    fake_queue = _FakeScansQueue()
+    monkeypatch.setattr("scan_worker.jobs._scans_queue", lambda redis_url: fake_queue)
 
     run_push_scan_job(
         installation_id=1,
@@ -4128,10 +4259,21 @@ def test_run_push_scan_job_scans_and_reconciles_wiki(bare_repo_with_two_commits,
         changed_files=["app.py"],
     )
 
-    assert called["installation_id"] == 1
-    assert called["repo_full_name"] == "octocat/hello-world"
-    assert called["changed_files"] == ["app.py"]
-    assert called["head_sha"] == head_sha
+    assert direct_calls == []
+
+    wiki_job = next(e for e in fake_queue.enqueued if "live_wiki_incremental" in e["func_name"])
+    assert wiki_job["installation_id"] == 1
+    assert wiki_job["repo_full_name"] == "octocat/hello-world"
+    assert wiki_job["changed_files"] == ["app.py"]
+    assert wiki_job["head_sha"] == head_sha
+    assert wiki_job["job_timeout"] == LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS
+
+    docs_job = next(e for e in fake_queue.enqueued if "live_docs_incremental" in e["func_name"])
+    assert docs_job["installation_id"] == 1
+    assert docs_job["repo_full_name"] == "octocat/hello-world"
+    assert docs_job["changed_files"] == ["app.py"]
+    assert docs_job["head_sha"] == head_sha
+    assert docs_job["job_timeout"] == LIVE_DOCS_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS
 
 
 def test_run_push_scan_job_skips_wiki_update_for_free_plan(bare_repo_with_two_commits, monkeypatch):
@@ -4144,8 +4286,8 @@ def test_run_push_scan_job_skips_wiki_update_for_free_plan(bare_repo_with_two_co
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
-    called = []
-    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: called.append(True))
+    fake_queue = _FakeScansQueue()
+    monkeypatch.setattr("scan_worker.jobs._scans_queue", lambda redis_url: fake_queue)
 
     run_push_scan_job(
         installation_id=1,
@@ -4154,7 +4296,7 @@ def test_run_push_scan_job_skips_wiki_update_for_free_plan(bare_repo_with_two_co
         changed_files=["app.py"],
     )
 
-    assert called == []
+    assert fake_queue.enqueued == []
 
 
 def test_run_push_scan_job_skips_paid_repo_past_monthly_scan_cap(bare_repo_with_two_commits, monkeypatch):


### PR DESCRIPTION
## Summary
Root-caused a real, recurring production incident (traced from `ops_monitor.failed_jobs.scans` alerts going back to Aug 13): `run_pr_scan_job` and `run_push_scan_job` call `_maybe_update_live_wiki`/`_maybe_update_live_docs` inline, sharing the scan job's own `job_timeout=300` (5 minutes). On a large real repo, AIRview's real LLM calls (with retries) push total job time past that budget, and RQ kills the whole job mid-flight - "Work-horse terminated unexpectedly" - losing the wiki/docs update entirely, with no partial result and no signal to the customer.

**Confirmed on Aletheore's own production install** (dogfooding, installation 147514632): two real failures this session, both PR/push scans of `Aletheore/Aletheore` itself, both killed at exactly 360s (300s timeout + RQ's watchdog grace period). Ruled out OOM (no kernel OOM events in either failure window via `journalctl -k`) and ruled out the bare scan being the memory culprit (a full local scan of this exact repo peaks at ~260MB, nowhere near the 1GiB container limit) before finding the real cause: real DeepSeek API calls (with a retry) logged seconds before both kills.

**Fix:** `_maybe_update_live_wiki`/`_maybe_update_live_docs` now run as their own enqueued jobs (`run_live_wiki_incremental_update_job`, `run_live_docs_incremental_update_job`) instead of being called inline, each with its own dedicated 600s timeout - twice the old shared budget, and fully decoupled from the scan job's critical path. The scan job's primary deliverable (the PR diff comment) is already posted before this point regardless, so this doesn't change what a customer sees for the PR review itself.

Interesting detail: the wiki timeout constant (`LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS`) already existed in the codebase at 300 but was never actually wired to a job - an orphaned constant anticipating exactly this fix.

Evidence is reloaded from `repo_history` in the new jobs rather than passed through the queue - the calling scan job already persists it via `_insert_history` before enqueueing, keeping the job payload small regardless of repo size.

## Test plan
- [x] 6 new tests (2 for each new job function's evidence-reload/delegate/no-op behavior, 2 for the enqueue wiring in `run_pr_scan_job`/`run_push_scan_job`) + 1 updated test for the free-plan skip path
- [x] Full `test_jobs.py`: 173 passed, real Postgres/Redis
- [x] Root cause independently verified against real production logs/timestamps before writing any fix (not guessed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)