### PR TITLE
fix: 5 remaining audit findings from the second-pass audit (#19, #22, #24, #25, #26)

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -26,14 +26,12 @@ from app_server.db import (
     DEFAULT_SEAT_LIMIT,
     INCLUDED_HEALTH_CHECK_TARGETS,
     INCLUDED_SEATS,
-    add_health_check_target,
+    add_health_check_target_within_limit,
     add_initial_installation_member_if_empty,
     add_installation_member_within_seat_limit,
     consume_deletion_otp_code,
-    count_active_tokens,
-    count_health_check_targets,
     count_installation_members,
-    create_api_token,
+    create_api_token_within_limit,
     create_deletion_otp_code,
     delete_session,
     get_docs_repo_commit_settings,
@@ -739,13 +737,13 @@ async def generate_token(org: str, repo: str, request: Request, body: GenerateTo
     installation_id = installation["installation_id"]
 
     max_tokens = await get_max_tokens(pool, installation_id)
-    if await count_active_tokens(pool, installation_id) >= max_tokens:
-        raise HTTPException(status_code=409, detail=f"token limit reached ({max_tokens})")
-
     raw_token = secrets.token_urlsafe(32)
     token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-    await create_api_token(pool, installation_id, token_hash, body.label, session["github_login"])
-    token_id = (await list_api_tokens(pool, installation_id))[0]["id"]
+    token_id = await create_api_token_within_limit(
+        pool, installation_id, token_hash, body.label, session["github_login"], max_tokens
+    )
+    if token_id is None:
+        raise HTTPException(status_code=409, detail=f"token limit reached ({max_tokens})")
     # Label only - never the raw token or its hash.
     await record_admin_action(
         pool, installation_id, session["github_login"], "api_token_created",
@@ -867,15 +865,14 @@ async def add_health_check_target_route(org: str, repo: str, request: Request, b
     installation_id = installation["installation_id"]
     repo_full_name = f"{org}/{repo}"
     limit = INCLUDED_HEALTH_CHECK_TARGETS.get(installation["plan"], DEFAULT_HEALTH_CHECK_TARGET_LIMIT)
-    if await count_health_check_targets(pool, installation_id, repo_full_name) >= limit:
+    target_id = await add_health_check_target_within_limit(
+        pool, installation_id, repo_full_name, body.label, body.base_url, body.latency_threshold_ms, limit
+    )
+    if target_id is None:
         raise HTTPException(
             status_code=409,
             detail=f"health check target limit reached ({limit} for the {installation['plan']} plan)",
         )
-
-    target_id = await add_health_check_target(
-        pool, installation_id, repo_full_name, body.label, body.base_url, body.latency_threshold_ms
-    )
     session = await get_current_session(request)
     await record_admin_action(
         pool, installation_id, session["github_login"], "health_check_target_added",
@@ -1184,14 +1181,13 @@ async def create_cli_token(request: Request, body: CreateCliTokenRequest):
         raise HTTPException(status_code=402, detail="this feature requires a paid plan")
 
     max_tokens = await get_max_tokens(pool, installation_id)
-    if await count_active_tokens(pool, installation_id) >= max_tokens:
-        raise HTTPException(status_code=409, detail=f"token limit reached ({max_tokens})")
-
     raw_token = secrets.token_urlsafe(32)
     token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
-    token_id = await create_api_token(
-        pool, installation_id, token_hash, body.label, installation["account_login"]
+    token_id = await create_api_token_within_limit(
+        pool, installation_id, token_hash, body.label, installation["account_login"], max_tokens
     )
+    if token_id is None:
+        raise HTTPException(status_code=409, detail=f"token limit reached ({max_tokens})")
     return {"token": raw_token, "id": token_id, "label": body.label}
 
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -495,6 +495,13 @@ MAX_SCANNED_REPOS_PER_MONTH = 10
 # the second key is the installation id.
 SCAN_SLOT_LOCK_NAMESPACE = 1
 SEAT_LOCK_NAMESPACE = 3
+# scan_worker/db.py separately claims 1 (shared, intentional - see above), 2
+# (SPEND_LOCK_NAMESPACE), and 3 (REPO_CHECKOUT_LOCK_NAMESPACE, an
+# independent, unintentional collision with SEAT_LOCK_NAMESPACE above - see
+# docs/audits/Claude_Audit.md finding 30). 4 and 5 chosen here specifically
+# because neither file has claimed them yet.
+HEALTH_CHECK_TARGET_LOCK_NAMESPACE = 4
+API_TOKEN_LOCK_NAMESPACE = 5
 ADVISORY_LOCK_TIMEOUT = "5s"
 
 
@@ -899,6 +906,78 @@ async def add_health_check_target(
     return row["id"]
 
 
+async def add_health_check_target_within_limit(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    repo_full_name: str,
+    label: str,
+    base_url: str,
+    latency_threshold_ms: int | None,
+    limit: int,
+) -> int | None:
+    """Atomic version of the route's former count-then-add_health_check_target
+    sequence, same concurrency pattern as add_installation_member_within_seat_limit.
+
+    The route-level read/count/insert was race-prone: two concurrent
+    requests for two different URLs, both already one below the limit,
+    could both read the same under-limit count before either insert
+    committed, leaving the installation over its plan's health-check-target
+    limit. A per-installation advisory transaction lock serializes the
+    count-bound upsert instead.
+
+    Returns the target's id (new or updated) if allowed, None if a
+    genuinely new target would have exceeded the limit. An existing target
+    (matched on installation_id, repo_full_name, base_url) is always
+    allowed to update - only a real new insert counts against the limit,
+    matching add_health_check_target's existing upsert semantics.
+    """
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("SELECT set_config('lock_timeout', $1, true)", ADVISORY_LOCK_TIMEOUT)
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock($1, $2)",
+                HEALTH_CHECK_TARGET_LOCK_NAMESPACE,
+                installation_id,
+            )
+            row = await conn.fetchrow(
+                """
+                WITH existing AS (
+                    SELECT id
+                    FROM health_check_targets
+                    WHERE installation_id = $1 AND repo_full_name = $2 AND base_url = $3
+                ),
+                updated AS (
+                    UPDATE health_check_targets
+                    SET label = $4, latency_threshold_ms = $5
+                    WHERE id IN (SELECT id FROM existing)
+                    RETURNING id
+                ),
+                inserted AS (
+                    INSERT INTO health_check_targets
+                        (installation_id, repo_full_name, label, base_url, latency_threshold_ms)
+                    SELECT $1, $2, $4, $3, $5
+                    WHERE NOT EXISTS (SELECT 1 FROM existing)
+                      AND (
+                          SELECT count(*)
+                          FROM health_check_targets
+                          WHERE installation_id = $1 AND repo_full_name = $2
+                      ) < $6
+                    RETURNING id
+                )
+                SELECT id FROM updated
+                UNION ALL
+                SELECT id FROM inserted
+                """,
+                installation_id,
+                repo_full_name,
+                base_url,
+                label,
+                latency_threshold_ms,
+                limit,
+            )
+    return row["id"] if row is not None else None
+
+
 async def remove_health_check_target(pool: asyncpg.Pool, installation_id: int, repo_full_name: str, target_id: int) -> None:
     await pool.execute(
         "DELETE FROM health_check_targets WHERE id = $1 AND installation_id = $2 AND repo_full_name = $3",
@@ -1288,6 +1367,48 @@ async def create_api_token(
         label,
         created_by_github_login,
     )
+
+
+async def create_api_token_within_limit(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    token_hash: str,
+    label: str,
+    created_by_github_login: str,
+    limit: int,
+) -> int | None:
+    """Atomic version of the route's former count-then-create_api_token
+    sequence, same concurrency pattern as add_installation_member_within_seat_limit
+    and add_health_check_target_within_limit. Unlike those two, every call
+    here is a genuinely new row (no natural key to upsert against - each
+    token is unique by its random hash), so the CTE only needs the
+    count-bound insert, not an existing/insert split.
+
+    Returns the new token's id if allowed, None if it would have exceeded
+    the limit.
+    """
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("SELECT set_config('lock_timeout', $1, true)", ADVISORY_LOCK_TIMEOUT)
+            await conn.execute(
+                "SELECT pg_advisory_xact_lock($1, $2)",
+                API_TOKEN_LOCK_NAMESPACE,
+                installation_id,
+            )
+            row = await conn.fetchrow(
+                """
+                INSERT INTO api_tokens (installation_id, token_hash, label, created_by_github_login)
+                SELECT $1, $2, $3, $4
+                WHERE (SELECT count(*) FROM api_tokens WHERE installation_id = $1 AND revoked_at IS NULL) < $5
+                RETURNING id
+                """,
+                installation_id,
+                token_hash,
+                label,
+                created_by_github_login,
+                limit,
+            )
+    return row["id"] if row is not None else None
 
 
 async def revoke_api_token(pool: asyncpg.Pool, installation_id: int, token_id: int) -> None:

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -367,6 +367,40 @@ async def test_generate_token_returns_raw_value_once(pool, monkeypatch):
     async with client:
         response = await client.post("/admin/octocat/hello-world/tokens", json={"label": "laptop"})
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_generate_token_returns_the_id_create_api_token_actually_created(pool, monkeypatch):
+    # Real incident this guards: generate_token used to discard
+    # create_api_token's own RETURNING id and re-derive it via
+    # list_api_tokens(...)[0]["id"] - an assumption that breaks under
+    # concurrent token creation for the same installation, since a second
+    # caller's newer row could sort first. Now that generate_token calls
+    # create_api_token_within_limit directly (also closing the separate
+    # count-then-insert race over the token limit), there's no second query
+    # left to race - this asserts the id it returns is used verbatim.
+    client = await _logged_in_client(pool, monkeypatch)
+
+    async def fake_create_api_token_within_limit(pool, installation_id, token_hash, label, created_by, limit):
+        return 42
+
+    monkeypatch.setattr(
+        "app_server.admin.create_api_token_within_limit", fake_create_api_token_within_limit
+    )
+
+    recorded_actions = []
+
+    async def fake_record_admin_action(pool, installation_id, github_login, action, details):
+        recorded_actions.append((action, details))
+
+    monkeypatch.setattr("app_server.admin.record_admin_action", fake_record_admin_action)
+
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/tokens", json={"label": "laptop"})
+
+    assert response.status_code == 200
+    assert response.json()["id"] == 42
+    assert recorded_actions[-1][1]["token_id"] == 42
     assert len(response.json()["token"]) > 20
 
 

--- a/github-app/tests/test_db.py
+++ b/github-app/tests/test_db.py
@@ -7,12 +7,14 @@ from app_server.evidence_limits import EvidenceTooLargeError, MAX_EVIDENCE_BYTES
 from app_server.db import (
     add_installation_member_within_seat_limit,
     add_health_check_target,
+    add_health_check_target_within_limit,
     add_installation_member,
     check_and_reserve_managed_audit,
     count_active_tokens,
     count_health_check_targets,
     count_installation_members,
     create_api_token,
+    create_api_token_within_limit,
     create_session,
     delete_installation,
     delete_session,
@@ -296,6 +298,69 @@ async def test_concurrent_api_token_creation_returns_each_inserted_id(pool):
     )
     assert {row["id"] for row in rows} == set(results)
     assert {row["token_hash"] for row in rows} == {f"hash-{index}" for index in range(10)}
+
+
+@pytest.mark.asyncio
+async def test_create_api_token_within_limit_is_concurrency_safe(pool):
+    # Real bug this guards (Claude_Audit.md finding 24): the route-level
+    # count-then-create_api_token sequence let two concurrent requests both
+    # read the same under-limit count before either insert committed,
+    # letting an installation end up over its plan's token limit. Mirrors
+    # test_add_installation_member_within_seat_limit_is_concurrency_safe's
+    # shape - 10 concurrent callers, limit 2, exactly 2 must win.
+    await upsert_installation(pool, 612, "octocat")
+
+    results = await asyncio.gather(
+        *(
+            create_api_token_within_limit(pool, 612, f"hash-{index}", f"token-{index}", "octocat", limit=2)
+            for index in range(10)
+        )
+    )
+
+    assert sum(1 for token_id in results if token_id is not None) == 2
+    rows = await pool.fetch("SELECT id FROM api_tokens WHERE installation_id = $1", 612)
+    assert len(rows) == 2
+    assert {row["id"] for row in rows} == {token_id for token_id in results if token_id is not None}
+
+
+@pytest.mark.asyncio
+async def test_add_health_check_target_within_limit_is_concurrency_safe(pool):
+    # Same fix, same reasoning as test_create_api_token_within_limit_is_concurrency_safe,
+    # the health-check-target quota.
+    await upsert_installation(pool, 613, "octocat")
+
+    results = await asyncio.gather(
+        *(
+            add_health_check_target_within_limit(
+                pool, 613, "octocat/repo1", f"target-{index}", f"https://{index}.example.com", None, limit=2
+            )
+            for index in range(10)
+        )
+    )
+
+    assert sum(1 for target_id in results if target_id is not None) == 2
+    assert await count_health_check_targets(pool, 613, "octocat/repo1") == 2
+
+
+@pytest.mark.asyncio
+async def test_add_health_check_target_within_limit_allows_updating_an_existing_target_over_the_limit(pool):
+    # An existing target (same installation/repo/base_url) must always be
+    # updatable - only a genuinely new insert counts against the limit,
+    # matching add_health_check_target's existing upsert semantics.
+    await upsert_installation(pool, 614, "octocat")
+    first_id = await add_health_check_target_within_limit(
+        pool, 614, "octocat/repo1", "Primary", "https://a.example.com", None, limit=1
+    )
+    assert first_id is not None
+
+    updated_id = await add_health_check_target_within_limit(
+        pool, 614, "octocat/repo1", "Primary (renamed)", "https://a.example.com", 500, limit=1
+    )
+
+    assert updated_id == first_id
+    row = await pool.fetchrow("SELECT label, latency_threshold_ms FROM health_check_targets WHERE id = $1", first_id)
+    assert row["label"] == "Primary (renamed)"
+    assert row["latency_threshold_ms"] == 500
 
 
 @pytest.mark.asyncio

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -629,9 +629,9 @@ def _fetch_whoami(
             "/v1/whoami", headers={"Authorization": f"Bearer {token}"}, timeout=5.0
         )
         response.raise_for_status()
-    except httpx.HTTPError:
+        return response.json()
+    except (httpx.HTTPError, ValueError):
         return None
-    return response.json()
 
 
 def _query_schema(repo_path: str) -> int:
@@ -1363,6 +1363,7 @@ def audit(
                 scan_git_history,
                 check_licenses,
                 map_endpoints,
+                map_schema,
             )
         )
     if token is not None:
@@ -1370,7 +1371,9 @@ def audit(
             "[bold yellow]warning:[/bold yellow] --token has no effect without --managed - ignored."
         )
     raise typer.Exit(
-        code=_audit(path, agent, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints)
+        code=_audit(
+            path, agent, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints, map_schema
+        )
     )
 
 

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -198,6 +198,21 @@ def _extract_flask_fastapi_routes(
         # (e.g. router = APIRouter(...); ...; app.include_router(router, prefix=...)
         # all in one module) - confirmed via a real map_api_endpoints() run:
         # "/internal" was applied twice, producing .../internal/internal/....
+        #
+        # Restricted to module scope: router_prefixes is a flat dict keyed
+        # only by variable name text, with no notion of which scope an
+        # identifier belongs to. Descending into function/class bodies let
+        # an unrelated local `router = APIRouter(...)` (the idiomatic
+        # FastAPI factory-function shape reusing the "router" name)
+        # silently overwrite the real module-level router's prefix -
+        # confirmed directly: a `make_test_router()` helper building its
+        # own local router flipped every `@router.get(...)` in the module
+        # onto the local router's prefix instead. The router a decorator
+        # actually binds to is always resolved from module scope (a
+        # decorator can only reference a name already in scope at that
+        # point), so nothing below module level is ever a real match here.
+        if n.type in ("function_definition", "class_definition"):
+            return
         if n.type == "call":
             function = n.child_by_field_name("function")
             args = n.child_by_field_name("arguments")

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -661,7 +661,7 @@ def test_main_audit_invokes_audit_flow(tmp_path):
         result = runner.invoke(app, ["audit", str(tmp_path), "--agent", "claude"])
 
     assert result.exit_code == 0
-    mock_audit.assert_called_once_with(str(tmp_path), "claude", None, None, None, None)
+    mock_audit.assert_called_once_with(str(tmp_path), "claude", None, None, None, None, None)
 
 
 def test_scan_command_reports_git_analysis_error_cleanly(tmp_path):
@@ -899,6 +899,38 @@ def test_main_audit_threads_no_check_licenses_flag(tmp_path):
     evidence = json.loads((repo / ".aletheore" / "air.json").read_text())
     assert evidence["security"]["dependency_licenses"]["checked"] is False
     assert evidence["security"]["dependency_licenses"]["reason"] == "skipped (--no-check-licenses)"
+
+
+def test_main_audit_threads_no_map_schema_flag(tmp_path):
+    # audit defines --map-schema/--no-map-schema identically to scan, but
+    # never forwarded it to _audit at either call site - --no-map-schema on
+    # `aletheore audit` was completely inert, silently ignoring the user's
+    # explicit opt-out from sending schema off-machine.
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+
+    runner.invoke(app, ["audit", str(repo), "--no-map-schema", "--agent", "nonexistent"])
+
+    evidence = json.loads((repo / ".aletheore" / "air.json").read_text())
+    assert evidence["repository"]["database"]["schema"]["checked"] is False
+    assert evidence["repository"]["database"]["schema"]["reason"] == "skipped (--no-map-schema)"
+
+
+def test_main_managed_audit_threads_no_map_schema_flag(tmp_path):
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+
+    with patch("aletheore.cli.get_api_key", return_value="fake-token"), patch(
+        "aletheore.cli.run_managed_audit_request", return_value="fake report"
+    ):
+        runner.invoke(
+            app,
+            ["audit", str(repo), "--managed", "--no-map-schema"],
+        )
+
+    evidence = json.loads((repo / ".aletheore" / "air.json").read_text())
+    assert evidence["repository"]["database"]["schema"]["checked"] is False
+    assert evidence["repository"]["database"]["schema"]["reason"] == "skipped (--no-map-schema)"
 
 
 def test_audit_warns_when_token_passed_without_managed(tmp_path):
@@ -1527,6 +1559,21 @@ def test_fetch_whoami_returns_none_on_invalid_token():
         transport=httpx.MockTransport(handler), base_url="https://app.aletheore.com"
     )
     assert _fetch_whoami("bad-token", http_client=client) is None
+
+
+def test_fetch_whoami_returns_none_on_malformed_json_body():
+    # A 200 with a body that isn't valid JSON (captive portal, misconfigured
+    # proxy, CDN error page returned with a 200 status) must degrade to None
+    # like any other failure, not raise json.JSONDecodeError uncaught.
+    from aletheore.cli import _fetch_whoami
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not json</html>")
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="https://app.aletheore.com"
+    )
+    assert _fetch_whoami("real-token", http_client=client) is None
 
 
 def test_status_reports_not_logged_in(monkeypatch):

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -154,6 +154,34 @@ def test_extract_fastapi_composes_router_and_include_prefixes():
     assert entries[0]["unresolved"] is False
 
 
+def test_extract_fastapi_module_level_prefix_not_shadowed_by_a_same_named_local():
+    # Real bug (Claude_Audit.md finding 19): collect_static_prefixes walked
+    # the entire file's AST with no scope tracking, keyed only by variable
+    # name text - a local `router = APIRouter(...)` inside an unrelated
+    # function (a common FastAPI factory-function shape reusing the
+    # idiomatic "router" name) silently overwrote the module-level
+    # router's real prefix. Reproduced exactly as documented: the
+    # module-level router's real "/api" prefix must survive a later,
+    # unrelated local "router" in a factory function.
+    root, source = parse_python(
+        'router = APIRouter(prefix="/api")\n'
+        '\n'
+        '@router.get("/x")\n'
+        'def handler():\n'
+        '    pass\n'
+        '\n'
+        'def make_test_router():\n'
+        '    router = APIRouter(prefix="/testing")\n'
+        '    return router\n'
+    )
+
+    entries = _extract_flask_fastapi_routes(root, source, "app/api.py")
+
+    assert entries[0]["path"] == "/api/x"
+    assert entries[0]["method"] == "GET"
+    assert entries[0]["unresolved"] is False
+
+
 def test_map_api_endpoints_composes_fastapi_prefix_from_another_file(tmp_path):
     (tmp_path / "users.py").write_text(
         'router = APIRouter(prefix="/users")\n'


### PR DESCRIPTION
## Summary
All five verified real (each independently reproduced against the running code before fixing), all fixed with tests. Full detail in `docs/audits/Claude_Audit.md`.

- **#19** - FastAPI router-prefix collection was scope-blind (`src/aletheore/endpoints.py`): a local `router = APIRouter(...)` in an unrelated factory function (a common FastAPI shape reusing the idiomatic "router" name) silently overwrote the real module-level router's prefix, since the collector walked the whole file with no scope tracking. Restricted the walk to module scope.
- **#22** - `audit`'s `--map-schema`/`--no-map-schema` was parsed but never forwarded (`src/aletheore/cli.py`): both call sites omitted `map_schema`, so `--no-map-schema` on `aletheore audit` was completely inert. Added it to both.
- **#24** - health-check-target and API-token creation were check-then-act, unlike the seat-limit fix already in the same file: two concurrent requests both one below the limit could both pass the check before either insert committed. Added `add_health_check_target_within_limit`/`create_api_token_within_limit`, mirroring `add_installation_member_within_seat_limit`'s advisory-lock-wrapped CTE pattern. New lock namespaces (4, 5) chosen specifically to avoid the independent-reuse collision that's its own separate, lower-priority finding (#30, not fixed here).
- **#25** - `generate_token` discarded the real token id and re-derived it via a racy re-query - folded into the #24 fix, since `create_api_token_within_limit` already returns the real id directly.
- **#26** - `_fetch_whoami`'s `response.json()` sat outside its own try/except, so a malformed-200 body raised uncaught instead of degrading to `None` like every other failure mode. Moved inside the try, added `ValueError` to the except clause.

## Test plan
- [x] New/updated tests for all five, TDD'd (confirmed failing against the pre-fix code).
- [x] New concurrency tests for #24 (`asyncio.gather` races against both limits).
- [x] Full `src/tests/`: 1339 passed.
- [x] Full `github-app` test suite run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)