### PR TITLE
fix: backup-freshness ops alert false-positives on the daily cron/dump-duration race

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2703,7 +2703,21 @@ OPS_DEFAULT_BACKUP_DIR = "/app/backups"
 OPS_DEFAULT_QUEUE_DEPTH_THRESHOLD = 25
 OPS_DEFAULT_FAILED_JOBS_THRESHOLD = 0
 OPS_THRESHOLD_DURATION_SECONDS = 600
-OPS_BACKUP_STALE_SECONDS = 86400
+# Not a bare 24h (86400s): the backup cron fires at a fixed wall-clock time
+# (0 3 * * * UTC) and pg_dump takes several seconds to finish - a dump's
+# mtime is only set once it completes and is renamed into place, see
+# backup-postgres.sh - while this check runs on its own independent
+# ~180s-interval loop (scheduler.py) with no wall-clock anchoring to the
+# cron at all. A zero-tolerance 86400s threshold means the two schedules
+# will eventually land a sample in the few-second gap after yesterday's
+# dump crosses exactly 24h old but before today's fresh dump lands, purely
+# by chance of where the independent loop's cadence happens to drift to -
+# confirmed in production 2026-08-25 (age_seconds=86403, 3s past the old
+# threshold, while every day's backup that week actually succeeded). +10
+# minutes absorbs that structural jitter without weakening what this check
+# actually exists to catch (a backup that's genuinely missing or days
+# stale) by any operationally meaningful amount.
+OPS_BACKUP_STALE_SECONDS = 86400 + 600
 OPS_APP_HEALTH_CONSECUTIVE_FAILURES = 2
 OPS_MONITORED_QUEUES = ("scans", "health")
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -6148,6 +6148,43 @@ def test_check_backup_freshness_missing_dir_and_stale_backup_both_alert_within_c
     assert alerts == ["ops_monitor.backup_freshness.stale", "ops_monitor.backup_freshness.missing_dir"]
 
 
+def test_check_backup_freshness_tolerates_normal_cron_and_dump_duration_jitter(monkeypatch, tmp_path):
+    # Real false positive from prod, 2026-08-25: the backup cron fires at a
+    # fixed wall-clock time (0 3 * * * UTC) and pg_dump takes ~7-11s to
+    # finish (mtime is only set once the dump completes and is renamed into
+    # place - see backup-postgres.sh), while this check runs on its own
+    # independent ~180s-interval loop (scan_worker/scheduler.py) with no
+    # wall-clock anchoring at all. The two schedules aren't correlated, so
+    # over enough days a sample eventually lands in the few-second gap
+    # after yesterday's dump crosses exactly 24h old but before today's
+    # fresh dump lands - exactly what happened: the real alert reported
+    # age_seconds=86403, just 3 seconds past the old threshold, while every
+    # single day's backup in the preceding week actually succeeded. A
+    # threshold with zero tolerance for this structural (cron latency +
+    # dump duration) jitter will keep re-triggering this false positive
+    # indefinitely, regardless of which specific day it next lands on.
+    from scan_worker.jobs import _check_backup_freshness
+
+    redis_conn = _FakeRedis()
+    alerts = []
+    monkeypatch.setattr("scan_worker.jobs.send_error_alert", lambda *a, **k: alerts.append(a[0]))
+
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    dump = backup_dir / "aletheore_app_20260101.dump"
+    dump.write_text("x")
+    os.utime(dump, (0, 0))
+    monkeypatch.setenv("ALETHEORE_BACKUP_DIR", str(backup_dir))
+
+    # The real incident's literal age_seconds from the alert body - a bare
+    # 24h (86400s) constant, not derived from OPS_BACKUP_STALE_SECONDS
+    # itself, so this test actually pins the real-world scenario rather
+    # than trivially tracking whatever the threshold is currently set to.
+    _check_backup_freshness(redis_conn, 86400 + 3)
+
+    assert alerts == []
+
+
 def test_run_ops_monitor_job_alerts_when_a_free_tier_provider_key_is_missing(monkeypatch):
     # Real incident this guards: writing_adapter_chain_for_free_tier silently
     # skips (info-log only) any provider whose key isn't set, so all four


### PR DESCRIPTION
## Summary
- An ops alert fired 2026-08-25 with `age_seconds=86403 stale_after=86400s` - a false positive, root-caused live against prod: the backup cron fires at a fixed `0 3 * * * UTC`, `pg_dump` takes ~7-11s to finish and land, and the freshness check runs on an independent ~180s loop with no wall-clock anchoring - so a sample can land in the few-second gap after yesterday's dump crosses exactly 24h old but before today's fresh dump lands. Every day's backup that week actually succeeded.
- Pads `OPS_BACKUP_STALE_SECONDS` from a bare 86400 to 86400+600 (+10min) to absorb the structural cron/dump-duration jitter without weakening the check's real purpose (catching a genuinely missing or multi-day-stale backup) by any operationally meaningful amount. Same shape as #365's cooldown-constant fix.
- Considered shifting the ops-monitor loop's cadence to avoid 03:00 UTC instead - rejected: the loop has no wall-clock anchoring to shift from (phase drifts with container start/restarts), so it wouldn't durably prevent recurrence and leaves cron-latency/dump-duration jitter unaddressed either way.

## Test plan
- [x] New regression test (`test_check_backup_freshness_tolerates_normal_cron_and_dump_duration_jitter`) reproduces the exact incident age (86400+3s), confirmed failing against the unfixed code, passing after.
- [x] Existing backup-freshness tests still pass (ages far past the padded threshold remain genuinely stale).
- [x] Full `github-app` suite: 1489 passed, 8 pre-existing skips (real Postgres/Redis, disposable `docker-compose.test.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)