### PR TITLE
fix: don't charge the demo-scan cooldown when the queue is full

### DIFF
--- a/github-app/app_server/demo_scan_api.py
+++ b/github-app/app_server/demo_scan_api.py
@@ -161,8 +161,18 @@ async def start_demo_scan(request: Request, body: StartDemoScanRequest):
     # Size (and existence) is checked before the rate-limit slot is
     # reserved - a repo that gets rejected here never reaches a worker, so
     # it shouldn't cost the visitor their one scan every 20 minutes. Only a
-    # request that's actually eligible to run consumes the cooldown.
+    # request that's actually eligible to run consumes the cooldown - which
+    # is why the queue-depth check below also runs before the reservation,
+    # not after: check_and_reserve_demo_scan stamps last_run_at the moment
+    # it succeeds, with no release/undo path, so a request rejected as
+    # "demo is busy" after that point would burn the visitor's cooldown for
+    # a scan that never ran.
     await _check_repo_size(owner, repo, settings.github_demo_readonly_token)
+
+    queue = _get_queue(settings.redis_url)
+    in_flight = queue.count + queue.started_job_registry.count
+    if in_flight >= DEMO_SCAN_MAX_QUEUE_DEPTH:
+        raise HTTPException(status_code=503, detail="demo is busy right now - try again shortly")
 
     allowed = await check_and_reserve_demo_scan(pool, client_ip, DEMO_SCAN_COOLDOWN_SECONDS)
     if not allowed:
@@ -173,11 +183,6 @@ async def start_demo_scan(request: Request, body: StartDemoScanRequest):
                 "try again shortly"
             ),
         )
-
-    queue = _get_queue(settings.redis_url)
-    in_flight = queue.count + queue.started_job_registry.count
-    if in_flight >= DEMO_SCAN_MAX_QUEUE_DEPTH:
-        raise HTTPException(status_code=503, detail="demo is busy right now - try again shortly")
 
     job = queue.enqueue(
         DEMO_SCAN_JOB_FUNCTION,

--- a/github-app/tests/test_demo_scan_api.py
+++ b/github-app/tests/test_demo_scan_api.py
@@ -5,6 +5,7 @@ import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app_server.demo_scan_api import DEMO_SCAN_MAX_QUEUE_DEPTH
 from app_server.main import app
 
 
@@ -258,6 +259,35 @@ async def test_queue_at_max_depth_returns_503(pool, monkeypatch):
             "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Hello-World"}
         )
     assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_rejected_due_to_full_queue_does_not_consume_rate_limit_slot(pool, monkeypatch):
+    # Same invariant as test_rejected_oversized_repo_does_not_consume_rate_limit_slot
+    # above, for the other rejection path: a visitor turned away because the
+    # demo is busy right now never actually got scanned either, so it
+    # shouldn't cost them their one scan every 20 minutes - the next request
+    # from the same IP, once the demo isn't busy anymore, must still be
+    # allowed.
+    _mock_github_response(monkeypatch, 200, size_kb=100)
+    fake_queue = _mock_queue(monkeypatch, count=DEMO_SCAN_MAX_QUEUE_DEPTH, started_count=0)
+    app.state.db_pool = pool
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"x-forwarded-for": "203.0.113.201"},
+    ) as client:
+        busy = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/torvalds/linux"}
+        )
+        assert busy.status_code == 503
+
+        fake_queue.count = 0
+        retry = await client.post(
+            "/v1/demo-scan", json={"repo_url": "https://github.com/octocat/Hello-World"}
+        )
+    assert retry.status_code == 202
+    assert fake_queue.enqueue.call_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `start_demo_scan` called `check_and_reserve_demo_scan` (an atomic UPSERT that stamps `last_run_at` immediately, with no release/undo path anywhere in the codebase) **before** checking whether the demo-scan queue had room. A visitor rejected with `503 "demo is busy right now"` because the queue was full still burned their one-scan-per-20-minutes cooldown for a scan that never ran.
- The code's own comment two lines above the reservation call already states the intended invariant: "Only a request that's actually eligible to run consumes the cooldown." That invariant was correctly honored for the oversized-repo rejection path (existing test: `test_rejected_oversized_repo_does_not_consume_rate_limit_slot`) but not for the queue-full path - the queue-depth check ran *after* the reservation instead of before it.
- Fixed by moving the queue-depth check before the cooldown reservation, so `check_and_reserve_demo_scan` is now the last gate before enqueuing - matching the same principle already applied to the repo-size check.
- Found via a fourth independent audit pass, on `app_server/demo_scan_api.py` (flagged as a critical-biomarker prior-defect file). Also checked `scan_worker/demo_scan.py` (the worker-side job), `app_server/frontend.py`, and `scan_worker/embedding_client.py` this same pass - no other real bugs found in those.

## Test plan
- [x] Added `test_rejected_due_to_full_queue_does_not_consume_rate_limit_slot` - confirmed it fails against pre-fix `demo_scan_api.py` (retry gets `429` instead of `202` once the queue drains), passes after.
- [x] All other `demo-scan-api` tests pass unchanged.
- [x] Full `github-app` suite: `1534 passed, 8 skipped`.

Per request: not merging - branched, fixed, tested, pushed for review alongside the earlier PRs from this pass, to be bundled into one deploy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr