### PR TITLE
feat: add email as an alert delivery channel for endpoint monitoring

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -95,7 +95,25 @@ class SetWebhookURLRequest(BaseModel):
     webhook_url: str | None = None
 
 
-_EMAIL_ADDRESS_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+def _looks_like_email(value: str) -> bool:
+    # Deliberately not a regex. `^[^@\s]+@[^@\s]+\.[^@\s]+$` (the obvious
+    # first attempt) is a real, exploitable polynomial-time ReDoS: CodeQL
+    # flagged it, and a crafted ~100KB string ("!@!" + "!." * 50000) took
+    # nearly 20 seconds to reject on this Python version, scaling
+    # quadratically with input length - both [^@\s]+ groups can absorb '.'
+    # characters, so a failing match forces backtracking across every
+    # combination of '@' and '.' split points. Plain string operations
+    # can't backtrack, so there's no equivalent attack surface. This is a
+    # typo check, not full RFC 5321 validation - that job belongs to
+    # Resend's own delivery attempt, not this endpoint.
+    if not value or any(ch.isspace() for ch in value):
+        return False
+    local, at, domain = value.partition("@")
+    if not local or at != "@" or "@" in domain:
+        return False
+    if not domain or domain.startswith(".") or domain.endswith("."):
+        return False
+    return "." in domain
 
 
 class SetAlertEmailRequest(BaseModel):
@@ -839,7 +857,7 @@ async def test_webhook_url_route(org: str, repo: str, request: Request):
 @admin_router.put("/admin/{org}/{repo}/alert-email")
 async def set_alert_email_route(org: str, repo: str, request: Request, body: SetAlertEmailRequest):
     installation = await _require_admin_installation(request, org, repo)
-    if body.alert_email and not _EMAIL_ADDRESS_PATTERN.match(body.alert_email):
+    if body.alert_email and not _looks_like_email(body.alert_email):
         raise HTTPException(status_code=400, detail="that doesn't look like a valid email address")
     pool = request.app.state.db_pool
     await set_alert_email(pool, installation["installation_id"], body.alert_email)

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -3,7 +3,9 @@ import hashlib
 import hmac
 import json
 import logging
+import re
 import secrets
+import time
 from datetime import datetime, timedelta, timezone
 
 import asyncpg
@@ -20,6 +22,7 @@ from app_server.github_auth import generate_app_jwt, get_installation_token, get
 from app_server.github_pagination import fetch_paginated_github_collection
 from app_server.http_client import get_github_api_client
 from app_server.email_client import send_transactional_email
+from app_server.email_queue import enqueue_transactional_email
 from app_server.email_templates import deletion_otp_email
 from app_server.db import (
     DEFAULT_HEALTH_CHECK_TARGET_LIMIT,
@@ -58,6 +61,7 @@ from app_server.db import (
     set_docs_repo_commit_enabled,
     set_llm_suggestions_enabled,
     set_public_status_enabled,
+    set_alert_email,
     set_webhook_url,
     update_session_tokens,
 )
@@ -89,6 +93,13 @@ class GenerateTokenRequest(BaseModel):
 
 class SetWebhookURLRequest(BaseModel):
     webhook_url: str | None = None
+
+
+_EMAIL_ADDRESS_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class SetAlertEmailRequest(BaseModel):
+    alert_email: str | None = None
 
 
 class SetDocsRepoCommitRequest(BaseModel):
@@ -822,6 +833,52 @@ async def test_webhook_url_route(org: str, repo: str, request: Request):
         # distinguishing "connection refused" from "timed out" from an
         # actual response body/status from whatever the URL resolved to.
         raise HTTPException(status_code=502, detail="could not reach that webhook URL") from None
+    return {"ok": True}
+
+
+@admin_router.put("/admin/{org}/{repo}/alert-email")
+async def set_alert_email_route(org: str, repo: str, request: Request, body: SetAlertEmailRequest):
+    installation = await _require_admin_installation(request, org, repo)
+    if body.alert_email and not _EMAIL_ADDRESS_PATTERN.match(body.alert_email):
+        raise HTTPException(status_code=400, detail="that doesn't look like a valid email address")
+    pool = request.app.state.db_pool
+    await set_alert_email(pool, installation["installation_id"], body.alert_email)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "alert_email_changed",
+        {"cleared": body.alert_email is None},
+    )
+    return {"ok": True}
+
+
+@admin_router.post("/admin/{org}/{repo}/alert-email/test")
+async def test_alert_email_route(org: str, repo: str, request: Request):
+    # Same reasoning as test_webhook_url_route above - a customer has no
+    # way to confirm the address is right short of waiting for a real
+    # incident to fire one.
+    installation = await _require_admin_installation(request, org, repo)
+    alert_email = installation.get("alert_email")
+    if not alert_email:
+        raise HTTPException(status_code=400, detail="no alert email is configured yet")
+
+    settings = get_settings()
+    # dedupe_key includes wall-clock time, not just the installation - a
+    # static key would silently no-op every click after the first, since
+    # email_already_sent's record is permanent (see scan_worker/db.py).
+    # The Slack/Teams test button doesn't have this problem (it sends
+    # synchronously with no dedup at all); this reproduces the same
+    # "always actually resends" behavior for email instead.
+    enqueue_transactional_email(
+        settings.redis_url,
+        dedupe_key=f"health_alert_test:{installation['installation_id']}:{time.time()}",
+        template_name="health_alert",
+        template_arg=(
+            f"*Aletheore*: test notification for `{org}/{repo}` - "
+            "your alert email is configured correctly."
+        ),
+        to_email=alert_email,
+        installation_id=installation["installation_id"],
+    )
     return {"ok": True}
 
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -30,7 +30,7 @@ async def upsert_installation(pool: asyncpg.Pool, installation_id: int, account_
 async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | None:
     row = await pool.fetchrow(
         """
-        SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
+        SELECT installation_id, account_login, plan, webhook_url, alert_email, max_api_tokens,
                health_check_base_url, health_check_latency_threshold_ms,
                paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
         FROM installations
@@ -47,7 +47,7 @@ async def get_installation_by_account_login(pool: asyncpg.Pool, account_login: s
     # row here would have made this an arbitrary pick.
     row = await pool.fetchrow(
         """
-        SELECT installation_id, account_login, plan, webhook_url, max_api_tokens,
+        SELECT installation_id, account_login, plan, webhook_url, alert_email, max_api_tokens,
                health_check_base_url, health_check_latency_threshold_ms,
                paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
         FROM installations
@@ -1326,6 +1326,14 @@ async def set_webhook_url(pool: asyncpg.Pool, installation_id: int, url: str | N
         "UPDATE installations SET webhook_url = $2, updated_at = now() WHERE installation_id = $1",
         installation_id,
         url,
+    )
+
+
+async def set_alert_email(pool: asyncpg.Pool, installation_id: int, email: str | None) -> None:
+    await pool.execute(
+        "UPDATE installations SET alert_email = $2, updated_at = now() WHERE installation_id = $1",
+        installation_id,
+        email,
     )
 
 

--- a/github-app/app_server/email_templates.py
+++ b/github-app/app_server/email_templates.py
@@ -9,6 +9,8 @@ renders consistently in Outlook desktop's Word engine as well as modern
 webmail/mobile clients - not just the ones a browser preview would show.
 """
 
+import re
+
 _LOGO_URL = "https://www.aletheore.com/assets/logo-mark.png"
 _PRICING_URL = "https://aletheore.com/pricing.html"
 _DASHBOARD_URL = "https://app.aletheore.com/dashboard"
@@ -188,6 +190,15 @@ def deletion_otp_email(account_login: str, code: str) -> dict:
     return {"subject": subject, "html": html, "text": text}
 
 
+def _slack_markdown_to_html(text: str) -> str:
+    # Only the two markdown patterns scan_worker/slack.py's format_* alert
+    # builders actually produce (*bold* and `code`) - not a general markdown
+    # parser, since there's nothing else to convert.
+    converted = re.sub(r"`([^`]+)`", rf'<code style="background:{_BODY_BG};padding:2px 6px;border-radius:4px;">\1</code>', text)
+    converted = re.sub(r"\*([^*]+)\*", r"<strong>\1</strong>", converted)
+    return converted.replace("\n", "<br>")
+
+
 def weekly_digest_email(
     account_login: str,
     scans_this_week: int,
@@ -283,5 +294,20 @@ def subscription_canceled_email(account_login: str) -> dict:
         'mistake, or something didn\'t work the way you expected? Just reply '
         '&mdash; we\'d genuinely like to know why.</p>'
     )
+    html = _shell(preheader, body_html)
+    return {"subject": subject, "html": html, "text": text}
+
+
+def health_alert_email(alert_text: str) -> dict:
+    # alert_text is exactly what scan_worker/slack.py's format_reachability_alert/
+    # format_latency_alert/format_shape_change_alert already built for
+    # Slack/Teams - reused verbatim as the email's plain-text body (the
+    # *bold*/`code` markdown reads fine unconverted as plain text) and
+    # converted to HTML for the html body, rather than writing parallel
+    # copy for a second channel.
+    subject = "Aletheore endpoint alert"
+    preheader = re.sub(r"[`*]", "", alert_text.split("\n", 1)[0])[:140]
+    text = f"{alert_text}{_FOOTER_TEXT}"
+    body_html = f'<p style="margin:0;">{_slack_markdown_to_html(alert_text)}</p>'
     html = _shell(preheader, body_html)
     return {"subject": subject, "html": html, "text": text}

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1967,6 +1967,27 @@ async function sendTestNotification() {{
   status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
 }}
 
+async function saveAlertEmail() {{
+  const input = document.getElementById('alert-email-input');
+  const status = document.getElementById('alert-email-status');
+  const res = await fetch(adminBase + '/alert-email', {{
+    method: 'PUT', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify({{ alert_email: input.value.trim() || null }}),
+  }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  status.textContent = res.ok ? 'Saved.' : (data.detail || 'Could not save.');
+  status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
+}}
+
+async function sendTestAlertEmail() {{
+  const status = document.getElementById('alert-email-status');
+  status.textContent = 'Sending...';
+  status.style.color = 'var(--slate-600)';
+  const res = await fetch(adminBase + '/alert-email/test', {{ method: 'POST' }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  status.textContent = res.ok ? 'Test email sent.' : (data.detail || 'Could not send test email.');
+  status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
+}}
+
 async function buySeat() {{
   const status = document.getElementById('seat-billing-status');
   status.textContent = 'Updating billing...';
@@ -2224,6 +2245,12 @@ async function loadSettings() {{
             '<a href="https://api.slack.com/messaging/webhooks" target="_blank" rel="noopener">Get a Slack webhook &rarr;</a>' +
             '<a href="https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498" target="_blank" rel="noopener">Get a Teams webhook &rarr;</a>' +
           '</div>' +
+        '</div>' +
+        '<div class="settings-block">' +
+          '<div class="settings-block-label">Alert email</div>' +
+          '<input class="field" id="alert-email-input" placeholder="ops@yourcompany.com" value="' + escapeHtml(installation.alert_email || '') + '">' +
+          '<div class="form-row"><button class="btn" onclick="saveAlertEmail()">Save</button><button class="btn" onclick="sendTestAlertEmail()" style="margin-left:6px;">Send test</button><span id="alert-email-status" class="settings-block-hint"></span></div>' +
+          '<div class="settings-block-hint">Same endpoint-monitoring alerts as the webhook above, delivered by email too - configure either, both, or neither.</div>' +
         '</div>' +
         '<div class="settings-block">' +
           '<div class="settings-block-label">Managed audit content</div>' +

--- a/github-app/migrations/055_alert_email.sql
+++ b/github-app/migrations/055_alert_email.sql
@@ -1,0 +1,5 @@
+-- A second alert delivery channel for endpoint monitoring, alongside the
+-- existing installations.webhook_url (Slack/Teams). Installation-level,
+-- not per-target, matching webhook_url's own scope - one configured
+-- address covers every health check target on the installation.
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS alert_email TEXT;

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -577,7 +577,7 @@ def get_installation(dsn: str, installation_id: int) -> dict | None:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT installation_id, account_login, plan, webhook_url,
+                SELECT installation_id, account_login, plan, webhook_url, alert_email,
                        health_check_base_url, health_check_latency_threshold_ms,
                        llm_suggestions_enabled
                 FROM installations
@@ -624,7 +624,7 @@ def list_health_check_targets_all(dsn: str) -> list[dict]:
             cur.execute(
                 """
                 SELECT t.id AS target_id, t.installation_id, t.repo_full_name, t.label,
-                       t.base_url, t.latency_threshold_ms, i.webhook_url
+                       t.base_url, t.latency_threshold_ms, i.webhook_url, i.alert_email
                 FROM health_check_targets t
                 JOIN installations i ON i.installation_id = t.installation_id
                 WHERE i.plan != 'free'

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -138,6 +138,7 @@ from scan_worker.github_api import (
     upsert_pr_comment,
 )
 from app_server.email_templates import (
+    health_alert_email,
     payment_failed_email,
     subscription_canceled_email,
     weekly_digest_email,
@@ -1868,10 +1869,40 @@ def _run_flash_review(
     return review_ran
 
 
-def _send_if_webhook_configured(installation: dict, message: dict) -> None:
+def _send_alerts_if_configured(installation: dict, message: dict) -> None:
+    """Fires on every configured channel independently - Slack/Teams via
+    installations.webhook_url, email via installations.alert_email. Either,
+    both, or neither may be set; nothing here requires the other.
+
+    The email send goes through the same async, RQ-queued path as every
+    other transactional email (see email_queue.enqueue_transactional_email)
+    rather than send_transactional_email directly - a slow/down Resend
+    must never delay the next target's check in this sweep, same reasoning
+    as the health sweep's own queue split from "scans" (see
+    send_transactional_email_job's docstring).
+
+    dedupe_key includes wall-clock time down to the second: a genuine
+    retry of the outer job re-sending the same flip is an accepted, rare
+    risk here, same as send_health_alert already accepts for Slack/Teams
+    (it has no dedup at all) - this isn't solving a harder problem than
+    the channel it's sitting next to already tolerates.
+    """
     webhook_url = installation.get("webhook_url")
     if webhook_url:
         send_health_alert(webhook_url, message)
+
+    alert_email = installation.get("alert_email")
+    if alert_email:
+        settings = get_settings()
+        target_id = installation.get("target_id")
+        enqueue_transactional_email(
+            settings.redis_url,
+            dedupe_key=f"health_alert:{target_id}:{time.time()}",
+            template_name="health_alert",
+            template_arg=message["text"],
+            to_email=alert_email,
+            installation_id=installation.get("installation_id"),
+        )
 
 
 def _endpoint_results(evidence: dict, base_url: str, pinned_ip: str) -> list[dict]:
@@ -2413,7 +2444,7 @@ def _run_health_check_sweep_for_target(
                     source_line=source_line,
                     include_fix_suggestion=not recently_down,
                 )
-            _send_if_webhook_configured(
+            _send_alerts_if_configured(
                 target,
                 format_reachability_alert(
                     repo_full_name,
@@ -2427,7 +2458,7 @@ def _run_health_check_sweep_for_target(
             )
 
         if _latency_flipped(prior, reachable, latency_ms, threshold_ms):
-            _send_if_webhook_configured(
+            _send_alerts_if_configured(
                 target,
                 format_latency_alert(
                     repo_full_name,
@@ -2452,7 +2483,7 @@ def _run_health_check_sweep_for_target(
             and prior["response_shape"] != response_shape
         )
         if shape_changed:
-            _send_if_webhook_configured(
+            _send_alerts_if_configured(
                 target,
                 format_shape_change_alert(
                     repo_full_name,
@@ -2551,7 +2582,7 @@ def run_health_check_down_retry_job(target: dict, entry: dict, attempt: int) -> 
                 source_line=source_line,
                 include_fix_suggestion=not recently_down,
             )
-        _send_if_webhook_configured(
+        _send_alerts_if_configured(
             target,
             format_reachability_alert(
                 repo_full_name,
@@ -3041,6 +3072,7 @@ _EMAIL_TEMPLATES = {
     "payment_failed": payment_failed_email,
     "subscription_canceled": subscription_canceled_email,
     "weekly_digest": weekly_digest_email,
+    "health_alert": health_alert_email,
 }
 
 

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -436,6 +436,78 @@ async def test_set_webhook_url(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_set_alert_email(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/alert-email",
+            json={"alert_email": "ops@example.com"},
+        )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_set_alert_email_rejects_malformed_address(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/alert-email",
+            json={"alert_email": "not-an-email"},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_test_alert_email_requires_a_saved_address(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/alert-email/test")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_saved_alert_email_is_reflected_back_on_the_admin_page(pool, monkeypatch):
+    # Regression test for a real bug found while building this: get_installation
+    # (app_server/db.py) used an explicit column list that didn't include the
+    # new alert_email column, so a save would silently never be visible to
+    # the settings page (or to test_alert_email_route's own "is one
+    # configured?" check) despite the UPDATE itself succeeding.
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        await client.put(
+            "/admin/octocat/hello-world/alert-email",
+            json={"alert_email": "ops@example.com"},
+        )
+        response = await client.get("/admin/octocat/hello-world")
+    assert response.status_code == 200
+    assert response.json()["installation"]["alert_email"] == "ops@example.com"
+
+
+@pytest.mark.asyncio
+async def test_send_test_alert_email_enqueues_to_saved_address(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    enqueued = []
+
+    def fake_enqueue(*args, **kwargs):
+        enqueued.append((args, kwargs))
+
+    monkeypatch.setattr("app_server.admin.enqueue_transactional_email", fake_enqueue)
+    async with client:
+        put_response = await client.put(
+            "/admin/octocat/hello-world/alert-email",
+            json={"alert_email": "ops@example.com"},
+        )
+        assert put_response.status_code == 200
+        response = await client.post("/admin/octocat/hello-world/alert-email/test")
+
+    assert response.status_code == 200
+    assert len(enqueued) == 1
+    _args, kwargs = enqueued[0]
+    assert kwargs["to_email"] == "ops@example.com"
+    assert kwargs["template_name"] == "health_alert"
+
+
+@pytest.mark.asyncio
 async def test_docs_repo_commit_defaults_to_disabled(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
     async with client:

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -15,6 +15,7 @@ from app_server.admin import (
     _administered_installation_ids_for_session_or_401,
     _build_updated_seat_items,
     _has_real_admin_permission,
+    _looks_like_email,
     _repo_installation_id,
 )
 from app_server.auth import decrypt_access_token, encrypt_access_token, sign_session_id
@@ -433,6 +434,41 @@ async def test_set_webhook_url(pool, monkeypatch):
             json={"webhook_url": "https://hooks.slack.com/services/x"},
         )
     assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("ops@example.com", True),
+        ("ops@sub.example.com", True),
+        ("not-an-email", False),
+        ("", False),
+        ("@example.com", False),
+        ("ops@", False),
+        ("ops@example", False),
+        ("ops@.com", False),
+        ("ops@example.", False),
+        ("ops has spaces@example.com", False),
+        ("a@b@c.com", False),
+    ],
+)
+def test_looks_like_email(value, expected):
+    assert _looks_like_email(value) is expected
+
+
+def test_looks_like_email_rejects_a_pathological_input_quickly():
+    # Regression test for a real CodeQL-flagged, empirically-confirmed
+    # ReDoS: the regex this replaced (`^[^@\s]+@[^@\s]+\.[^@\s]+$`) took
+    # ~20 seconds to reject a 100KB crafted string on this Python version,
+    # scaling quadratically. _looks_like_email is plain string operations
+    # with no backtracking, so this must stay fast regardless of input
+    # shape or size.
+    payload = "!@!." + ("!." * 50_000)
+    start = time.monotonic()
+    result = _looks_like_email(payload)
+    elapsed = time.monotonic() - start
+    assert result is False
+    assert elapsed < 1.0
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_email_templates.py
+++ b/github-app/tests/test_email_templates.py
@@ -1,5 +1,6 @@
 from app_server.email_templates import (
     deletion_otp_email,
+    health_alert_email,
     payment_failed_email,
     subscription_canceled_email,
     weekly_digest_email,
@@ -35,6 +36,27 @@ def test_deletion_otp_email_includes_the_code_and_a_10_minute_expiry():
     assert "10 minutes" in message["text"]
     for key in ("subject", "html", "text"):
         assert message[key]
+
+
+def test_health_alert_email_reuses_the_slack_alert_text_verbatim():
+    # No parallel copywriting - the email carries exactly what
+    # format_reachability_alert/format_latency_alert/format_shape_change_alert
+    # already built for Slack/Teams, just re-rendered for email.
+    alert_text = "*Aletheore*: endpoint down on `octocat/hello-world`\n`GET /users` is unreachable"
+    message = health_alert_email(alert_text)
+    assert alert_text in message["text"]
+    for key in ("subject", "html", "text"):
+        assert message[key]
+
+
+def test_health_alert_email_converts_slack_markdown_to_html():
+    alert_text = "*Aletheore*: endpoint down on `octocat/hello-world`\n`GET /users` is unreachable"
+    message = health_alert_email(alert_text)
+    assert "<strong>Aletheore</strong>" in message["html"]
+    assert "<code" in message["html"] and "octocat/hello-world" in message["html"]
+    # The literal markdown characters must not leak into the rendered HTML.
+    assert "*Aletheore*" not in message["html"]
+    assert "`octocat/hello-world`" not in message["html"]
 
 
 def test_subscription_canceled_email_names_account_and_lists_what_is_lost():

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2773,6 +2773,73 @@ def _patch_sweep(
     return sent
 
 
+def test_send_alerts_if_configured_sends_email_when_alert_email_set(monkeypatch):
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda *a, **k: None)
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **k: enqueued.append(k),
+    )
+
+    _send_alerts_if_configured(
+        {"installation_id": 1, "target_id": 900, "alert_email": "ops@example.com"},
+        {"text": "*Aletheore*: endpoint down on `octocat/hello-world`"},
+    )
+
+    assert len(enqueued) == 1
+    assert enqueued[0]["to_email"] == "ops@example.com"
+    assert enqueued[0]["template_name"] == "health_alert"
+    assert enqueued[0]["template_arg"] == "*Aletheore*: endpoint down on `octocat/hello-world`"
+    assert enqueued[0]["installation_id"] == 1
+
+
+def test_send_alerts_if_configured_sends_both_channels_when_both_set(monkeypatch):
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    slack_sent = []
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: slack_sent.append(msg))
+    email_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **k: email_sent.append(k),
+    )
+
+    _send_alerts_if_configured(
+        {
+            "installation_id": 1,
+            "target_id": 900,
+            "webhook_url": "https://hooks.slack.com/x",
+            "alert_email": "ops@example.com",
+        },
+        {"text": "down"},
+    )
+
+    assert len(slack_sent) == 1
+    assert len(email_sent) == 1
+
+
+def test_send_alerts_if_configured_sends_neither_when_unconfigured(monkeypatch):
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    slack_sent = []
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: slack_sent.append(msg))
+    email_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **k: email_sent.append(k),
+    )
+
+    _send_alerts_if_configured({"installation_id": 1, "target_id": 900}, {"text": "down"})
+
+    assert slack_sent == []
+    assert email_sent == []
+
+
 def test_sweep_sends_reachability_down_alert(monkeypatch):
     sent = _patch_sweep(
         monkeypatch,

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -115,6 +115,16 @@ async def test_list_health_check_targets_all_includes_webhook_url_and_repo(pool)
 
 
 @pytest.mark.asyncio
+async def test_list_health_check_targets_all_includes_alert_email(pool):
+    await _insert_installation(pool, 306, "f", plan="indie", alert_email="ops@f.example.com")
+    await _insert_health_target(pool, 306, "f/repo1", "https://f.example.com")
+
+    targets = list_health_check_targets_all(TEST_DATABASE_URL)
+    row = next(t for t in targets if t["installation_id"] == 306)
+    assert row["alert_email"] == "ops@f.example.com"
+
+
+@pytest.mark.asyncio
 async def test_list_health_check_targets_all_returns_one_row_per_target(pool):
     await _insert_installation(pool, 305, "e", plan="indie")
     await _insert_health_target(pool, 305, "e/repo1", "https://staging.example.com")


### PR DESCRIPTION
## Summary
- Adds `installations.alert_email` as a second, independent endpoint-monitoring alert channel alongside the existing Slack/Teams webhook — configure either, both, or neither.
- Mirrors the webhook_url column/route/settings-UI pattern exactly (admin PUT/test-POST routes, settings page block, JS handlers).
- Email delivery goes through the existing async RQ-queued transactional email path, so a slow/down Resend can't delay the health-check sweep.

## Bug found via TDD
Three separate SELECT queries fetching "the installation" used explicit column lists rather than `SELECT *`, so adding the `alert_email` column didn't make it visible anywhere until each was updated individually:
- `app_server/db.py`'s `get_installation` and `get_installation_by_account_login`
- `scan_worker/db.py`'s `list_health_check_targets_all` and its own `get_installation`

Confirmed no further instances via a grep sweep for the `health_check_latency_threshold_ms` canary column.

## Test plan
- [x] Full github-app test suite: 1504 passed, 8 skipped
- [x] New regression test documents the SELECT-list bug directly (`test_saved_alert_email_is_reflected_back_on_the_admin_page`)
- [x] New unit tests for `_send_alerts_if_configured` covering email-only, both-channels, and neither-configured cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)