### PR TITLE
fix: close the PR-triggered managed audit's spend-cap check-then-act race

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1328,11 +1328,19 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                 f"{cooldown_seconds // 3600} hours. Try again later."
             )
         else:
-            with installation_spend_lock(settings.database_url, installation_id):
-                extra_seats = get_extra_seats(settings.database_url, installation_id)
-                monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
-                current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
-                cap_reached = current_spend >= monthly_cap
+            extra_seats = get_extra_seats(settings.database_url, installation_id)
+            monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
+            # No lock: this is a fast-fail hint (skip straight to a clear PR
+            # comment when the cap is obviously already blown), not the
+            # enforcement itself - real enforcement is spend_budget.
+            # can_start_next_call() below, reserving atomically against the
+            # live total before every real LLM call this (possibly
+            # multi-call) audit makes. Same discipline as
+            # run_managed_audit_api_job - a stale read here has no
+            # financial-integrity consequence, just a possibly-later-than-
+            # ideal rejection.
+            current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
+            cap_reached = current_spend >= monthly_cap
 
             if cap_reached:
                 body = (
@@ -1341,30 +1349,33 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                     "Resumes next month, or email support@aletheore.com to raise the limit sooner."
                 )
             else:
-                spend_accumulator = {"total": 0.0, "model": model_for_plan(plan)}
-
-                def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-                    spend_accumulator["total"] += cost_for_usage(
-                        spend_accumulator["model"], prompt_tokens, completion_tokens
-                    )
-
-                # LLM call, measured to take minutes for large repos - must not
-                # run while installation_spend_lock is held (see
-                # run_flash_review_job's comment on the same pattern).
+                # run_managed_audit can make several sequential LLM calls and
+                # has been observed to take minutes. The old
+                # installation_spend_lock check-then-record pair around the
+                # whole call left a real window: two concurrent managed
+                # audits for the same installation (different repos -
+                # check_and_reserve_managed_audit above is scoped per-repo,
+                # not per-installation) could both pass this check before
+                # either recorded a cost, and even a single run had no gate
+                # between its own individual LLM calls.
+                # _IncrementalSpendBudget closes both - the same atomic
+                # reserve-per-call primitive run_managed_audit_api_job
+                # already uses (see its own comment at this same call).
+                spend_budget = _IncrementalSpendBudget(
+                    settings.database_url,
+                    installation_id,
+                    model_for_plan(plan),
+                    monthly_cap,
+                    feature="managed_audit",
+                )
                 report_text = run_managed_audit(
                     repo_dir,
-                    on_usage=_on_usage,
+                    on_usage=spend_budget.record_usage,
+                    before_llm_call=spend_budget.can_start_next_call,
+                    allow_partial_report=True,
                     plan=plan,
                     include_llm_suggestions=include_suggestions,
                 )
-                with installation_spend_lock(settings.database_url, installation_id):
-                    record_llm_spend(
-                        settings.database_url,
-                        installation_id,
-                        spend_accumulator["total"],
-                        monthly_cap=monthly_cap,
-                        feature="managed_audit",
-                    )
                 verification_token = _sign_and_persist_audit_report(
                     settings,
                     installation_id,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1238,17 +1238,16 @@ def test_managed_audit_pr_job_clones_pr_head_runs_audit_and_replies(monkeypatch,
     assert posted["marker"] == AUDIT_COMMENT_MARKER
 
 
-def test_managed_audit_pr_job_releases_lock_during_audit(monkeypatch, tmp_path):
-    lock_state = {"held": False, "observed_during_audit": None}
-
-    @contextmanager
-    def _tracking_spend_lock(*args, **kwargs):
-        lock_state["held"] = True
-        try:
-            yield
-        finally:
-            lock_state["held"] = False
-
+def test_managed_audit_pr_job_records_each_call_and_stops_mid_run_when_cap_reached(monkeypatch, tmp_path):
+    # Mirrors test_managed_audit_api_job_records_each_call_and_exposes_budget_stop:
+    # run_managed_audit_pr_job must gate on the same atomic per-call
+    # reservation (_IncrementalSpendBudget/reserve_llm_spend) that
+    # run_managed_audit_api_job, run_flash_review_job, and AIRview/Docs
+    # builds already use - not the old check-once-then-record-once pattern
+    # around installation_spend_lock, which left the entire (possibly
+    # multi-call) audit run, and any other job racing the same
+    # installation's cap concurrently, completely ungated between the one
+    # check and the one record.
     def _clone_pr_head(url, pr_number, dest):
         dest.mkdir(parents=True, exist_ok=True)
         (dest / "app.py").write_text("print('hello')\n")
@@ -1270,22 +1269,52 @@ def test_managed_audit_pr_job_releases_lock_during_audit(monkeypatch, tmp_path):
     monkeypatch.setattr("scan_worker.jobs._clone_pr_head", _clone_pr_head)
     monkeypatch.setattr("scan_worker.jobs._run_scan", _run_scan)
     monkeypatch.setattr("scan_worker.jobs.get_github_api_client", lambda: object())
-    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _tracking_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
-    monkeypatch.setattr("scan_worker.jobs.run_managed_audit", lambda *a, **k: (
-        lock_state.update(observed_during_audit=lock_state["held"]) or "# Managed Audit"
-    ))
-    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: 0.0012)
+    monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a, **k: 0.0006)
     monkeypatch.setattr("scan_worker.jobs._sign_and_persist_audit_report", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+
+    # In-memory stand-in for the real atomic reserve_llm_spend/record_llm_spend
+    # pair, sharing running-total state the same way the real DB row does -
+    # same shape as the API-job test this mirrors.
+    spend_state = {"total": 0.0}
+    recorded_deltas = []
+
+    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+        if spend_state["total"] + reserve_usd <= monthly_cap:
+            spend_state["total"] += reserve_usd
+            return True
+        return False
+
+    def _record_llm_spend(dsn, iid, delta, **k):
+        spend_state["total"] += delta
+        recorded_deltas.append(delta)
+
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
+
+    budget_checks = []
+
+    def fake_run_managed_audit(repo_dir, *, on_usage, before_llm_call=None, **kwargs):
+        assert before_llm_call is not None, (
+            "run_managed_audit_pr_job must thread an atomic before_llm_call gate into "
+            "run_managed_audit, not just a single check before the whole run"
+        )
+        budget_checks.append(before_llm_call())
+        on_usage(1, 1)
+        budget_checks.append(before_llm_call())
+        return "# Managed Audit"
+
+    monkeypatch.setattr("scan_worker.jobs.run_managed_audit", fake_run_managed_audit)
 
     from scan_worker.jobs import run_managed_audit_pr_job
 
     run_managed_audit_pr_job(1, "octocat/hello-world", 42)
 
-    assert lock_state["observed_during_audit"] is False
-    assert lock_state["held"] is False
+    assert recorded_deltas == [pytest.approx(-0.0004)]
+    assert budget_checks == [True, False]
 
 
 def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- `run_managed_audit_pr_job` was still on the pre-#304 pattern (`installation_spend_lock` wrapping a single `current_spend >= monthly_cap` check, released for the entire multi-minute audit, re-acquired once to record the final cost). Two real gaps:
  - Two concurrent PR-triggered managed audits for the **same installation** (different repos - `check_and_reserve_managed_audit` is scoped per-repo, not per-installation) could both pass the check before either recorded spend.
  - `run_managed_audit` itself makes several sequential LLM calls (reasoning-phase tool loop + optional suggestion section) with **no gate between them** - a single large audit could overshoot the cap on its own.
- `run_managed_audit_api_job` (the ChatOps/ingestion-triggered sibling) and `run_flash_review_job` already use the atomic per-call reservation primitive `_IncrementalSpendBudget`/`reserve_llm_spend` that PR #304 introduced specifically for this race - `run_managed_audit_pr_job` was simply never migrated. Fixed by wiring the same primitive through `before_llm_call`/`on_usage`, matching `run_managed_audit_api_job` exactly (including `allow_partial_report=True`, so a mid-run cap hit degrades gracefully instead of raising).
- Found via a third independent audit pass on `github-app/scan_worker/db.py` (this repo's `installation_spend_lock`/`repo_checkout_lock` file), specifically the area flagged for extra scrutiny since it had a real, confirmed race bug fixed before (#304).

## Test plan
- [x] Added `test_managed_audit_pr_job_records_each_call_and_stops_mid_run_when_cap_reached`, mirroring the API job's own budget-gating test - confirmed it fails against pre-fix `jobs.py`, passes after.
- [x] All other `managed_audit_pr` tests (cap-reached messaging, rate-limit messaging, report signing/persistence, failure comments) pass unchanged.
- [x] Full `github-app` suite: `1533 passed, 8 skipped`.

Per request: not merging - branched, fixed, tested, pushed for review alongside #405/#406/#407, to be bundled into one deploy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr