### PR TITLE
feat: add Pushover as an alert delivery channel for endpoint monitoring

### DIFF
--- a/github-app/.env.example
+++ b/github-app/.env.example
@@ -60,6 +60,15 @@ EMAIL_REPLY_TO_ADDRESS=support@aletheore.com
 # stats. Also requires PADDLE_API_KEY to be set.
 AFFILIATE_ADMIN_TOKEN=
 
+# Optional. Set to enable the Pushover endpoint-monitoring alert channel
+# (alongside the existing Slack/Teams webhook and alert email). This is
+# Aletheore's own Application API Token from a Pushover developer account
+# (https://pushover.net/apps/build) - not any one customer's credential;
+# each installation supplies only its own recipient user key via the
+# dashboard. Missing token means an installation's saved
+# pushover_user_key is skipped with a warning log rather than failing.
+PUSHOVER_API_TOKEN=
+
 # Free-tier PR review model routing (Community/free-plan installations),
 # read by model_tiers.writing_adapter_chain_for_free_tier - Groq, Gemini,
 # OpenAI free-tier, then OpenRouter, in that fallback order. Separate from

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -24,6 +24,7 @@ from app_server.http_client import get_github_api_client
 from app_server.email_client import send_transactional_email
 from app_server.email_queue import enqueue_transactional_email
 from app_server.email_templates import deletion_otp_email
+from scan_worker.pushover import send_pushover_alert
 from app_server.db import (
     DEFAULT_HEALTH_CHECK_TARGET_LIMIT,
     DEFAULT_SEAT_LIMIT,
@@ -62,6 +63,7 @@ from app_server.db import (
     set_llm_suggestions_enabled,
     set_public_status_enabled,
     set_alert_email,
+    set_pushover_user_key,
     set_webhook_url,
     update_session_tokens,
 )
@@ -118,6 +120,18 @@ def _looks_like_email(value: str) -> bool:
 
 class SetAlertEmailRequest(BaseModel):
     alert_email: str | None = None
+
+
+# Pushover user/group keys are always exactly 30 characters from this
+# charset (https://pushover.net/api#identifiers) - same "catch an obvious
+# typo before it's saved" purpose as _looks_like_email above, not an
+# attempt to verify the key is real (only Pushover's own API can do that,
+# which is exactly what the /test route is for).
+_PUSHOVER_KEY_PATTERN = re.compile(r"^[A-Za-z0-9]{30}$")
+
+
+class SetPushoverUserKeyRequest(BaseModel):
+    pushover_user_key: str | None = None
 
 
 class SetDocsRepoCommitRequest(BaseModel):
@@ -897,6 +911,49 @@ async def test_alert_email_route(org: str, repo: str, request: Request):
         to_email=alert_email,
         installation_id=installation["installation_id"],
     )
+    return {"ok": True}
+
+
+@admin_router.put("/admin/{org}/{repo}/pushover-user-key")
+async def set_pushover_user_key_route(org: str, repo: str, request: Request, body: SetPushoverUserKeyRequest):
+    installation = await _require_admin_installation(request, org, repo)
+    if body.pushover_user_key and not _PUSHOVER_KEY_PATTERN.match(body.pushover_user_key):
+        raise HTTPException(status_code=400, detail="that doesn't look like a valid Pushover user key")
+    pool = request.app.state.db_pool
+    await set_pushover_user_key(pool, installation["installation_id"], body.pushover_user_key)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation["installation_id"], session["github_login"], "pushover_user_key_changed",
+        {"cleared": body.pushover_user_key is None},
+    )
+    return {"ok": True}
+
+
+@admin_router.post("/admin/{org}/{repo}/pushover-user-key/test")
+async def test_pushover_user_key_route(org: str, repo: str, request: Request):
+    # Same reasoning as test_webhook_url_route/test_alert_email_route above
+    # - a customer has no way to confirm the key is right short of waiting
+    # for a real incident to fire one.
+    installation = await _require_admin_installation(request, org, repo)
+    pushover_user_key = installation.get("pushover_user_key")
+    if not pushover_user_key:
+        raise HTTPException(status_code=400, detail="no Pushover user key is configured yet")
+
+    settings = get_settings()
+    if not settings.pushover_api_token:
+        # This installation's config is fine - Aletheore's own server-wide
+        # Pushover Application token just isn't set yet. A generic 502 here
+        # would look like the customer's key is wrong when it isn't.
+        raise HTTPException(status_code=400, detail="push notifications aren't enabled on this server yet")
+
+    try:
+        send_pushover_alert(
+            settings.pushover_api_token,
+            pushover_user_key,
+            {"text": f"*Aletheore*: test notification for `{org}/{repo}` - your Pushover key is configured correctly."},
+        )
+    except httpx.HTTPError:
+        raise HTTPException(status_code=502, detail="could not send a Pushover notification to that key") from None
     return {"ok": True}
 
 

--- a/github-app/app_server/config.py
+++ b/github-app/app_server/config.py
@@ -27,6 +27,7 @@ class Settings:
     email_from_address: str
     email_reply_to_address: str
     affiliate_admin_token: str | None
+    pushover_api_token: str | None
 
 
 def _required_env(name: str) -> str:
@@ -136,4 +137,10 @@ def get_settings() -> Settings:
         # and see revenue, a different privilege level than read-only queue
         # stats.
         affiliate_admin_token=os.environ.get("AFFILIATE_ADMIN_TOKEN", "").strip() or None,
+        # Optional, not required: the endpoint-monitoring Pushover channel is
+        # additive, same as resend_api_key above - an installation can still
+        # have a pushover_user_key saved from before this was configured (or
+        # after it's removed), and _send_alerts_if_configured just skips
+        # that channel rather than the server refusing to start.
+        pushover_api_token=os.environ.get("PUSHOVER_API_TOKEN", "").strip() or None,
     )

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -30,9 +30,10 @@ async def upsert_installation(pool: asyncpg.Pool, installation_id: int, account_
 async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | None:
     row = await pool.fetchrow(
         """
-        SELECT installation_id, account_login, plan, webhook_url, alert_email, max_api_tokens,
-               health_check_base_url, health_check_latency_threshold_ms,
-               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
+        SELECT installation_id, account_login, plan, webhook_url, alert_email,
+               pushover_user_key, max_api_tokens, health_check_base_url,
+               health_check_latency_threshold_ms, paddle_subscription_id,
+               paddle_customer_id, llm_suggestions_enabled
         FROM installations
         WHERE installation_id = $1
         """,
@@ -47,9 +48,10 @@ async def get_installation_by_account_login(pool: asyncpg.Pool, account_login: s
     # row here would have made this an arbitrary pick.
     row = await pool.fetchrow(
         """
-        SELECT installation_id, account_login, plan, webhook_url, alert_email, max_api_tokens,
-               health_check_base_url, health_check_latency_threshold_ms,
-               paddle_subscription_id, paddle_customer_id, llm_suggestions_enabled
+        SELECT installation_id, account_login, plan, webhook_url, alert_email,
+               pushover_user_key, max_api_tokens, health_check_base_url,
+               health_check_latency_threshold_ms, paddle_subscription_id,
+               paddle_customer_id, llm_suggestions_enabled
         FROM installations
         WHERE account_login = $1
         """,
@@ -1334,6 +1336,14 @@ async def set_alert_email(pool: asyncpg.Pool, installation_id: int, email: str |
         "UPDATE installations SET alert_email = $2, updated_at = now() WHERE installation_id = $1",
         installation_id,
         email,
+    )
+
+
+async def set_pushover_user_key(pool: asyncpg.Pool, installation_id: int, user_key: str | None) -> None:
+    await pool.execute(
+        "UPDATE installations SET pushover_user_key = $2, updated_at = now() WHERE installation_id = $1",
+        installation_id,
+        user_key,
     )
 
 

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1988,6 +1988,27 @@ async function sendTestAlertEmail() {{
   status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
 }}
 
+async function savePushoverKey() {{
+  const input = document.getElementById('pushover-key-input');
+  const status = document.getElementById('pushover-key-status');
+  const res = await fetch(adminBase + '/pushover-user-key', {{
+    method: 'PUT', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify({{ pushover_user_key: input.value.trim() || null }}),
+  }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  status.textContent = res.ok ? 'Saved.' : (data.detail || 'Could not save.');
+  status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
+}}
+
+async function sendTestPushover() {{
+  const status = document.getElementById('pushover-key-status');
+  status.textContent = 'Sending...';
+  status.style.color = 'var(--slate-600)';
+  const res = await fetch(adminBase + '/pushover-user-key/test', {{ method: 'POST' }});
+  const data = await res.json().catch(function () {{ return {{}}; }});
+  status.textContent = res.ok ? 'Test notification sent.' : (data.detail || 'Could not send test notification.');
+  status.style.color = res.ok ? 'var(--success)' : 'var(--critical)';
+}}
+
 async function buySeat() {{
   const status = document.getElementById('seat-billing-status');
   status.textContent = 'Updating billing...';
@@ -2251,6 +2272,15 @@ async function loadSettings() {{
           '<input class="field" id="alert-email-input" placeholder="ops@yourcompany.com" value="' + escapeHtml(installation.alert_email || '') + '">' +
           '<div class="form-row"><button class="btn" onclick="saveAlertEmail()">Save</button><button class="btn" onclick="sendTestAlertEmail()" style="margin-left:6px;">Send test</button><span id="alert-email-status" class="settings-block-hint"></span></div>' +
           '<div class="settings-block-hint">Same endpoint-monitoring alerts as the webhook above, delivered by email too - configure either, both, or neither.</div>' +
+        '</div>' +
+        '<div class="settings-block">' +
+          '<div class="settings-block-label">Pushover</div>' +
+          '<input class="field" id="pushover-key-input" placeholder="Your Pushover user key" value="' + escapeHtml(installation.pushover_user_key || '') + '">' +
+          '<div class="form-row"><button class="btn" onclick="savePushoverKey()">Save</button><button class="btn" onclick="sendTestPushover()" style="margin-left:6px;">Send test</button><span id="pushover-key-status" class="settings-block-hint"></span></div>' +
+          '<div class="settings-block-hint">Same endpoint-monitoring alerts, delivered as a phone push notification - a down alert repeats until you acknowledge it.</div>' +
+          '<div class="settings-help-links">' +
+            '<a href="https://pushover.net" target="_blank" rel="noopener">Get your Pushover user key &rarr;</a>' +
+          '</div>' +
         '</div>' +
         '<div class="settings-block">' +
           '<div class="settings-block-label">Managed audit content</div>' +

--- a/github-app/migrations/056_pushover_user_key.sql
+++ b/github-app/migrations/056_pushover_user_key.sql
@@ -1,0 +1,11 @@
+-- A third alert delivery channel for endpoint monitoring, alongside the
+-- existing installations.webhook_url (Slack/Teams) and installations.
+-- alert_email. Installation-level, not per-target, matching those columns'
+-- own scope - one configured key covers every health check target on the
+-- installation.
+--
+-- Only the recipient's key lives here. The sending side's credential (the
+-- Pushover Application API Token identifying Aletheore as the sender) is a
+-- server-wide secret (PUSHOVER_API_TOKEN), not a per-installation value -
+-- same split as RESEND_API_KEY vs. alert_email.
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS pushover_user_key TEXT;

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -578,8 +578,8 @@ def get_installation(dsn: str, installation_id: int) -> dict | None:
             cur.execute(
                 """
                 SELECT installation_id, account_login, plan, webhook_url, alert_email,
-                       health_check_base_url, health_check_latency_threshold_ms,
-                       llm_suggestions_enabled
+                       pushover_user_key, health_check_base_url,
+                       health_check_latency_threshold_ms, llm_suggestions_enabled
                 FROM installations
                 WHERE installation_id = %s
                 """,
@@ -624,7 +624,8 @@ def list_health_check_targets_all(dsn: str) -> list[dict]:
             cur.execute(
                 """
                 SELECT t.id AS target_id, t.installation_id, t.repo_full_name, t.label,
-                       t.base_url, t.latency_threshold_ms, i.webhook_url, i.alert_email
+                       t.base_url, t.latency_threshold_ms, i.webhook_url, i.alert_email,
+                       i.pushover_user_key
                 FROM health_check_targets t
                 JOIN installations i ON i.installation_id = t.installation_id
                 WHERE i.plan != 'free'

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -159,6 +159,7 @@ from scan_worker.model_tiers import (
 from scan_worker.packet_cache import lookup_cached_result, store_result
 from scan_worker.code_graph_store import CodeGraphStore
 from scan_worker.postgres_graph_store import PostgresRepoGraphStore
+from scan_worker.pushover import send_pushover_alert
 from scan_worker.slack import (
     format_latency_alert,
     format_reachability_alert,
@@ -1871,15 +1872,19 @@ def _run_flash_review(
 
 def _send_alerts_if_configured(installation: dict, message: dict) -> None:
     """Fires on every configured channel independently - Slack/Teams via
-    installations.webhook_url, email via installations.alert_email. Either,
-    both, or neither may be set; nothing here requires the other.
+    installations.webhook_url, email via installations.alert_email,
+    Pushover via installations.pushover_user_key. Any combination may be
+    set; nothing here requires any other.
 
     The email send goes through the same async, RQ-queued path as every
     other transactional email (see email_queue.enqueue_transactional_email)
     rather than send_transactional_email directly - a slow/down Resend
     must never delay the next target's check in this sweep, same reasoning
     as the health sweep's own queue split from "scans" (see
-    send_transactional_email_job's docstring).
+    send_transactional_email_job's docstring). Pushover stays a direct,
+    synchronous call like Slack/Teams (both are already fire-and-forget,
+    single-request webhooks with no comparable "queue or don't" decision
+    to make).
 
     dedupe_key includes wall-clock time down to the second: a genuine
     retry of the outer job re-sending the same flip is an accepted, rare
@@ -1903,6 +1908,24 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
             to_email=alert_email,
             installation_id=installation.get("installation_id"),
         )
+
+    pushover_user_key = installation.get("pushover_user_key")
+    if pushover_user_key:
+        settings = get_settings()
+        if settings.pushover_api_token:
+            send_pushover_alert(settings.pushover_api_token, pushover_user_key, message)
+        else:
+            # A saved user key with no server-side app token configured -
+            # not an error in the installation's own config, so it
+            # degrades silently like the other two channels do when
+            # their own config is missing, rather than raising into the
+            # sweep loop's per-target isolation (see run_health_check_
+            # sweep_job's own comment on why one target's failure must
+            # not take down the rest).
+            logging.getLogger("scan_worker.jobs").warning(
+                "pushover_user_key is set for installation=%s but PUSHOVER_API_TOKEN is not configured",
+                installation.get("installation_id"),
+            )
 
 
 def _endpoint_results(evidence: dict, base_url: str, pinned_ip: str) -> list[dict]:

--- a/github-app/scan_worker/pushover.py
+++ b/github-app/scan_worker/pushover.py
@@ -1,0 +1,43 @@
+import re
+
+import httpx
+
+from app_server.http_client import get_generic_http_client
+
+PUSHOVER_API_URL = "https://api.pushover.net/1/messages.json"
+
+# Pushover's emergency priority (2) repeats the notification and requires
+# acknowledgement until dismissed or expire seconds pass - the "blaring,
+# can't-ignore" behavior a real endpoint-down alert wants. Every other
+# alert (recovered, latency, shape-change) stays at normal priority (0):
+# a single, non-repeating notification.
+EMERGENCY_RETRY_SECONDS = 60
+EMERGENCY_EXPIRE_SECONDS = 3600
+
+
+def _strip_slack_markdown(text: str) -> str:
+    # message["text"] is written for Slack/Teams mrkdwn (*bold*, `code`) -
+    # a phone push notification has no markdown rendering, so the markers
+    # would otherwise show up literally.
+    return re.sub(r"[`*]", "", text)
+
+
+def send_pushover_alert(
+    api_token: str,
+    user_key: str,
+    message: dict,
+    http_client: httpx.Client | None = None,
+) -> None:
+    client = http_client or get_generic_http_client()
+    priority = message.get("pushover_priority", 0)
+    payload = {
+        "token": api_token,
+        "user": user_key,
+        "message": _strip_slack_markdown(message["text"]),
+        "priority": priority,
+    }
+    if priority == 2:
+        payload["retry"] = EMERGENCY_RETRY_SECONDS
+        payload["expire"] = EMERGENCY_EXPIRE_SECONDS
+    response = client.post(PUSHOVER_API_URL, data=payload, timeout=10)
+    response.raise_for_status()

--- a/github-app/scan_worker/slack.py
+++ b/github-app/scan_worker/slack.py
@@ -168,7 +168,11 @@ def format_reachability_alert(
             f"`{method} {path}` is unreachable (was reachable as of the last check){location}"
             f"{_format_evidence_context(evidence_resolution)}"
         )
-    return {"text": text}
+    # Read by _send_alerts_if_configured for the Pushover channel only -
+    # down is the one endpoint-monitoring event worth an emergency-priority
+    # (repeats until acknowledged) push; every other alert defaults to a
+    # single normal-priority notification.
+    return {"text": text, "pushover_priority": 0 if now_reachable else 2}
 
 
 def format_latency_alert(

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -544,6 +544,104 @@ async def test_send_test_alert_email_enqueues_to_saved_address(pool, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_set_pushover_user_key(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/pushover-user-key",
+            json={"pushover_user_key": "u" * 30},
+        )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_set_pushover_user_key_rejects_malformed_key(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/pushover-user-key",
+            json={"pushover_user_key": "too-short"},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_test_pushover_requires_a_saved_key(pool, monkeypatch):
+    monkeypatch.setenv("PUSHOVER_API_TOKEN", "server-app-token")
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.post("/admin/octocat/hello-world/pushover-user-key/test")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_send_test_pushover_requires_server_token_configured(pool, monkeypatch):
+    # PUSHOVER_API_TOKEN is Aletheore's own credential, not something any
+    # one installation controls - if the founder hasn't configured it
+    # server-wide yet, every installation's test click must fail with a
+    # clear reason, not a raw exception from send_pushover_alert.
+    monkeypatch.delenv("PUSHOVER_API_TOKEN", raising=False)
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        await client.put(
+            "/admin/octocat/hello-world/pushover-user-key",
+            json={"pushover_user_key": "u" * 30},
+        )
+        response = await client.post("/admin/octocat/hello-world/pushover-user-key/test")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_saved_pushover_user_key_is_reflected_back_on_the_admin_page(pool, monkeypatch):
+    # Same class of bug as alert_email's regression test above: an explicit
+    # SELECT column list in get_installation that doesn't include the new
+    # column means a save is silently invisible everywhere that reads the
+    # installation dict, despite the UPDATE itself succeeding.
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        await client.put(
+            "/admin/octocat/hello-world/pushover-user-key",
+            json={"pushover_user_key": "u" * 30},
+        )
+        response = await client.get("/admin/octocat/hello-world")
+    assert response.status_code == 200
+    assert response.json()["installation"]["pushover_user_key"] == "u" * 30
+
+
+@pytest.mark.asyncio
+async def test_send_test_pushover_sends_to_saved_key(pool, monkeypatch):
+    monkeypatch.setenv("PUSHOVER_API_TOKEN", "server-app-token")
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+    client = await _logged_in_client(pool, monkeypatch)
+    sent = []
+    monkeypatch.setattr(
+        "app_server.admin.send_pushover_alert",
+        lambda token, user_key, message, **k: sent.append((token, user_key, message)),
+    )
+    async with client:
+        put_response = await client.put(
+            "/admin/octocat/hello-world/pushover-user-key",
+            json={"pushover_user_key": "u" * 30},
+        )
+        assert put_response.status_code == 200
+        response = await client.post("/admin/octocat/hello-world/pushover-user-key/test")
+
+    assert response.status_code == 200
+    assert len(sent) == 1
+    token, user_key, _message = sent[0]
+    assert token == "server-app-token"
+    assert user_key == "u" * 30
+
+
+@pytest.mark.asyncio
 async def test_docs_repo_commit_defaults_to_disabled(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
     async with client:

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2833,11 +2833,70 @@ def test_send_alerts_if_configured_sends_neither_when_unconfigured(monkeypatch):
         "scan_worker.jobs.enqueue_transactional_email",
         lambda *a, **k: email_sent.append(k),
     )
+    pushover_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_pushover_alert",
+        lambda *a, **k: pushover_sent.append(k),
+    )
 
     _send_alerts_if_configured({"installation_id": 1, "target_id": 900}, {"text": "down"})
 
     assert slack_sent == []
     assert email_sent == []
+    assert pushover_sent == []
+
+
+def test_send_alerts_if_configured_sends_pushover_when_user_key_set(monkeypatch):
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setenv("PUSHOVER_API_TOKEN", "server-app-token")
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+    pushover_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_pushover_alert",
+        lambda token, user_key, message, **k: pushover_sent.append((token, user_key, message)),
+    )
+
+    _send_alerts_if_configured(
+        {"installation_id": 1, "target_id": 900, "pushover_user_key": "user-key-y"},
+        {"text": "*Aletheore*: endpoint down on `octocat/hello-world`", "pushover_priority": 2},
+    )
+
+    assert len(pushover_sent) == 1
+    token, user_key, message = pushover_sent[0]
+    assert token == "server-app-token"
+    assert user_key == "user-key-y"
+    assert message["pushover_priority"] == 2
+
+
+def test_send_alerts_if_configured_skips_pushover_when_server_token_unset(monkeypatch):
+    # An installation can have pushover_user_key set (from before the
+    # server-side token was ever configured, or after it was later
+    # removed) - this must degrade silently, the same as the other two
+    # channels degrade when their own config is missing, not raise into
+    # the sweep loop.
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.delenv("PUSHOVER_API_TOKEN", raising=False)
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+    pushover_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_pushover_alert",
+        lambda *a, **k: pushover_sent.append(k),
+    )
+
+    _send_alerts_if_configured(
+        {"installation_id": 1, "target_id": 900, "pushover_user_key": "user-key-y"},
+        {"text": "down"},
+    )
+
+    assert pushover_sent == []
 
 
 def test_sweep_sends_reachability_down_alert(monkeypatch):

--- a/github-app/tests/test_pushover.py
+++ b/github-app/tests/test_pushover.py
@@ -1,0 +1,77 @@
+import httpx
+
+from scan_worker.pushover import send_pushover_alert
+
+
+def test_send_pushover_alert_posts_token_user_and_message():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json={"status": 1, "request": "abc"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    send_pushover_alert(
+        "app-token-x",
+        "user-key-y",
+        {"text": "*Aletheore*: endpoint down on `octocat/hello-world`"},
+        http_client=client,
+    )
+
+    assert len(calls) == 1
+    body = calls[0].read().decode()
+    assert "token=app-token-x" in body
+    assert "user=user-key-y" in body
+    # Slack markdown markers are stripped for a plain-text phone notification.
+    assert "Aletheore" in body
+    assert "*" not in body
+    assert "`" not in body
+
+
+def test_send_pushover_alert_defaults_to_normal_priority():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json={"status": 1})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    send_pushover_alert("token", "user", {"text": "endpoint recovered"}, http_client=client)
+
+    body = calls[0].read().decode()
+    assert "priority=0" in body
+    assert "retry=" not in body
+    assert "expire=" not in body
+
+
+def test_send_pushover_alert_sends_emergency_priority_with_retry_and_expire():
+    calls = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json={"status": 1})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    send_pushover_alert(
+        "token",
+        "user",
+        {"text": "endpoint down", "pushover_priority": 2},
+        http_client=client,
+    )
+
+    body = calls[0].read().decode()
+    assert "priority=2" in body
+    assert "retry=60" in body
+    assert "expire=3600" in body
+
+
+def test_send_pushover_alert_raises_on_http_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"status": 0, "errors": ["user identifier is invalid"]})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        send_pushover_alert("token", "bad-user", {"text": "x"}, http_client=client)
+    except httpx.HTTPStatusError:
+        return
+    raise AssertionError("expected send_pushover_alert to raise on a non-2xx response")

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -125,6 +125,16 @@ async def test_list_health_check_targets_all_includes_alert_email(pool):
 
 
 @pytest.mark.asyncio
+async def test_list_health_check_targets_all_includes_pushover_user_key(pool):
+    await _insert_installation(pool, 307, "g", plan="indie", pushover_user_key="user-key-g")
+    await _insert_health_target(pool, 307, "g/repo1", "https://g.example.com")
+
+    targets = list_health_check_targets_all(TEST_DATABASE_URL)
+    row = next(t for t in targets if t["installation_id"] == 307)
+    assert row["pushover_user_key"] == "user-key-g"
+
+
+@pytest.mark.asyncio
 async def test_list_health_check_targets_all_returns_one_row_per_target(pool):
     await _insert_installation(pool, 305, "e", plan="indie")
     await _insert_health_target(pool, 305, "e/repo1", "https://staging.example.com")

--- a/github-app/tests/test_slack.py
+++ b/github-app/tests/test_slack.py
@@ -77,6 +77,9 @@ def test_format_reachability_alert_down():
     assert "abcdef12" in body["text"]
     assert "UserService" in body["text"]
     assert "recently unreachable" in body["text"]
+    # Down is the "blaring, can't-ignore" case - Pushover's emergency
+    # priority (repeats until acknowledged), not a single quiet ping.
+    assert body["pushover_priority"] == 2
 
 
 def test_format_reachability_alert_recovered():
@@ -90,6 +93,7 @@ def test_format_reachability_alert_recovered():
     )
     assert "recovered" in body["text"]
     assert "controllers/user.controller.ts:42" in body["text"]
+    assert body["pushover_priority"] == 0
 
 
 def test_format_latency_alert_over():


### PR DESCRIPTION
## Summary
- Adds `installations.pushover_user_key` as a third, independent endpoint-monitoring alert channel, alongside the existing Slack/Teams webhook and alert email — configure any combination.
- Mirrors both prior channels' pattern exactly (admin PUT/test-POST routes, settings-page block).
- Down alerts use Pushover's **emergency priority** (`format_reachability_alert` now returns `pushover_priority`: 2 for down, 0 for recovered) — repeats and requires acknowledgement until dismissed, the "blaring, can't-ignore" behavior this channel exists for. Latency/shape-change alerts stay at normal priority.

## Two separate credentials, matching who controls each
- `pushover_user_key` — the **recipient**, entered per-installation by each customer from their own Pushover account (same as `webhook_url`/`alert_email`). Aletheore never pays for this; it's each customer's own $4.99 one-time Pushover license.
- `PUSHOVER_API_TOKEN` — the **sender**, Aletheore's own Pushover Application token, a server-wide secret like `RESEND_API_KEY`, documented in `.env.example`. A saved user key with no server token configured degrades silently (logged, not raised) — matches how the other two channels degrade when their own config is missing.

## Test plan
- [x] Full github-app test suite: 1529 passed, 8 skipped
- [x] New `scan_worker/pushover.py` unit tests (payload shape, priority/retry/expire, error propagation)
- [x] New `_send_alerts_if_configured` tests covering pushover-only, server-token-missing-degrades-silently cases
- [x] New admin-route tests mirroring the alert_email test block, including a SELECT-list regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)