### PR TITLE
fix: ReDoS regression test payload didn't actually trigger the bug

### DIFF
--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -463,7 +463,16 @@ def test_looks_like_email_rejects_a_pathological_input_quickly():
     # scaling quadratically. _looks_like_email is plain string operations
     # with no backtracking, so this must stay fast regardless of input
     # shape or size.
-    payload = "!@!." + ("!." * 50_000)
+    #
+    # Aletheore's own Flash Review caught a real bug in an earlier version
+    # of this test: without the trailing space, the payload actually
+    # *matches* the old regex (via the second-to-last dot as the "@...\."
+    # separator and the final dot as the one-character suffix) - fast, not
+    # slow, and accepted rather than rejected. A trailing space is required
+    # so no split of the string can ever satisfy the old regex's final
+    # [^@\s]+$, forcing it to exhaust every '@'/'.' combination before
+    # giving up.
+    payload = "!@!." + ("!." * 50_000) + " "
     start = time.monotonic()
     result = _looks_like_email(payload)
     elapsed = time.monotonic() - start


### PR DESCRIPTION
## Summary
Aletheore's own Flash Review caught this on PR #389: `test_looks_like_email_rejects_a_pathological_input_quickly`'s payload (`"!@!." + "!." * 50000`) ends in a dot, so the old vulnerable regex (`^[^@\s]+@[^@\s]+\.[^@\s]+$`) actually *matches* it — fast, using the second-to-last dot as the `@...\.` separator and the final dot as the one-character suffix — rather than slowly rejecting it. The test passed for the wrong reason and would not have caught a future reintroduction of the vulnerable pattern.

## Fix
Appending a trailing space closes the gap: no split of the string can satisfy the old regex's final `[^@\s]+$` (a space is excluded from that character class), forcing it to exhaust every `@`/`.` combination before giving up. Confirmed empirically at ~5s for half this payload size against the old regex.

`_looks_like_email` itself is correct and unaffected — only the test's adversarial input needed fixing.

## Test plan
- [x] `test_looks_like_email_rejects_a_pathological_input_quickly` and all sibling email-validation tests pass
- [x] Manually verified the corrected payload is genuinely slow (~5s) against the old vulnerable regex, confirming the test would now catch a regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)