### PR TITLE
fix: Pushover key validation accepted a trailing newline

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -127,7 +127,12 @@ class SetAlertEmailRequest(BaseModel):
 # typo before it's saved" purpose as _looks_like_email above, not an
 # attempt to verify the key is real (only Pushover's own API can do that,
 # which is exactly what the /test route is for).
-_PUSHOVER_KEY_PATTERN = re.compile(r"^[A-Za-z0-9]{30}$")
+# \Z, not the bare $ a first attempt reaches for: without re.MULTILINE, $
+# matches either the true end of the string OR right before a single
+# trailing newline - so "u"*30 + "\n" (30 valid characters plus a trailing
+# newline) incorrectly passed this check, confirmed directly. \Z only ever
+# matches the true end of the string, no such exception.
+_PUSHOVER_KEY_PATTERN = re.compile(r"^[A-Za-z0-9]{30}\Z")
 
 
 class SetPushoverUserKeyRequest(BaseModel):

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -575,6 +575,21 @@ async def test_set_pushover_user_key_rejects_malformed_key(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_set_pushover_user_key_rejects_a_trailing_newline(pool, monkeypatch):
+    # Regression: the validation regex used a bare $ instead of \Z -
+    # without re.MULTILINE, $ matches either the true end of the string OR
+    # right before a single trailing newline, so 30 valid characters plus
+    # a trailing "\n" incorrectly passed. Confirmed directly before fixing.
+    client = await _logged_in_client(pool, monkeypatch)
+    async with client:
+        response = await client.put(
+            "/admin/octocat/hello-world/pushover-user-key",
+            json={"pushover_user_key": "u" * 30 + "\n"},
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_send_test_pushover_requires_a_saved_key(pool, monkeypatch):
     monkeypatch.setenv("PUSHOVER_API_TOKEN", "server-app-token")
     from app_server.config import get_settings


### PR DESCRIPTION
Found during a hardening pass on `app_server/frontend.py` (highest prior-defect count in the repo - 20 fixes in 6 months) and its `admin.py` backend, checking the alert-channel settings area since `jobs.py`'s own alert-channel bugs were found earlier tonight (#423, #425). Same "boundary condition" bug class already found 3 times elsewhere in this codebase this session.

## The bug

`_PUSHOVER_KEY_PATTERN` used a bare `$` instead of `\Z`. Without `re.MULTILINE`, `$` matches either the true end of the string OR right before a single trailing newline - so `"u"*30 + "\n"` (30 valid characters plus a trailing newline) incorrectly passed validation:

```python
re.compile(r"^[A-Za-z0-9]{30}$").match("u"*30 + "\n")   # matches - wrong
re.compile(r"^[A-Za-z0-9]{30}\Z").match("u"*30 + "\n")  # no match - correct
```

Not a security issue - the value still goes to Pushover's own API via the `/test` route, which would reject it - but it defeats the whole point of this check (catch an obvious typo before it's saved, with a friendly error, per the function's own docstring) for exactly the shape of mistake a copy-paste from an email or terminal most commonly introduces: a trailing newline.

## The fix

`\Z` instead of `$`.

New regression test confirmed to fail against the pre-fix pattern (`200` instead of the expected `400`) and pass after.

## Verification

`tests/test_admin.py -k pushover`: 7 passed. Full `test_admin.py`: **104 passed** (against a real Postgres, not mocked).

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr