### PR TITLE
fix: escape repo-controlled content in the health-alert email HTML body

### DIFF
--- a/github-app/app_server/email_templates.py
+++ b/github-app/app_server/email_templates.py
@@ -9,6 +9,7 @@ renders consistently in Outlook desktop's Word engine as well as modern
 webmail/mobile clients - not just the ones a browser preview would show.
 """
 
+import html
 import re
 
 _LOGO_URL = "https://www.aletheore.com/assets/logo-mark.png"
@@ -191,10 +192,20 @@ def deletion_otp_email(account_login: str, code: str) -> dict:
 
 
 def _slack_markdown_to_html(text: str) -> str:
-    # Only the two markdown patterns scan_worker/slack.py's format_* alert
-    # builders actually produce (*bold* and `code`) - not a general markdown
-    # parser, since there's nothing else to convert.
-    converted = re.sub(r"`([^`]+)`", rf'<code style="background:{_BODY_BG};padding:2px 6px;border-radius:4px;">\1</code>', text)
+    # text is built from scan_worker/slack.py's format_* alert functions,
+    # which interpolate repository-controlled content (commit subjects,
+    # symbol names, risk summaries) - escape first, then promote markdown
+    # on the escaped text, same ordering the wiki markdown renderer already
+    # uses for the same reason (see test_wiki_markdown_escapes_before_
+    # promoting_tags in test_frontend_js_syntax.py). Escaping first also
+    # means the *bold*/`code` markers below still match literally, since
+    # html.escape doesn't touch '*' or '`'.
+    #
+    # Only the two markdown patterns those builders actually produce
+    # (*bold* and `code`) - not a general markdown parser, since there's
+    # nothing else to convert.
+    escaped = html.escape(text)
+    converted = re.sub(r"`([^`]+)`", rf'<code style="background:{_BODY_BG};padding:2px 6px;border-radius:4px;">\1</code>', escaped)
     converted = re.sub(r"\*([^*]+)\*", r"<strong>\1</strong>", converted)
     return converted.replace("\n", "<br>")
 
@@ -306,8 +317,11 @@ def health_alert_email(alert_text: str) -> dict:
     # converted to HTML for the html body, rather than writing parallel
     # copy for a second channel.
     subject = "Aletheore endpoint alert"
-    preheader = re.sub(r"[`*]", "", alert_text.split("\n", 1)[0])[:140]
+    # Truncate/strip the raw text first, escape last - escaping expands
+    # characters into multi-character entities, so escaping before
+    # truncating risks slicing an entity in half.
+    preheader = html.escape(re.sub(r"[`*]", "", alert_text.split("\n", 1)[0])[:140])
     text = f"{alert_text}{_FOOTER_TEXT}"
     body_html = f'<p style="margin:0;">{_slack_markdown_to_html(alert_text)}</p>'
-    html = _shell(preheader, body_html)
-    return {"subject": subject, "html": html, "text": text}
+    rendered_html = _shell(preheader, body_html)
+    return {"subject": subject, "html": rendered_html, "text": text}

--- a/github-app/tests/test_email_templates.py
+++ b/github-app/tests/test_email_templates.py
@@ -59,6 +59,28 @@ def test_health_alert_email_converts_slack_markdown_to_html():
     assert "`octocat/hello-world`" not in message["html"]
 
 
+def test_health_alert_email_escapes_html_in_repo_controlled_alert_text():
+    # Aletheore's own Flash Review caught this on PR #390: alert_text is
+    # built from format_reachability_alert/format_latency_alert/format_
+    # shape_change_alert, which interpolate repo-controlled content (commit
+    # subjects, symbol names, risk summaries) - a malicious repo could
+    # smuggle live HTML into this transactional email's body. Same bug
+    # class as the wiki markdown renderer already guards against (see
+    # test_wiki_markdown_renders_untrusted_html_inert in
+    # test_frontend_js_syntax.py) - escape first, only then promote the
+    # *bold*/`code` markdown.
+    alert_text = "*Aletheore*: endpoint down on `<img src=x onerror=alert(1)>`"
+    message = health_alert_email(alert_text)
+    # Every email already contains a legitimate <img> for the logo, so
+    # check the specific attacker-controlled tag rather than the bare
+    # "<img" substring.
+    assert "<img src=x onerror" not in message["html"]
+    assert "onerror" in message["html"]
+    assert "&lt;img src=x onerror" in message["html"]
+    # Escaping must not break the legitimate markdown-to-HTML conversion.
+    assert "<strong>Aletheore</strong>" in message["html"]
+
+
 def test_subscription_canceled_email_names_account_and_lists_what_is_lost():
     message = subscription_canceled_email("acme-corp")
     assert "acme-corp" in message["text"]


### PR DESCRIPTION
## Summary
Aletheore's own Flash Review caught this on PR #390: `health_alert_email`'s `alert_text` is built from `scan_worker/slack.py`'s `format_reachability_alert`/`format_latency_alert`/`format_shape_change_alert`, which interpolate repository-controlled content (commit subjects, symbol names, risk summaries) directly into HTML with no escaping — in both the preheader (via `_shell`) and the body (via `_slack_markdown_to_html`). A crafted repo could inject live markup into this transactional email. This is already live on master (shipped in #389), not just the open Pushover PR.

Same bug class the wiki markdown renderer already guards against — escape first, only then promote `*bold*`/`` `code` `` markdown.

## Fix
`html.escape()` runs before both the preheader's markdown-strip and the body's markdown-to-HTML conversion. Truncates the raw preheader text before escaping, not after — escaping expands characters into multi-character entities, so escaping first risks slicing one in half.

## Test plan
- [x] New test proving a crafted `<img onerror=...>` payload renders escaped, not live, in both preheader and body
- [x] Existing markdown-conversion test still passes (escaping doesn't break legitimate `*bold*`/`` `code` `` rendering)
- [x] Full `test_email_templates.py`: 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)