### PR TITLE
fix: live-docs build reported "ready" even when it did nothing

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -3863,6 +3863,25 @@ def _run_docs_build_for_modules(
         try:
             content = fetch_file_content(client, token, repo_full_name, module["path"], ref)
             if content is None:
+                # fetch_file_content returns None on a 404 or a malformed
+                # content response - a real failure signal, not "nothing to
+                # do here" (unlike _module_has_uncovered_docs_work's own
+                # skip cases, which are legitimate no-ops). Recording it as
+                # last_error matters most when every module in this batch
+                # hits it (e.g. GitHub's Contents API lagging right after
+                # the push that triggered this job, or a token missing
+                # contents:read): without this, succeeded stays 0 and
+                # last_error stays None, and the caller's `succeeded == 0
+                # and last_error is not None` failed-status check never
+                # fires - a build that did nothing gets reported "ready"
+                # with no detail, the same shape of bug #405 already fixed
+                # for free-tier Flash Review claiming a diff was clean when
+                # it never ran.
+                last_error = f"could not fetch content for {module['path']}"
+                logger.warning(
+                    "live docs: %s for installation=%s repo=%s - continuing with the remaining modules",
+                    last_error, installation_id, repo_full_name,
+                )
                 continue
             _store_docs_generation_for_module(
                 dsn, installation_id, repo_full_name, module, writing_adapter,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -5797,6 +5797,44 @@ def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(mon
     assert status_calls == [("failed", "model provider unavailable")]
 
 
+def test_run_live_docs_full_build_job_reports_failed_when_every_fetch_returns_none(monkeypatch):
+    # Regression: fetch_file_content returning None (a 404, or a malformed
+    # content response) is a real failure, not "nothing to do" - but
+    # _run_docs_build_for_modules used to `continue` without recording it
+    # as last_error. If every module in the batch hit this (e.g. GitHub's
+    # Contents API lagging right after the push that triggered this job),
+    # succeeded stayed 0 and last_error stayed None, so the caller's
+    # `succeeded == 0 and last_error is not None` failed-status check never
+    # fired - a build that did nothing got reported "ready" with no detail.
+    # Same shape of bug as #405 (free-tier Flash Review claiming a diff was
+    # clean when it never ran).
+    _patch_no_spend_cap(monkeypatch)
+    from scan_worker.jobs import run_live_docs_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    module = _docs_module(functions=[{"name": "f", "is_public": True, "docstring": None}])
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _docs_evidence([module]))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_docs_symbols", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan, on_usage=None: object()
+    )
+    monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: None)
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_docs_build_status",
+        lambda dsn, iid, repo, status, error=None: status_calls.append((status, error)),
+    )
+
+    run_live_docs_full_build_job(1, "octocat/hello-world")
+
+    assert status_calls[0][0] == "failed"
+    assert status_calls[0][1] is not None
+
+
 def test_maybe_update_live_docs_skips_llm_call_when_spend_cap_reached(monkeypatch):
     from scan_worker.jobs import _maybe_update_live_docs
 


### PR DESCRIPTION
Found during a systematic, function-by-function read of jobs.py - continuing the hardening pass after #420/#421/#422/#423, this time working straight through the file in order rather than a targeted heuristic.

## The bug

`_run_docs_build_for_modules` treated `fetch_file_content` returning `None` (a 404, or a malformed content response) as "nothing to do here" - silently `continue`d without recording it as `last_error`. That's a real failure signal, not a legitimate no-op: `fetch_file_content` only returns `None` on a 404 or bad encoding, both genuine problems for a module the scan's own evidence says exists.

If every module in a build's batch hit this - plausible right after the push that triggered the job, while GitHub's Contents API is still catching up, or with a token missing `contents:read` - `succeeded` stayed 0 and `last_error` stayed `None`. Both call sites (`run_live_docs_full_build_job`, `_maybe_update_live_docs`) gate their "failed" status specifically on `succeeded == 0 and last_error is not None`; with `last_error` never set, that check silently doesn't fire, and a build that generated nothing gets reported "ready" with no detail message.

Confirmed the real consequence directly: reverting the fix and running the new regression test, execution fell all the way through to `_maybe_sync_docs_to_repo` (only reached on believed-successful builds) - attempting to sync docs to the customer's repo after a build that produced zero of them. `run_live_docs_full_build_job`'s own early-return guard at `succeeded == 0 and last_error is not None` exists specifically to prevent that, and this bug bypassed it.

Same shape as #405 (free-tier Flash Review claiming a diff was clean when it never ran) - a total failure silently reported as success because the specific failure mode didn't populate the error field the status check reads.

## The fix

Record `last_error` when `content is None`, same as the exception branch already does.

New regression test simulates every module's fetch returning `None` and asserts the build is reported "failed", not "ready" - confirmed to fail against the pre-fix code (falls through to an unmocked DB call in `_maybe_sync_docs_to_repo`, since the early-return guard never fires) and pass after.

## Verification

`tests/test_jobs.py -k live_docs`: 15 passed.

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr