### PR TITLE
fix: harden TOON encoding against silent failures and unguarded crashes

### DIFF
--- a/src/aletheore/adapters/anthropic_native.py
+++ b/src/aletheore/adapters/anthropic_native.py
@@ -17,6 +17,7 @@ from aletheore.adapters.openai_compatible import (
     _read_manual_text,
 )
 from aletheore.credentials import DEFAULT_CREDENTIALS_PATH, get_api_key, has_api_key
+from aletheore.toon_encoding import ToonEncodingError, to_toon
 
 MAX_TOKENS = 8192
 
@@ -26,7 +27,9 @@ ANTHROPIC_TOOLS = [
         "description": (
             "Read a specific section of the repository evidence by dot-path. "
             "Array items use zero-based brackets. Returns evidence wrapped in "
-            "an <evidence> tag, or an error message if the path does not exist."
+            "an <evidence> tag, or an error message if the path does not exist. "
+            "Returns the entire matched section with no size limit - prefer a "
+            "specific, narrow path over a broad one like a large top-level array."
         ),
         "input_schema": {
             "type": "object",
@@ -110,6 +113,10 @@ class AnthropicAdapter(AgentAdapter):
             evidence = toon.decode(evidence_path.read_text())
         except OSError as exc:
             raise AdapterInvocationError(f"could not read evidence at {evidence_path}") from exc
+        except toon.ToonDecodeError as exc:
+            raise AdapterInvocationError(
+                f"could not decode evidence at {evidence_path}: {exc}"
+            ) from exc
 
         system_prompt = SYSTEM_PROMPT_TEMPLATE.format(
             evidence_schema_map=EVIDENCE_SCHEMA_MAP,
@@ -232,4 +239,8 @@ class AnthropicAdapter(AgentAdapter):
         value = _get_by_dot_path(evidence, path)
         if value is None:
             return f"no such path: {path}"
-        return f'<evidence path="{path}">\n{toon.encode(value)}\n</evidence>'
+        try:
+            encoded = to_toon(value)
+        except ToonEncodingError as exc:
+            return f"could not encode section {path}: {exc}"
+        return f'<evidence path="{path}">\n{encoded}\n</evidence>'

--- a/src/aletheore/adapters/openai_compatible.py
+++ b/src/aletheore/adapters/openai_compatible.py
@@ -12,6 +12,7 @@ from openai import OpenAI
 
 from aletheore.adapters.base import AdapterInvocationError, AgentAdapter
 from aletheore.credentials import DEFAULT_CREDENTIALS_PATH, get_api_key, has_api_key
+from aletheore.toon_encoding import ToonEncodingError, to_toon
 
 MAX_TOOL_ROUNDS = 20
 REQUEST_TIMEOUT_SECONDS = 120
@@ -85,7 +86,9 @@ READ_EVIDENCE_TOOL = {
         "name": "read_evidence_section",
         "description": (
             "Read a specific section of the repository evidence by dot-path. "
-            "Array items use zero-based brackets, such as repository.modules[0].path."
+            "Array items use zero-based brackets, such as repository.modules[0].path. "
+            "Returns the entire matched section with no size limit - prefer a "
+            "specific, narrow path over a broad one like a large top-level array."
         ),
         "parameters": {
             "type": "object",
@@ -367,6 +370,10 @@ class OpenAICompatibleAdapter(AgentAdapter):
             evidence = toon.decode(evidence_path.read_text())
         except OSError as exc:
             raise AdapterInvocationError(f"could not read evidence at {evidence_path}") from exc
+        except toon.ToonDecodeError as exc:
+            raise AdapterInvocationError(
+                f"could not decode evidence at {evidence_path}: {exc}"
+            ) from exc
 
         system_prompt = SYSTEM_PROMPT_TEMPLATE.format(
             evidence_schema_map=EVIDENCE_SCHEMA_MAP,
@@ -501,4 +508,8 @@ class OpenAICompatibleAdapter(AgentAdapter):
         value = _get_by_dot_path(evidence, path)
         if value is None:
             return f"no such path: {path}"
-        return f'<evidence path="{path}">\n{toon.encode(value)}\n</evidence>'
+        try:
+            encoded = to_toon(value)
+        except ToonEncodingError as exc:
+            return f"could not encode section {path}: {exc}"
+        return f'<evidence path="{path}">\n{encoded}\n</evidence>'

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -61,7 +61,7 @@ from aletheore.report import (
     run_reasoning_phase,
     select_adapter,
 )
-from aletheore.toon_encoding import to_toon
+from aletheore.toon_encoding import ToonEncodingError, to_toon
 from aletheore.watch import DEBOUNCE_SECONDS as WATCH_DEBOUNCE_SECONDS
 
 KNOWN_ADAPTERS = [
@@ -262,6 +262,16 @@ def _print_result(title: str, lines: list[str], color: str = "green") -> None:
     console.print(f"[bold {color}]✓ {title}[/bold {color}]")
     for line in lines:
         console.print(f"  {line}", soft_wrap=True)
+
+
+def _print_query_result(result: object) -> None:
+    # Falls back to plain JSON on a TOON encoding failure rather than
+    # crashing `query` outright - a less compact result beats no result.
+    try:
+        print(to_toon({"result": result}))
+    except ToonEncodingError as exc:
+        console.print(f"[yellow]warning: TOON encoding failed ({exc}); falling back to JSON[/yellow]")
+        print(json.dumps({"result": result}, indent=2, default=str))
 
 
 _COMMAND_SUMMARIES = [
@@ -801,7 +811,7 @@ def _query(
         except IndexDimensionMismatchError as exc:
             console.print(f"[bold red]error:[/bold red] {exc}")
             return 1
-        print(to_toon({"result": result}))
+        _print_query_result(result)
         return 0
 
     if kind == "answer":
@@ -834,7 +844,7 @@ def _query(
         except IndexDimensionMismatchError as exc:
             console.print(f"[bold red]error:[/bold red] {exc}")
             return 1
-        print(to_toon({"result": result}))
+        _print_query_result(result)
         return 0
 
     repo = Path(repo_path).resolve()
@@ -853,7 +863,7 @@ def _query(
         except (ModuleNotFoundInEvidenceError, SymbolNotFoundInEvidenceError) as exc:
             print(f"error: {exc}")
             return 1
-        print(to_toon({"result": result}))
+        _print_query_result(result)
         return 0
 
     func, requires_target = QUERY_FUNCTIONS[kind]

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import warnings
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,7 +34,7 @@ from aletheore.secrets import (
     find_secrets_in_history,
     load_secrets_baseline,
 )
-from aletheore.toon_encoding import to_toon
+from aletheore.toon_encoding import ToonEncodingError, to_toon
 from aletheore.vulnerabilities import check_vulnerabilities as check_dependency_vulnerabilities
 
 EVIDENCE_VERSION = "0.4.0"
@@ -622,7 +623,18 @@ def write_evidence(evidence: dict, repo_path: Path) -> Path:
     # shape (uniform arrays of same-shaped objects almost everywhere) is
     # exactly TOON's best case. air.json stays the canonical machine-
     # readable copy (the dashboard's JS and any external tooling need real
-    # JSON), so this is additive, not a replacement.
-    (aletheore_dir / "air.toon").write_text(to_toon(evidence))
+    # JSON), so this is additive, not a replacement - a TOON encoding
+    # failure must never take scan down with it, since air.json (the file
+    # that actually matters) is already written by this point.
+    try:
+        (aletheore_dir / "air.toon").write_text(to_toon(evidence))
+    except ToonEncodingError as exc:
+        warnings.warn(
+            f"could not write .aletheore/air.toon ({exc}) - air.json (the canonical "
+            "evidence file) was written successfully; only 'aletheore audit' needs "
+            "the TOON copy, and it will fail with a clear error if it's missing "
+            "when audit next runs",
+            stacklevel=2,
+        )
 
     return output_path

--- a/src/aletheore/managed_audit_client.py
+++ b/src/aletheore/managed_audit_client.py
@@ -2,7 +2,7 @@ import time
 
 import httpx
 
-from aletheore.toon_encoding import to_toon
+from aletheore.toon_encoding import ToonEncodingError, to_toon
 
 
 class ManagedAuditError(Exception):
@@ -28,9 +28,14 @@ def run_managed_audit_request(
     client = http_client or httpx.Client(base_url=api_base_url)
     headers = {"Authorization": f"Bearer {token}"}
 
+    try:
+        encoded_evidence = to_toon(evidence)
+    except ToonEncodingError as exc:
+        raise ManagedAuditError(f"could not encode evidence for managed audit: {exc}") from exc
+
     response = client.post(
         "/v1/managed-audit",
-        json={"evidence": to_toon(evidence), "repo_full_name": repo_full_name},
+        json={"evidence": encoded_evidence, "repo_full_name": repo_full_name},
         headers=headers,
     )
     if response.status_code in (401, 402, 429):

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -40,7 +40,7 @@ from aletheore.query import (
 from aletheore.repo_config import load_repo_config
 from aletheore.secrets import iter_all_files
 from aletheore.search_index import IndexDimensionMismatchError, IndexNotFoundError, search_index
-from aletheore.toon_encoding import to_toon
+from aletheore.toon_encoding import ToonEncodingError, to_toon
 
 
 # repo_path -> ((mtime, size) of the evidence file at load time, parsed
@@ -88,8 +88,13 @@ def _toon_result(data: object) -> str:
     # (which MCPServer would otherwise auto-serialize to JSON) - this is the
     # actual token-cost surface for whatever agent is calling these tools,
     # and evidence's own shape (uniform arrays of same-shaped objects almost
-    # everywhere) is exactly TOON's best case.
-    return to_toon({"result": data})
+    # everywhere) is exactly TOON's best case. Falls back to plain JSON on a
+    # TOON encoding failure rather than raising - a tool call returning a
+    # slightly less compact result beats it crashing outright.
+    try:
+        return to_toon({"result": data})
+    except ToonEncodingError:
+        return json.dumps({"result": data})
 
 
 _TOOL_NAME_TO_QUERY_KIND = {

--- a/src/aletheore/toon_encoding.py
+++ b/src/aletheore/toon_encoding.py
@@ -10,8 +10,44 @@
 # first and rejected: its encoder is a literal stub as of 0.1.0
 # ("NotImplementedError: TOON encoder is not yet implemented"), confirmed by
 # actually calling it, not assumed from the README.
+import math
+
 import toon
 
 
+class ToonEncodingError(Exception):
+    """Raised when data can't be TOON-encoded, wrapping whatever the
+    underlying library raised (confirmed live: at minimum ToonDecodeError-
+    shaped round-trip failures on certain nested-list shapes, and
+    RecursionError on pathologically deep data). Every caller of to_toon
+    decides its own fallback here - skip a side file, fall back to JSON,
+    surface a clean CLI error - so this module never decides that for them.
+    """
+
+
+def _sanitize_for_toon(data: object) -> object:
+    # toon.encode() silently turns float('inf')/float('nan') into `null`
+    # with no error - confirmed directly: toon.encode({"v": float("inf")})
+    # -> 'v: null', indistinguishable from a real null on decode. air.json
+    # (written via json.dumps, which permits Infinity/NaN by default) keeps
+    # the real value, so an unsanitized TOON copy would silently diverge
+    # from the canonical file on any ratio/division-derived evidence field.
+    # Replacing non-finite floats with their str() here keeps that honest -
+    # a visible "inf"/"nan" string survives round-tripping instead of a
+    # silent, indistinguishable null.
+    if isinstance(data, float):
+        if math.isnan(data) or math.isinf(data):
+            return str(data)
+        return data
+    if isinstance(data, dict):
+        return {key: _sanitize_for_toon(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [_sanitize_for_toon(item) for item in data]
+    return data
+
+
 def to_toon(data: object) -> str:
-    return toon.encode(data)
+    try:
+        return toon.encode(_sanitize_for_toon(data))
+    except Exception as exc:
+        raise ToonEncodingError(str(exc)) from exc

--- a/src/aletheore/toon_encoding.py
+++ b/src/aletheore/toon_encoding.py
@@ -48,6 +48,24 @@ def _sanitize_for_toon(data: object) -> object:
 
 def to_toon(data: object) -> str:
     try:
-        return toon.encode(_sanitize_for_toon(data))
+        sanitized = _sanitize_for_toon(data)
+        encoded = toon.encode(sanitized)
+        # toon.encode() can succeed while producing output toon.decode()
+        # then rejects - confirmed live and reproducibly:
+        # {"nested": [[1, [2, 3]], [4, 5]]} encodes cleanly, but
+        # toon.decode() on that exact output raises
+        # ToonDecodeError("Expected 2 items, but got 0"). A heterogeneous
+        # nested-list shape like this would otherwise slip past every
+        # try/except in this codebase - they all catch ToonEncodingError,
+        # but encode() itself never raises here, so the corruption would
+        # sit silently in a written air.toon/MCP result until something
+        # else calls decode() on it, possibly much later and with no way
+        # to trace the failure back to this specific write. Verifying the
+        # round trip here, once, means every existing call site's handling
+        # also catches this class - not just the shapes where the
+        # underlying library happens to raise on encode.
+        if toon.decode(encoded) != sanitized:
+            raise ValueError("encoded output does not round-trip back to the original data")
+        return encoded
     except Exception as exc:
         raise ToonEncodingError(str(exc)) from exc

--- a/src/tests/test_anthropic_adapter.py
+++ b/src/tests/test_anthropic_adapter.py
@@ -120,6 +120,60 @@ def test_read_evidence_section_tool_returns_wrapped_data(mock_anthropic_class, t
     assert "app.py" in tool_result_content["content"]
 
 
+def test_invoke_raises_clean_error_on_undecodable_evidence(tmp_path):
+    # Confirmed bug: ToonDecodeError does not inherit from OSError, so the
+    # old `except OSError` around toon.decode() let a malformed/empty
+    # air.toon crash with a raw traceback instead of the intended clean
+    # AdapterInvocationError.
+    repo = tmp_path / "repo"
+    (repo / ".aletheore").mkdir(parents=True)
+    (repo / ".aletheore" / "air.toon").write_text("x[3]: not enough items")
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.anthropic_native.get_api_key", return_value="sk-ant-test"):
+        with pytest.raises(AdapterInvocationError, match="could not decode evidence"):
+            adapter.invoke("audit this repo", cwd=str(repo))
+
+
+@patch("aletheore.adapters.anthropic_native.Anthropic")
+def test_read_evidence_section_reports_encoding_failure_instead_of_crashing(
+    mock_anthropic_class, tmp_path
+):
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": [{"path": "app.py"}]}})
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+    read_response = MagicMock()
+    read_response.content = [
+        _tool_use_block("read_evidence_section", {"path": "repository.modules"})
+    ]
+    responses = [read_response] + _write_all_sections_then_finish_responses()
+    mock_client.messages.create.side_effect = responses
+
+    from aletheore.toon_encoding import ToonEncodingError
+
+    def _boom(_data):
+        raise ToonEncodingError("simulated failure")
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.anthropic_native.get_api_key", return_value="sk-ant-test"):
+        with patch("aletheore.adapters.anthropic_native.to_toon", _boom):
+            adapter.invoke("audit this repo", cwd=str(repo))
+
+    second_call = mock_client.messages.create.call_args_list[1]
+    messages = second_call.kwargs["messages"]
+    tool_results = [
+        content
+        for message in messages
+        if message["role"] == "user" and isinstance(message["content"], list)
+        for content in message["content"]
+        if content["type"] == "tool_result"
+    ]
+    tool_result_content = next(
+        result for result in tool_results if "could not encode section" in result["content"]
+    )
+    assert "could not encode section repository.modules" in tool_result_content["content"]
+
+
 @patch("aletheore.adapters.anthropic_native.Anthropic")
 def test_invoke_raises_if_never_finishes_within_max_rounds(mock_anthropic_class, tmp_path):
     repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -21,6 +21,7 @@ from aletheore.cli import (
     _MCP_CLIENT_CONFIGS,
     _make_progress_printer,
     _opencode_entry,
+    _print_query_result,
     _stdio_entry,
     _write_json_mcp_client_config,
     _write_toml_mcp_client_config,
@@ -40,6 +41,24 @@ from aletheore.report import (
 )
 
 runner = CliRunner()
+
+
+def test_print_query_result_falls_back_to_json_on_encoding_failure(capsys, monkeypatch):
+    from aletheore.toon_encoding import ToonEncodingError
+
+    def _boom(_data):
+        raise ToonEncodingError("simulated failure")
+
+    monkeypatch.setattr("aletheore.cli.to_toon", _boom)
+
+    _print_query_result({"symbols": ["a", "b"]})
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "falling back to JSON" in combined
+    assert '"symbols"' in combined
+    assert '"a"' in combined
+    assert '"b"' in combined
 
 
 def test_importing_cli_does_not_eagerly_load_heavy_dependencies():

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -613,6 +613,28 @@ def test_write_evidence_also_writes_a_toon_copy(tmp_path):
     assert toon.decode(toon_path.read_text()) == evidence
 
 
+def test_write_evidence_survives_a_toon_encoding_failure(tmp_path, monkeypatch):
+    import pytest
+
+    from aletheore.toon_encoding import ToonEncodingError
+
+    def _boom(_data):
+        raise ToonEncodingError("simulated failure")
+
+    monkeypatch.setattr("aletheore.evidence.to_toon", _boom)
+
+    repo = make_repo(tmp_path)
+    evidence = scan_repository(repo, check_vulnerabilities=False, check_licenses=False)
+
+    with pytest.warns(UserWarning, match="could not write .aletheore/air.toon"):
+        written_path = write_evidence(evidence, repo)
+
+    # air.json (the file that actually matters) is written regardless -
+    # a TOON encoding failure must never take scan down with it.
+    assert written_path.exists()
+    assert not (repo / ".aletheore" / "air.toon").exists()
+
+
 def test_write_evidence_adds_aletheore_dir_to_a_missing_gitignore(tmp_path):
     repo = make_repo(tmp_path)
     evidence = scan_repository(repo, check_vulnerabilities=False, check_licenses=False)

--- a/src/tests/test_managed_audit_client.py
+++ b/src/tests/test_managed_audit_client.py
@@ -42,6 +42,22 @@ def test_pending_then_finished_polls_until_done():
     assert report == "done"
 
 
+def test_encoding_failure_raises_managed_audit_error_not_a_raw_exception(monkeypatch):
+    def _boom(_data):
+        from aletheore.toon_encoding import ToonEncodingError
+
+        raise ToonEncodingError("simulated failure")
+
+    monkeypatch.setattr("aletheore.managed_audit_client.to_toon", _boom)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("should never reach the network on an encoding failure")
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://aletheore.com")
+    with pytest.raises(ManagedAuditError, match="could not encode evidence"):
+        run_managed_audit_request({"scanned_at": "x"}, "real-token", http_client=client)
+
+
 def test_unauthorized_raises_managed_audit_error():
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, json={"detail": "invalid or revoked token"})

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -319,6 +319,20 @@ async def test_answer_tool_present_with_adapter(tmp_path):
     assert "aletheore_answer" in names
 
 
+def test_toon_result_falls_back_to_json_on_encoding_failure(monkeypatch):
+    from aletheore.mcp_server import _toon_result
+    from aletheore.toon_encoding import ToonEncodingError
+
+    def _boom(_data):
+        raise ToonEncodingError("simulated failure")
+
+    monkeypatch.setattr("aletheore.mcp_server.to_toon", _boom)
+
+    result = _toon_result({"symbols": ["a", "b"]})
+
+    assert json.loads(result) == {"result": {"symbols": ["a", "b"]}}
+
+
 @pytest.mark.asyncio
 async def test_aletheore_search_codebase_returns_toon_results(tmp_path):
     repo = make_repo_with_evidence(tmp_path)

--- a/src/tests/test_openai_compatible_adapter.py
+++ b/src/tests/test_openai_compatible_adapter.py
@@ -476,6 +476,51 @@ def test_read_evidence_section_tool_returns_wrapped_data(mock_openai_class, tmp_
     assert "</evidence>" in tool_message["content"]
 
 
+def test_invoke_raises_clean_error_on_undecodable_evidence(tmp_path):
+    # Confirmed bug: ToonDecodeError does not inherit from OSError, so the
+    # old `except OSError` around toon.decode() let a malformed/empty
+    # air.toon crash with a raw traceback instead of the intended clean
+    # AdapterInvocationError.
+    repo = tmp_path / "repo"
+    (repo / ".aletheore").mkdir(parents=True)
+    (repo / ".aletheore" / "air.toon").write_text("x[3]: not enough items")
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"):
+        with pytest.raises(AdapterInvocationError, match="could not decode evidence"):
+            adapter.invoke("audit this repo", cwd=str(repo))
+
+
+@patch("aletheore.adapters.openai_compatible.OpenAI")
+def test_read_evidence_section_reports_encoding_failure_instead_of_crashing(
+    mock_openai_class, tmp_path
+):
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": [{"path": "app.py"}]}})
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    responses = [
+        _mock_response(
+            tool_calls=[_mock_tool_call("read_evidence_section", {"path": "repository.modules"})]
+        )
+    ]
+    responses += _write_all_sections_then_finish_responses()
+    mock_client.chat.completions.create.side_effect = responses
+
+    from aletheore.toon_encoding import ToonEncodingError
+
+    def _boom(_data):
+        raise ToonEncodingError("simulated failure")
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"):
+        with patch("aletheore.adapters.openai_compatible.to_toon", _boom):
+            adapter.invoke("audit this repo", cwd=str(repo))
+
+    second_call = mock_client.chat.completions.create.call_args_list[1]
+    tool_message = next(m for m in second_call.kwargs["messages"] if m.get("role") == "tool")
+    assert "could not encode section repository.modules" in tool_message["content"]
+
+
 @patch("aletheore.adapters.openai_compatible.OpenAI")
 def test_read_evidence_section_missing_path_reports_clearly(mock_openai_class, tmp_path):
     repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})

--- a/src/tests/test_toon_encoding.py
+++ b/src/tests/test_toon_encoding.py
@@ -1,4 +1,5 @@
 import math
+import random
 
 import pytest
 import toon
@@ -118,3 +119,85 @@ def test_to_toon_catches_encode_success_decode_failure_asymmetry():
     data = {"nested": [[1, [2, 3]], [4, 5]]}
     with pytest.raises(ToonEncodingError):
         to_toon(data)
+
+
+def _sanitize_reference(data):
+    # Independent re-implementation of _sanitize_for_toon, kept separate
+    # (not imported) so the fuzz test below doesn't just validate to_toon's
+    # internal logic against itself.
+    if isinstance(data, float):
+        if math.isnan(data) or math.isinf(data):
+            return str(data)
+        return data
+    if isinstance(data, dict):
+        return {key: _sanitize_reference(value) for key, value in data.items()}
+    if isinstance(data, list):
+        return [_sanitize_reference(item) for item in data]
+    return data
+
+
+def _random_shape(rng, depth=0, max_depth=4):
+    choice = "scalar" if depth >= max_depth else rng.choice(
+        ["dict", "list", "mixed_list", "scalar"]
+    )
+    if choice == "scalar":
+        return rng.choice(
+            [
+                rng.randint(-1000, 1000),
+                rng.uniform(-1000, 1000),
+                True,
+                False,
+                None,
+                "".join(rng.choices("abcXYZ 012,:\"'\n", k=rng.randint(0, 12))),
+            ]
+        )
+    if choice == "dict":
+        return {
+            f"k{i}": _random_shape(rng, depth + 1, max_depth) for i in range(rng.randint(0, 4))
+        }
+    if choice == "list":
+        return [_random_shape(rng, depth + 1, max_depth) for _ in range(rng.randint(0, 4))]
+    # mixed_list deliberately targets the exact shape class that broke: a
+    # bare list value sitting alongside non-list siblings in the same array
+    # (this is what test_to_toon_catches_encode_success_decode_failure_asymmetry
+    # hand-picked one instance of).
+    return [
+        [_random_shape(rng, depth + 1, max_depth) for _ in range(rng.randint(1, 3))]
+        if rng.random() < 0.4
+        else _random_shape(rng, depth + 1, max_depth)
+        for _ in range(rng.randint(2, 4))
+    ]
+
+
+def test_to_toon_round_trips_or_cleanly_rejects_thousands_of_random_shapes():
+    # No hypothesis dependency (not currently in pyproject.toml, and adding
+    # one for a single test file isn't worth the new-dependency footprint
+    # right after this module's own supply-chain posture was tightened
+    # elsewhere) - a seeded, bounded, recursive shape generator gets most
+    # of the real value instead: broad coverage plus a generator
+    # deliberately weighted toward the "list value among non-list array
+    # siblings" shape class that produced a real, previously-undetected
+    # bug (see test_to_toon_catches_encode_success_decode_failure_asymmetry).
+    # For every shape to_toon() doesn't reject, independently re-decode and
+    # compare - not just trusting to_toon's own internal round-trip check,
+    # since a bug in that check itself wouldn't be caught by relying on it.
+    rng = random.Random(20260826)
+    successes = 0
+    for _ in range(3000):
+        data = {"root": _random_shape(rng)}
+        try:
+            encoded = to_toon(data)
+        except ToonEncodingError:
+            # to_toon already verified this specific shape doesn't
+            # round-trip and rejected it - that's the contract working,
+            # not a test failure.
+            continue
+        assert toon.decode(encoded) == _sanitize_reference(data)
+        successes += 1
+    # Sanity check only - not a claim about real evidence data. The 40%
+    # mixed_list weighting deliberately over-represents the shape class
+    # that broke, so a large rejection rate here (measured: ~60% of the
+    # 3000) is the round-trip check doing its job on adversarial input,
+    # not evidence of a problem - this just confirms the generator isn't
+    # producing exclusively-unencodable garbage.
+    assert successes > 500

--- a/src/tests/test_toon_encoding.py
+++ b/src/tests/test_toon_encoding.py
@@ -1,4 +1,9 @@
-from aletheore.toon_encoding import to_toon
+import math
+
+import pytest
+import toon
+
+from aletheore.toon_encoding import ToonEncodingError, to_toon
 
 
 def test_to_toon_encodes_a_uniform_array_of_objects():
@@ -45,3 +50,55 @@ def test_to_toon_is_more_compact_than_json_for_uniform_arrays():
 def test_to_toon_handles_empty_list():
     result = to_toon({"endpoints": []})
     assert "endpoints" in result
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"endpoints": [{"method": "GET", "path": "/users", "note": "returns: users, sorted"}]},
+        {"note": 'a "quoted" value, with comma'},
+        {"note": "multi\nline\nvalue"},
+        {"items": [{"a": 1, "b": 2}, {"a": 1, "c": 3}, {"x": 9}]},  # non-uniform shapes
+        {"items": [{"a": None, "b": 1}, {"a": "x", "b": None}]},
+        {"items": [{"code": "007"}, {"code": "0.10"}, {"code": True}, {"code": "true"}]},
+        {"unicode": "café ☃ \U0001f600"},
+        {"empty_string": "", "nested": {"deep": {"deeper": [1, 2, 3]}}},
+    ],
+)
+def test_to_toon_round_trips_losslessly(data):
+    # "Lossless" was asserted (CHANGELOG 0.3.0) but never actually verified
+    # by decoding the output back - this closes that gap for the shapes
+    # most likely to appear in real evidence data.
+    encoded = to_toon(data)
+    assert toon.decode(encoded) == data
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_to_toon_sanitizes_non_finite_floats_instead_of_silently_nulling_them(value):
+    # Confirmed bug in the underlying library: toon.encode({"v": float("inf")})
+    # silently produces 'v: null', indistinguishable on decode from a real
+    # null. air.json (json.dumps, which permits Infinity/NaN) keeps the real
+    # value, so an unsanitized TOON copy would silently diverge. The
+    # sanitized encoding must not decode back to None.
+    encoded = to_toon({"v": value})
+    decoded = toon.decode(encoded)
+    assert decoded["v"] is not None
+    assert math.isnan(value) or math.isinf(value)  # sanity on the parametrize itself
+
+
+def test_to_toon_sanitizes_non_finite_floats_nested_in_arrays():
+    data = {"scores": [{"confidence": 0.5}, {"confidence": float("nan")}]}
+    encoded = to_toon(data)
+    decoded = toon.decode(encoded)
+    assert decoded["scores"][0]["confidence"] == 0.5
+    assert decoded["scores"][1]["confidence"] is not None
+
+
+def test_to_toon_raises_toon_encoding_error_on_failure(monkeypatch):
+    def _boom(_data):
+        raise RecursionError("simulated pathological nesting")
+
+    monkeypatch.setattr("aletheore.toon_encoding.toon.encode", _boom)
+
+    with pytest.raises(ToonEncodingError):
+        to_toon({"x": 1})

--- a/src/tests/test_toon_encoding.py
+++ b/src/tests/test_toon_encoding.py
@@ -102,3 +102,19 @@ def test_to_toon_raises_toon_encoding_error_on_failure(monkeypatch):
 
     with pytest.raises(ToonEncodingError):
         to_toon({"x": 1})
+
+
+def test_to_toon_catches_encode_success_decode_failure_asymmetry():
+    # Real, reproducible bug in the underlying library (not hypothetical):
+    # toon.encode({"nested": [[1, [2, 3]], [4, 5]]}) succeeds and returns
+    # output that toon.decode() then rejects with
+    # ToonDecodeError("Expected 2 items, but got 0") - a heterogeneous
+    # nested-list shape where encode() itself never raises. Without a
+    # self-verifying round trip inside to_toon(), this class of corruption
+    # would slip past every try/except in the codebase (they all catch
+    # ToonEncodingError, which encode() alone never produces here) and sit
+    # silently in a written air.toon/MCP result until something else
+    # eventually calls decode() on it.
+    data = {"nested": [[1, [2, 3]], [4, 5]]}
+    with pytest.raises(ToonEncodingError):
+        to_toon(data)


### PR DESCRIPTION
## Summary
Audited `src/aletheore/toon_encoding.py` (unchanged since v0.3.0, the project's oldest untouched feature) after using it in outward-facing marketing material. Found six real gaps, confirmed independently via direct testing and two blind subagent reviews:

- **No error handling anywhere `to_toon()`/`toon.encode()` is called.** Worst at `evidence.py`'s `write_evidence()`: the canonical `air.json` write already succeeds, then the unguarded TOON write could crash the entire `scan`/`watch` command - contradicting the code's own comment that it's "additive, not a replacement." Also unguarded in `mcp_server.py`'s `_toon_result` (every MCP tool response), `managed_audit_client.py` (paid managed-audit request), `cli.py`'s three `query` subcommands, and both adapters' `read_evidence_section` tool.
- **Silent data corruption**: `toon.encode(float('inf'))` → `'null'` with no error, indistinguishable from a real null on decode, while `air.json` (`json.dumps`) keeps the real value. `to_toon()` now sanitizes non-finite floats to their `str()` representation before encoding.
- **Adapter decode-error bug**: both adapters caught only `OSError` around `toon.decode()`, but `ToonDecodeError` doesn't inherit from `OSError` - a malformed/empty `air.toon` crashed with a raw traceback instead of the intended clean `AdapterInvocationError`.
- **Missing doc note**: `read_evidence_section`'s tool description now documents that it returns a matched section with no size limit.
- **Missing round-trip test coverage**: the "lossless" claim (CHANGELOG 0.3.0) was never actually verified by a test that decodes the output back.

## Test plan
- [x] Full test suite: 1364 passed
- [x] New tests cover every fixed call site: `to_toon`'s sanitization + typed exception, `write_evidence`'s graceful skip-and-warn, `_toon_result`'s JSON fallback, `_print_query_result`'s JSON fallback, `run_managed_audit_request`'s `ManagedAuditError`, both adapters' `AdapterInvocationError` on undecodable evidence and error-string on encode failure in `read_evidence_section`