### PR TITLE
fix: secrets scanner missed quoted-key credentials (JSON/YAML/dict-literal)

### DIFF
--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -110,8 +110,24 @@ SECRET_PATTERNS = [
             # - one of the most common hardcoded-credential shapes in object-oriented
             # code) isn't silently invisible to this pattern the way a bare "." boundary
             # was. MYPASSWORD= (no separator at all) still correctly does not match.
-            r"(?i)(?:^|[\s_.-])(PASSWORD|SECRET|API_KEY)\s*[:=]\s*"
-            r"['\"]?([A-Za-z0-9+/=_.-]{16,})['\"]?(?=\s|$|[,#;)])"
+            #
+            # The left-boundary class also includes '"' and "'", and an optional quote
+            # is now consumed right after the keyword too (['\"]? before \s*[:=]) - without
+            # both, a quoted-key credential ("API_KEY": "...", 'password': '...') was
+            # completely invisible: the keyword's own closing quote sat between it and
+            # the ':', which \s*[:=]\s* alone can't skip over. This is the single most
+            # common real shape a hardcoded secret takes in JSON/YAML/dict-literal config
+            # (docker-compose environment blocks, terraform.tfvars, settings.json, a
+            # Python/JS dict literal) - confirmed as a real, silent false negative by
+            # direct testing, not hypothetical: '{"API_KEY": "sk-..."}' never matched.
+            #
+            # The right-boundary class includes "}" and "]" alongside the pre-existing
+            # whitespace/end-of-line/",#;)" set, for the same reason: a quoted value that
+            # closes a JSON object or array (the overwhelmingly common case - the key is
+            # rarely the last thing on the line followed by nothing) was invisible too,
+            # since neither character was in the original lookahead's boundary set.
+            r"(?i)(?:^|[\s_.'\"-])(PASSWORD|SECRET|API_KEY)['\"]?\s*[:=]\s*"
+            r"['\"]?([A-Za-z0-9+/=_.-]{16,})['\"]?(?=\s|$|[,#;)}\]])"
         ),
         2,
     ),

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -229,6 +229,29 @@ def test_find_secrets_detects_dotted_attribute_credential_assignment(tmp_path):
     assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 2
 
 
+def test_find_secrets_detects_quoted_key_credential_assignment(tmp_path):
+    # Regression: neither the left-boundary class nor the post-keyword gap
+    # before ':'/'=' accounted for the keyword's own closing quote, and the
+    # right-boundary lookahead didn't include '}' or ']' - so a JSON/YAML/
+    # dict-literal quoted-key credential ("API_KEY": "...", 'password': '...')
+    # was completely invisible, whether or not it was the last key in the
+    # object. This is the single most common real shape a hardcoded secret
+    # takes in config files (docker-compose environment blocks, terraform
+    # .tfvars, settings.json, a Python/JS dict literal) - not an edge case.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "config.json").write_text(
+        '{"API_KEY": "sk-abcdefghijklmnopqrstuv"}\n'
+        '{"password": "abcdefghijklmnopqrstuv", "x": 1}\n'
+        "{'API_KEY': 'sk-abcdefghijklmnopqrstuv'}\n"
+        '["API_KEY=sk-abcdefghijklmnopqrstuv"]\n'
+    )
+
+    findings = find_secrets(repo)["findings"]
+
+    assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 4
+
+
 def test_find_secrets_detects_fine_grained_github_and_sts_aws_tokens(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
Found during a sibling-bug sweep after #420 (dead-code boundary-regex bug) - looked for other regexes in the codebase with the same "boundary condition doesn't cover a real, common shape" pattern.

## The bug

`generic_credential_assignment` in `src/aletheore/secrets.py` never matched a quoted-key credential assignment:

```python
{"API_KEY": "sk-abcdefghijklmnopqrstuv"}          # never matched
{"password": "abcdefghijklmnopqrstuv", "x": 1}    # never matched
{'API_KEY': 'sk-abcdefghijklmnopqrstuv'}           # never matched
["API_KEY=sk-abcdefghijklmnopqrstuv"]              # never matched
```

Two separate gaps compounded:
1. The left-boundary class (`[\s_.-]`) didn't include a quote character, and there was no allowance for the keyword's own closing quote before the `:`/`=` separator - so `"API_KEY":` never even got past the left side of the match.
2. The right-boundary lookahead only accepted whitespace, end-of-line, or `[,#;)]` - missing `}` and `]`, the two most common JSON/array closers.

This is arguably the single most common real shape a hardcoded secret takes in config: JSON files, YAML flow mappings, docker-compose `environment:` blocks, terraform `.tfvars`, a Python/JS dict literal - all silently invisible to this scanner before this fix.

## The fix

- Added quote characters to the left-boundary class.
- Consume an optional quote right after the keyword, before the separator.
- Added `}` and `]` to the right-boundary lookahead.

All 4 existing `generic_credential_assignment` tests pass unchanged (dotted-attribute, unquoted, dotted-value-with-a-dot, `MYPASSWORD`-must-not-match) - this only adds coverage, doesn't change any existing matching behavior. New regression test added covering the 4 cases above.

## Verification

Full `src/aletheore` suite: 1379 passed.

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr