### PR TITLE
fix: health-alert email dedupe key never actually deduped

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1924,6 +1924,13 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
     risk here, same as send_health_alert already accepts for Slack/Teams
     (it has no dedup at all) - this isn't solving a harder problem than
     the channel it's sitting next to already tolerates.
+
+    int(time.time()), not the raw float: time.time() carries microsecond
+    precision, so two calls a millisecond apart (a real retry) would each
+    get their own unique key and neither would ever collide with the
+    other - the same-second collapse this docstring describes never
+    actually happened. Confirmed directly: two time.time() calls back to
+    back differed at the 6th decimal place, never equal.
     """
     webhook_url = installation.get("webhook_url")
     if webhook_url:
@@ -1935,7 +1942,7 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
         target_id = installation.get("target_id")
         enqueue_transactional_email(
             settings.redis_url,
-            dedupe_key=f"health_alert:{target_id}:{time.time()}",
+            dedupe_key=f"health_alert:{target_id}:{int(time.time())}",
             template_name="health_alert",
             template_arg=message["text"],
             to_email=alert_email,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3021,6 +3021,31 @@ def test_send_alerts_if_configured_sends_both_channels_when_both_set(monkeypatch
     assert len(email_sent) == 1
 
 
+def test_send_alerts_if_configured_email_dedupe_key_collapses_within_the_same_second(monkeypatch):
+    # Regression: the docstring says the dedupe_key includes wall-clock
+    # time "down to the second" specifically so a genuine retry of the
+    # outer job re-sending the same flip collapses into one email - but
+    # time.time() carries microsecond precision, so two calls a
+    # millisecond apart (an actual retry) each got their own unique key
+    # and dedup never fired at all. A retried flip must produce the same
+    # dedupe_key when it happens within the same second.
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **k: enqueued.append(k),
+    )
+
+    installation = {"installation_id": 1, "target_id": 900, "alert_email": "ops@example.com"}
+    _send_alerts_if_configured(installation, {"text": "down"})
+    _send_alerts_if_configured(installation, {"text": "down"})
+
+    assert len(enqueued) == 2
+    assert enqueued[0]["dedupe_key"] == enqueued[1]["dedupe_key"]
+
+
 def test_send_alerts_if_configured_sends_neither_when_unconfigured(monkeypatch):
     from scan_worker.jobs import _send_alerts_if_configured
 


### PR DESCRIPTION
Found during a hardening pass on `jobs.py`'s alert-delivery fan-out (`_send_alerts_if_configured`) - this file is the documented worst health-score hotspot in the repo (38 bug-fixes in 6 months). Looked specifically at the most recently-added code (email/Pushover alert channels, #389/#390) rather than the older, already-hardened paths.

## The bug

The function's own docstring says:

> dedupe_key includes wall-clock time down to the second: a genuine retry of the outer job re-sending the same flip is an accepted, rare risk here

implying same-second retries collapse into one email via `send_transactional_email_job`'s `dedupe_key` -> `email_already_sent()` check (that check is real and does work elsewhere in this file - it's what stops a retried Paddle webhook from double-sending).

But the code used the raw `time.time()` float (microsecond precision), not rounded to the second:

```python
dedupe_key=f"health_alert:{target_id}:{time.time()}"
```

Two calls milliseconds apart - an actual retry, the exact case this was meant to handle - produce different keys and never collide:

```python
>>> f"health_alert:5:{time.time()}"
'health_alert:5:1787819865.182878'
>>> f"health_alert:5:{time.time()}"
'health_alert:5:1787819865.182889'
```

The dedupe mechanism as documented never fired at all - a retried flip would double-send the alert email with no protection.

## The fix

`int(time.time())` instead of the raw float, matching what the docstring already claimed.

New regression test calls `_send_alerts_if_configured` twice back-to-back and asserts the two enqueued `dedupe_key`s are equal - confirmed to fail against the pre-fix code (two different values) and pass after.

## Verification

Targeted subset (6 tests, no DB/Redis dependency - these monkeypatch out `send_health_alert`/`enqueue_transactional_email`): `tests/test_jobs.py -k send_alerts_if_configured`, all pass.

The full `test_jobs.py` file needs a real Postgres this environment doesn't have locally, so it was not run end-to-end here - CI has real Postgres/Redis service containers and will cover it.

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr