### PR TITLE
fix: ops/error alert cooldown was 15 minutes, not the agreed 6 hours

### DIFF
--- a/github-app/app_server/error_alerts.py
+++ b/github-app/app_server/error_alerts.py
@@ -24,7 +24,11 @@ logger = logging.getLogger("app_server.error_alerts")
 # bug during the same window should still get its own alert. Process-local
 # and reset on restart, which is fine: the goal is "don't flood," not a
 # durable dedupe ledger.
-_ALERT_COOLDOWN_SECONDS = 900
+#
+# 6 hours, matching ops_monitor's OPS_ALERT_COOLDOWN_SECONDS - same
+# policy in both places: alert once, then only remind every 6 hours for
+# as long as the same issue keeps recurring, not on every occurrence.
+_ALERT_COOLDOWN_SECONDS = 6 * 60 * 60
 _last_alert_at: dict[str, float] = {}
 
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2784,18 +2784,27 @@ def _fetch_app_health(url: str) -> tuple[bool, str]:
     return False, f"HTTP {response.status_code}: {response.text[:200]}"
 
 
-# Must stay comfortably under _check_threshold_duration's own state-key TTL
-# (OPS_THRESHOLD_DURATION_SECONDS * 3 = 1800s, never refreshed once set,
-# counted from the condition's original detection - not from when an
-# alert fires) - a cooldown too close to that window risks the underlying
-# "how long has this persisted" tracking expiring and resetting before the
-# cooldown clears, which would silently skip the next legitimate reminder
-# alert instead of sending it. 900s (15min) leaves real margin: the
-# earliest an alert (and so a cooldown) can start is
-# OPS_THRESHOLD_DURATION_SECONDS (600s) after first detection, so the
-# latest a cooldown started then could still clear before the 1800s
-# state-key TTL is 1800 - 600 = 1200s - 900s has real headroom under that.
-OPS_ALERT_COOLDOWN_SECONDS = 900
+# Deliberately much longer than _check_threshold_duration's own state-key
+# TTL (OPS_THRESHOLD_DURATION_SECONDS * 3 = 1800s, never refreshed once
+# set). That's fine, not a bug: once this cooldown blocks a send, the
+# state key can expire and reset ("first seen" restarts) any number of
+# times without causing an extra alert, since _send_ops_alert's own
+# cooldown key is what actually gates the email - the state key only
+# gates how quickly a *persisting* condition is allowed to re-qualify for
+# an attempt. Worst case is the reminder landing up to one
+# OPS_THRESHOLD_DURATION_SECONDS + one ops_monitor cycle late, never
+# early and never skipped.
+#
+# Real incident: a persisting scan-timeout bug (see run_pr_scan_job /
+# run_push_scan_job's live-wiki/live-docs decoupling) kept
+# ops_monitor.failed_jobs.scans above threshold continuously for over a
+# day. At the old 900s (15min) cooldown that meant a fresh alert email
+# roughly every 15-30 minutes the whole time - confirmed against the
+# actual inbox. The intended policy (already the working assumption
+# elsewhere) is: alert once, then only send a reminder every 6 hours for
+# as long as the same condition keeps recurring - not nag every ops_monitor
+# cycle just because nobody has fixed it yet.
+OPS_ALERT_COOLDOWN_SECONDS = 6 * 60 * 60
 
 
 def _send_ops_alert(redis_conn, source: str, message: str, context: str) -> None:

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -6049,14 +6049,23 @@ def test_run_ops_monitor_job_does_not_repeat_alert_within_cooldown(monkeypatch):
     # Once the cooldown has genuinely elapsed (anchored to when it was
     # actually set - alert_fired_at - not to whatever t happens to be now),
     # a still-persisting condition should alert again as a "this is still
-    # ongoing" reminder, not stay silent forever. Must land before
-    # _check_threshold_duration's own first_seen state (set at t=1000,
-    # TTL OPS_THRESHOLD_DURATION_SECONDS*3=1800s, expires at t=2800) also
-    # expires - otherwise this test would exercise a second, different
-    # pre-existing behavior (first_seen resetting) instead of the cooldown
-    # clearing.
+    # ongoing" reminder, not stay silent forever. OPS_ALERT_COOLDOWN_SECONDS
+    # (6h) is now far longer than _check_threshold_duration's own
+    # first_seen state-key TTL (OPS_THRESHOLD_DURATION_SECONDS*3=1800s), so
+    # by the time the cooldown clears that state key has long since expired
+    # - in production, continuous ~3-minute ops_monitor runs keep
+    # re-seeding it the whole time, so a "seasoned" (>=600s old) first_seen
+    # is already in place the moment the cooldown clears. This test only
+    # jumps in time, so it reproduces that same two-step shape explicitly:
+    # one run to re-seed first_seen after its old value expired, then one
+    # more run past OPS_THRESHOLD_DURATION_SECONDS later to actually
+    # re-cross the duration threshold with the cooldown now clear.
     t = alert_fired_at + OPS_ALERT_COOLDOWN_SECONDS + 1
-    assert t < 1000.0 + 1800  # stay inside first_seen's own TTL window
+    monkeypatch.setattr(jobs.time, "time", lambda: t)
+    run_ops_monitor_job()
+    assert len(alerts) == 1  # first_seen re-seeded, not yet past the duration threshold again
+
+    t += OPS_THRESHOLD_DURATION_SECONDS + 1
     monkeypatch.setattr(jobs.time, "time", lambda: t)
     run_ops_monitor_job()
     assert len(alerts) == 2


### PR DESCRIPTION
## Summary
- Confirmed against the live inbox: `ops_monitor.failed_jobs.scans` re-alerted roughly every 15-30 minutes through 2026-08-22, while the (now-fixed) AIRview/Docs timeout bug kept the scans queue's failed-jobs count continuously above threshold.
- Both cooldown constants that gate repeat alerts for a persisting issue - `OPS_ALERT_COOLDOWN_SECONDS` (`scan_worker/jobs.py`) and `_ALERT_COOLDOWN_SECONDS` (`app_server/error_alerts.py`) - were set to 900s (15min). The intended policy was: alert once, then only remind every 6 hours for as long as the same issue keeps recurring, not nag every ops_monitor cycle.
- Bumped both to `6 * 60 * 60`.

## Why the comment/test also changed
`OPS_ALERT_COOLDOWN_SECONDS`'s old comment justified 900s specifically by staying under `_check_threshold_duration`'s own 1800s `first_seen` state-key TTL. That reasoning doesn't hold at 6h (1800s « 21600s), but correctness still does: once the cooldown blocks a send, the state key expiring and resetting mid-cooldown just means the "how long has this persisted" tracking restarts - it can't cause an early alert, since the cooldown key is what actually gates the send. Updated the comment to explain this, and rewrote `test_run_ops_monitor_job_does_not_repeat_alert_within_cooldown`'s final assertion: continuous ~3-minute production polling naturally re-seeds `first_seen` before the cooldown clears, but a test that only jumps in time doesn't get that for free, so it now explicitly reproduces the two-step shape (one run to re-seed `first_seen` after its old value expired, one more run past the duration threshold to actually re-alert).

## Test plan
- [x] `tests/test_jobs.py` full suite: 169 passed (real Postgres/Redis)
- [x] `tests/test_error_alerts.py`: 5 passed
- [x] Full `github-app` suite already re-verified clean (1480 passed, 8 skipped) as part of the sibling AIRview/Docs timeout PR (#364), merged just before this one from the same investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)