### PR TITLE
fix: recent_commits ended up oldest-first instead of newest-first

### DIFF
--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -74,12 +74,18 @@ async def test_owner_attachment_from_graph_uses_most_recent_committer(pool, monk
 
     from aletheore.git_intel.graph_store import CommitTouch
 
+    # Newest first (s2, then s1) - matching git log's real default order.
+    # See src/tests/test_incremental.py's
+    # test_fold_caps_recent_commits_per_file_newest_first (and PR #430) for
+    # why this matters: an oldest-first fixture here masked the same
+    # fold()/recent_commits ordering bug three sibling fixtures had, purely
+    # by feeding backwards input to backwards logic.
     store.apply_commits(
         "unused",
         GRAPH_BRANCH,
         [
-            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",)),
             CommitTouch("s2", "Bob", "b@example.com", datetime(2026, 6, 8), ("app/handler.py",)),
+            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",)),
         ],
         new_sync_sha="s2",
         new_sync_at=datetime(2026, 6, 8),
@@ -120,12 +126,14 @@ async def test_commit_attachment_from_graph_uses_most_recent_commit(pool, monkey
 
     from aletheore.git_intel.graph_store import CommitTouch
 
+    # Newest first (s2, then s1) - see the identical comment on
+    # test_owner_attachment_from_graph_uses_most_recent_committer above.
     store.apply_commits(
         "unused",
         GRAPH_BRANCH,
         [
-            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",), "initial handler"),
             CommitTouch("s2", "Bob", "b@example.com", datetime(2026, 6, 8), ("app/handler.py",), "fix null check"),
+            CommitTouch("s1", "Alice", "a@example.com", datetime(2026, 6, 1), ("app/handler.py",), "initial handler"),
         ],
         new_sync_sha="s2",
         new_sync_at=datetime(2026, 6, 8),

--- a/github-app/tests/test_postgres_graph_store.py
+++ b/github-app/tests/test_postgres_graph_store.py
@@ -43,9 +43,15 @@ async def test_load_returns_empty_snapshot_for_unknown_repo(pool):
 async def test_apply_commits_then_load_round_trips_correctly(pool):
     await _insert_installation(pool, 602, "org")
     store = PostgresRepoGraphStore(TEST_DATABASE_URL, 602, "org/repo")
+    # Newest first (s2, then s1) - matching git log's real default order.
+    # See src/tests/test_incremental.py's
+    # test_fold_caps_recent_commits_per_file_newest_first for why this
+    # matters: an oldest-first fixture here masked a real bug in fold()'s
+    # recent_commits ordering, on this exact hosted-production code path
+    # (PostgresRepoGraphStore also calls the same shared fold()).
     commits = [
-        _touch("s1", "Alice", "a@example.com", "2026-06-01T00:00:00", ("a.txt", "b.txt")),
         _touch("s2", "Bob", "b@example.com", "2026-06-08T00:00:00", ("a.txt",)),
+        _touch("s1", "Alice", "a@example.com", "2026-06-01T00:00:00", ("a.txt", "b.txt")),
     ]
 
     store.apply_commits(

--- a/src/aletheore/git_intel/incremental.py
+++ b/src/aletheore/git_intel/incremental.py
@@ -249,7 +249,25 @@ def fold(snapshot: GraphSnapshot, commits: list[CommitTouch]) -> GraphSnapshot:
         for path, f in snapshot.file_churn.items()
     }
 
-    for commit in commits:
+    # Reversed, not `commits` in its natural order: every caller feeds this
+    # `git log`'s own default order, newest commit first (stream_commit_touches
+    # issues no --reverse, and analyzer.py's list(stream_commit_touches(...))
+    # doesn't add one either). Every OTHER aggregate below is order-independent
+    # (a running sum, or a set union) - recent_commits is the one exception:
+    # insert(0, recent) puts each processed commit at the front, so processing
+    # newest-first ends with the OLDEST commit at index 0 and the newest
+    # buried at the back, exactly backwards from what "recent" means. Once a
+    # file's touches in one batch exceed RECENT_COMMITS_PER_FILE, the
+    # truncation below then keeps the oldest ones and drops the genuinely
+    # recent ones. Confirmed directly against fold() itself, not just traced:
+    # three commits newest-to-oldest in, recent_commits[0] came back as the
+    # oldest of the three. Iterating oldest-of-this-batch-first instead makes
+    # the last insert(0, ...) - the real newest commit - land at index 0,
+    # matching every reader of recent_commits[0] (jobs.py's
+    # _commit_attachment_from_graph/_owner_attachment_from_graph, both of
+    # which treat it as "the latest commit" for health-check-failure
+    # correlation and likely-owner inference).
+    for commit in reversed(commits):
         email_key = commit.author_email.lower()
         total = ownership.get(email_key)
         if total is None:

--- a/src/tests/test_incremental.py
+++ b/src/tests/test_incremental.py
@@ -249,9 +249,18 @@ def test_fold_bumping_an_already_tracked_partner_never_evicts():
 
 
 def test_fold_caps_recent_commits_per_file_newest_first():
+    # Newest-first, matching git log's real default order (no --reverse is
+    # ever passed - see stream_commit_touches) - the exact order every real
+    # caller (analyzer.py's list(stream_commit_touches(...))) actually feeds
+    # fold(). Regression: this fixture used to build commits oldest-first
+    # (ascending dates, s0..s14), which is backwards from reality and made
+    # the old, buggy insert(0, ...)-in-forward-order code look correct
+    # purely because the test's input order happened to be the mirror image
+    # of what real git log produces - confirmed directly against fold()
+    # itself before fixing either the code or this fixture.
     commits = [
         _touch(f"s{i}", "Alice", "a@example.com", f"2026-06-{i + 1:02d}T00:00:00+00:00", ("a.txt",))
-        for i in range(15)
+        for i in reversed(range(15))
     ]
     result = fold(GraphSnapshot.empty(), commits)
     recent = result.file_churn["a.txt"].recent_commits

--- a/src/tests/test_sqlite_store.py
+++ b/src/tests/test_sqlite_store.py
@@ -25,9 +25,13 @@ def test_load_returns_empty_snapshot_for_unknown_repo(tmp_path):
 
 def test_apply_commits_then_load_round_trips_correctly(tmp_path):
     store = _store(tmp_path)
+    # Newest first (s2, then s1) - matching git log's real default order
+    # (see test_fold_caps_recent_commits_per_file_newest_first for why this
+    # matters: the old oldest-first fixture order masked a real bug in
+    # fold()'s recent_commits ordering).
     commits = [
-        _touch("s1", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", ("a.txt", "b.txt")),
         _touch("s2", "Bob", "b@example.com", "2026-06-08T00:00:00+00:00", ("a.txt",)),
+        _touch("s1", "Alice", "a@example.com", "2026-06-01T00:00:00+00:00", ("a.txt", "b.txt")),
     ]
     store.apply_commits(
         "repo-1", "main", commits, new_sync_sha="s2", new_sync_at=datetime(2026, 6, 8), reset=True


### PR DESCRIPTION
Found auditing `git_intel/incremental.py` - `stream_commit_touches` has the deepest nesting flagged anywhere in the repo (6 levels), which is what made this worth a close read; the real bug turned out to be one level up, in `fold()`'s aggregation loop, not the streaming parser itself.

## The bug

`fold()` iterated `commits` in the order every real caller provides it: git log's own default, newest commit first (`stream_commit_touches` issues no `--reverse`, and `analyzer.py`'s `list(stream_commit_touches(...))` doesn't add one either - confirmed directly against a real `git log` run in this repo: HEAD comes first). For each commit, `churn.recent_commits.insert(0, recent)` puts it at the front - so processing newest-first, oldest-last, ends with the **oldest** commit at index 0 and the true newest one buried at the back. Once a file's touches in one `fold()` batch exceed `RECENT_COMMITS_PER_FILE` (10), the truncation right after then keeps the oldest ones and drops the genuinely recent ones - exactly backwards from what `recent_commits` is supposed to mean.

Confirmed directly against `fold()` itself, not just traced: three commits fed newest-to-oldest (matching real git log order) came back with `recent_commits[0]` as the **oldest** of the three.

**Consequence:** this is what `jobs.py`'s `_commit_attachment_from_graph` and `_owner_attachment_from_graph` read as "the latest commit" for health-check-failure correlation and likely-owner inference (`latest = churn.recent_commits[0]`) - both features were pointing at stale commits and, once a file had enough churn, potentially the wrong author entirely.

## Why this went unnoticed

Three existing tests (`test_incremental.py`, `test_sqlite_store.py`, and `test_postgres_graph_store.py` - the exact hosted-production code path, `PostgresRepoGraphStore` calls the same shared `fold()`) all built their `commits` fixture in ascending/oldest-first order, the mirror image of what git log actually produces. That happened to make the old, buggy code look correct, since feeding backwards input to backwards logic produces the right answer by coincidence. All three fixtures fixed to newest-first, matching reality, alongside the real fix.

## The fix

`for commit in reversed(commits):` instead of `for commit in commits:`. Every other aggregate in that loop (ownership counts, cadence, co-change counts) is order-independent - a running sum or set union - so this only changes `recent_commits`' ordering, nothing else.

## Verification

The newly-fixed `test_postgres_graph_store.py` assertion confirmed to fail against the pre-fix code with the exact same symptom (`s1` instead of `s2`) before fixing, and pass after.

Full `src/aletheore` suite: **1388 passed**. github-app `test_postgres_graph_store.py` + `test_jobs.py` (real Postgres, the downstream consumer of `recent_commits`): **194 passed**.

Not merged - flagging for review.

Claude-Session: https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr