### PR TITLE
fix: stop PR scans from folding unmerged commits into the default-branch code graph

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -879,18 +879,20 @@ def run_pr_scan_job(
         # scan-worker replica racing this same repo needs to wait for the
         # whole thing, not just the initial checkout.
         #
-        # Deliberately does NOT call _sync_persistent_git_graph: head_dir is
-        # checked out at this PR's head_sha, which may sit on a feature
-        # branch that never merges. _sync_persistent_git_graph always writes
-        # under the fixed GRAPH_BRANCH="default" key that run_push_scan_job/
+        # Deliberately does NOT call _sync_persistent_git_graph or
+        # _sync_code_graph: head_dir is checked out at this PR's head_sha,
+        # which may sit on a feature branch that never merges. Both
+        # functions write unconditionally under the fixed
+        # GRAPH_BRANCH="default" key that run_push_scan_job/
         # run_initial_scan_job use for the repo's real default branch -
         # syncing a PR head into that same bucket would permanently fold
-        # unmerged, possibly-rejected commits into the persisted "default"
-        # branch ownership/churn/cadence graph the dashboard and future
-        # incremental syncs read from. This evidence keeps whichever git
-        # data `aletheore scan` computed locally for this PR's own checkout
-        # instead (see _sync_persistent_git_graph's docstring) - correct for
-        # describing this one scan, just not persisted or incremental.
+        # unmerged, possibly-rejected commits/module-endpoint deltas into
+        # the persisted "default" branch graphs the dashboard, several MCP
+        # tools, and future incremental syncs read from. This evidence
+        # keeps whichever git/code data `aletheore scan` computed locally
+        # for this PR's own checkout instead (see _sync_persistent_git_graph
+        # and _sync_code_graph's docstrings) - correct for describing this
+        # one scan, just not persisted or incremental.
         with repo_checkout_lock(settings.database_url, installation_id, repo_full_name):
             head_dir = _prepare_head_checkout(
                 clone_url, head_sha, installation_id, repo_full_name, job_dir / "head"
@@ -927,7 +929,6 @@ def run_pr_scan_job(
 
             client = get_github_api_client()
             upsert_pr_comment(client, token, repo_full_name, pr_number, format_diff_comment(diff))
-        _sync_code_graph(installation_id, repo_full_name, head_sha, new)
         history_id = _insert_history(installation_id, repo_full_name, new)
 
         # These are side effects, not the primary deliverable above - a failure in

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -391,6 +391,53 @@ def test_run_pr_scan_job_never_syncs_the_pr_head_checkout_into_the_persistent_gi
     assert sync_calls == []
 
 
+def test_run_pr_scan_job_never_syncs_the_pr_head_checkout_into_the_persistent_code_graph(
+    bare_repo_with_two_commits, monkeypatch
+):
+    # Direct sibling of the git-graph bug fixed above: _sync_code_graph is
+    # its own docstring's "counterpart to _sync_persistent_git_graph...for
+    # the code model rather than git history" - it too writes unconditionally
+    # under the fixed GRAPH_BRANCH="default" key (apply_module_deltas/
+    # apply_endpoint_deltas), the same key run_push_scan_job/
+    # run_initial_scan_job use for the repo's real default branch. Calling it
+    # here with this PR's own head_sha/evidence would permanently fold that
+    # PR's file/symbol/dependency-edge/endpoint deltas into the durable code
+    # graph several MCP tools and future incremental syncs read from, even
+    # for PRs closed without merging. run_pr_scan_job must never call it.
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"secret": set(), "vulnerability": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_send_slack_alert", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_create_check_run", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._maybe_update_live_wiki", lambda *a, **k: None)
+
+    sync_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs._sync_code_graph",
+        lambda *a, **k: sync_calls.append(a),
+    )
+
+    run_pr_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        pr_number=7,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+    assert sync_calls == []
+
+
 def test_happy_path_posts_comment_and_writes_history(bare_repo_with_two_commits, monkeypatch):
     bare_path, base_sha, head_sha = bare_repo_with_two_commits
     posted = {}


### PR DESCRIPTION
## Summary
- Direct sibling of #406 (already merged). `_sync_code_graph` is its own docstring's "counterpart to `_sync_persistent_git_graph`...for the code model rather than git history" - it also writes unconditionally under the fixed `GRAPH_BRANCH="default"` key (`apply_module_deltas`/`apply_endpoint_deltas`), same key `run_push_scan_job`/`run_initial_scan_job` use for the repo's real default branch.
- `run_pr_scan_job` was still calling it with the PR's own `head_sha`/scan evidence right after #406 removed the sibling git-graph call from the same spot - so every PR scan kept folding that PR's file/symbol/dependency-edge/endpoint deltas into the durable code graph (`code_graph_files/symbols/dependency_edges/endpoints`) that several MCP tools and future incremental syncs read from, even for PRs closed without merging.
- Verified `run_push_scan_job`/`run_initial_scan_job` (the only other two callers) only ever check out the real default branch - unaffected. Fixed by removing the call, same shape as #406.
- Found by a second independent audit pass (veridion-8b) after #406 merged, checking for other unconditional `GRAPH_BRANCH`-keyed writes in `jobs.py`.

## Test plan
- [x] Added `test_run_pr_scan_job_never_syncs_the_pr_head_checkout_into_the_persistent_code_graph` - confirmed it fails against pre-fix `jobs.py`, passes after the fix.
- [x] Full `github-app` suite: `1532 passed, 8 skipped`.

Per request: not merging - branched, fixed, tested, pushed for review alongside #405, to be bundled into one deploy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr