### PR TITLE
fix: run_initial_scan_job crashes on a repo with no commits yet

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -156,7 +156,7 @@ def fetch_default_branch_head_sha(
     client: httpx.Client,
     token: str,
     repo_full_name: str,
-) -> str:
+) -> str | None:
     headers = {
         "Authorization": f"token {token}",
         "Accept": "application/vnd.github+json",
@@ -169,6 +169,12 @@ def fetch_default_branch_head_sha(
         f"/repos/{repo_full_name}/commits/{default_branch}",
         headers=headers,
     )
+    # 409 is GitHub's actual response for "this repository has no commits
+    # yet" on the commits endpoint - a normal state for a freshly created
+    # or freshly connected repo, not an error. Distinct from a 404 (repo
+    # or ref doesn't exist at all), which still raises below.
+    if commit_response.status_code == 409:
+        return None
     commit_response.raise_for_status()
     return commit_response.json()["sha"]
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1038,6 +1038,13 @@ def run_initial_scan_job(installation_id: int, repo_full_name: str) -> None:
         client = get_github_api_client()
 
         head_sha = fetch_default_branch_head_sha(client, token, repo_full_name)
+        if head_sha is None:
+            # Repo has no commits yet (a freshly created or freshly
+            # connected empty repo) - nothing to scan, and not a failure:
+            # matches this job's own "best-effort and silent" contract
+            # above, and the dashboard's "Initialization required" state
+            # is still an honest description of a repo with no code in it.
+            return
         clone_url = _clone_url(repo_full_name, token)
         repo_dir = job_dir / "repo"
         _clone_ref(clone_url, head_sha, repo_dir)

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -12,6 +12,7 @@ from scan_worker.github_api import (
     ensure_branch_at,
     ensure_docs_pull_request,
     fetch_default_branch_and_head_sha,
+    fetch_default_branch_head_sha,
     fetch_file_content,
     fetch_pr_changed_files,
     fetch_pr_diff,
@@ -307,6 +308,21 @@ def test_fetch_default_branch_and_head_sha_returns_name_and_sha():
     assert len(calls) == 2
     assert calls[0].endswith("/repos/octocat/hello-world")
     assert calls[1].endswith("/repos/octocat/hello-world/commits/trunk")
+
+
+def test_fetch_default_branch_head_sha_returns_none_for_empty_repo_409():
+    # Found live: a real installation's fresh, genuinely-empty repo (no
+    # commits pushed yet) sent run_initial_scan_job an unhandled
+    # HTTPStatusError, firing an ops alert for what's actually a normal,
+    # expected state - GitHub's commits endpoint 409s specifically for a
+    # repo with no commits at all, distinct from a 404 (missing repo/ref).
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/repos/octocat/hello-world"):
+            return httpx.Response(200, json={"default_branch": "main"})
+        return httpx.Response(409, json={"message": "Git Repository is empty."})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    assert fetch_default_branch_head_sha(client, "token", "octocat/hello-world") is None
 
 
 def test_ensure_branch_at_creates_ref_when_missing():

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -4366,6 +4366,29 @@ def test_run_initial_scan_job_logs_and_reraises_on_inner_failure(monkeypatch, ca
     assert any("initial scan job failed" in record.message for record in caplog.records)
 
 
+def test_run_initial_scan_job_skips_silently_for_a_repo_with_no_commits_yet(monkeypatch, caplog):
+    from scan_worker.jobs import run_initial_scan_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.get_github_api_client", lambda *a, **k: object())
+    # A genuinely empty repo (no commits) - fetch_default_branch_head_sha
+    # returns None for this rather than raising (see test_github_api.py's
+    # 409 test); run_initial_scan_job's own docstring already says it's
+    # "best-effort and silent on failure" for exactly this kind of case.
+    monkeypatch.setattr("scan_worker.jobs.fetch_default_branch_head_sha", lambda *a, **k: None)
+    clone_calls = []
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda *a, **k: clone_calls.append(1))
+
+    with caplog.at_level("WARNING", logger="scan_worker.jobs"):
+        run_initial_scan_job(1, "octocat/hello-world")
+
+    assert clone_calls == []
+    assert not any("initial scan job failed" in record.message for record in caplog.records)
+
+
 def test_run_push_scan_job_logs_and_reraises_on_scan_failure(bare_repo_with_two_commits, monkeypatch, caplog):
     from scan_worker.jobs import run_push_scan_job
 


### PR DESCRIPTION
## Summary
- GitHub's commits API returns 409 for a repo with no commits at all - a normal state, not an error - but the code called `raise_for_status()` unconditionally, firing an unhandled `HTTPStatusError` and an ops alert.
- Root-caused against a real incident: `ArihantK15/git-sample`, a genuinely empty test repo, triggered exactly this.
- `fetch_default_branch_head_sha` now returns `None` on a 409 (matching the existing 404-handling pattern already in this file for `fetch_file_content`), and `run_initial_scan_job` treats that as "nothing to scan yet," returning early - matching its own docstring's stated "best-effort and silent on failure" contract.

## Test plan
- [x] TDD: both new tests reproduced failing against the real incident's exact exception shape, then fixed
- [x] `test_fetch_default_branch_head_sha_returns_none_for_empty_repo_409`, `test_run_initial_scan_job_skips_silently_for_a_repo_with_no_commits_yet` - pass
- [x] Full github-app suite: 1504 passed (run separately, prior to this isolated commit)