### PR TITLE
fix: runtime-error alerts only ever reached Slack/Teams, never email/Pushover

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2337,14 +2337,26 @@ def run_runtime_event_job(
     "zero-hop debugging" for a second real trigger, not a second
     implementation. See app_server/runtime_events.py for the inbound
     webhook this is enqueued from.
+
+    Delivery itself must be the same second implementation too: this used
+    to call send_health_alert(webhook_url, ...) directly and gate the
+    whole job on webhook_url alone, from before email/Pushover existed as
+    alert channels (see _send_alerts_if_configured). Never updated when
+    those landed - an installation with only alert_email or
+    pushover_user_key configured (no Slack/Teams webhook) got every
+    health-check alert through those channels correctly, but silently
+    zero runtime-error alerts, with no signal anything was missing.
     """
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
     if installation is None or installation["plan"] == "free":
         return
 
-    webhook_url = installation.get("webhook_url")
-    if not webhook_url:
+    if not (
+        installation.get("webhook_url")
+        or installation.get("alert_email")
+        or installation.get("pushover_user_key")
+    ):
         return
 
     evidence = _latest_evidence_or_none(settings.database_url, installation_id, repo_full_name)
@@ -2369,7 +2381,19 @@ def run_runtime_event_job(
         path=path,
         evidence_resolution=evidence_resolution,
     )
-    send_health_alert(webhook_url, message)
+    # target_id distinguishes both the installation and the specific error
+    # location - health_check_targets.id (the health-check sweep's own
+    # dedupe scope) is a globally unique DB primary key, not per-
+    # installation, so leaving this as None here (no target concept exists
+    # for a runtime event) would let two different installations' alerts
+    # landing in the same wall-clock second collide on the exact same
+    # email dedupe_key and silently suppress one of them - confirmed via
+    # email_already_sent's dedupe_key-only WHERE clause, no installation_id
+    # in it at all.
+    _send_alerts_if_configured(
+        {**installation, "target_id": f"runtime:{installation_id}:{source_file}:{source_line}"},
+        message,
+    )
 
 
 @log_job
@@ -3863,6 +3887,25 @@ def _run_docs_build_for_modules(
         try:
             content = fetch_file_content(client, token, repo_full_name, module["path"], ref)
             if content is None:
+                # fetch_file_content returns None on a 404 or a malformed
+                # content response - a real failure signal, not "nothing to
+                # do here" (unlike _module_has_uncovered_docs_work's own
+                # skip cases, which are legitimate no-ops). Recording it as
+                # last_error matters most when every module in this batch
+                # hits it (e.g. GitHub's Contents API lagging right after
+                # the push that triggered this job, or a token missing
+                # contents:read): without this, succeeded stays 0 and
+                # last_error stays None, and the caller's `succeeded == 0
+                # and last_error is not None` failed-status check never
+                # fires - a build that did nothing gets reported "ready"
+                # with no detail, the same shape of bug #405 already fixed
+                # for free-tier Flash Review claiming a diff was clean when
+                # it never ran.
+                last_error = f"could not fetch content for {module['path']}"
+                logger.warning(
+                    "live docs: %s for installation=%s repo=%s - continuing with the remaining modules",
+                    last_error, installation_id, repo_full_name,
+                )
                 continue
             _store_docs_generation_for_module(
                 dsn, installation_id, repo_full_name, module, writing_adapter,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3466,6 +3466,59 @@ def test_run_runtime_event_job_skips_when_no_webhook_configured(monkeypatch):
     assert called == []
 
 
+def test_run_runtime_event_job_sends_via_email_when_no_webhook_configured(monkeypatch):
+    # Regression: run_runtime_event_job used to call send_health_alert
+    # directly and gate the whole job on webhook_url alone - predating
+    # email/Pushover as alert channels (_send_alerts_if_configured) and
+    # never updated when those landed. An installation with only
+    # alert_email configured got every health-check alert correctly but
+    # silently zero runtime-error alerts.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "alert_email": "ops@example.com"},
+    )
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._attach_recent_commit_for_failure", lambda *a, **k: None)
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **k: enqueued.append(k),
+    )
+
+    from scan_worker.jobs import run_runtime_event_job
+
+    run_runtime_event_job(1, "octocat/hello-world", "ZeroDivisionError", "division by zero", "a.py", 1)
+
+    assert len(enqueued) == 1
+    assert enqueued[0]["to_email"] == "ops@example.com"
+    assert "ZeroDivisionError" in enqueued[0]["template_arg"]
+
+
+def test_run_runtime_event_job_sends_via_pushover_when_no_webhook_configured(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setenv("PUSHOVER_API_TOKEN", "server-app-token")
+    from app_server.config import get_settings
+
+    get_settings.cache_clear()
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "pushover_user_key": "u1"},
+    )
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._attach_recent_commit_for_failure", lambda *a, **k: None)
+    pushover_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_pushover_alert", lambda *a, **k: pushover_sent.append(a)
+    )
+
+    from scan_worker.jobs import run_runtime_event_job
+
+    run_runtime_event_job(1, "octocat/hello-world", "ZeroDivisionError", "division by zero", "a.py", 1)
+
+    assert len(pushover_sent) == 1
+
+
 def test_sweep_sends_shape_change_alert_while_still_reachable(monkeypatch):
     sent = _patch_sweep(
         monkeypatch,
@@ -5795,6 +5848,44 @@ def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(mon
     run_live_docs_full_build_job(1, "octocat/hello-world")
 
     assert status_calls == [("failed", "model provider unavailable")]
+
+
+def test_run_live_docs_full_build_job_reports_failed_when_every_fetch_returns_none(monkeypatch):
+    # Regression: fetch_file_content returning None (a 404, or a malformed
+    # content response) is a real failure, not "nothing to do" - but
+    # _run_docs_build_for_modules used to `continue` without recording it
+    # as last_error. If every module in the batch hit this (e.g. GitHub's
+    # Contents API lagging right after the push that triggered this job),
+    # succeeded stayed 0 and last_error stayed None, so the caller's
+    # `succeeded == 0 and last_error is not None` failed-status check never
+    # fired - a build that did nothing got reported "ready" with no detail.
+    # Same shape of bug as #405 (free-tier Flash Review claiming a diff was
+    # clean when it never ran).
+    _patch_no_spend_cap(monkeypatch)
+    from scan_worker.jobs import run_live_docs_full_build_job
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    module = _docs_module(functions=[{"name": "f", "is_public": True, "docstring": None}])
+    monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _docs_evidence([module]))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_docs_symbols", lambda *a, **k: [])
+    monkeypatch.setattr(
+        "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan, on_usage=None: object()
+    )
+    monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: None)
+    status_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_docs_build_status",
+        lambda dsn, iid, repo, status, error=None: status_calls.append((status, error)),
+    )
+
+    run_live_docs_full_build_job(1, "octocat/hello-world")
+
+    assert status_calls[0][0] == "failed"
+    assert status_calls[0][1] is not None
 
 
 def test_maybe_update_live_docs_skips_llm_call_when_spend_cap_reached(monkeypatch):


### PR DESCRIPTION
Found during the same systematic, function-by-function read of jobs.py as #424 - continuing straight through the file.

## The bug

`run_runtime_event_job` (the "Phase 3 - zero-hop debugging" Sentry-compatible runtime error alert) called `send_health_alert(webhook_url, ...)` directly and gated the entire job on `webhook_url` alone. Every other alert type in this file (endpoint reachability, latency, response-shape-change) fans out through `_send_alerts_if_configured`, which checks all three channels independently: Slack/Teams webhook, email, Pushover. `run_runtime_event_job` predates email/Pushover as alert channels (#389/#390) and was never updated when those landed.

**Consequence:** an installation with only `alert_email` or `pushover_user_key` configured (no Slack/Teams webhook) received every health-check alert correctly through those channels, but silently zero runtime-error alerts - no error, no log signal, nothing to indicate the feature wasn't working for that configuration. The function's own docstring claims this uses "the SAME correlation chain already proven for HTTP health-check failures" - true for the evidence-resolution half, false for delivery.

## The fix

Route through `_send_alerts_if_configured` like every other alert type, gating the early-return on any of the three channels instead of `webhook_url` alone.

`target_id` in the dict passed to it is synthesized as `f"runtime:{installation_id}:{source_file}:{source_line}"` rather than left absent (`None`) - `health_check_targets.id` (the sweep's own dedupe scope) is a globally unique DB primary key, not per-installation, so an absent `target_id` here would let two different installations' runtime alerts landing in the same wall-clock second collide on the identical email `dedupe_key` and silently suppress one of them (confirmed via `email_already_sent`'s `dedupe_key`-only WHERE clause - no `installation_id` in it at all).

## Verification

Two new regression tests (email-only, pushover-only configurations) confirmed to fail against the pre-fix code (zero alerts sent) and pass after. Existing 3 `runtime_event_job` tests pass unchanged - the webhook path behaves identically, since `_send_alerts_if_configured` still calls `send_health_alert(webhook_url, message)` for that channel.

`tests/test_jobs.py -k "runtime_event or send_alerts_if_configured"`: 11 passed.

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr