### PR TITLE
fix: retry transient provider errors in the Anthropic adapter

### DIFF
--- a/src/aletheore/adapters/anthropic_native.py
+++ b/src/aletheore/adapters/anthropic_native.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Callable
 
+import anthropic
 import toon
 from anthropic import Anthropic
 
@@ -13,6 +14,7 @@ from aletheore.adapters.openai_compatible import (
     REQUIRED_SECTIONS,
     SYSTEM_PROMPT_TEMPLATE,
     WEAK_MODEL_HINT,
+    _call_with_retry,
     _get_by_dot_path,
     _read_manual_text,
 )
@@ -20,6 +22,18 @@ from aletheore.credentials import DEFAULT_CREDENTIALS_PATH, get_api_key, has_api
 from aletheore.toon_encoding import ToonEncodingError, to_toon
 
 MAX_TOKENS = 8192
+
+# Same transient set as openai_compatible.py's _RETRYABLE_EXCEPTIONS, mirrored
+# for the Anthropic SDK's own exception hierarchy - see that module's comment
+# for why AuthenticationError is included (a real production run observed it
+# recover on retry with no config change in between).
+_RETRYABLE_EXCEPTIONS: tuple[type[Exception], ...] = (
+    anthropic.AuthenticationError,
+    anthropic.RateLimitError,
+    anthropic.APIConnectionError,
+    anthropic.APITimeoutError,
+    anthropic.InternalServerError,
+)
 
 ANTHROPIC_TOOLS = [
     {
@@ -86,11 +100,14 @@ class AnthropicAdapter(AgentAdapter):
 
         client = Anthropic(api_key=api_key)
         try:
-            response = client.messages.create(
-                model=self._model,
-                max_tokens=MAX_TOKENS,
-                system=system_prompt,
-                messages=[{"role": "user", "content": user_prompt}],
+            response = _call_with_retry(
+                lambda: client.messages.create(
+                    model=self._model,
+                    max_tokens=MAX_TOKENS,
+                    system=system_prompt,
+                    messages=[{"role": "user", "content": user_prompt}],
+                ),
+                _RETRYABLE_EXCEPTIONS,
             )
         except Exception as exc:
             raise AdapterInvocationError(
@@ -136,13 +153,16 @@ class AnthropicAdapter(AgentAdapter):
                     "the monthly LLM spend cap would be exceeded"
                 )
             try:
-                response = client.messages.create(
-                    model=self._model,
-                    max_tokens=MAX_TOKENS,
-                    system=system_prompt,
-                    messages=messages,
-                    tools=ANTHROPIC_TOOLS,
-                    tool_choice={"type": "any"},
+                response = _call_with_retry(
+                    lambda: client.messages.create(
+                        model=self._model,
+                        max_tokens=MAX_TOKENS,
+                        system=system_prompt,
+                        messages=messages,
+                        tools=ANTHROPIC_TOOLS,
+                        tool_choice={"type": "any"},
+                    ),
+                    _RETRYABLE_EXCEPTIONS,
                 )
             except Exception as exc:
                 raise AdapterInvocationError(

--- a/src/aletheore/adapters/openai_compatible.py
+++ b/src/aletheore/adapters/openai_compatible.py
@@ -44,12 +44,15 @@ _RETRY_BASE_DELAY_SECONDS = 1.0
 _T = TypeVar("_T")
 
 
-def _call_with_retry(fn: Callable[[], _T]) -> _T:
+def _call_with_retry(
+    fn: Callable[[], _T],
+    retryable_exceptions: tuple[type[Exception], ...] = _RETRYABLE_EXCEPTIONS,
+) -> _T:
     last_exc: Exception | None = None
     for attempt in range(_MAX_CALL_ATTEMPTS):
         try:
             return fn()
-        except _RETRYABLE_EXCEPTIONS as exc:
+        except retryable_exceptions as exc:
             last_exc = exc
             if attempt < _MAX_CALL_ATTEMPTS - 1:
                 time.sleep(_RETRY_BASE_DELAY_SECONDS * (2**attempt))

--- a/src/tests/test_anthropic_adapter.py
+++ b/src/tests/test_anthropic_adapter.py
@@ -1,11 +1,19 @@
 from unittest.mock import MagicMock, patch
 
+import anthropic
+import httpx
 import pytest
 import toon
 
 from aletheore.adapters.anthropic_native import AnthropicAdapter
 from aletheore.adapters.base import AdapterInvocationError
 from aletheore.adapters.openai_compatible import REQUIRED_SECTIONS
+
+
+def _anthropic_error(cls, status_code=None):
+    request = httpx.Request("POST", "https://example.test/v1/messages")
+    response = httpx.Response(status_code, request=request)
+    return cls("boom", response=response, body=None)
 
 
 def _tool_use_block(name, input_dict, block_id="toolu_1"):
@@ -208,6 +216,101 @@ def test_invoke_normalizes_provider_errors_without_leaking_details(
     message = str(exc_info.value)
     assert "anthropic invocation failed: RuntimeError" in message
     assert "secret detail" not in message
+
+
+@patch("aletheore.adapters.openai_compatible.time.sleep")
+@patch("aletheore.adapters.anthropic_native.Anthropic")
+def test_invoke_retries_a_transient_authentication_error_and_succeeds(
+    mock_anthropic_class, mock_sleep, tmp_path
+):
+    # Same transient-auth-error scenario openai_compatible.py's own retry
+    # test documents (a real production run recovered on retry with no
+    # config change in between) - anthropic_native.py shares the same
+    # _call_with_retry helper now, so it must recover here too instead of
+    # failing the whole run on the first transient hiccup.
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+    mock_client.messages.create.side_effect = [
+        _anthropic_error(anthropic.AuthenticationError, status_code=401),
+        _anthropic_error(anthropic.AuthenticationError, status_code=401),
+        *_write_all_sections_then_finish_responses(),
+    ]
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.anthropic_native.get_api_key", return_value="sk-ant-test"):
+        result = adapter.invoke("audit this repo", cwd=str(repo))
+
+    assert "Summary" in result
+    assert mock_sleep.call_count == 2
+
+
+@patch("aletheore.adapters.openai_compatible.time.sleep")
+@patch("aletheore.adapters.anthropic_native.Anthropic")
+def test_invoke_gives_up_after_exhausting_retries_on_persistent_auth_error(
+    mock_anthropic_class, mock_sleep, tmp_path
+):
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+    mock_client.messages.create.side_effect = _anthropic_error(
+        anthropic.AuthenticationError, status_code=401
+    )
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.anthropic_native.get_api_key", return_value="sk-ant-test"):
+        with pytest.raises(AdapterInvocationError) as exc_info:
+            adapter.invoke("audit this repo", cwd=str(repo))
+
+    assert "anthropic invocation failed: AuthenticationError" in str(exc_info.value)
+    assert mock_client.messages.create.call_count == 3
+
+
+@patch("aletheore.adapters.openai_compatible.time.sleep")
+@patch("aletheore.adapters.anthropic_native.Anthropic")
+def test_invoke_does_not_retry_a_non_transient_error(mock_anthropic_class, mock_sleep, tmp_path):
+    # Only the conventional transient set (auth/rate-limit/connection/
+    # timeout/5xx) is retried - a generic error (e.g. a genuine bad
+    # request) fails identically every time, so retrying it just delays
+    # surfacing it.
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+    mock_client.messages.create.side_effect = RuntimeError("bad request")
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.anthropic_native.get_api_key", return_value="sk-ant-test"):
+        with pytest.raises(AdapterInvocationError):
+            adapter.invoke("audit this repo", cwd=str(repo))
+
+    assert mock_client.messages.create.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+@patch("aletheore.adapters.openai_compatible.time.sleep")
+@patch("aletheore.adapters.anthropic_native.Anthropic")
+def test_simple_completion_retries_a_transient_rate_limit_error(
+    mock_anthropic_class, mock_sleep, tmp_path
+):
+    mock_client = MagicMock()
+    mock_anthropic_class.return_value = mock_client
+    text_block = MagicMock()
+    text_block.type = "text"
+    text_block.text = "ok"
+    success = MagicMock()
+    success.content = [text_block]
+    success.usage = None
+    mock_client.messages.create.side_effect = [
+        _anthropic_error(anthropic.RateLimitError, status_code=429),
+        success,
+    ]
+
+    adapter = _adapter(tmp_path)
+    with patch("aletheore.adapters.anthropic_native.get_api_key", return_value="sk-ant-test"):
+        result = adapter.simple_completion("system", "user", cwd=str(tmp_path))
+
+    assert result == "ok"
+    assert mock_sleep.call_count == 1
 
 
 @patch("aletheore.adapters.anthropic_native.Anthropic")


### PR DESCRIPTION
## Summary

`AnthropicAdapter` (`src/aletheore/adapters/anthropic_native.py`) had zero retry logic on transient provider errors. Every `client.messages.create()` call, on any `AuthenticationError`, `RateLimitError`, `APIConnectionError`, `APITimeoutError`, or `InternalServerError`, immediately failed the whole `invoke()`/`simple_completion()` call.

Its sibling `OpenAICompatibleAdapter` retries the exact same error classes up to 3x with exponential backoff - see `_RETRYABLE_EXCEPTIONS`' comment in `openai_compatible.py`, which documents a real production incident: a transient `AuthenticationError` was observed to recover on retry with no config change in between.

Reproduced directly before fixing: a single transient `AuthenticationError` fed to a mocked Anthropic client killed an `adapter.invoke(...)` call instantly with zero retry (`call_count == 1`).

## Fix

Generalized `openai_compatible.py`'s `_call_with_retry` to accept a `retryable_exceptions` parameter (default unchanged - fully backward compatible with every existing caller/test), then reused it from `anthropic_native.py` with the Anthropic SDK's own exception tuple, rather than duplicating the retry/backoff loop across two files.

## Impact

Reachable only via the local CLI's `KNOWN_ADAPTERS` (`cli.py`) - the hosted github-app path never constructs `AnthropicAdapter` (confirmed via `grep`, zero references in `scan_worker/model_tiers.py` or anywhere in `github-app/`). So no production hosted-service impact, but real impact for any CLI user auditing with an Anthropic key - a transient hiccup previously killed the whole run instead of quietly recovering like every other adapter.

## Test plan
- [x] Reproduced the bug directly against the pre-fix code (confirmed `call_count == 1`, immediate failure)
- [x] 4 new regression tests added: retries-and-succeeds, gives-up-after-exhausting-retries, does-not-retry-non-transient-errors, and `simple_completion`'s own retry path - 3 of the 4 confirmed to fail against the pre-fix code, 1 (the non-transient-error case) confirmed already-passing (not broken, just guarded against regressing)
- [x] Full `src/` suite: 1406 passed, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr