### PR TITLE
fix: dead-code dotted-string index over-matched quoted prose as a reference

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -80,12 +80,16 @@ _QUOTED_WORD_DOT_RUN_RE = re.compile(r'["\']([\w][\w.]*)')
 
 
 def _dot_boundary_prefixes(token: str) -> set[str]:
-    # "pkg.mod.func" -> {"pkg", "pkg.mod", "pkg.mod.func"} - every prefix
-    # ending exactly at a '.' boundary, the same set of strings the old
-    # regex's `(?=[.\'"])` lookahead would each independently match against
-    # this same quoted run.
+    # "pkg.mod.func" -> {"pkg", "pkg.mod"} - every STRICT prefix, i.e.
+    # shorter than the full token. Each one is immediately followed by a
+    # literal '.' inside the captured run itself, which is always a valid
+    # boundary per the old regex's `(?=[.\'"])` lookahead, regardless of
+    # what comes after the run in the source. The full token is deliberately
+    # excluded here: its validity depends on what character follows the run
+    # in the source (only a closing quote counts - see
+    # _dotted_string_token_index), which this function has no access to.
     parts = token.split(".")
-    return {".".join(parts[:k]) for k in range(1, len(parts) + 1)}
+    return {".".join(parts[:k]) for k in range(1, len(parts))}
 
 
 def _dotted_string_token_index(sources: dict[str, str]) -> dict[str, set[str]]:
@@ -93,12 +97,29 @@ def _dotted_string_token_index(sources: dict[str, str]) -> dict[str, set[str]]:
     (quote-adjacent, at a '.'-or-closing-quote boundary) - built once for
     the whole corpus, replacing what used to be a fresh regex scan of every
     file per candidate. O(total source size) instead of
-    O(candidates x total source size)."""
+    O(candidates x total source size).
+
+    _QUOTED_WORD_DOT_RUN_RE greedily consumes every '.' as part of the run,
+    so the run can never stop right before a '.' - it only stops at a
+    non-word-non-dot character (or end of string). That means the full
+    captured token's closing boundary is never a '.': it has to be checked
+    against the literal next character in the source, and only a quote
+    character satisfies the old regex's [.\'"] boundary class here. Without
+    this check, a quoted string like "pkg.mod completed successfully" would
+    wrongly register "pkg.mod" as referenced - the old regex required the
+    next character to be '.', "'", or '"', and a space is none of those.
+    Confirmed as a real divergence (not hypothetical) by direct comparison
+    against the old per-candidate regex on that exact string.
+    """
     index: dict[str, set[str]] = {}
     for path, content in sources.items():
         for match in _QUOTED_WORD_DOT_RUN_RE.finditer(content):
-            for prefix in _dot_boundary_prefixes(match.group(1)):
+            token = match.group(1)
+            for prefix in _dot_boundary_prefixes(token):
                 index.setdefault(prefix, set()).add(path)
+            next_char = content[match.end() : match.end() + 1]
+            if next_char in ("'", '"'):
+                index.setdefault(token, set()).add(path)
     return index
 
 

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -213,6 +213,10 @@ def test_dotted_string_detection_matches_naive_reference_implementation(tmp_path
             "# elsewhere: \"app.orphan_partial\" appears but never continues to "
             "\".match\" - candidate app.orphan_partial_match should not match this\n"
         ),
+        "app/prose_false_positive.py": "def unused():\n    pass\n",
+        "app/prose_false_positive_ref.py": (
+            'log.info("app.prose_false_positive completed successfully")\n'
+        ),
     }
     unreachable_candidates = [
         "scan_worker/jobs.py",
@@ -221,6 +225,7 @@ def test_dotted_string_detection_matches_naive_reference_implementation(tmp_path
         "app/deeply/nested/pkg/mod.py",
         "app/orphan_no_reference.py",
         "app/orphan_partial_match.py",
+        "app/prose_false_positive.py",
     ]
 
     for candidate_path in unreachable_candidates:
@@ -255,6 +260,10 @@ def test_dotted_string_detection_real_corpus_full_parity(tmp_path):
         "app/deeply/nested/pkg/mod.py": "def helper():\n    pass\n",
         "app/deeply/nested/registry.py": 'TASKS = {"x": "app.deeply.nested.pkg.mod.helper"}\n',
         "app/orphan_no_reference.py": "def unused():\n    pass\n",
+        "app/prose_false_positive.py": "def unused():\n    pass\n",
+        "app/prose_false_positive_ref.py": (
+            'log.info("app.prose_false_positive completed successfully")\n'
+        ),
     }
     for path, content in files.items():
         (tmp_path / path).parent.mkdir(parents=True, exist_ok=True)
@@ -265,6 +274,7 @@ def test_dotted_string_detection_real_corpus_full_parity(tmp_path):
         "scan_worker/other.py",
         "app/deeply/nested/pkg/mod.py",
         "app/orphan_no_reference.py",
+        "app/prose_false_positive.py",
     ]
     expected_rescued = {
         p for p in unreachable_candidates if _reference_referenced_by_dotted_string(p, files)


### PR DESCRIPTION
Found during a splash-radius audit of #414/#417 right before the 0.9.5 release cut.

## The bug

perf#417's O(files) index rewrite treated the full captured quoted-word-dot run as always boundary-valid, but the old per-candidate regex only accepted a `.` or a closing quote as the terminating boundary (`(?=[.\'"])`) - not any arbitrary character.

Concretely:

```python
content = 'log.info("pkg.mod completed successfully")'
old_referenced("pkg.mod", content)  # False - correct, space isn't a valid boundary
new_referenced("pkg.mod", content)  # True  - wrong, false positive
```

Since the capture regex (`[\w][\w.]*`) greedily consumes every `.`, the full run can never stop right before a `.` - it only stops at a non-word-non-dot character or end of string. The new index unconditionally included that full run as a valid match regardless of what actually followed it in the source. A false positive here means a genuinely dead/unreachable module gets silently "rescued" and never reported as dead code - a real regression in detection accuracy for the exact feature the perf rewrite was supposed to leave unchanged.

The original PR's parity tests (naive-reference comparison + full ERPNext corpus set-equality) never happened to include a quoted string that starts dotted-path-shaped but is terminated by prose rather than a quote, so they didn't catch this.

## The fix

Only include the full captured token in the index when the next character in the source is actually a quote. Strict prefixes (always followed by a literal `.` within the token itself) were already unconditionally valid and are unaffected.

Added a regression case reproducing this exact shape to both existing parity tests.

## Verification

Full `src/aletheore` suite: 1378 passed (same count as #417, confirming no other regression).

Not merged - flagging for review since #414/#417 are about to ship in the 0.9.5 release (#419).

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr