### PR TITLE
feat: reduce AIR's included seats to 3, reprice extra seat to $6.99

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -706,7 +706,7 @@ async def set_extra_seats(pool: asyncpg.Pool, installation_id: int, extra_seats:
     )
 
 
-INCLUDED_SEATS = {"air": 5}
+INCLUDED_SEATS = {"air": 3}
 DEFAULT_SEAT_LIMIT = 5
 
 

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -24,8 +24,8 @@ MODEL_RATES_PER_MILLION_USD = {
 STALE_PRICE_MAX_AGE_DAYS = 90
 
 # What a seat actually bills at (paddle_pricing.EXTRA_SEAT_PRICE_ID,
-# pricing.html's "+$4.99/mo per additional team member").
-EXTRA_SEAT_PRICE_USD = 4.99
+# pricing.html's "+$6.99/mo per additional team member").
+EXTRA_SEAT_PRICE_USD = 6.99
 
 # How much of that a seat is allowed to add to the LLM spend cap. Kept
 # deliberately below EXTRA_SEAT_PRICE_USD (not equal to it, as this used to

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -1,13 +1,18 @@
 """Paddle price ID to Aletheore plan mapping."""
 
-# The AIR add-on for a seat beyond the plan's included count ($4.99/mo,
-# pricing.html's "+$4.99/mo per additional team member"). Added as a second
+# The AIR add-on for a seat beyond the plan's included count ($6.99/mo,
+# pricing.html's "+$6.99/mo per additional team member"). Added as a second
 # line item (by quantity) on a customer's existing AIR subscription, not a
-# separate subscription of its own. Replaces the original $3.99 price
-# (pri_01kym2q99kevmdg7h71nwpm4ej, now archived in Paddle) - archived rather
-# than mutated in place so any pre-existing $3.99 subscribers (there were
-# none at the time of the swap) would never have been silently repriced.
-EXTRA_SEAT_PRICE_ID = "pri_01kzks8ccwf6h5bxxtmjfdy1fg"
+# separate subscription of its own. Replaces the $4.99 price
+# (pri_01kzks8ccwf6h5bxxtmjfdy1fg, now archived in Paddle), which itself
+# replaced the original $3.99 price (pri_01kym2q99kevmdg7h71nwpm4ej, also
+# archived) - each swap archived the old price rather than mutating it in
+# place, and each was only done after confirming zero live subscribers on
+# it, so no pre-existing subscriber was ever silently repriced. The included
+# seat count for the "air" plan also dropped from 5 to 3 alongside this
+# price change (db.py's INCLUDED_SEATS) - 5 seats was too much value to
+# bundle into the base $29.99/mo price.
+EXTRA_SEAT_PRICE_ID = "pri_01m123rwvvtgbm6bmmxcbav4hh"
 
 PADDLE_PRICE_TO_PLAN: dict[str, str] = {
     "pri_01kyhevc8bkcghfpwjymz16y2h": "air",

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -1128,7 +1128,7 @@ async def test_first_admin_to_arrive_is_auto_seated(pool, monkeypatch):
         response = await client.get("/admin/octocat/hello-world")
     assert response.status_code == 200
     assert [m["github_login"] for m in response.json()["members"]] == ["octocat"]
-    assert response.json()["seat_limit"] == 5
+    assert response.json()["seat_limit"] == 3
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -1176,12 +1176,12 @@ async def test_removing_a_member_revokes_access(pool, monkeypatch):
 async def test_add_member_enforces_seat_cap(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
     async with client:
-        await client.get("/admin/octocat/hello-world")  # seats octocat (1 of 5)
-        await client.post("/admin/octocat/hello-world/members", json={"github_login": "alice"})  # 2 of 5
-        await client.post("/admin/octocat/hello-world/members", json={"github_login": "bob"})  # 3 of 5
-        await client.post("/admin/octocat/hello-world/members", json={"github_login": "carol"})  # 4 of 5
-        await client.post("/admin/octocat/hello-world/members", json={"github_login": "dave"})  # 5 of 5
-        response = await client.post("/admin/octocat/hello-world/members", json={"github_login": "erin"})
+        await client.get("/admin/octocat/hello-world")  # seats octocat (1 of 3, INCLUDED_SEATS["air"])
+        alice = await client.post("/admin/octocat/hello-world/members", json={"github_login": "alice"})  # 2 of 3
+        bob = await client.post("/admin/octocat/hello-world/members", json={"github_login": "bob"})  # 3 of 3
+        response = await client.post("/admin/octocat/hello-world/members", json={"github_login": "carol"})
+    assert alice.status_code == 200
+    assert bob.status_code == 200
     assert response.status_code == 409
     assert "seat limit reached" in response.json()["detail"]
 

--- a/website/index.html
+++ b/website/index.html
@@ -42,7 +42,7 @@
         "name": "Aletheore AIR",
         "price": "29.99",
         "priceCurrency": "USD",
-        "description": "Up to 5 team members. Managed audits and AIRview builds run on an OpenAI frontier model."
+        "description": "Up to 3 team members. Managed audits and AIRview builds run on an OpenAI frontier model."
       }
     ],
     "featureList": [
@@ -60,7 +60,7 @@
       "Live API endpoint health monitoring across multiple targets, with a public status API",
       "AIRview: an AI-generated, always-current map of your repo's architecture with dependency diagrams",
       "AI-generated Docs: grounded, per-symbol descriptions written and kept current automatically, marked AI-generated or AI-polished, exportable as a single Markdown file",
-      "Team seat management, up to 5 seats included on Aletheore AIR"
+      "Team seat management, up to 3 seats included on Aletheore AIR"
     ]
   }
   </script>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -67,7 +67,7 @@
             <span class="price-kicker">Hosted GitHub App</span>
             <h3>Aletheore AIR</h3>
             <div class="price-now">$29.99</div>
-            <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 5 team members</div>
+            <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 3 team members</div>
           </div>
           <ul>
             <li>Everything in Community.</li>
@@ -77,7 +77,7 @@
             <li>Slack / Teams alerts on new findings.</li>
             <li>Branch-protection Check Runs for new secrets.</li>
             <li>Endpoint health monitoring across multiple targets, with a public status API.</li>
-            <li>+$4.99/mo per additional team member.</li>
+            <li>+$6.99/mo per additional team member.</li>
           </ul>
           <button type="button" class="btn btn-primary" data-subscribe="air">Subscribe</button>
         </article>

--- a/website/terms.html
+++ b/website/terms.html
@@ -33,7 +33,7 @@
       <p>Aletheore is a repository audit tool: a local-first CLI, free for personal, noncommercial use under the <a href="https://github.com/Aletheore/Aletheore/blob/master/LICENSE">PolyForm Noncommercial License 1.0.0</a>, and a paid GitHub App tier for managed audits, Slack/Teams alerts, branch-protection Check Runs, and endpoint health monitoring. Using the CLI for or within a company or other organization is a commercial use and requires a separate commercial license, regardless of whether you also subscribe to the paid GitHub App tier.</p>
 
       <h2>The paid subscription</h2>
-      <p>The paid plan is Aletheore AIR ($29.99/month or $299.90/year, up to 5 team members), with additional members beyond the plan's included seats billed at $4.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>
+      <p>The paid plan is Aletheore AIR ($29.99/month or $299.90/year, up to 3 team members), with additional members beyond the plan's included seats billed at $6.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>
 
       <h2>Acceptable use</h2>
       <p>You may not use Aletheore to scan repositories you do not have the right to scan, or to circumvent security measures of systems you do not own or have explicit permission to test.</p>


### PR DESCRIPTION
5 included seats was too much value to bundle into the base $29.99/mo price. Drops INCLUDED_SEATS["air"] to 3 and repriced the per-extra-seat add-on from $4.99 to $6.99 (new Paddle price created, old one archived after confirming zero live subscribers, same discipline as the prior $3.99->$4.99 swap). Updates pricing.html, terms.html, and index.html to match.