### PR TITLE
feat: cap parallel-parse worker count to the real available CPU quota

### DIFF
--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import re
 import xml.etree.ElementTree as ET
@@ -2405,6 +2406,100 @@ def _worker_parse_and_extract_one(path: Path) -> dict:
     )
 
 
+# Explicit override, matching PARALLEL_PARSE_MIN_FILES's "no CLI flag"
+# convention for scan-tuning knobs. Always wins over every auto-detected
+# signal below.
+_PARALLEL_PARSE_JOBS_ENV = "ALETHEORE_PARALLEL_PARSE_JOBS"
+
+_CGROUP_V2_CPU_MAX_PATH = Path("/sys/fs/cgroup/cpu.max")
+_CGROUP_V1_CFS_QUOTA_PATH = Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+_CGROUP_V1_CFS_PERIOD_PATH = Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+
+
+def _cgroup_v2_cpu_quota(path: Path = _CGROUP_V2_CPU_MAX_PATH) -> int | None:
+    """cgroup v2's own CPU quota (Docker `--cpus`, most Kubernetes CPU
+    *limits*) - the only signal that reflects a quota-based restriction
+    (CPU time throttling), verified directly against real containers
+    (2026-08-27): a container capped at `docker run --cpus=2` on a
+    10-core host still reports os.cpu_count() == 10 AND
+    len(os.sched_getaffinity(0)) == 10 - sched_getaffinity only sees
+    explicit core pinning (`--cpuset-cpus`), a different, rarer
+    mechanism (see _combined_cpu_quota below). cpu.max holds
+    "<quota> <period>" in microseconds, or "max <period>" when
+    unrestricted.
+    """
+    try:
+        raw = path.read_text().split()
+    except OSError:
+        return None
+    if len(raw) != 2 or raw[0] == "max":
+        return None
+    try:
+        quota, period = int(raw[0]), int(raw[1])
+    except ValueError:
+        return None
+    if period <= 0:
+        return None
+    return max(1, math.ceil(quota / period))
+
+
+def _cgroup_v1_cpu_quota(
+    quota_path: Path = _CGROUP_V1_CFS_QUOTA_PATH, period_path: Path = _CGROUP_V1_CFS_PERIOD_PATH
+) -> int | None:
+    """cgroup v1 fallback (cpu.max is v2-only) - same quota/period shape,
+    split across two files instead of one, quota=-1 meaning unrestricted."""
+    try:
+        quota = int(quota_path.read_text().strip())
+        period = int(period_path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    if quota <= 0 or period <= 0:
+        return None
+    return max(1, math.ceil(quota / period))
+
+
+def _available_parallelism() -> int:
+    """How many worker processes it's actually sensible to spawn.
+
+    os.cpu_count() (ProcessPoolExecutor's own default) reports the
+    host/VM's raw core count - not what this process is actually allowed
+    to use inside a resource-limited container. A repo scanned inside a
+    CI job capped at 2 CPUs on a 32-core host would otherwise spawn 32
+    worker processes, each independently loading the tree-sitter grammar
+    libraries, for a container that can only actually run 2 of them at
+    once - wasted memory and no real speedup, the opposite of this
+    feature's purpose.
+
+    Takes the tightest of every real restriction mechanism, since a
+    container can have any combination active: a cgroup CPU quota
+    (invisible to both os.cpu_count() and os.sched_getaffinity - see
+    _cgroup_v2_cpu_quota's docstring) and CPU-set pinning
+    (os.sched_getaffinity - k8s static CPU manager policy, invisible to
+    the cgroup quota check). Verified directly against real `docker run`
+    containers across all 4 combinations (unrestricted, quota-only,
+    pinning-only, both together) before this was written, not guessed.
+
+    ALETHEORE_PARALLEL_PARSE_JOBS always wins over all of this when set.
+    """
+    override = os.environ.get(_PARALLEL_PARSE_JOBS_ENV)
+    if override:
+        try:
+            parsed = int(override)
+        except ValueError:
+            parsed = None
+        if parsed is not None and parsed > 0:
+            return parsed
+
+    candidates = [os.cpu_count() or 1]
+    for quota_fn in (_cgroup_v2_cpu_quota, _cgroup_v1_cpu_quota):
+        quota = quota_fn()
+        if quota is not None:
+            candidates.append(quota)
+    if hasattr(os, "sched_getaffinity"):
+        candidates.append(len(os.sched_getaffinity(0)))
+    return max(1, min(candidates))
+
+
 def _parse_many_in_parallel(
     paths: list[Path],
     repo_path: Path,
@@ -2414,6 +2509,7 @@ def _parse_many_in_parallel(
     php_psr4_map: dict[str, Path],
 ) -> list[dict]:
     with ProcessPoolExecutor(
+        max_workers=_available_parallelism(),
         initializer=_init_worker,
         initargs=(repo_path, python_source_roots, go_module_prefix, has_rust_crate_root, php_psr4_map),
     ) as executor:

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -2687,7 +2687,16 @@ def build_module_graph(
             )
         )
 
-    if len(paths_needing_parse) >= PARALLEL_PARSE_MIN_FILES:
+    # _available_parallelism() > 1, not just the file-count threshold: a
+    # container whose real CPU quota only allows one worker anyway (see
+    # _available_parallelism's docstring - confirmed against this
+    # project's own hosted scan-worker containers, cpus: "1.0" in
+    # docker-compose.yml) gets zero benefit from a pool sized at 1 - only
+    # the ~150ms pool-creation cost plus a second process independently
+    # loading every tree-sitter grammar library, for exactly the same
+    # work the sequential path below already does in this process. Below
+    # that quota, staying sequential is strictly better, not just equal.
+    if len(paths_needing_parse) >= PARALLEL_PARSE_MIN_FILES and _available_parallelism() > 1:
         modules.extend(
             _parse_many_in_parallel(
                 paths_needing_parse,

--- a/src/tests/test_graph_parallel.py
+++ b/src/tests/test_graph_parallel.py
@@ -247,6 +247,16 @@ def test_available_parallelism_ignores_a_malformed_env_override(monkeypatch):
     monkeypatch.setattr(graph_module, "_cgroup_v2_cpu_quota", lambda: None)
     monkeypatch.setattr(graph_module, "_cgroup_v1_cpu_quota", lambda: None)
     monkeypatch.setattr(graph_module.os, "cpu_count", lambda: 8)
+    # Real bug caught in CI (GitHub Actions runner, not this local
+    # environment): the malformed override falls through to real
+    # auto-detection, which also takes os.sched_getaffinity into account
+    # when the platform has it (Linux does, macOS doesn't) - without
+    # mocking it too, this test's result depended on that CI runner's
+    # actual affinity mask (4, not 8) instead of being isolated to just
+    # the cpu_count() signal it claims to test. Same guard the two
+    # sibling auto-detection tests below already use.
+    if hasattr(graph_module.os, "sched_getaffinity"):
+        monkeypatch.setattr(graph_module.os, "sched_getaffinity", lambda pid: set(range(8)))
     assert _available_parallelism() == 8
 
 

--- a/src/tests/test_graph_parallel.py
+++ b/src/tests/test_graph_parallel.py
@@ -80,6 +80,32 @@ def test_small_repo_never_invokes_the_process_pool(tmp_path, monkeypatch):
     assert {m["path"] for m in modules} == {"app/__init__.py", "app/config.py", "app/auth.py", "app/main.py"}
 
 
+def test_a_single_available_core_never_invokes_the_process_pool(tmp_path, monkeypatch):
+    # Regression: a repo well over PARALLEL_PARSE_MIN_FILES still must not
+    # spawn a pool when _available_parallelism() says only one worker is
+    # actually usable (confirmed against this project's own hosted
+    # scan-worker containers: cpus: "1.0" in docker-compose.yml) - a pool
+    # sized at 1 pays the ~150ms creation cost plus a second process
+    # independently loading every tree-sitter grammar, for zero
+    # parallelism benefit over staying sequential.
+    monkeypatch.setattr(graph_module, "PARALLEL_PARSE_MIN_FILES", 0)
+    monkeypatch.setattr(graph_module, "_available_parallelism", lambda: 1)
+
+    repo = _make_multi_file_python_repo(tmp_path)
+
+    calls = []
+    monkeypatch.setattr(
+        graph_module,
+        "_parse_many_in_parallel",
+        lambda *a, **k: calls.append(True) or [],
+    )
+
+    modules, _graph, _unparseable = build_module_graph(repo)
+
+    assert calls == []
+    assert {m["path"] for m in modules} == {"app/__init__.py", "app/config.py", "app/auth.py", "app/main.py"}
+
+
 def test_parallel_parse_min_files_default_is_reasonable():
     # Not asserting an exact number (the design doc calls this an
     # implementation-time empirical choice, not a fixed contract) - just

--- a/src/tests/test_graph_parallel.py
+++ b/src/tests/test_graph_parallel.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from aletheore.scanner import graph as graph_module
 from aletheore.scanner.graph import (
     PARALLEL_PARSE_MIN_FILES,
+    _available_parallelism,
+    _cgroup_v1_cpu_quota,
+    _cgroup_v2_cpu_quota,
     _extract_module,
     _parse_and_extract_one,
     build_module_graph,
@@ -156,3 +159,94 @@ def test_parse_and_extract_one_matches_extract_module(tmp_path):
     assert result["path"] == "a.py"
     assert result["language"] == "python"
     assert result["symbols"]["functions"][0]["name"] == "foo"
+
+
+def test_cgroup_v2_cpu_quota_parses_a_real_restriction(tmp_path):
+    cpu_max = tmp_path / "cpu.max"
+    cpu_max.write_text("200000 100000\n")
+    assert _cgroup_v2_cpu_quota(cpu_max) == 2
+
+
+def test_cgroup_v2_cpu_quota_rounds_a_fractional_quota_up(tmp_path):
+    # 1.5 effective cores - a real shape (`docker run --cpus=1.5`), confirmed
+    # directly. Rounds up rather than down: a container with 1.5 CPUs' worth
+    # of quota can still usefully run 2 workers some of the time, and
+    # truncating to 1 would waste half a core's worth of real parallelism.
+    cpu_max = tmp_path / "cpu.max"
+    cpu_max.write_text("150000 100000\n")
+    assert _cgroup_v2_cpu_quota(cpu_max) == 2
+
+
+def test_cgroup_v2_cpu_quota_returns_none_when_unrestricted(tmp_path):
+    cpu_max = tmp_path / "cpu.max"
+    cpu_max.write_text("max 100000\n")
+    assert _cgroup_v2_cpu_quota(cpu_max) is None
+
+
+def test_cgroup_v2_cpu_quota_returns_none_when_file_is_absent(tmp_path):
+    # Non-Linux (macOS, Windows) or a cgroup v1 host - both real, both
+    # must degrade to "no v2 signal", not raise.
+    assert _cgroup_v2_cpu_quota(tmp_path / "does-not-exist") is None
+
+
+def test_cgroup_v1_cpu_quota_parses_a_real_restriction(tmp_path):
+    quota_path = tmp_path / "cfs_quota_us"
+    period_path = tmp_path / "cfs_period_us"
+    quota_path.write_text("200000\n")
+    period_path.write_text("100000\n")
+    assert _cgroup_v1_cpu_quota(quota_path, period_path) == 2
+
+
+def test_cgroup_v1_cpu_quota_returns_none_when_unrestricted():
+    # cgroup v1's unrestricted marker is quota=-1, not a missing file.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        quota_path = Path(d) / "cfs_quota_us"
+        period_path = Path(d) / "cfs_period_us"
+        quota_path.write_text("-1\n")
+        period_path.write_text("100000\n")
+        assert _cgroup_v1_cpu_quota(quota_path, period_path) is None
+
+
+def test_available_parallelism_env_override_wins_over_everything(monkeypatch):
+    monkeypatch.setenv("ALETHEORE_PARALLEL_PARSE_JOBS", "3")
+    monkeypatch.setattr(graph_module, "_cgroup_v2_cpu_quota", lambda: 1)
+    monkeypatch.setattr(graph_module, "_cgroup_v1_cpu_quota", lambda: 1)
+    assert _available_parallelism() == 3
+
+
+def test_available_parallelism_ignores_a_malformed_env_override(monkeypatch):
+    monkeypatch.setenv("ALETHEORE_PARALLEL_PARSE_JOBS", "not-a-number")
+    monkeypatch.setattr(graph_module, "_cgroup_v2_cpu_quota", lambda: None)
+    monkeypatch.setattr(graph_module, "_cgroup_v1_cpu_quota", lambda: None)
+    monkeypatch.setattr(graph_module.os, "cpu_count", lambda: 8)
+    assert _available_parallelism() == 8
+
+
+def test_available_parallelism_takes_the_tightest_of_cpu_count_and_cgroup_quota(monkeypatch):
+    monkeypatch.delenv("ALETHEORE_PARALLEL_PARSE_JOBS", raising=False)
+    monkeypatch.setattr(graph_module.os, "cpu_count", lambda: 32)
+    monkeypatch.setattr(graph_module, "_cgroup_v2_cpu_quota", lambda: 2)
+    monkeypatch.setattr(graph_module, "_cgroup_v1_cpu_quota", lambda: None)
+    if hasattr(graph_module.os, "sched_getaffinity"):
+        monkeypatch.setattr(graph_module.os, "sched_getaffinity", lambda pid: set(range(32)))
+    assert _available_parallelism() == 2
+
+
+def test_available_parallelism_falls_back_to_cpu_count_when_unrestricted(monkeypatch):
+    monkeypatch.delenv("ALETHEORE_PARALLEL_PARSE_JOBS", raising=False)
+    monkeypatch.setattr(graph_module.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(graph_module, "_cgroup_v2_cpu_quota", lambda: None)
+    monkeypatch.setattr(graph_module, "_cgroup_v1_cpu_quota", lambda: None)
+    if hasattr(graph_module.os, "sched_getaffinity"):
+        monkeypatch.setattr(graph_module.os, "sched_getaffinity", lambda pid: set(range(8)))
+    assert _available_parallelism() == 8
+
+
+def test_available_parallelism_never_returns_less_than_one(monkeypatch):
+    monkeypatch.delenv("ALETHEORE_PARALLEL_PARSE_JOBS", raising=False)
+    monkeypatch.setattr(graph_module.os, "cpu_count", lambda: None)
+    monkeypatch.setattr(graph_module, "_cgroup_v2_cpu_quota", lambda: None)
+    monkeypatch.setattr(graph_module, "_cgroup_v1_cpu_quota", lambda: None)
+    assert _available_parallelism() >= 1


### PR DESCRIPTION
Follow-up to #414 (ProcessPoolExecutor parallel scan parsing), flagged during the pre-0.9.5-release splash-radius audit and built as an approved spike-then-implement, per Arihant.

## The problem

`build_module_graph`'s worker pool defaulted to `os.cpu_count()`, which reports the host/VM's raw core count - not what this process is actually allowed to use inside a resource-limited container. A repo scanned inside a CI job capped at 2 CPUs on a 32-core host would spawn 32 worker processes, each independently loading the tree-sitter grammar libraries, for a container that can only run 2 of them at once - wasted memory and no real speedup, the opposite of this feature's purpose. Running a code scanner inside CI is a normal, expected usage pattern, not an edge case.

## The original idea was wrong, verified before building anything

The first plan (swap `os.cpu_count()` for `os.sched_getaffinity(0)`) turned out not to work, confirmed by testing against real containers before writing any implementation code:

```
docker run --rm --cpus=2 python:3.12-slim python3 -c "
import os
print(os.cpu_count())                    # 10 - wrong
print(len(os.sched_getaffinity(0)))       # 10 - also wrong
"
```

`sched_getaffinity` only sees CPU-set pinning (`--cpuset-cpus`, k8s static CPU manager policy), not a quota-based restriction (`--cpus`, most Kubernetes CPU *limits*) - the mechanism that actually matters for CI. Even Python 3.13's newer `os.process_cpu_count()` doesn't solve this either (also tested, also returned 10 under `--cpus=2`) - moot anyway since the scan-worker Dockerfile pins Python 3.12.

## The actual fix

The real signal is the cgroup's own CPU quota file (`/sys/fs/cgroup/cpu.max` on v2: `"<quota> <period>"` or `"max <period>"` if unrestricted; `cfs_quota_us`/`cfs_period_us` on v1) - `quota/period` is the real effective core count.

`_available_parallelism()` takes the **tightest** of `os.cpu_count()`, the cgroup quota, and `sched_getaffinity` (when available), since either restriction mechanism can be set independently or together. An `ALETHEORE_PARALLEL_PARSE_JOBS` env var always wins over auto-detection, matching this codebase's existing no-CLI-flag convention for scan-tuning knobs (see `PARALLEL_PARSE_MIN_FILES`).

## Verification

Against real `docker run` containers, not just mocked unit tests - both the isolated logic and the actual wired-in `aletheore.scanner.graph._available_parallelism`, pip-installed fresh inside each container:

| Scenario | `os.cpu_count()` | `_available_parallelism()` |
|---|---|---|
| unrestricted | 10 | 10 |
| `--cpus=2` | 10 | **2** |
| `--cpuset-cpus` (3 cores pinned) | 10 | **3** |
| both set (quota=2, pinned to 4) | 10 | **2** (tighter bound) |

17 new/existing tests in `test_graph_parallel.py`, full `src/aletheore` suite: **1390 passed**.

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr