### PR TITLE
fix: silent subscription-plan-flip failure now fires an ops alert

### DIFF
--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -20,6 +20,7 @@ from app_server.db import (
     set_paid_installation_plan,
 )
 from app_server.email_queue import enqueue_transactional_email
+from app_server.error_alerts import send_error_alert
 from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
 from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID, resolve_plan_for_price_id
 from app_server.paddle_webhook_verify import verify_paddle_signature
@@ -54,6 +55,11 @@ _ACTIVE_SUBSCRIPTION_STATUSES = {"active", "trialing"}
 _AFFILIATE_COMMISSION_RATE = Decimal("0.15")
 
 
+class PaddleWebhookAttributionError(RuntimeError):
+    """A real, signature-verified Paddle webhook that can't be attributed
+    to any installation - see the installation_id is None branch below."""
+
+
 async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue=None) -> None:
     event_type = payload.get("event_type")
     if event_type == "transaction.completed":
@@ -86,7 +92,20 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         else None
     )
     if installation_id is None:
+        # A real, signature-verified Paddle event (not a spoofed/tampered
+        # token - those are legitimately silent, see the tests covering
+        # them above) whose plan-flip can't be attributed to anyone. Still
+        # returns 200 below (no reason to make Paddle retry a payload that
+        # will never carry a valid token no matter how many times it's
+        # redelivered), so nothing else would ever surface this - a real
+        # payer's subscription silently not activating would otherwise look
+        # identical to a successful transaction from the outside.
         logger.warning("%s missing or invalid installation_token in custom_data", event_type)
+        send_error_alert(
+            "paddle_webhook",
+            PaddleWebhookAttributionError(f"{event_type} missing or invalid installation_token"),
+            f"event_id={payload.get('event_id')} subscription_id={data.get('id')}",
+        )
         return
 
     items = data.get("items") or []

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -284,6 +284,54 @@ async def test_missing_installation_id_returns_200_but_writes_nothing(pool, monk
 
 
 @pytest.mark.asyncio
+async def test_missing_installation_token_fires_an_ops_alert(pool, monkeypatch):
+    """Real gap this closes: a subscription event with a missing/invalid
+    installation_token used to only logger.warning() and return - no
+    retry (still 200 to Paddle), no alert, so a real payer's plan-flip
+    silently failing looked identical to a successful transaction from
+    the outside. This is a real-money path (about to onboard a real
+    affiliate's referral) - it needs to page someone, not just log."""
+    from app_server.webhooks import paddle as paddle_module
+
+    alerts = []
+    monkeypatch.setattr(paddle_module, "send_error_alert", lambda *a, **k: alerts.append((a, k)))
+
+    payload = _subscription_created_payload(
+        "pri_01kyhevc8bkcghfpwjymz16y2h", 104, event_id="evt_missing_token"
+    )
+    del payload["data"]["custom_data"]["installation_token"]
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    assert len(alerts) == 1
+    args, kwargs = alerts[0]
+    assert args[0] == "paddle_webhook"
+    assert "evt_missing_token" in (args[2] if len(args) > 2 else kwargs.get("context", ""))
+
+
+@pytest.mark.asyncio
+async def test_invalid_installation_token_fires_an_ops_alert(pool, monkeypatch):
+    """Same as the missing-token case above, but for a token that's
+    present and well-formed yet fails to unsign (tampered, forged, or
+    for a different secret) - unsign_checkout_installation_id returns
+    None for all of these, hitting the exact same silent-failure path."""
+    from app_server.webhooks import paddle as paddle_module
+
+    alerts = []
+    monkeypatch.setattr(paddle_module, "send_error_alert", lambda *a, **k: alerts.append((a, k)))
+
+    payload = _subscription_event_payload(
+        "subscription.canceled", "canceled", 951, event_id="evt_invalid_token"
+    )
+    payload["data"]["custom_data"]["installation_token"] = "not-a-real-token"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    assert len(alerts) == 1
+    assert alerts[0][0][0] == "paddle_webhook"
+
+
+@pytest.mark.asyncio
 async def test_a_raw_unsigned_installation_id_is_rejected_not_trusted(pool):
     """The actual vulnerability this closes: custom_data is set by the
     browser calling Paddle.Checkout.open(), which nothing stops from being


### PR DESCRIPTION
## Summary
- A real, signature-verified Paddle subscription event (subscription.created/updated/canceled/paused/resumed) whose `custom_data.installation_token` is missing or fails to unsign only `logger.warning()`'d and returned - still 200 to Paddle, no retry, nothing else surfaces it. A real payer's plan-flip silently not activating would look identical to a successful transaction from the outside - a real gap on the one path this product moves money through, surfaced ahead of onboarding the first real affiliate referral.
- Fires `app_server.error_alerts.send_error_alert` (the existing "something's wrong, don't crash the handler" pattern already used elsewhere in app_server) instead of inventing a new mechanism.
- Scoped to the subscription-event handler only - `_handle_transaction_completed`'s own identical-looking silent check (affiliate-commission attribution) is a separate, lower-stakes gap left alone here.

## Test plan
- [x] New regression tests (missing token, invalid/tampered token) confirm `send_error_alert` fires; both confirmed failing against the unfixed code (`AttributeError` - the function wasn't imported, nothing called it), passing after.
- [x] Full `github-app` suite: 1491 passed, 8 pre-existing skips (real Postgres/Redis, disposable `docker-compose.test.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)