### PR TITLE
fix: FastAPI endpoint mapping lost the mount prefix for module.router-style include_router

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -58,19 +58,15 @@ def _string_literal_text(node: Node, source: bytes) -> str:
     return raw.strip("'\"")
 
 
-def _resolve_router_definition_file(
+def _resolve_from_import_binding(
     root: Node, source: bytes, name: str, repo_path: Path, path: Path, source_roots: list[Path]
-) -> str:
-    """Finds which file `name` (the identifier passed as include_router's
-    router argument) actually originates from, by following a `from
-    <module> import name [as alias]` statement in this same file - "router"
-    is the idiomatic FastAPI variable name, so without this, two different
-    files' routers both imported under that same conventional bare name
-    would be indistinguishable to the caller (see before_launch_fixes.md
-    Batch 4 finding #4). Falls back to this file's own rel_path when no
-    such import binds the name - the pre-existing, still-correct same-file
-    case (`router = APIRouter()` and `include_router(router, ...)` both
-    here)."""
+) -> str | None:
+    """Finds which file `name` is bound to by a `from <module> import name
+    [as alias]` statement in this same file - None if no such import binds
+    it (the caller decides what that means: a same-file definition for a
+    bare router name, or an unresolvable reference for a module alias -
+    see _resolve_router_definition_file and the attribute-access branch of
+    _collect_fastapi_include_prefixes)."""
     for n in _walk_tree(root):
         if n.type != "import_from_statement":
             continue
@@ -94,7 +90,24 @@ def _resolve_router_definition_file(
             target = _resolve_python_from_import(repo_path, module_name, imported_name, path, source_roots)
             if target is not None:
                 return target
-    return _rel(repo_path, path)
+    return None
+
+
+def _resolve_router_definition_file(
+    root: Node, source: bytes, name: str, repo_path: Path, path: Path, source_roots: list[Path]
+) -> str:
+    """Finds which file `name` (the identifier passed as include_router's
+    router argument) actually originates from, by following a `from
+    <module> import name [as alias]` statement in this same file - "router"
+    is the idiomatic FastAPI variable name, so without this, two different
+    files' routers both imported under that same conventional bare name
+    would be indistinguishable to the caller (see before_launch_fixes.md
+    Batch 4 finding #4). Falls back to this file's own rel_path when no
+    such import binds the name - the pre-existing, still-correct same-file
+    case (`router = APIRouter()` and `include_router(router, ...)` both
+    here)."""
+    target = _resolve_from_import_binding(root, source, name, repo_path, path, source_roots)
+    return target if target is not None else _rel(repo_path, path)
 
 
 def _collect_fastapi_include_prefixes(
@@ -112,7 +125,43 @@ def _collect_fastapi_include_prefixes(
         if name is None or source[name.start_byte:name.end_byte].decode() != "include_router":
             continue
         positional = [arg for arg in args.named_children if arg.type != "keyword_argument"]
-        if not positional or positional[0].type != "identifier":
+        if not positional:
+            continue
+        router_arg = positional[0]
+        if router_arg.type == "identifier":
+            router = source[router_arg.start_byte:router_arg.end_byte].decode()
+            defining_file: str | None = _resolve_router_definition_file(
+                root, source, router, repo_path, path, source_roots
+            )
+        elif router_arg.type == "attribute":
+            # include_router(users.router, prefix="/users") - the exact
+            # namespacing pattern this whole feature exists to disambiguate
+            # (a bare "router" collides across files) done properly, and
+            # previously invisible to this scan entirely: positional[0].type
+            # was required to be a plain identifier, so this branch never
+            # matched and the call was silently skipped - the mount prefix
+            # never applied, producing a real, reachable endpoint's path
+            # with its mount prefix missing. Confirmed directly: a router
+            # mounted this way reported "/list" instead of "/users/list".
+            #
+            # No same-file fallback here (unlike the identifier case above):
+            # a locally-defined router is always referenced by its own bare
+            # name, never via module.attribute, so if the module alias
+            # can't be resolved to a real import, this mount is genuinely
+            # unknown rather than "must be this file" - skip only this
+            # mount, same discipline as the non-literal-prefix case below.
+            object_node = router_arg.child_by_field_name("object")
+            attribute_node = router_arg.child_by_field_name("attribute")
+            if object_node is None or object_node.type != "identifier" or attribute_node is None:
+                continue
+            module_alias = source[object_node.start_byte:object_node.end_byte].decode()
+            router = source[attribute_node.start_byte:attribute_node.end_byte].decode()
+            defining_file = _resolve_from_import_binding(
+                root, source, module_alias, repo_path, path, source_roots
+            )
+            if defining_file is None:
+                continue
+        else:
             continue
         prefix_arg = next(
             (arg for arg in args.named_children if arg.type == "keyword_argument"
@@ -140,8 +189,6 @@ def _collect_fastapi_include_prefixes(
                 # this mount rather than guessing at its value.
                 continue
             prefix_text = _string_literal_text(value, source)
-        router = source[positional[0].start_byte:positional[0].end_byte].decode()
-        defining_file = _resolve_router_definition_file(root, source, router, repo_path, path, source_roots)
         prefixes.setdefault((defining_file, router), []).append(prefix_text)
     return prefixes
 

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -301,6 +301,55 @@ def test_map_api_endpoints_does_not_cross_contaminate_same_named_routers_in_diff
     assert items_paths == {"/items/list"}
 
 
+def test_map_api_endpoints_applies_mount_prefix_for_attribute_style_include_router(tmp_path):
+    # Regression: include_router(users.router, prefix="/users") - routers
+    # namespaced by module attribute access instead of a bare imported
+    # name, the idiomatic way to avoid exactly the bare-"router"-name
+    # collision the test above guards against - was invisible to this scan
+    # entirely. positional[0] was required to be a plain identifier, so an
+    # attribute node (`users.router`) never matched and the whole
+    # include_router call was silently skipped: the mount prefix never
+    # applied, and a real, reachable endpoint reported its path without it
+    # ("/list" instead of "/users/list"). Confirmed directly before fixing.
+    (tmp_path / "routers").mkdir()
+    (tmp_path / "routers" / "__init__.py").write_text("")
+    (tmp_path / "routers" / "users.py").write_text(
+        'router = APIRouter()\n'
+        '@router.get("/list")\n'
+        'def list_users():\n    pass\n'
+    )
+    (tmp_path / "main.py").write_text(
+        "from routers import users\n"
+        'app.include_router(users.router, prefix="/users")\n'
+    )
+
+    result = map_api_endpoints(tmp_path)
+
+    paths = {e["path"] for e in result["endpoints"] if e["file"] == "routers/users.py"}
+    assert paths == {"/users/list"}
+
+
+def test_map_api_endpoints_skips_attribute_style_include_router_when_module_unresolved(tmp_path):
+    # The module-alias analog of the non-literal-prefix case: if the object
+    # in `module.router` can't be traced back to a real import, this mount
+    # is genuinely unknown - skip only this mount rather than guessing, and
+    # never fall back to "this file", unlike the bare-identifier case where
+    # a same-file local definition is a real, common possibility.
+    (tmp_path / "users.py").write_text(
+        'router = APIRouter()\n'
+        '@router.get("/list")\n'
+        'def list_users():\n    pass\n'
+    )
+    (tmp_path / "main.py").write_text(
+        'app.include_router(some_dynamically_built_module.router, prefix="/users")\n'
+    )
+
+    result = map_api_endpoints(tmp_path)
+
+    paths = {e["path"] for e in result["endpoints"] if e["file"] == "users.py"}
+    assert paths == {"/list"}
+
+
 def test_extract_flask_fastapi_ignores_non_route_decorators():
     root, source = parse_python("@staticmethod\ndef helper():\n    pass\n")
 


### PR DESCRIPTION
Found auditing `endpoints.py` - "3 bug-fixes in 6 months" per its own health-tool signal, and git history showed all 4 relevant fixes (ce17178, 39199da, fc7af35, 651c74d) concentrated in exactly this one function's mount-prefix handling, not spread across the file's other 9 framework extractors. That concentration is what made this worth a close read.

## The bug

`_collect_fastapi_include_prefixes` required the router argument to `include_router(...)` to be a bare identifier (`positional[0].type == "identifier"`). A call shaped like `include_router(users.router, prefix="/users")` - referencing the router via module attribute access instead of a bare imported name - has `positional[0].type == "attribute"` instead, so the whole call was silently skipped: no exception, no log, just a missing mount-prefix record.

This is the exact namespacing pattern the feature's own history is about: 4 prior fixes exist specifically because two different files' routers both idiomatically named "router" collide when imported bare - `before_launch_fixes.md` Batch 4 finding #4 is literally that problem. A codebase that avoids the collision by referencing routers as `module.router` (`import routers.users; app.include_router(users.router, ...)`) instead of importing the bare name was completely invisible to this whole mount-prefix-tracking feature as a result.

Confirmed directly, not hypothetical:

```python
app.include_router(users.router, prefix="/users")
# reported: GET /list        (wrong - not a real, reachable path)
# should be: GET /users/list
```

Consequence: this powers both the dashboard's endpoint list and the hosted health-check monitor (`scan_worker/jobs.py`'s `_run_health_check_sweep_for_target`) - a wrong path here means the health check probes a URL that was never the real endpoint, and the dashboard shows the same wrong path to the customer.

## The fix

Handle `router_arg.type == "attribute"` as its own case, resolving the module alias (the object side of `module.router`) via the same import-following logic `_resolve_router_definition_file` already uses for bare names - extracted into a shared `_resolve_from_import_binding` helper.

Deliberately **no same-file fallback** for this branch (unlike the bare-identifier case): a locally-defined router is always referenced by its own bare name, never via `module.attribute`, so an unresolvable module alias means the mount is genuinely unknown, not "must be this file" - skip only that one mount, same discipline already used for a non-literal `prefix=` value.

## Verification

Two new regression tests: the fixed case (mount prefix now applies), and the graceful-skip case (an unresolvable module alias doesn't guess or crash). The first confirmed to fail against the pre-fix gate (reported `/list` instead of `/users/list`) and pass after.

`tests/test_endpoints.py`: 62 passed. Full `src/aletheore` suite: **1390 passed**.

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr