### PR TITLE
docs: record the 2026-08-24 backup restore drill

### DIFF
--- a/docs/audits/global_launch_punchlist_2026-08-23.md
+++ b/docs/audits/global_launch_punchlist_2026-08-23.md
@@ -172,19 +172,38 @@ more than product correctness):**
 **Estimated effort:** 3-4 days for the first group, the second group can
 reasonably slip past launch and get picked off afterward.
 
-## 5. Restore drill - not re-verified recently
+## 5. Restore drill - done and passed (2026-08-24)
 
-`docs/operations/DEPLOYMENT-VERIFICATION.md` flags this as outstanding
-across the last several deploys. Before a launch that's supposed to bring
-in real paying customers at higher volume, need actual proof a restore
-from backup works, not just that the backup file gets created on schedule
-(that part was verified 2026-08-10).
+Copied the latest real backup (`aletheore_app_2026-08-24T03-00-01Z.dump`,
+35.7MB) off the production server via `scp`, confirmed byte-identical
+transfer (`md5sum` matched between server and local copy before touching
+it), restored it into a fresh, empty, throwaway local Postgres 16 container
+(matching prod's Postgres version) via `pg_restore`, then verified against
+live production rather than just checking the restore "looked" successful:
 
-**Plan:** spin up a throwaway Postgres instance, restore the latest real
-backup into it, verify the data is actually intact and queryable (spot
-check a few tables against known values from the live DB).
+- All 49 tables restored, no `pg_restore` errors.
+- Row counts for 8 spot-checked tables (`installations`, `api_tokens`,
+  `repo_history`, `affiliates`, `affiliate_referrals`, `sessions`,
+  `sent_emails`, `schema_migrations`) matched live production exactly.
+- Actual values matched too, not just counts: all 3 `installations` rows
+  identical (id/login/plan); the restored snapshot's most-recent
+  `repo_history` row (by exact timestamp) confirmed to still exist in
+  live prod's full history - proving real continuity between the backup
+  and the live database, not coincidentally-equal counts. Live prod's 3
+  newest `repo_history` rows postdate the 03:00 UTC backup (from today's
+  deploy activity) - expected and correctly absent from the restored copy.
+- Ran the app's real `scripts/migrate.py` against the restored DB:
+  **"no pending migrations"** - the restored schema is genuinely current
+  with what the running application code expects, not just structurally
+  similar.
+- Spot-checked a large `evidence` JSONB blob (273KB) for corruption:
+  valid `jsonb_typeof`, real `aletheore_version` field intact.
+- Local copy and throwaway container both destroyed immediately after
+  verification - the dump contains real production data (installation
+  logins, session state) and wasn't left lying around.
 
-**Estimated effort:** half a day.
+**Verdict: the backup-and-restore path genuinely works**, not just "the
+file gets created on schedule" (verified separately, 2026-08-10).
 
 ---
 

--- a/docs/operations/DEPLOYMENT-VERIFICATION.md
+++ b/docs/operations/DEPLOYMENT-VERIFICATION.md
@@ -65,8 +65,10 @@ As of 2026-08-24, following a redeploy to `master` (`git reset --hard origin/mas
 - No errors, tracebacks, or exceptions in `app-server`, `scan-worker-1`, `scan-worker-2`,
   `health-worker`, or `scheduler` logs in the 5 minutes after restart.
 - Not re-verified this pass (no relevant Dockerfile/host changes): Docker socket mount absence,
-  non-root users, CPU/mem limits, backup cron execution, base-image digest pinning, restore-drill
-  target availability, disk space - each last directly verified 2026-08-10.
+  non-root users, CPU/mem limits, backup cron execution, base-image digest pinning, disk space -
+  each last directly verified 2026-08-10. **Restore drill upgraded beyond "target availability"
+  this same day (2026-08-24) - see the dedicated section below**, a real restore-and-verify, not
+  just confirming a target database is reachable.
 
 ## 2026-08-23 Snapshot
 
@@ -128,6 +130,35 @@ As of 2026-08-22 (second deploy), following a redeploy to `master` (`git reset -
 - Health checks: internal `http://127.0.0.1:8000/healthz` and public `https://app.aletheore.com/healthz` both return `200 {"status":"ok","checks":{"database":"ok","redis":"ok"}}`.
 - No errors, tracebacks, or exceptions found in `app-server`, `scan-worker-1`, `scan-worker-2`, `health-worker`, or `scheduler` logs after restart (targeted grep for `error|traceback|exception`).
 - Not re-verified this pass (out of scope, no relevant Dockerfile/script changes in the diff): Docker socket mount absence, non-root users, CPU/mem limits, backup cron execution, base-image digest pinning, restore-drill target availability, disk space. Each was last directly verified in the 2026-08-10 deploy - re-check if any host-level or Dockerfile change touches them.
+
+## Restore Drill (2026-08-24)
+
+Previously only "the backup file gets created on schedule" (2026-08-10) and "the restore-drill
+target database is reachable" (last checked with every deploy above) had been verified - neither
+proves a restore actually *works*. This is the first real restore-and-verify:
+
+Copied the latest real backup (`aletheore_app_2026-08-24T03-00-01Z.dump`, 35.7MB) off the
+production server via `scp`, confirmed byte-identical transfer (`md5sum` matched server vs. local
+copy before touching it), restored into a fresh, empty, throwaway local Postgres 16 container
+(matching prod's Postgres version) via `pg_restore`. Verified against live production, not just
+that the restore "looked" successful:
+
+- All 49 tables restored, zero `pg_restore` errors.
+- Row counts for 8 spot-checked tables matched live production exactly
+  (`installations`, `api_tokens`, `repo_history`, `affiliates`, `affiliate_referrals`, `sessions`,
+  `sent_emails`, `schema_migrations`).
+- Actual values matched too: all 3 `installations` rows identical (id/login/plan); the restored
+  snapshot's most-recent `repo_history` row confirmed (by exact timestamp) to still exist in live
+  prod's full history - proving real continuity, not coincidentally-equal counts.
+- Ran the app's real `scripts/migrate.py` against the restored DB: **"no pending migrations"** -
+  the restored schema is genuinely current with what the running application code expects.
+- Spot-checked a 273KB `evidence` JSONB blob for corruption: valid `jsonb_typeof`, real
+  `aletheore_version` field intact.
+- Local copy and throwaway container both destroyed immediately after verification - the dump
+  contains real production data and wasn't left lying around.
+
+**The backup-and-restore path genuinely works.** Re-run this drill if the backup script, Postgres
+major version, or schema-migration tooling changes in a way that could affect restorability.
 
 ## Free-Tier Flash Review Provider Keys (live server config, not in git)
 


### PR DESCRIPTION
## Summary
Records the results of the global launch punch list's item 5 - the first real end-to-end verification that Aletheore's Postgres backups actually restore, not just that the backup file gets created on schedule.

## What was verified
- Byte-identical transfer of the latest backup (md5sum matched server vs local).
- Clean `pg_restore` into a fresh, empty, throwaway Postgres 16 container - all 49 tables, zero errors.
- Row counts for 8 spot-checked tables matched live production exactly.
- Actual values matched, not just counts: `installations` rows identical; a specific `repo_history` row from the restored snapshot confirmed (by exact timestamp) to still exist in prod's full history, proving real continuity.
- The app's real `scripts/migrate.py` reported **"no pending migrations"** against the restored DB.
- A 273KB `evidence` JSONB blob checked for corruption - valid and intact.
- Local copy and throwaway container destroyed immediately after, since the dump contains real production data.

No code changes - docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)