### PR TITLE
feat: nudge free CLI users toward the GitHub App, drop "early access" framing

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -233,6 +233,19 @@ def _sponsor_panel() -> Panel:
     return Panel(body, border_style="magenta", width=78)
 
 
+def _free_pr_review_nudge() -> str:
+    # Lives in the top-level 'scan'/'audit' command bodies, not inside the
+    # shared _scan()/_audit() helpers - 'watch' also calls those helpers on
+    # every re-scan cycle, and printing this on every cycle would be exactly
+    # the naggy behavior this is meant to avoid.
+    return (
+        "\n[dim]You're on the free tier - Aletheore also does free, "
+        "evidence-grounded PR reviews on your pull requests, globally "
+        "rate-limited and subject to availability. Install the app: "
+        "https://github.com/apps/aletheore/installations/new[/dim]"
+    )
+
+
 def _print_result(title: str, lines: list[str], color: str = "green") -> None:
     """No box: these lines are almost always absolute file paths of
     unpredictable length, and a boxed panel's normal wrapping breaks a
@@ -537,6 +550,7 @@ def _audit(
     _print_result("Audit complete", result_lines)
     console.print()
     console.print(_sponsor_panel())
+    console.print(_free_pr_review_nudge())
     return 0
 
 
@@ -1413,6 +1427,8 @@ def scan(
     exit_code, _evidence, _evidence_path = _scan(
         path, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints, map_schema
     )
+    if exit_code == 0:
+        console.print(_free_pr_review_nudge())
     raise typer.Exit(code=exit_code)
 
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -680,6 +680,26 @@ def test_scan_command_reports_git_analysis_error_cleanly(tmp_path):
     assert not isinstance(result.exception, GitAnalysisError)
 
 
+def test_scan_command_nudges_free_tier_users_toward_the_github_app(tmp_path):
+    (tmp_path / "main.py").write_text("x = 1\n")
+
+    result = runner.invoke(app, ["scan", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "github.com/apps/aletheore/installations/new" in result.output
+
+
+def test_scan_command_does_not_nudge_after_a_git_analysis_error(tmp_path):
+    with patch(
+        "aletheore.cli.scan_repository",
+        side_effect=GitAnalysisError("git log was killed (likely out of memory)"),
+    ):
+        result = runner.invoke(app, ["scan", str(tmp_path)])
+
+    assert result.exit_code == GIT_ANALYSIS_RESOURCE_EXIT_CODE
+    assert "github.com/apps/aletheore/installations/new" not in result.output
+
+
 def test_audit_command_bails_out_cleanly_when_scan_hits_git_analysis_error(tmp_path):
     with patch(
         "aletheore.cli.scan_repository",
@@ -747,6 +767,23 @@ def test_audit_sponsor_panel_does_not_claim_nothing_left_the_machine(tmp_path):
 
     assert result.exit_code == 0
     assert "nothing leaves this machine" not in result.output.lower()
+
+
+def test_audit_command_nudges_free_tier_users_toward_the_github_app(tmp_path):
+    repo = tmp_path
+    (repo / "main.py").write_text("x = 1\n")
+
+    fake_adapter = MagicMock()
+    fake_adapter.name = "openai"
+    fake_adapter.requires_consent = True
+    fake_adapter.invoke.return_value = "## Summary\n\nreport text"
+
+    with patch("aletheore.cli.select_adapter", return_value=fake_adapter):
+        with patch("builtins.input", return_value="y"):
+            result = runner.invoke(app, ["audit", str(repo)])
+
+    assert result.exit_code == 0
+    assert "github.com/apps/aletheore/installations/new" in result.output
 
 
 def test_audit_cancels_cleanly_when_consent_is_declined(tmp_path):

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -58,7 +58,7 @@
             <li>Targeted query and diff commands from existing evidence.</li>
             <li>Local dashboard, history, and MCP tools.</li>
             <li>GitHub Action PR comments for new secrets, vulnerabilities, and layer violations.</li>
-            <li>Free AI-powered PR reviews during early access.<sup>*</sup></li>
+            <li>Free AI-powered PR reviews, no expiration planned.<sup>*</sup></li>
           </ul>
         </article>
 
@@ -89,7 +89,7 @@
         Install it on your GitHub account or organization, then hit Subscribe above to activate AIR on that installation. The public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find and install it today.
       </p>
       <p class="cta-note">
-        <sup>*</sup><strong>Free AI Reviews:</strong> AI-powered PR reviews are available for free during the early access period, built on the same evidence-only (compact) prompt as AIR - see the <a href="benchmarks.html">Benchmarks page</a> for the methodology. They don't include AIR's independent second-model verification pass. Usage is globally rate-limited and subject to availability. Free AI access may be modified, restricted, or revoked at any time.
+        <sup>*</sup><strong>Free AI Reviews:</strong> AI-powered PR reviews are free, built on the same evidence-only (compact) prompt as AIR - see the <a href="benchmarks.html">Benchmarks page</a> for the methodology. They don't include AIR's independent second-model verification pass. Routed across multiple providers' free tiers so it isn't tied to any single company's quota - usage is globally rate-limited and subject to availability, and access may be adjusted if that changes.
       </p>
       <div class="pricing-proof">
         <span>Source-grounded PR reviews</span>


### PR DESCRIPTION
## Summary
- Added a single tasteful line after successful `scan`/`audit` completion pointing free CLI users at installing the GitHub App - addresses the biggest funnel gap (2,000+ direct PyPI installs vs. 3 real App installs).
- Lives in the top-level command bodies, not the shared `_scan()`/`_audit()` helpers, so it structurally can't repeat on `watch`'s internal re-scan loop.
- Corrected `website/pricing.html`: "during early access" wrongly implied a fixed expiration. Free AI PR reviews route across multiple providers' free tiers rather than one company's quota, so the real constraint is rate limits under load, not a countdown - reworded honestly.

## Test plan
- [x] TDD: wrote failing tests first, confirmed failure, implemented, confirmed passing
- [x] `test_scan_command_nudges_free_tier_users_toward_the_github_app`, `test_scan_command_does_not_nudge_after_a_git_analysis_error`, `test_audit_command_nudges_free_tier_users_toward_the_github_app` - all pass
- [x] Full `src/` suite: 1342 passed
- [x] Pricing page copy verified rendered correctly in browser