### PR TITLE
fix: stop free-tier Flash Review from claiming a diff is clean when it never ran

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1786,6 +1786,19 @@ def _run_flash_review(
             verify_with_second_model=not is_free_tier,
             on_verification_usage=_on_verification_usage,
         )
+    # Every free-tier provider failed mid-review (see
+    # _on_free_tier_exhausted above) - this review never actually ran, the
+    # same as the no-free-tier-keys-configured branch earlier in this
+    # function. Bail out the same way that branch does, before posting
+    # anything or touching last_reviewed_sha: posting the "no issues found"
+    # body below would falsely tell the user this diff was checked and
+    # found clean, and advancing last_reviewed_sha would silently and
+    # permanently skip re-reviewing the diff that just failed. The
+    # caller (run_flash_review_job) releases this review's reservation
+    # when it sees False returned here.
+    if free_tier_exhausted["value"]:
+        return False
+
     # The review-count reservation already happened atomically up front (see
     # run_flash_review_job); nothing left to do for it here on the success
     # path. The dollar reservation was a conservative flat estimate, not the
@@ -1793,14 +1806,10 @@ def _run_flash_review(
     # record_llm_spend's own UPSERT is already atomic per call, and it was
     # only ever paired with the (now-removed) count increment for the
     # illusion of atomicity, not because either write needed one on its own.
-    # Skipped entirely when free-tier was fully exhausted before producing a
-    # result - that reservation gets released, not trued up, by the caller.
-    review_ran = not free_tier_exhausted["value"]
-    if review_ran:
-        record_llm_spend(
-            settings.database_url, installation_id, spend_accumulator["total"] - reserved_spend,
-            monthly_cap=monthly_cap, feature="flash_review",
-        )
+    record_llm_spend(
+        settings.database_url, installation_id, spend_accumulator["total"] - reserved_spend,
+        monthly_cap=monthly_cap, feature="flash_review",
+    )
 
     proposed = grounding_result.get("proposed", 0)
     kept = grounding_result.get("kept", 0)
@@ -1867,7 +1876,7 @@ def _run_flash_review(
     set_last_reviewed_sha(
         settings.database_url, installation_id, repo_full_name, pr_number, head_sha
     )
-    return review_ran
+    return True
 
 
 def _send_alerts_if_configured(installation: dict, message: dict) -> None:

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1723,6 +1723,81 @@ def test_flash_review_job_alerts_ops_when_all_free_tier_providers_fail(monkeypat
     assert ops_alert_calls[0][1] == "flash_review.free_tier_exhausted"
 
 
+def test_flash_review_does_not_post_or_advance_sha_when_free_tier_exhausted(monkeypatch):
+    # Same all-providers-failed scenario as
+    # test_flash_review_job_alerts_ops_when_all_free_tier_providers_fail,
+    # but checking the other half of the contract: a review that never
+    # actually ran must not tell the user their PR is clean, and must not
+    # advance last_reviewed_sha - doing either would silently and
+    # permanently skip reviewing the diff that failed. The
+    # no-free-tier-keys-configured branch a few lines up in
+    # _run_flash_review already bails before touching either; this
+    # confirms the mid-review-exhaustion branch does the same.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"}
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
+    )
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0
+    )
+    from unittest.mock import MagicMock
+    failing_adapter = MagicMock()
+    failing_adapter.name = "Groq"
+    failing_adapter.simple_completion.side_effect = RuntimeError("rate limited")
+    monkeypatch.setattr(
+        "scan_worker.model_tiers.writing_adapter_chain_for_free_tier",
+        lambda *a, **k: [failing_adapter],
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_redis_client", lambda: _FakeRedis())
+    monkeypatch.setattr("scan_worker.jobs.resolve_model", lambda *a: "gpt-5.6-luna")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- a.py ---\n+real change\n")
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["a.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_context", lambda *a, **k: "")
+    monkeypatch.setattr("scan_worker.jobs.is_non_substantive_diff", lambda *a: False)
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+    monkeypatch.setattr("scan_worker.jobs.files_missing_from_review_context", lambda *a: [])
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a: None)
+    monkeypatch.setattr("scan_worker.jobs.build_code_evidence_context", lambda *a: "")
+    monkeypatch.setattr("scan_worker.jobs.build_dependency_impact_context", lambda *a: "")
+    monkeypatch.setattr("scan_worker.jobs.build_change_impact_context", lambda *a: "")
+    monkeypatch.setattr("scan_worker.jobs.build_blast_radius_context", lambda *a, **k: "")
+    monkeypatch.setattr("scan_worker.jobs.build_referenced_symbol_context", lambda *a: "")
+    monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a: 999.0)
+    monkeypatch.setattr("scan_worker.jobs.lookup_cached_flash_review_result", lambda *a: None)
+    monkeypatch.setattr("scan_worker.jobs.store_flash_review_result", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._send_ops_alert", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+
+    comment_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.upsert_pr_comment",
+        lambda *a, **k: comment_calls.append(a),
+    )
+    sha_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_last_reviewed_sha",
+        lambda *a, **k: sha_calls.append(a),
+    )
+
+    from scan_worker.jobs import run_flash_review_job
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert comment_calls == []
+    assert sha_calls == []
+
+
 def test_flash_review_job_skips_when_debounced(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Found during a proactive health-pass audit of `jobs.py` (repo's own worst-scoring hotspot: 1.65/10 defect risk, 38 prior bug-fixes in 6 months).
- When every free-tier provider fails mid-review (a real production scenario the code already fires an ops alert for), `_run_flash_review` correctly skipped billing but still posted `"No issues found in this diff."` to the PR and advanced `last_reviewed_sha` — falsely telling the user the diff was reviewed clean, and permanently skipping the range that actually failed to review on every future update.
- The sibling "no free-tier provider keys configured" branch a few lines up already bails out before touching either. This makes the mid-review-exhaustion branch do the same.

## Test plan
- [x] New regression test reproduces the bug against the pre-fix code (fails: posts the false-clean comment)
- [x] Test passes after the fix (no comment posted, `last_reviewed_sha` untouched)
- [x] Full `github-app/tests/test_jobs.py` suite: 179 passed
- [x] Full `github-app` suite: 906 passed, 0 regressions (3 pre-existing failures are local-environment-only: no Redis/Postgres running, unrelated to this change)