### PR TITLE
docs: add CODE_OF_CONDUCT.md and CONTRIBUTING.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,67 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+our community a harassment-free experience for everyone, regardless of age,
+body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces for this project —
+issues, pull requests, discussions — and also applies when an individual is
+officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at
+[support@aletheore.com](mailto:support@aletheore.com). All complaints will be
+reviewed and investigated promptly and fairly.
+
+All maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+[contributor-covenant.org/version/2/1/code_of_conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Aletheore isn't currently accepting external pull requests. Development is
+driven by the maintainer, so unsolicited PRs will likely sit unaddressed or
+get closed, not out of disregard for the effort but because they aren't
+being triaged right now.
+
+## What's still welcome
+
+- **Bug reports and feature proposals** via [GitHub
+  Issues](https://github.com/Aletheore/Aletheore/issues) — the issue
+  templates cover bug reports, documentation gaps, and proposals.
+- **Security reports** — see [SECURITY.md](SECURITY.md), not a public issue.
+- **Questions and discussion** via [GitHub
+  Discussions](https://github.com/Aletheore/Aletheore/discussions).
+
+## Commercial use and licensing
+
+Aletheore is licensed under the
+[PolyForm Noncommercial License 1.0.0](LICENSE), free for personal use,
+research, and evaluation. Use within or for a company — including internal
+tooling — requires a separate commercial license. Reach out at
+[arihantkaul@outlook.com](mailto:arihantkaul@outlook.com) for commercial
+licensing.
+
+This policy may change as the project matures — if you're interested in
+contributing code, opening an issue to ask is a reasonable way to check
+whether that's changed.


### PR DESCRIPTION
## Summary
- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1, enforcement contact matches `SECURITY.md`'s existing `support@aletheore.com`)
- Adds `CONTRIBUTING.md` stating plainly that external PRs aren't currently being accepted, rather than implying a review process that doesn't exist — bug reports/proposals/discussions still welcome via existing issue templates, commercial licensing questions point to the email `README.md`'s Licensing section already uses

Closes 2 of the 3 gaps GitHub's community-profile check (62%) flagged. The third — issue templates — is a false alarm: the real files (`bug-report.md`, `documentation.md`, `proposal.md`, `config.yml`) already exist with correct frontmatter, this looks like a lag in GitHub's own detection, not an actual gap.

## Test plan
- [x] `cspell` clean on both new files
- [x] `markdownlint-cli2` clean on both new files
- [x] Confirmed the linked GitHub Issues/Discussions URLs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZDTpGBZgNYRTXM2MiFwVq