### PR TITLE
fix: stop PR scans from folding unmerged commits into the default-branch git graph

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -872,12 +872,25 @@ def run_pr_scan_job(
         base_dir = job_dir / "base"
         _clone_ref(clone_url, base_sha, base_dir)
 
-        # Locked for the whole checkout-through-git-graph-sync span, not just
-        # the checkout call: _ensure_persistent_checkout has no filesystem
+        # Locked for the whole checkout-through-scan span, not just the
+        # checkout call: _ensure_persistent_checkout has no filesystem
         # locking of its own (see repo_checkout_lock's docstring), and
-        # _sync_persistent_git_graph also runs git commands against head_dir.
-        # A second scan-worker replica racing this same repo needs to wait
-        # for the whole thing, not just the initial checkout.
+        # _run_scan below also runs git commands against head_dir. A second
+        # scan-worker replica racing this same repo needs to wait for the
+        # whole thing, not just the initial checkout.
+        #
+        # Deliberately does NOT call _sync_persistent_git_graph: head_dir is
+        # checked out at this PR's head_sha, which may sit on a feature
+        # branch that never merges. _sync_persistent_git_graph always writes
+        # under the fixed GRAPH_BRANCH="default" key that run_push_scan_job/
+        # run_initial_scan_job use for the repo's real default branch -
+        # syncing a PR head into that same bucket would permanently fold
+        # unmerged, possibly-rejected commits into the persisted "default"
+        # branch ownership/churn/cadence graph the dashboard and future
+        # incremental syncs read from. This evidence keeps whichever git
+        # data `aletheore scan` computed locally for this PR's own checkout
+        # instead (see _sync_persistent_git_graph's docstring) - correct for
+        # describing this one scan, just not persisted or incremental.
         with repo_checkout_lock(settings.database_url, installation_id, repo_full_name):
             head_dir = _prepare_head_checkout(
                 clone_url, head_sha, installation_id, repo_full_name, job_dir / "head"
@@ -914,7 +927,6 @@ def run_pr_scan_job(
 
             client = get_github_api_client()
             upsert_pr_comment(client, token, repo_full_name, pr_number, format_diff_comment(diff))
-            new = _sync_persistent_git_graph(installation_id, repo_full_name, head_dir, new)
         _sync_code_graph(installation_id, repo_full_name, head_sha, new)
         history_id = _insert_history(installation_id, repo_full_name, new)
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -343,6 +343,54 @@ def test_run_pr_scan_job_uses_persistent_checkout_and_unchanged_cache_for_head(
     assert cache_calls[0][4] == head_sha  # current_sha
 
 
+def test_run_pr_scan_job_never_syncs_the_pr_head_checkout_into_the_persistent_git_graph(
+    bare_repo_with_two_commits, monkeypatch
+):
+    # head_dir is checked out at this PR's head_sha, which may sit on a
+    # feature branch that never merges. _sync_persistent_git_graph always
+    # persists under the fixed GRAPH_BRANCH="default" key that
+    # run_push_scan_job/run_initial_scan_job use for the repo's real
+    # default branch, so calling it here would permanently fold unmerged,
+    # possibly-rejected PR commits into the persisted "default" branch
+    # ownership/churn/cadence graph (confirmed directly: see
+    # test_jobs_git_graph_sync.py's
+    # test_sync_persistent_git_graph_does_not_fold_unmerged_pr_commits_into_default_branch_stats).
+    # run_pr_scan_job must never call it.
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_create_check_run", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._sync_code_graph", lambda *a, **k: None)
+
+    sync_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs._sync_persistent_git_graph",
+        lambda *a, **k: sync_calls.append(a) or (a[3] if len(a) > 3 else k.get("evidence")),
+    )
+
+    run_pr_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        pr_number=7,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+    assert sync_calls == []
+
+
 def test_happy_path_posts_comment_and_writes_history(bare_repo_with_two_commits, monkeypatch):
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     posted = {}


### PR DESCRIPTION
## Summary
- `run_pr_scan_job` checks out a PR's `head_sha` onto the same persistent checkout directory push/initial scans reuse for the real default branch, then called `_sync_persistent_git_graph` on it - which always persists under the fixed `GRAPH_BRANCH="default"` key. Every PR scan was permanently folding that PR's commits (author, churn, cadence) into the persisted "default" branch git graph the dashboard and future incremental syncs read from, even for PRs closed without merging.
- Fixed by removing the call from `run_pr_scan_job`. It now keeps whichever git data `aletheore scan` computed locally for this PR's own checkout, instead of persisting it into the shared default-branch bucket. `run_push_scan_job`/`run_initial_scan_job` are unaffected - they only ever check out the real default branch.
- Found via a second independent audit pass on `scan_worker/jobs.py` (repo's worst code-health hotspot), separate from PR #405's free-tier Flash Review fix already up for review.

## Test plan
- [x] Wrote a failing test reproducing the pollution directly against `_sync_persistent_git_graph` (an unmerged PR-only commit's author appeared in the "default" graph) - confirmed it fails on current `master`, then removed it in favor of a wiring-level regression test once the actual fix (call-site removal) was in place.
- [x] Added `test_run_pr_scan_job_never_syncs_the_pr_head_checkout_into_the_persistent_git_graph` in `tests/test_jobs.py` - confirmed it fails against pre-fix `jobs.py` (via `git stash`) and passes after the fix.
- [x] Full `github-app` suite: `1531 passed, 8 skipped` (`python -m pytest tests/ -q`).

Per request: not merging - branched, fixed, tested, pushed for review alongside PR #405, to be bundled into one deploy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr