### PR TITLE
chore: upload real coverage to Codecov instead of just an artifact

### DIFF
--- a/.github/workflows/github-app-tests.yml
+++ b/.github/workflows/github-app-tests.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC, so Codecov upload below needs no stored token
 
     services:
       postgres:
@@ -74,3 +77,12 @@ jobs:
           name: coverage-github-app
           path: github-app/coverage.xml
           retention-days: 14
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          use_oidc: true
+          files: github-app/coverage.xml
+          flags: github-app
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC, so Codecov upload below needs no stored token
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
@@ -40,3 +43,12 @@ jobs:
           name: coverage-src-py${{ matrix.python-version }}
           path: src/coverage.xml
           retention-days: 14
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          use_oidc: true
+          files: src/coverage.xml
+          flags: cli-py${{ matrix.python-version }}
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://pypi.org/project/aletheore/"><img src="https://img.shields.io/pypi/pyversions/aletheore" alt="Python versions"></a>
   <a href="https://github.com/Aletheore/Aletheore/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm--Noncommercial--1.0.0-blue" alt="License"></a>
   <a href="https://github.com/Aletheore/Aletheore/actions/workflows/tests.yml"><img src="https://github.com/Aletheore/Aletheore/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
+  <a href="https://codecov.io/gh/Aletheore/Aletheore"><img src="https://codecov.io/gh/Aletheore/Aletheore/graph/badge.svg" alt="Coverage"></a>
   <a href="https://github.com/Aletheore/Aletheore/actions/workflows/container-security.yml"><img src="https://github.com/Aletheore/Aletheore/actions/workflows/container-security.yml/badge.svg" alt="Container Security"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/Aletheore/Aletheore"><img src="https://api.securityscorecards.dev/projects/github.com/Aletheore/Aletheore/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://pepy.tech/projects/aletheore"><img src="https://static.pepy.tech/personalized-badge/aletheore?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads" alt="PyPI Downloads"></a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+comment: false


### PR DESCRIPTION
## Summary
- The Codecov GitHub App is installed, but nothing uploads to it yet (confirmed via Codecov's API: repo recognized, `active: false`, `totals: null`)
- Adds a real `codecov/codecov-action` upload step to both coverage-generating jobs (`tests.yml`, `github-app-tests.yml`), authenticated via OIDC (`use_oidc: true` + `id-token: write`) — no `CODECOV_TOKEN` secret needed for this public repo
- Adds `codecov.yml` marking project/patch coverage checks informational — `pytest --cov-fail-under=85` is already the real enforced gate in both jobs, this isn't meant to be a second blocking check
- Adds the coverage badge to the README

## Test plan
- [x] Validated all edited/new YAML files
- [x] Confirmed the badge URL and Codecov project page both resolve (200)
- [x] `cspell` clean on README
- [ ] CI (this PR) — first real upload happens here; badge will show real data once this lands on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZDTpGBZgNYRTXM2MiFwVq