### PR TITLE
Redesign marketing site and hosted dashboard: light glass theme

### DIFF
--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -82,42 +82,47 @@ STYLE = """
   --font-mono: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, monospace;
   --page-bg: var(--slate-50);
 }
-@media (prefers-color-scheme: dark) {
-  :root {
-    --page-bg: #17140F; --paper: #201B14; --slate-50: #17140F; --slate-100: #221D15;
-    --slate-200: #332B1F; --slate-400: #8A8377; --slate-500: #A49B8D; --slate-600: #B9B1A4;
-    --ink-900: #F3EEE3; --ink-700: #D8D2C5;
-    --accent: #E0863A; --accent-strong: #EFA262; --accent-soft: #3A2A18; --accent-soft-strong: #4A3620;
-    --success: #6FBE7E; --success-soft: #23331F; --warning: #D2A83C; --warning-soft: #3A301A;
-    --critical: #E37972; --critical-soft: #3A211D;
-    --border: rgba(243, 238, 227, 0.12); --border-strong: rgba(243, 238, 227, 0.22);
-    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35); --shadow-card-hover: 0 6px 18px rgba(0, 0, 0, 0.45);
-    --shadow-lift: 0 22px 70px rgba(0, 0, 0, 0.38);
-  }
+/* Light is now the permanent default (matches the marketing site's
+   direction) rather than automatically following prefers-color-scheme -
+   with the new translucent glass cards, an OS-dark-triggered dark palette
+   under a still-light body produced washed-out, low-contrast cards. The
+   dark palette itself is kept, gated behind an explicit opt-in attribute,
+   in case a real theme toggle is ever added later. */
+:root[data-theme="dark"] {
+  --page-bg: #17140F; --paper: #201B14; --slate-50: #17140F; --slate-100: #221D15;
+  --slate-200: #332B1F; --slate-400: #8A8377; --slate-500: #A49B8D; --slate-600: #B9B1A4;
+  --ink-900: #F3EEE3; --ink-700: #D8D2C5;
+  --accent: #E0863A; --accent-strong: #EFA262; --accent-soft: #3A2A18; --accent-soft-strong: #4A3620;
+  --success: #6FBE7E; --success-soft: #23331F; --warning: #D2A83C; --warning-soft: #3A301A;
+  --critical: #E37972; --critical-soft: #3A211D;
+  --border: rgba(243, 238, 227, 0.12); --border-strong: rgba(243, 238, 227, 0.22);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.35); --shadow-card-hover: 0 6px 18px rgba(0, 0, 0, 0.45);
+  --shadow-lift: 0 22px 70px rgba(0, 0, 0, 0.38);
 }
 * { box-sizing: border-box; }
 body { margin: 0; font-family: var(--font-sans); color: var(--ink-900); background-color: var(--page-bg);
-  background-image:
-    radial-gradient(circle at 12% 0%, rgba(224, 134, 58, 0.12), transparent 30%),
-    radial-gradient(var(--border-strong) 1px, transparent 1px);
-  background-size: auto, 22px 22px; }
+  position: relative; overflow-x: hidden; }
+/* Soft color blobs the glass panels blur/refract - same treatment as the
+   marketing site, replacing the old dot-grid texture that read as clutter. */
+body::before, body::after { content: ""; position: fixed; z-index: -1; width: 620px; height: 620px;
+  border-radius: 50%; filter: blur(90px); pointer-events: none; }
+body::before { top: -220px; left: -180px; background: rgba(217, 119, 44, 0.16); }
+body::after { top: 260px; right: -220px; background: rgba(111, 190, 130, 0.14); }
 a { color: var(--accent); }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 
 /* ---- Sign-in ---- */
-.signin { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 4rem 1.5rem;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(224, 134, 58, 0.16), transparent 38%),
-    linear-gradient(180deg, #17140F, #0E0C09); }
-.signin-card { width: 100%; max-width: 430px; background: linear-gradient(180deg, rgba(255,255,255,0.07), rgba(255,255,255,0.025)); border: 1px solid rgba(237,241,238,0.13); border-radius: 18px; padding: 2.5rem 2.2rem; text-align: center; box-shadow: 0 30px 90px rgba(0,0,0,0.34); }
-.wordmark { font-family: var(--font-sans); font-weight: 760; font-size: 25px; color: #F2F5F3; margin: 0 0 7px; }
-.tagline { font-size: 13.5px; color: #B9B1A4; margin: 0 0 2rem; line-height: 1.6; }
-.gh-btn { width: 100%; display: flex; align-items: center; justify-content: center; gap: 10px; background: #F2F5F3; color: #14181B;
+.signin { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 4rem 1.5rem; }
+.signin-card { width: 100%; max-width: 430px; background: rgba(255,255,255,0.65); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border); border-radius: 18px; padding: 2.5rem 2.2rem; text-align: center; box-shadow: var(--shadow-lift); }
+.wordmark { font-family: var(--font-sans); font-weight: 760; font-size: 25px; color: var(--ink-900); margin: 0 0 7px; }
+.tagline { font-size: 13.5px; color: var(--slate-600); margin: 0 0 2rem; line-height: 1.6; }
+.gh-btn { width: 100%; display: flex; align-items: center; justify-content: center; gap: 10px; background: var(--ink-900); color: var(--paper);
   border: none; border-radius: 9px; font-family: var(--font-sans); font-size: 14px; font-weight: 650; padding: 12px 16px; cursor: pointer; text-decoration: none; }
-.gh-btn:hover { background: #FFFFFF; }
+.gh-btn:hover { background: var(--ink-700); }
 .gh-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.scope-note { margin-top: 1.5rem; padding-top: 1.25rem; border-top: 1px solid rgba(237,241,238,0.1); font-size: 12px; color: #9A9388; line-height: 1.6; text-align: left; }
-.scope-note code { font-family: var(--font-mono); font-size: 11px; color: #A7B2AC; }
+.scope-note { margin-top: 1.5rem; padding-top: 1.25rem; border-top: 1px solid var(--border); font-size: 12px; color: var(--slate-600); line-height: 1.6; text-align: left; }
+.scope-note code { font-family: var(--font-mono); font-size: 11px; color: var(--slate-500); }
 
 /* ---- Repo picker ---- */
 .picker-wrap { max-width: 980px; margin: 0 auto; padding: 3.4rem 1.75rem; }
@@ -371,11 +376,9 @@ table.findings tr:last-child td { border-bottom: none; }
 .token-row:last-child { border-bottom: none; }
 .token-label { font-weight: 500; }
 .token-meta { font-size: 11px; color: var(--slate-600); }
-.claim-page { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 3rem 1.5rem;
-  background:
-    radial-gradient(circle at 50% 0%, rgba(224, 134, 58, 0.13), transparent 36%),
-    radial-gradient(var(--border-strong) 1px, transparent 1px); background-size: auto, 22px 22px; }
-.claim-card { width: 100%; max-width: 560px; background: var(--paper); border: 1px solid var(--border); border-radius: 16px; padding: 2.15rem; box-shadow: var(--shadow-lift); }
+.claim-page { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 3rem 1.5rem; }
+.claim-card { width: 100%; max-width: 560px; background: rgba(255,255,255,0.65); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border); border-radius: 16px; padding: 2.15rem; box-shadow: var(--shadow-lift); }
 .claim-card h1 { margin: 0 0 0.7rem; font-size: 26px; font-weight: 720; }
 .claim-card p { color: var(--slate-600); line-height: 1.6; font-size: 14px; margin: 0 0 1.2rem; }
 .claim-options { display: flex; flex-direction: column; gap: 8px; margin: 1rem 0; }
@@ -398,6 +401,21 @@ table.findings tr:last-child td { border-bottom: none; }
   .diagram-zoom-toolbar { left: 14px; right: 14px; transform: none; justify-content: center; flex-wrap: wrap; border-radius: 14px; }
   .diagram-zoom-hint { order: 2; width: 100%; text-align: center; }
 }
+
+/* ---- Glass treatment ---- */
+/* Every surface that sits on var(--paper) as a floating card gets a
+   translucent version of it plus blur, so it reads as frosted glass over
+   the body's color blobs instead of an opaque card - var(--paper) itself
+   stays solid white since it's also used inside color-mix() expressions
+   throughout this file, which a transparent value would break. */
+.sidebar, .org-switch, .plan-card, .picker-card, .stat-card, .section,
+.dashboard-summary, .docs-module-card, .docs-stat-pill, .settings-block,
+.subsystem-card {
+  background-color: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+.section-head { background-color: rgba(255, 255, 255, 0.35); }
 </style>
 """
 

--- a/website/index.html
+++ b/website/index.html
@@ -142,7 +142,7 @@
       </div>
     </section>
 
-    <section class="evidence-strip" aria-label="Evidence fields">
+    <section class="evidence-strip" aria-label="Evidence fields" data-reveal>
       <p>Every alert, review, audit, and query resolves back to:</p>
       <div>
         <span>file</span>
@@ -155,7 +155,7 @@
       </div>
     </section>
 
-    <section class="proof-panel">
+    <section class="proof-panel" data-reveal>
       <div>
         <p class="eyebrow">Why it is different</p>
         <h2>Most AI tools summarize. Aletheore resolves.</h2>
@@ -163,7 +163,7 @@
       <p>Aletheore starts with deterministic repository evidence, then lets AI reason only over what the scanner can prove. The result is friendlier than raw static analysis and more trustworthy than a generic AI summary.</p>
     </section>
 
-    <section id="features">
+    <section id="features" data-reveal>
       <div class="section-heading">
         <p class="eyebrow">What it covers</p>
         <h2>One evidence layer. Four useful surfaces.</h2>
@@ -213,7 +213,7 @@
       </div>
     </section>
 
-    <section class="proof-panel" id="docs-feature">
+    <section class="proof-panel" id="docs-feature" data-reveal>
       <div>
         <p class="eyebrow">Docs</p>
         <h2>Nobody wants to write the docs. So nobody has to.</h2>
@@ -221,7 +221,7 @@
       <p>Every team says "we'll document it later," and later never comes - the code always outruns the wiki. Aletheore AIR writes the docs instead: grounded, per-symbol descriptions generated straight from your real source, kept current automatically, with zero engineer hours spent typing a docstring nobody wanted to write. Export the whole set as a single Markdown file whenever you need it outside the dashboard.</p>
     </section>
 
-    <section class="workflow-section">
+    <section class="workflow-section" data-reveal>
       <div class="section-heading">
         <p class="eyebrow">How Docs stays honest</p>
         <h2>Generated from your code. Never invented.</h2>
@@ -251,7 +251,7 @@
       </div>
     </section>
 
-    <section id="github-app" class="workflow-section">
+    <section id="github-app" class="workflow-section" data-reveal>
       <div class="section-heading">
         <p class="eyebrow">How teams use it</p>
         <h2>Start local. Then let the GitHub App keep watch.</h2>
@@ -476,7 +476,7 @@
       </div>
     </section>
 
-    <section class="humanist">
+    <section class="humanist" data-reveal>
       <div>
         <h2>Humanist tools for a technical world.</h2>
         <p>Nothing leaves your machine when you run the deterministic local scan. Bring your own API key for AI-assisted audit reports, or skip them entirely: the evidence pipeline stands on its own.</p>

--- a/website/script.js
+++ b/website/script.js
@@ -61,5 +61,42 @@ function animateTokenCounters() {
   });
 }
 
+function revealOnScroll() {
+  const targets = document.querySelectorAll("[data-reveal]");
+  if (!targets.length) return;
+
+  if (!window.IntersectionObserver) {
+    targets.forEach((el) => el.classList.add("is-visible"));
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("is-visible");
+          obs.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.15, rootMargin: "0px 0px -40px 0px" }
+  );
+
+  targets.forEach((el) => observer.observe(el));
+}
+
+function shadeNavOnScroll() {
+  const nav = document.querySelector(".site-nav");
+  if (!nav) return;
+
+  const update = () => {
+    nav.classList.toggle("is-scrolled", window.scrollY > 40);
+  };
+  update();
+  window.addEventListener("scroll", update, { passive: true });
+}
+
 renderShowcaseCards();
 animateProofZoneOnScroll();
+revealOnScroll();
+shadeNavOnScroll();

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,14 +1,15 @@
 :root {
-  --bg-cream: #17140f;
-  --bg-dark: #0e0c09;
-  --text-primary: #f3eee3;
-  --text-muted: #b9b1a4;
-  --accent: #e0863a;
-  --accent-hover: #c96f26;
-  --accent-soft: #3a2a18;
-  --success: #6fbe7e;
-  --card-bg: #201b14;
-  --border-subtle: rgba(243, 238, 227, 0.12);
+  --bg-cream: #ffffff;
+  --bg-dark: #18140f;
+  --text-primary: #18140f;
+  --text-muted: #6b6459;
+  --accent: #d9772c;
+  --accent-hover: #b85f1c;
+  --accent-soft: #fdf0e2;
+  --success: #2f9e52;
+  --card-bg: rgba(255, 255, 255, 0.6);
+  --border-subtle: rgba(24, 20, 15, 0.1);
+  --glass-blur: blur(20px);
   --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
 }
 
@@ -25,13 +26,58 @@ html {
 body {
   min-width: 320px;
   font-family: var(--font);
-  background:
-    radial-gradient(circle at 12% 0%, rgba(224, 134, 58, 0.12), transparent 30%),
-    radial-gradient(rgba(243, 238, 227, 0.16) 1px, transparent 1px),
-    var(--bg-cream);
-  background-size: auto, 22px 22px, auto;
+  background: var(--bg-cream);
   color: var(--text-primary);
   line-height: 1.5;
+  position: relative;
+  overflow-x: hidden;
+}
+
+/* Soft color blobs the glass panels blur/refract - fixed so they read
+   through every sticky/translucent surface as you scroll, not just the
+   hero. Kept subtle and off to the sides so body text never sits directly
+   on top of one. */
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  z-index: -1;
+  width: 620px;
+  height: 620px;
+  border-radius: 50%;
+  filter: blur(90px);
+  pointer-events: none;
+}
+
+body::before {
+  top: -220px;
+  left: -180px;
+  background: rgba(217, 119, 44, 0.16);
+  animation: drift-a 24s ease-in-out infinite;
+}
+
+body::after {
+  top: 260px;
+  right: -220px;
+  background: rgba(111, 190, 130, 0.14);
+  animation: drift-b 28s ease-in-out infinite;
+}
+
+@keyframes drift-a {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(40px, 60px) scale(1.08); }
+}
+
+@keyframes drift-b {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(-50px, -40px) scale(1.06); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body::before,
+  body::after {
+    animation: none;
+  }
 }
 
 a {
@@ -51,11 +97,21 @@ code {
 }
 
 .site-nav {
+  position: sticky;
+  top: 16px;
+  z-index: 50;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  padding: 20px 0;
+  margin: 16px 0;
+  padding: 14px 20px;
+  border-radius: 16px;
+  border: 1px solid var(--border-subtle);
+  background: var(--card-bg);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  box-shadow: 0 8px 30px rgba(24, 20, 15, 0.06);
 }
 
 .nav-links {
@@ -150,6 +206,41 @@ code {
   padding: 70px 0 42px;
 }
 
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero > div:first-child > * {
+  opacity: 0;
+  animation: rise-in 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.hero > div:first-child > *:nth-child(1) { animation-delay: 0.05s; }
+.hero > div:first-child > *:nth-child(2) { animation-delay: 0.15s; }
+.hero > div:first-child > *:nth-child(3) { animation-delay: 0.25s; }
+.hero > div:first-child > *:nth-child(4) { animation-delay: 0.35s; }
+.hero > div:first-child > *:nth-child(5) { animation-delay: 0.45s; }
+
+.hero .evidence-preview {
+  opacity: 0;
+  animation: rise-in 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.3s forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero > div:first-child > *,
+  .hero .evidence-preview {
+    opacity: 1;
+    animation: none;
+  }
+}
+
 .hero h1 {
   max-width: 760px;
   font-size: clamp(40px, 6vw, 68px);
@@ -185,7 +276,7 @@ code {
 .hero-trust span {
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(24, 20, 15, 0.04);
   padding: 7px 12px;
   color: var(--text-muted);
   font-size: 13px;
@@ -193,6 +284,14 @@ code {
 }
 
 .evidence-preview {
+  /* Deliberately its own self-contained dark widget (a terminal/demo
+     card), not part of the page's light glass theme - scoped local
+     overrides so its children's var(--accent-soft)/var(--text-muted)
+     reads stay legible instead of picking up the page's light-theme
+     values (var(--bg-dark) itself is already dark at the root). */
+  --accent-soft: #3a2a18;
+  --border-subtle: rgba(243, 238, 227, 0.13);
+  --text-muted: #b9b1a4;
   position: relative;
   overflow: hidden;
   border: 1px solid rgba(243, 238, 227, 0.13);
@@ -277,7 +376,7 @@ code {
   margin: 0 24px 22px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(24, 20, 15, 0.04);
   padding: 14px;
   font-family: "SF Mono", Menlo, Consolas, monospace;
   font-size: 13px;
@@ -304,7 +403,7 @@ code {
 }
 
 .evidence-grid div {
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(24, 20, 15, 0.04);
   padding: 14px;
 }
 
@@ -377,7 +476,7 @@ section h2 {
   border-radius: 12px;
   background:
     radial-gradient(circle at 92% 0%, rgba(224, 134, 58, 0.12), transparent 32%),
-    rgba(255, 255, 255, 0.035);
+    rgba(24, 20, 15, 0.035);
   padding: 22px;
 }
 
@@ -396,7 +495,7 @@ section h2 {
 .evidence-strip span {
   border: 1px solid rgba(224, 134, 58, 0.22);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(24, 20, 15, 0.04);
   padding: 7px 11px;
   color: var(--text-primary);
   font-family: "SF Mono", Menlo, Consolas, monospace;
@@ -433,7 +532,7 @@ section h2 {
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.018)),
+    linear-gradient(180deg, rgba(24, 20, 15, 0.05), rgba(24, 20, 15, 0.018)),
     var(--card-bg);
   padding: 24px;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
@@ -521,7 +620,7 @@ section h2 {
 
 .workflow-grid article {
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.016)),
+    linear-gradient(180deg, rgba(24, 20, 15, 0.045), rgba(24, 20, 15, 0.016)),
     var(--card-bg);
   padding: 24px;
 }
@@ -630,7 +729,7 @@ pre {
   border: 1px solid var(--border-subtle);
   border-radius: 16px;
   background:
-    linear-gradient(rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.02)),
+    linear-gradient(rgba(24, 20, 15, 0.045), rgba(24, 20, 15, 0.02)),
     radial-gradient(circle at 12% 0%, rgba(224, 134, 58, 0.16), transparent 32%);
   padding: 18px;
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
@@ -685,7 +784,7 @@ pre {
 
 .query-board div {
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.016)),
+    linear-gradient(180deg, rgba(24, 20, 15, 0.045), rgba(24, 20, 15, 0.016)),
     var(--card-bg);
   padding: 24px;
 }
@@ -742,7 +841,7 @@ pre {
   gap: 0;
   border: 1px solid var(--border-subtle);
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.035);
+  background: rgba(24, 20, 15, 0.035);
   padding: 18px;
 }
 
@@ -1385,7 +1484,7 @@ pre {
   padding: 34px;
   border-radius: 16px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.018)),
+    linear-gradient(180deg, rgba(24, 20, 15, 0.055), rgba(24, 20, 15, 0.018)),
     var(--card-bg);
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.22);
 }
@@ -1394,7 +1493,7 @@ pre {
   border-color: var(--accent);
   background:
     radial-gradient(circle at 85% 4%, rgba(224, 134, 58, 0.2), transparent 32%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.065), rgba(255, 255, 255, 0.018)),
+    linear-gradient(180deg, rgba(24, 20, 15, 0.065), rgba(24, 20, 15, 0.018)),
     var(--card-bg);
   box-shadow: 0 24px 70px rgba(224, 134, 58, 0.18);
 }
@@ -1491,7 +1590,7 @@ pre {
 .pricing-proof span {
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(24, 20, 15, 0.04);
   padding: 8px 12px;
   color: var(--text-muted);
   font-size: 13px;
@@ -1822,7 +1921,7 @@ footer a:hover {
     padding: 8px 11px;
     border: 1px solid rgba(23, 20, 15, 0.08);
     border-radius: 8px;
-    background: rgba(255, 255, 255, 0.34);
+    background: rgba(24, 20, 15, 0.34);
     font-size: 14px;
     line-height: 1.2;
   }
@@ -2076,4 +2175,101 @@ footer a:hover {
   font-size: 13px;
   margin-top: 40px;
   padding-bottom: 8px;
+}
+
+/* Glass treatment: every surface that sits on var(--card-bg) gets the
+   blur too, consolidated here rather than repeated at each declaration -
+   var(--card-bg) alone is just a translucent color, backdrop-filter is
+   what actually reads as frosted glass over the color blobs above. */
+.pillar-card,
+.workflow-grid article,
+.command-grid article,
+.query-board div,
+.contract-list article,
+.price-card,
+.feature-card,
+.billing-toggle,
+.dogfood-table tbody,
+.bench-details,
+.bench-chart,
+.status-banner,
+.status-table tbody {
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  /* Panels far from a color blob (the fixed background glows only reach
+     the upper viewport) still need to read as glass, not vanish into a
+     flat white section - a soft shadow + slightly firmer border carries
+     the effect on its own everywhere else. */
+  box-shadow: 0 8px 30px rgba(24, 20, 15, 0.05);
+}
+
+.pillar-card,
+.workflow-grid article,
+.command-grid article,
+.contract-list article,
+.price-card,
+.feature-card {
+  border-color: rgba(24, 20, 15, 0.14);
+}
+
+/* Glass card hover lift - reinforces the tactile "frosted panel" feel;
+   transform/shadow only, layout untouched, so it can't cause reflow. */
+.pillar-card,
+.workflow-grid article,
+.command-grid article,
+.contract-list article,
+.price-card,
+.feature-card {
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.pillar-card:hover,
+.workflow-grid article:hover,
+.command-grid article:hover,
+.contract-list article:hover,
+.price-card:hover,
+.feature-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(24, 20, 15, 0.1);
+  border-color: rgba(24, 20, 15, 0.22);
+}
+
+/* Nav gains a touch more shadow once scrolled - .is-scrolled toggled by
+   script.js past the hero, pure decoration so pages without the script
+   (no JS, or the class never applied) just keep the resting shadow. */
+.site-nav.is-scrolled {
+  box-shadow: 0 12px 34px rgba(24, 20, 15, 0.1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pillar-card,
+  .workflow-grid article,
+  .command-grid article,
+  .contract-list article,
+  .price-card,
+  .feature-card,
+  .site-nav {
+    transition: none;
+  }
+}
+
+/* Scroll-reveal targets: hidden until .is-visible is added by
+   script.js's IntersectionObserver. */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-reveal].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
 }


### PR DESCRIPTION
Replaces the dark, dot-grid-textured theme across the public marketing site and the hosted product dashboard (sign-in, repo picker, overview/security/dead-code/health/wiki/docs/settings) with a consistent light glass aesthetic - white base, translucent blurred panels, soft ambient color blobs instead of a repeating dot texture, orange accent preserved.

**Marketing site:** new light tokens, backdrop-filter glass on nav/cards, ambient blob drift, staggered hero entrance, scroll-reveal, card hover lift - all respecting `prefers-reduced-motion`. Also fixes a real regression from an earlier design pass in this same work: several self-contained dark showcase panels (the Linux-kernel dependency-graph section, TOON/live-demo stats, repo showcase cards, terminal titles) had their light-on-dark accents incorrectly flipped to dark-on-dark, making borders and the graph's edges invisible.

**Hosted dashboard:** same glass treatment on the existing (already token-driven) light theme. Dark mode is now an explicit opt-in rather than auto-following OS preference, since the new translucent cards read as washed-out/illegible when a light body picked up an OS-triggered dark palette - the dark palette itself is kept for a possible future theme toggle.

Verified: `test_frontend_subscribe.py` + `test_frontend_js_syntax.py` pass (19 passed, 1 skipped), `website/index.html`/`script.js` pass cspell (the only marketing-site files CI actually scans).