### PR TITLE
feat: confidence-tagged import edges, adapted from Graphify's schema

### DIFF
--- a/docs/AIR-SCHEMA.md
+++ b/docs/AIR-SCHEMA.md
@@ -35,6 +35,10 @@ alone.
 Version `0.4.0` adds `git.file_ownership`, a current-source-file keyed
 ownership breakdown used by file-scoped ownership queries.
 
+Version `0.5.0` adds `repository.modules[].import_confidence`, an optional
+per-module map from a resolved import target to `"inferred"` or
+`"ambiguous"` - see the changelog entry below.
+
 ## Migration rules
 
 1. **Any change to `AIR_JSON_SCHEMA` requires an `EVIDENCE_VERSION` MINOR bump.**
@@ -98,5 +102,6 @@ architecture config, which is the common case.
 
 | Version | Change |
 | --- | --- |
+| `0.5.0` | Added `repository.modules[].import_confidence` (optional): a map from a resolved import target already present in that module's own `imports` to `"inferred"` (a source-root/namespace-prefix/PSR-4-prefix tiebreak among genuinely multiple candidates picked a winner) or `"ambiguous"` (C# only - a type-reference edge kept despite more than one file declaring that type name, rather than the previous behavior of dropping it outright). Omitted for a module with no non-exact edges - every module in six of the eleven supported languages (js/ts, go, rust, ruby, c/cpp), whose resolvers are never ambiguous, plus the common single-candidate case in the other five. Also fixed a real non-determinism bug found while adding this: Java's multi-source-root tiebreak previously picked whichever root came first in filesystem walk order (not guaranteed stable across runs/platforms), now sorted the same shallowest-first way Python's own source roots already were. |
 | `0.3.0` | Added `repository.database.schema`: tables, columns, foreign-key relations, and indexes replayed from Postgres DDL migrations, each citing the file:line that introduced it. Gated — present with `checked: false` when the installation is not entitled, so the section's keys are identical for every user and only `checked` varies. |
 | `0.2.0` | Contract formalized: JSON Schema extracted, published, and enforced in CI. No shape change from the `0.2.0` documents already in the wild — this version documents the existing shape rather than altering it. |

--- a/schemas/air.schema.json
+++ b/schemas/air.schema.json
@@ -468,6 +468,9 @@
         "modules": {
           "items": {
             "properties": {
+              "import_confidence": {
+                "type": "object"
+              },
               "imported_by": {
                 "type": "array"
               },

--- a/src/aletheore/air_schema.py
+++ b/src/aletheore/air_schema.py
@@ -89,7 +89,23 @@ _SCHEMA_MAP = _obj(
         "sources": _ANY_LIST,
     }
 )
-_MODULE = _obj({"path": _STR, "language": _STR, "imports": _ANY_LIST, "imported_by": _ANY_LIST})
+# import_confidence is optional and, when present, a plain object mapping a
+# resolved import target (a value already present in this module's own
+# "imports") to "inferred" or "ambiguous" - see scanner/graph.py's
+# _extract_module. Omitted entirely for a module with no non-exact edges,
+# which is the common case and every module in six of Aletheore's eleven
+# supported languages (js/ts, go, rust, ruby, c/cpp), whose resolvers are
+# never ambiguous at all.
+_MODULE = _obj(
+    {
+        "path": _STR,
+        "language": _STR,
+        "imports": _ANY_LIST,
+        "imported_by": _ANY_LIST,
+        "import_confidence": _ANY_OBJECT,
+    },
+    required=["path", "language", "imports", "imported_by"],
+)
 _LANGUAGE = _obj({"name": _STR, "file_count": _INT, "loc": _INT})
 _OWNERSHIP = _obj({"email": _STR, "commit_count": _INT, "percent": _NUM})
 _BRANCH = _obj({"name": _STR, "type": _STR})

--- a/src/aletheore/dashboard.py
+++ b/src/aletheore/dashboard.py
@@ -88,13 +88,16 @@ def build_history_summary(repo_path: Path) -> list[dict]:
 def build_graph_summary(evidence: dict) -> dict:
     dependency_graph = evidence["repository"]["dependency_graph"]
     clusters = evidence["architecture"]["clusters"]
-    # Same exclusion, same reasoning, as wiki_diagrams.py's mermaid builders:
-    # a rendered edge in this interactive graph reads as "this file depends
-    # on that one," a stronger claim than a citable-but-uncertain evidence
-    # edge should make. Only genuine multi-candidate uncertainty (currently
-    # C# type-reference edges - see scanner/graph.py's
-    # _csharp_type_reference_targets) is excluded; a source-root/prefix
-    # tiebreak among real candidates ("inferred") is still drawn.
+    # Unlike wiki_diagrams.py's static mermaid builders (which exclude these
+    # entirely - a rendered mermaid edge has no way to look "less certain"),
+    # this graph is interactive, so an edge whose resolution was genuinely
+    # uncertain (currently C# type-reference edges kept despite more than
+    # one file declaring that type name - see scanner/graph.py's
+    # _csharp_type_reference_targets) is still drawn, just marked so the
+    # frontend can dim/dash it rather than presenting it identically to a
+    # certain edge. A source-root/prefix tiebreak among real candidates
+    # ("inferred") is not marked - that resolution is generally still
+    # correct, unlike genuine which-of-several-files uncertainty.
     ambiguous = _ambiguous_edges(evidence["repository"].get("modules", []))
 
     node_to_cluster: dict[str, int] = {}
@@ -107,9 +110,12 @@ def build_graph_summary(evidence: dict) -> dict:
         for node in dependency_graph["nodes"]
     ]
     edges = [
-        {"source": edge[0], "target": edge[1]}
+        {
+            "source": edge[0],
+            "target": edge[1],
+            **({"ambiguous": True} if (edge[0], edge[1]) in ambiguous else {}),
+        }
         for edge in dependency_graph["edges"]
-        if (edge[0], edge[1]) not in ambiguous
     ]
 
     return {"nodes": nodes, "edges": edges, "clusters": clusters}
@@ -589,8 +595,15 @@ function renderGraph(data) {
   let svgContent = '';
   edges.forEach(e => {
     const a = nodeById[e.source], b = nodeById[e.target];
+    // Ambiguous (see build_graph_summary) draws dashed and dimmed rather than
+    // being excluded entirely - still a real, citable edge, just one the
+    // resolver picked among more than one equally-plausible candidate for,
+    // so it should read as less certain rather than vanish outright.
+    const dash = e.ambiguous ? ' stroke-dasharray="4,3"' : '';
     svgContent += '<line data-source="' + escapeAttr(e.source) + '" data-target="' + escapeAttr(e.target) +
-      '" x1="' + a.x + '" y1="' + a.y + '" x2="' + b.x + '" y2="' + b.y + '" stroke="#333" stroke-width="1" />';
+      '" data-ambiguous="' + (e.ambiguous ? '1' : '0') + '"' +
+      ' x1="' + a.x + '" y1="' + a.y + '" x2="' + b.x + '" y2="' + b.y +
+      '" stroke="#333" stroke-width="1" opacity="' + (e.ambiguous ? '0.35' : '1') + '"' + dash + ' />';
   });
   nodes.forEach(n => {
     svgContent += '<circle data-id="' + escapeAttr(n.id) + '" data-base-r="6" cx="' + n.x + '" cy="' + n.y +
@@ -634,10 +647,13 @@ function highlightNodes(highlightSet, focusId) {
     const source = line.getAttribute('data-source');
     const target = line.getAttribute('data-target');
     const connectedToFocus = focusId ? (source === focusId || target === focusId) : (highlightSet.has(source) && highlightSet.has(target));
+    const ambiguous = line.getAttribute('data-ambiguous') === '1';
     // Unrelated edges go fully invisible (not just dim) while hovering - with ~1700 edges
     // rendered at once, even a low dim opacity reads as "many connections" purely from
-    // unrelated lines visually crossing near the hovered node's screen position.
-    line.setAttribute('opacity', connectedToFocus ? '0.9' : '0');
+    // unrelated lines visually crossing near the hovered node's screen position. An
+    // ambiguous edge stays visibly less certain even while focused, rather than
+    // reading as equally solid as every other highlighted connection.
+    line.setAttribute('opacity', connectedToFocus ? (ambiguous ? '0.5' : '0.9') : '0');
     line.setAttribute('stroke', connectedToFocus ? '#fff' : '#333');
   });
 }
@@ -663,7 +679,8 @@ function applyClusterFilter(clusterId) {
       const source = line.getAttribute('data-source');
       const target = line.getAttribute('data-target');
       const inCluster = memberSet.has(source) && memberSet.has(target);
-      line.setAttribute('opacity', inCluster ? '0.9' : '0');
+      const ambiguous = line.getAttribute('data-ambiguous') === '1';
+      line.setAttribute('opacity', inCluster ? (ambiguous ? '0.5' : '0.9') : '0');
       line.setAttribute('stroke', inCluster ? '#fff' : '#333');
     });
   });
@@ -693,7 +710,7 @@ function clearGraphFilter() {
       circle.setAttribute('r', circle.getAttribute('data-base-r') || '6');
     });
     svg.querySelectorAll('line').forEach(line => {
-      line.setAttribute('opacity', '1');
+      line.setAttribute('opacity', line.getAttribute('data-ambiguous') === '1' ? '0.35' : '1');
       line.setAttribute('stroke', '#333');
     });
   });

--- a/src/aletheore/dashboard.py
+++ b/src/aletheore/dashboard.py
@@ -14,6 +14,7 @@ from aletheore.evidence import (
 )
 from aletheore.history import list_snapshots
 from aletheore.mcp_server import build_server, read_evidence
+from aletheore.wiki_diagrams import _ambiguous_edges
 
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
 
@@ -87,6 +88,14 @@ def build_history_summary(repo_path: Path) -> list[dict]:
 def build_graph_summary(evidence: dict) -> dict:
     dependency_graph = evidence["repository"]["dependency_graph"]
     clusters = evidence["architecture"]["clusters"]
+    # Same exclusion, same reasoning, as wiki_diagrams.py's mermaid builders:
+    # a rendered edge in this interactive graph reads as "this file depends
+    # on that one," a stronger claim than a citable-but-uncertain evidence
+    # edge should make. Only genuine multi-candidate uncertainty (currently
+    # C# type-reference edges - see scanner/graph.py's
+    # _csharp_type_reference_targets) is excluded; a source-root/prefix
+    # tiebreak among real candidates ("inferred") is still drawn.
+    ambiguous = _ambiguous_edges(evidence["repository"].get("modules", []))
 
     node_to_cluster: dict[str, int] = {}
     for cluster in clusters:
@@ -98,7 +107,9 @@ def build_graph_summary(evidence: dict) -> dict:
         for node in dependency_graph["nodes"]
     ]
     edges = [
-        {"source": edge[0], "target": edge[1]} for edge in dependency_graph["edges"]
+        {"source": edge[0], "target": edge[1]}
+        for edge in dependency_graph["edges"]
+        if (edge[0], edge[1]) not in ambiguous
     ]
 
     return {"nodes": nodes, "edges": edges, "clusters": clusters}

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -87,7 +87,9 @@ def _resolve_from_import_binding(
                 continue
             module_name = source[module_node.start_byte:module_node.end_byte].decode()
             imported_name = source[imported_node.start_byte:imported_node.end_byte].decode()
-            target = _resolve_python_from_import(repo_path, module_name, imported_name, path, source_roots)
+            target, _ambiguous = _resolve_python_from_import(
+                repo_path, module_name, imported_name, path, source_roots
+            )
             if target is not None:
                 return target
     return None

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -37,7 +37,7 @@ from aletheore.secrets import (
 from aletheore.toon_encoding import ToonEncodingError, to_toon
 from aletheore.vulnerabilities import check_vulnerabilities as check_dependency_vulnerabilities
 
-EVIDENCE_VERSION = "0.4.0"
+EVIDENCE_VERSION = "0.5.0"
 
 
 def _version_compatibility_key(version: str) -> tuple[int, int] | None:

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1315,43 +1315,47 @@ def _java_class_file(root: Path, segments: list[str]) -> Path | None:
 
 def _resolve_java_import(
     source_roots: list[Path], dotted: str, is_static: bool, is_wildcard: bool
-) -> list[Path]:
+) -> tuple[list[Path], bool]:
+    """Returns (resolved files, was_ambiguous) - was_ambiguous is True when
+    more than one source root had a matching candidate and a fixed tiebreak
+    (source_roots' own order - see its sort in build_module_graph) had to
+    pick one, as opposed to there only ever having been one candidate.
+    """
     segments = dotted.split(".")
     if not segments:
-        return []
+        return [], False
 
     if is_wildcard:
         # dotted is a package path with no class name - every .java file directly
         # in that package's directory is what a wildcard import pulls in, the same
         # "import the whole package" fan-out Go's package-level imports need.
-        for root in source_roots:
-            package_dir = root.joinpath(*segments)
-            if package_dir.is_dir():
-                return sorted(package_dir.glob("*.java"))
-        return []
+        matching_roots = [root for root in source_roots if root.joinpath(*segments).is_dir()]
+        if not matching_roots:
+            return [], False
+        return sorted(matching_roots[0].joinpath(*segments).glob("*.java")), len(matching_roots) > 1
 
     if is_static:
         # "import static a.b.C.MEMBER" - MEMBER is a field or method, not a class;
         # the file that actually exists is a.b.C.java.
         segments = segments[:-1]
         if not segments:
-            return []
+            return [], False
 
-    for root in source_roots:
-        target = _java_class_file(root, segments)
-        if target is not None:
-            return [target]
+    matches = [target for root in source_roots if (target := _java_class_file(root, segments)) is not None]
+    if matches:
+        return [matches[0]], len(matches) > 1
 
     # One segment short: the same fallback Python/Rust already use - the last
     # segment might be a nested class rather than its own top-level file, in
     # which case the containing class's own file is the real target.
     if len(segments) > 1:
-        for root in source_roots:
-            target = _java_class_file(root, segments[:-1])
-            if target is not None:
-                return [target]
+        matches = [
+            target for root in source_roots if (target := _java_class_file(root, segments[:-1])) is not None
+        ]
+        if matches:
+            return [matches[0]], len(matches) > 1
 
-    return []
+    return [], False
 
 
 def _leading_ruby_doc_comment(source: bytes, enclosing_node: Node) -> str | None:
@@ -1588,29 +1592,35 @@ def _load_php_psr4_map(repo_path: Path) -> dict[str, Path]:
     return mapping
 
 
-def _resolve_php_use(psr4_map: dict[str, Path], qualified_name: str) -> Path | None:
+def _resolve_php_use(psr4_map: dict[str, Path], qualified_name: str) -> tuple[Path | None, bool]:
+    """Returns (resolved file, was_ambiguous) - was_ambiguous is True when
+    more than one registered PSR-4 prefix matched and the longest-prefix rule
+    had to pick one.
+    """
     qualified_name = qualified_name.lstrip("\\")
 
     # PSR-4 requires the longest matching prefix to win when more than one could
     # apply (e.g. "App\\" -> src/ and "App\\Tests\\" -> tests/ both matching
     # "App\Tests\Foo" - the more specific one is correct).
-    best_prefix: str | None = None
+    matching_prefixes: list[str] = []
     for prefix in psr4_map:
         normalized = prefix.rstrip("\\")
         if qualified_name == normalized or qualified_name.startswith(normalized + "\\"):
-            if best_prefix is None or len(normalized) > len(best_prefix.rstrip("\\")):
-                best_prefix = prefix
+            matching_prefixes.append(prefix)
 
-    if best_prefix is None:
-        return None
+    if not matching_prefixes:
+        return None, False
+    best_prefix = max(matching_prefixes, key=lambda p: len(p.rstrip("\\")))
 
     remainder = qualified_name[len(best_prefix.rstrip("\\")):].lstrip("\\")
     if not remainder:
-        return None
+        return None, False
 
     parts = remainder.split("\\")
     candidate = psr4_map[best_prefix].joinpath(*parts[:-1], f"{parts[-1]}.php")
-    return candidate if candidate.is_file() else None
+    if not candidate.is_file():
+        return None, False
+    return candidate, len(matching_prefixes) > 1
 
 
 def _resolve_php_include(from_file: Path, spec: str) -> Path | None:
@@ -1882,7 +1892,7 @@ def _csharp_type_reference_targets(
     source: bytes,
     own_types: set[str],
     type_owners: dict[str, set[Path]],
-) -> list[Path]:
+) -> list[tuple[Path, bool]]:
     """Files this one depends on by *naming their types*, not by importing them.
 
     C# needs no `using` to reference a type in the same namespace, so an
@@ -1893,11 +1903,13 @@ def _csharp_type_reference_targets(
     modules, one per file. That is not a parsing bug; there is genuinely nothing
     to parse. The dependency exists in the body, where a type is named.
 
-    Deliberately conservative, because a false edge invents a relationship the
-    wiki will then confidently explain: only names declared in exactly ONE file
-    in the repository count, so an ambiguous name contributes nothing.
+    Returns (target, was_ambiguous) pairs. A name declared in more than one
+    file in the repository still produces an edge - to a deterministically
+    chosen owner - flagged ambiguous, rather than silently contributing
+    nothing (the previous behavior: dropping it outright, which loses
+    strictly more information than keeping a flagged guess does).
     """
-    referenced: list[Path] = []
+    referenced: list[tuple[Path, bool]] = []
     seen: set[str] = set()
     for match in _IDENTIFIER_RE.finditer(source.decode("utf-8", "ignore")):
         name = match.group(0)
@@ -1908,11 +1920,14 @@ def _csharp_type_reference_targets(
         ):
             continue
         owners = type_owners.get(name)
-        # Exactly one declaring file, or we cannot say which one is meant.
-        if owners is None or len(owners) != 1:
+        if not owners:
             continue
         seen.add(name)
-        referenced.append(next(iter(owners)))
+        # More than one declaring file: still an edge (more informative than
+        # dropping it - the reader loses nothing that a dropped edge would
+        # have preserved), just to a deterministically-chosen one, flagged
+        # ambiguous rather than presented as certain.
+        referenced.append((sorted(owners)[0], len(owners) > 1))
         if len(referenced) >= _CSHARP_MAX_TYPE_EDGES:
             break
     return referenced
@@ -1967,7 +1982,11 @@ def _csharp_prefix_and_root_for(file_path: Path, namespace: str | None) -> tuple
     return namespace + ".", file_path.parent
 
 
-def _resolve_csharp_using(prefix_map: dict[str, Path], dotted: str) -> list[Path]:
+def _resolve_csharp_using(prefix_map: dict[str, Path], dotted: str) -> tuple[list[Path], bool]:
+    """Returns (resolved files, was_ambiguous) - was_ambiguous is True when
+    more than one registered namespace prefix matched and the longest-prefix
+    rule had to pick one.
+    """
     # "using Namespace;" imports the WHOLE namespace, not any specific type -
     # unlike Java's import (which explicitly names one class to bring in), C#
     # offers no way to tell which specific class is actually depended on from the
@@ -1980,22 +1999,18 @@ def _resolve_csharp_using(prefix_map: dict[str, Path], dotted: str) -> list[Path
     # instead the same way Go's package-level import already is: fan out to
     # every file in the corresponding directory, since a namespace is the actual
     # granularity "using" operates at.
-    best_prefix: str | None = None
-    for prefix in prefix_map:
-        if dotted.startswith(prefix):
-            if best_prefix is None or len(prefix) > len(best_prefix):
-                best_prefix = prefix
-
-    if best_prefix is None:
-        return []
+    matching_prefixes = [prefix for prefix in prefix_map if dotted.startswith(prefix)]
+    if not matching_prefixes:
+        return [], False
+    best_prefix = max(matching_prefixes, key=len)
 
     remainder = dotted[len(best_prefix):]
     root = prefix_map[best_prefix]
     namespace_dir = root if not remainder else root.joinpath(*remainder.split("."))
     if not namespace_dir.is_dir():
-        return []
+        return [], False
 
-    return sorted(namespace_dir.glob("*.cs"))
+    return sorted(namespace_dir.glob("*.cs")), len(matching_prefixes) > 1
 
 
 def _load_csharp_implicit_usings(repo_path: Path, source_paths: list[Path]) -> dict[Path, list[str]]:
@@ -2114,9 +2129,15 @@ def _resolve_python_module(
     dotted: str,
     from_file: Path | None = None,
     source_roots: list[Path] | None = None,
-) -> str | None:
+) -> tuple[str | None, bool]:
+    """Returns (resolved module path, was_ambiguous) - was_ambiguous is True
+    when more than one source root resolved this dotted path and a fixed
+    tiebreak (source_roots' own order - see its sort in _python_source_roots)
+    had to pick one, as opposed to there only ever having been one root that
+    could resolve it.
+    """
     if not dotted:
-        return None
+        return None, False
 
     if dotted.startswith("."):
         # Relative import ("from ..services.sessions import x"). tree-sitter hands us
@@ -2125,20 +2146,28 @@ def _resolve_python_module(
         # "the package containing from_file" (from_file.parent itself), each
         # additional dot goes up one more parent directory.
         if from_file is None:
-            return None
+            return None, False
         dot_count = len(dotted) - len(dotted.lstrip("."))
         remainder = dotted[dot_count:]
         base_dir = from_file.parent
         for _ in range(dot_count - 1):
             base_dir = base_dir.parent
         as_path = base_dir if not remainder else base_dir / Path(*remainder.split("."))
-        return _module_or_package_path(repo_path, as_path)
+        return _module_or_package_path(repo_path, as_path), False
 
-    for root in (source_roots if source_roots is not None else [repo_path]):
+    roots = source_roots if source_roots is not None else [repo_path]
+    matches: list[str] = []
+    for root in roots:
         target = _module_or_package_path(repo_path, root / Path(*dotted.split(".")))
         if target is not None:
-            return target
-    return None
+            matches.append(target)
+            if len(roots) == 1:
+                # Only one root exists at all - it can't be ambiguous, so
+                # there is nothing to gain from continuing to check others.
+                break
+    if not matches:
+        return None, False
+    return matches[0], len(matches) > 1
 
 
 def _resolve_python_from_import(
@@ -2147,7 +2176,7 @@ def _resolve_python_from_import(
     imported_name: str,
     from_file: Path,
     source_roots: list[Path] | None = None,
-) -> str | None:
+) -> tuple[str | None, bool]:
     # A relative module_name already ends in the dots that separate it from what
     # follows ("." or ".." or "..services.sessions"); appending imported_name with an
     # extra "." separator only when module_name does NOT already end in a dot avoids
@@ -2159,9 +2188,9 @@ def _resolve_python_from_import(
         submodule_dotted = f"{module_name}.{imported_name}"
     else:
         submodule_dotted = f"{module_name}{imported_name}"
-    target = _resolve_python_module(repo_path, submodule_dotted, from_file, source_roots)
+    target, ambiguous = _resolve_python_module(repo_path, submodule_dotted, from_file, source_roots)
     if target is not None:
-        return target
+        return target, ambiguous
     return _resolve_python_module(repo_path, module_name, from_file, source_roots)
 
 
@@ -2211,6 +2240,16 @@ def _extract_module(
     """
     rel_path = _rel(repo_path, path)
     resolved_imports: list[str] = []
+    # Populated only for a resolved edge whose resolution wasn't a single
+    # deterministic outcome - a source root/namespace-prefix/PSR-4-prefix
+    # tiebreak among genuine multiple candidates ("inferred"), or a C#
+    # type-reference kept despite more than one file declaring that type
+    # name ("ambiguous"). Deliberately omitted (both the key and, when
+    # empty, the whole field on the returned module dict below) for the
+    # common single-candidate case, so this costs nothing in evidence-packet
+    # size for the large majority of edges and the six languages whose
+    # resolvers are never ambiguous at all (js/ts, go, rust, ruby, c/cpp).
+    import_confidence: dict[str, str] = {}
 
     constants: list[dict] = []
     if language_name != "python":
@@ -2222,23 +2261,29 @@ def _extract_module(
         plain_imports, from_imports, functions, classes, constants = _extract_python(tree.root_node, source)
 
         for dotted in plain_imports:
-            target = _resolve_python_module(repo_path, dotted, path, python_source_roots)
+            target, ambiguous = _resolve_python_module(repo_path, dotted, path, python_source_roots)
             if target is not None:
                 resolved_imports.append(target)
+                if ambiguous:
+                    import_confidence[target] = "inferred"
 
         for module_name, names in from_imports:
             targets: set[str] = set()
             if names:
                 for name in names:
-                    target = _resolve_python_from_import(
+                    target, ambiguous = _resolve_python_from_import(
                         repo_path, module_name, name, path, python_source_roots
                     )
                     if target is not None:
                         targets.add(target)
+                        if ambiguous:
+                            import_confidence[target] = "inferred"
             else:
-                target = _resolve_python_module(repo_path, module_name, path, python_source_roots)
+                target, ambiguous = _resolve_python_module(repo_path, module_name, path, python_source_roots)
                 if target is not None:
                     targets.add(target)
+                    if ambiguous:
+                        import_confidence[target] = "inferred"
             resolved_imports.extend(sorted(targets))
     elif language_name == "go":
         raw_imports, functions, classes = _extract_go(tree.root_node, source)
@@ -2256,10 +2301,13 @@ def _extract_module(
     elif language_name == "java":
         raw_imports, functions, classes = _extract_java(tree.root_node, source)
         for dotted, is_static, is_wildcard in raw_imports:
-            for target_path in _resolve_java_import(java_source_roots, dotted, is_static, is_wildcard):
+            targets, ambiguous = _resolve_java_import(java_source_roots, dotted, is_static, is_wildcard)
+            for target_path in targets:
                 target = _rel(repo_path, target_path)
                 if target is not None and target != rel_path:
                     resolved_imports.append(target)
+                    if ambiguous:
+                        import_confidence[target] = "inferred"
     elif language_name == "ruby":
         raw_imports, functions, classes = _extract_ruby(tree.root_node, source)
         for kind, spec in raw_imports:
@@ -2271,13 +2319,17 @@ def _extract_module(
     elif language_name == "php":
         raw_imports, functions, classes = _extract_php(tree.root_node, source)
         for kind, spec in raw_imports:
-            target_path = (
-                _resolve_php_use(php_psr4_map, spec) if kind == "use" else _resolve_php_include(path, spec)
-            )
+            ambiguous = False
+            if kind == "use":
+                target_path, ambiguous = _resolve_php_use(php_psr4_map, spec)
+            else:
+                target_path = _resolve_php_include(path, spec)
             if target_path is not None:
                 target = _rel(repo_path, target_path)
                 if target is not None and target != rel_path:
                     resolved_imports.append(target)
+                    if ambiguous:
+                        import_confidence[target] = "inferred"
     elif language_name in ("c", "cpp"):
         raw_imports, functions, classes = _extract_c_family(tree.root_node, source)
         for spec in raw_imports:
@@ -2290,19 +2342,26 @@ def _extract_module(
         raw_imports, functions, classes = _extract_csharp(tree.root_node, source)
         raw_imports.extend((csharp_implicit_usings or {}).get(path, []))
         for dotted in raw_imports:
-            for target_path in _resolve_csharp_using(csharp_prefix_map or {}, dotted):
+            targets, ambiguous = _resolve_csharp_using(csharp_prefix_map or {}, dotted)
+            for target_path in targets:
                 target = _rel(repo_path, target_path)
                 if target is not None and target != rel_path:
                     resolved_imports.append(target)
+                    if ambiguous:
+                        import_confidence[target] = "inferred"
         # Same-namespace references need no `using`, so usings alone leave
         # the graph near-empty - see _csharp_type_reference_targets.
         own_type_names = {c["name"] for c in classes if c.get("name")}
         already = set(resolved_imports)
-        for target_path in _csharp_type_reference_targets(source, own_type_names, csharp_type_owners or {}):
+        for target_path, type_ref_ambiguous in _csharp_type_reference_targets(
+            source, own_type_names, csharp_type_owners or {}
+        ):
             target = _rel(repo_path, target_path)
             if target is not None and target != rel_path and target not in already:
                 already.add(target)
                 resolved_imports.append(target)
+                if type_ref_ambiguous:
+                    import_confidence[target] = "ambiguous"
     else:
         raw_imports, functions, classes = _extract_javascript(tree.root_node, source)
         for spec in raw_imports:
@@ -2310,13 +2369,16 @@ def _extract_module(
             if target is not None:
                 resolved_imports.append(target)
 
-    return {
+    module: dict = {
         "path": rel_path,
         "language": language_name,
         "imports": resolved_imports,
         "imported_by": [],
         "symbols": {"functions": functions, "classes": classes, "constants": constants},
     }
+    if import_confidence:
+        module["import_confidence"] = import_confidence
+    return module
 
 
 def _read_and_parse(path: Path, parser: Parser, ts_language: Language) -> tuple[bytes, Tree]:
@@ -2586,6 +2648,14 @@ def build_module_graph(
         root = _java_source_root_for(path, package)
         if root is not None and root not in java_source_roots:
             java_source_roots.append(root)
+    # Appended in _iter_source_files walk order, which is filesystem-dependent
+    # and not guaranteed stable across runs/platforms - an ambiguous import
+    # (resolvable via more than one root) could otherwise resolve differently
+    # between two scans of the identical repo. Same fix, same reasoning, as
+    # _python_source_roots' own sort below: shallower roots first, since a
+    # root closer to repo_path is more likely to be the actually-configured
+    # one than one nested deep inside a single module.
+    java_source_roots.sort(key=lambda p: (len(p.parts), str(p)))
 
     php_psr4_map = _load_php_psr4_map(repo_path)
 

--- a/src/aletheore/wiki_diagrams.py
+++ b/src/aletheore/wiki_diagrams.py
@@ -22,6 +22,28 @@ def _file_to_cluster_map(clusters: list[dict]) -> dict[str, int]:
     return mapping
 
 
+def _ambiguous_edges(modules: list[dict]) -> set[tuple[str, str]]:
+    """(source, target) pairs whose resolution was genuinely uncertain - a C#
+    type-reference edge kept despite more than one file declaring that type
+    name (see scanner/graph.py's _csharp_type_reference_targets). Excluded
+    from diagrams, not from the underlying evidence: a diagram asserts "this
+    relationship exists" more strongly than a citable-but-uncertain graph
+    edge should. "inferred" edges (a source-root/prefix tiebreak among
+    multiple real candidates, still likely correct) are drawn as normal -
+    only a name that could equally be any of several files is excluded.
+    """
+    pairs: set[tuple[str, str]] = set()
+    for module in modules:
+        confidence = module.get("import_confidence")
+        if not confidence:
+            continue
+        source = module.get("path")
+        for target, level in confidence.items():
+            if level == "ambiguous":
+                pairs.add((source, target))
+    return pairs
+
+
 def build_overview_diagram(evidence: dict, cluster_names: dict[int, str] | None = None) -> str:
     """One node per subsystem (cluster), edges for inter-cluster dependencies.
 
@@ -35,16 +57,23 @@ def build_overview_diagram(evidence: dict, cluster_names: dict[int, str] | None 
     where nothing happens to import across cluster boundaries yet), there
     is no meaningful subset to narrow down to - showing every cluster is
     strictly better than showing none.
+
+    Ambiguous edges (see _ambiguous_edges) are excluded - see
+    build_subsystem_diagram's own docstring for why.
     """
     cluster_names = cluster_names or {}
     clusters = evidence.get("architecture", {}).get("clusters", [])
+    modules = evidence.get("repository", {}).get("modules", [])
     edges = evidence.get("repository", {}).get("dependency_graph", {}).get("edges", [])
+    ambiguous = _ambiguous_edges(modules)
 
     file_to_cluster = _file_to_cluster_map(clusters)
 
     cluster_edges: set[tuple[int, int]] = set()
     for edge in edges:
         source_file, target_file = edge[0], edge[1]
+        if (source_file, target_file) in ambiguous:
+            continue
         source_cluster = file_to_cluster.get(source_file)
         target_cluster = file_to_cluster.get(target_file)
         if source_cluster is None or target_cluster is None or source_cluster == target_cluster:
@@ -72,6 +101,18 @@ def build_subsystem_diagram(evidence: dict, cluster: dict) -> str:
     file the scanner doesn't track, e.g. a third-party package) are not
     drawn - this diagram is intentionally scoped to the subsystem's own
     internal structure, not the whole repo.
+
+    Edges flagged "ambiguous" in import_confidence (currently only C#
+    type-reference edges kept despite more than one file declaring that
+    type name - see scanner/graph.py's _csharp_type_reference_targets) are
+    excluded here even though they remain in the underlying evidence. A
+    diagram is a stronger claim than a citable graph edge - "this file
+    depends on that one" read as fact, not as "probably, among a few
+    candidates" - and measured on a real C#-heavy corpus (AutoMapper),
+    keeping instead of dropping these added roughly a third more raw edges
+    than existed before. "inferred" edges (a source-root/prefix tiebreak
+    among multiple real candidates, generally still correct) are drawn as
+    normal; only genuine "which-of-several-files" uncertainty is excluded.
     """
     member_files = cluster.get("modules", [])
     member_set = set(member_files)
@@ -88,8 +129,11 @@ def build_subsystem_diagram(evidence: dict, cluster: dict) -> str:
         module = modules_by_path.get(path)
         if module is None:
             continue
+        confidence = module.get("import_confidence") or {}
         for imported in module.get("imports", []):
             if imported not in member_set:
+                continue
+            if confidence.get(imported) == "ambiguous":
                 continue
             edge = (path, imported)
             if edge in drawn_edges:

--- a/src/tests/test_air_schema.py
+++ b/src/tests/test_air_schema.py
@@ -22,8 +22,8 @@ from tests.air_fixtures import minimal_air_evidence
 # stays "compatible" by version check while actually having a different
 # shape - which is exactly the silent drift the version field exists to
 # prevent. See docs/AIR-SCHEMA.md for the migration rules.
-EXPECTED_SCHEMA_FINGERPRINT = "a1913a5f5c1e8756"
-EXPECTED_EVIDENCE_VERSION = "0.4.0"
+EXPECTED_SCHEMA_FINGERPRINT = "97617d14cabe43a5"
+EXPECTED_EVIDENCE_VERSION = "0.5.0"
 
 
 def test_schema_changes_require_an_evidence_version_bump():

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -169,6 +169,26 @@ def test_build_graph_summary_handles_unclustered_node():
     assert result["nodes"] == [{"id": "orphan.py", "cluster": None}]
 
 
+def test_build_graph_summary_excludes_ambiguous_edges():
+    # Same reasoning as wiki_diagrams.py's mermaid builders: this graph is
+    # rendered as fact ("a.py depends on b.py"), a stronger claim than a
+    # citable-but-uncertain evidence edge should make.
+    evidence = {
+        "repository": {
+            "modules": [{"path": "a.py", "imports": ["b.py"], "import_confidence": {"b.py": "ambiguous"}}],
+            "dependency_graph": {
+                "nodes": ["a.py", "b.py"],
+                "edges": [["a.py", "b.py"]],
+            },
+        },
+        "architecture": {"clusters": []},
+    }
+
+    result = build_graph_summary(evidence)
+
+    assert result["edges"] == []
+
+
 def _deep_merge(base: dict, overrides: dict) -> dict:
     for key, value in overrides.items():
         if isinstance(value, dict) and isinstance(base.get(key), dict):

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -169,16 +169,23 @@ def test_build_graph_summary_handles_unclustered_node():
     assert result["nodes"] == [{"id": "orphan.py", "cluster": None}]
 
 
-def test_build_graph_summary_excludes_ambiguous_edges():
-    # Same reasoning as wiki_diagrams.py's mermaid builders: this graph is
-    # rendered as fact ("a.py depends on b.py"), a stronger claim than a
-    # citable-but-uncertain evidence edge should make.
+def test_build_graph_summary_marks_ambiguous_edges_rather_than_excluding_them():
+    # Unlike wiki_diagrams.py's static mermaid builders (which exclude these
+    # entirely), this graph is interactive - an ambiguous edge is still
+    # drawn, just marked so the frontend can dim/dash it instead of
+    # presenting it identically to a certain edge.
     evidence = {
         "repository": {
-            "modules": [{"path": "a.py", "imports": ["b.py"], "import_confidence": {"b.py": "ambiguous"}}],
+            "modules": [
+                {
+                    "path": "a.py",
+                    "imports": ["b.py", "c.py"],
+                    "import_confidence": {"b.py": "ambiguous"},
+                }
+            ],
             "dependency_graph": {
-                "nodes": ["a.py", "b.py"],
-                "edges": [["a.py", "b.py"]],
+                "nodes": ["a.py", "b.py", "c.py"],
+                "edges": [["a.py", "b.py"], ["a.py", "c.py"]],
             },
         },
         "architecture": {"clusters": []},
@@ -186,7 +193,10 @@ def test_build_graph_summary_excludes_ambiguous_edges():
 
     result = build_graph_summary(evidence)
 
-    assert result["edges"] == []
+    assert result["edges"] == [
+        {"source": "a.py", "target": "b.py", "ambiguous": True},
+        {"source": "a.py", "target": "c.py"},
+    ]
 
 
 def _deep_merge(base: dict, overrides: dict) -> dict:

--- a/src/tests/test_evidence.py
+++ b/src/tests/test_evidence.py
@@ -36,12 +36,13 @@ def run(repo: Path, *args: str):
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
 
 
-def test_evidence_version_is_0_4_0():
-    # Bumped 0.3.0 -> 0.4.0 alongside AIR_JSON_SCHEMA's new git.file_ownership
-    # field - see docs/AIR-SCHEMA.md's migration rules (any schema change
-    # requires a MINOR bump). This test asserts the exact pin deliberately,
-    # so it must move in lockstep with the next schema change too.
-    assert EVIDENCE_VERSION == "0.4.0"
+def test_evidence_version_is_0_5_0():
+    # Bumped 0.4.0 -> 0.5.0 alongside AIR_JSON_SCHEMA's new
+    # repository.modules[].import_confidence field - see docs/AIR-SCHEMA.md's
+    # migration rules (any schema change requires a MINOR bump). This test
+    # asserts the exact pin deliberately, so it must move in lockstep with
+    # the next schema change too.
+    assert EVIDENCE_VERSION == "0.5.0"
 
 
 def make_repo(tmp_path: Path) -> Path:

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -397,6 +397,48 @@ def test_python_source_roots_returns_a_sorted_deterministic_list(tmp_path):
     assert roots == [repo, repo / "app", repo / "src"]
 
 
+def test_ambiguous_absolute_import_is_flagged_inferred(tmp_path):
+    # Same two-project monorepo shape as the sorted-roots test above, but this
+    # time the same dotted path ("shared.util") genuinely exists under both
+    # source roots - a real tiebreak, not just multiple roots existing. The
+    # edge still resolves (to whichever root sorts first, same determinism as
+    # above), but import_confidence must record that a choice was made among
+    # more than one real candidate, not presented as a certain resolution.
+    repo = tmp_path / "repo"
+    for project in ("app", "src"):
+        pkg_dir = repo / project / "shared"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "util.py").write_text("x = 1\n")
+    (repo / "main.py").write_text("import shared.util\n")
+
+    modules, _graph, _unparseable = build_module_graph(repo)
+    by_path = {m["path"]: m for m in modules}
+
+    main = by_path["main.py"]
+    assert main["imports"] == ["app/shared/util.py"]
+    assert main["import_confidence"] == {"app/shared/util.py": "inferred"}
+
+
+def test_unambiguous_absolute_import_gets_no_confidence_entry(tmp_path):
+    # The overwhelmingly common case (single source root, or a dotted path
+    # only one root can resolve) must cost nothing - no import_confidence
+    # key for the edge, and no import_confidence field on the module at all.
+    repo = tmp_path / "repo"
+    pkg_dir = repo / "shared"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "util.py").write_text("x = 1\n")
+    (repo / "main.py").write_text("import shared.util\n")
+
+    modules, _graph, _unparseable = build_module_graph(repo)
+    by_path = {m["path"]: m for m in modules}
+
+    main = by_path["main.py"]
+    assert main["imports"] == ["shared/util.py"]
+    assert "import_confidence" not in main
+
+
 def test_build_module_graph_import_resolution_ignores_nested_git_worktree(tmp_path):
     # A different layer of the same real bug as
     # test_build_module_graph_ignores_nested_git_worktree above: that test

--- a/src/tests/test_graph_csharp.py
+++ b/src/tests/test_graph_csharp.py
@@ -375,9 +375,40 @@ def test_csharp_type_reference_does_not_invent_edges_for_unrelated_files(tmp_pat
     assert "src/Loner.cs" not in by_path["src/Mapper.cs"]["imports"]
 
 
-def test_csharp_ambiguous_type_name_declared_twice_creates_no_edge(tmp_path):
-    """A false edge invents a dependency the wiki then explains, so a name that
-    two files declare must contribute nothing rather than guess."""
+def test_csharp_ambiguous_using_prefix_is_flagged_inferred(tmp_path):
+    # Two distinct registered namespace prefixes both match "App.Extra.Foo" -
+    # "App." (from Handler.cs, whose directory doesn't mirror the "App"
+    # segment) and the more specific "App.Extra." (from Thing.cs, same
+    # reasoning one level deeper). The longest-prefix rule resolves it
+    # deterministically, but two real candidates existed, not one.
+    repo = tmp_path / "repo"
+    (repo / "Handlers").mkdir(parents=True)
+    (repo / "Extra" / "Sub").mkdir(parents=True)
+    (repo / "Extra" / "Foo").mkdir(parents=True)
+    (repo / "Handlers" / "Handler.cs").write_text(
+        "namespace App.Handlers\n{\n    public class Handler\n    {\n    }\n}\n"
+    )
+    (repo / "Extra" / "Sub" / "Thing.cs").write_text(
+        "namespace App.Extra.Sub\n{\n    public class Thing\n    {\n    }\n}\n"
+    )
+    (repo / "Extra" / "Foo" / "Bar.cs").write_text(
+        "namespace App.Extra.Foo\n{\n    public class Bar\n    {\n    }\n}\n"
+    )
+    (repo / "Main.cs").write_text("using App.Extra.Foo;\n\nclass Program\n{\n}\n")
+
+    modules, _dependency_graph, _unparseable = build_module_graph(repo)
+    by_path = {m["path"]: m for m in modules}
+
+    main = by_path["Main.cs"]
+    assert main["imports"] == ["Extra/Foo/Bar.cs"]
+    assert main["import_confidence"] == {"Extra/Foo/Bar.cs": "inferred"}
+
+
+def test_csharp_ambiguous_type_name_declared_twice_creates_a_flagged_edge(tmp_path):
+    """A name two files declare still produces an edge - to a deterministically
+    chosen owner (sorted first) - rather than contributing nothing, since dropping
+    it loses strictly more information than keeping a flagged guess does. The
+    uncertainty is surfaced via import_confidence, not by silently guessing."""
     repo = tmp_path / "repo"
     (repo / "a").mkdir(parents=True)
     (repo / "b").mkdir(parents=True)
@@ -390,7 +421,8 @@ def test_csharp_ambiguous_type_name_declared_twice_creates_no_edge(tmp_path):
     )
     modules, _edges = build_module_graph(repo)[:2]
     by_path = {m["path"]: m for m in modules}
-    assert by_path["user.cs"]["imports"] == []
+    assert by_path["user.cs"]["imports"] == ["a/Duplicate.cs"]
+    assert by_path["user.cs"]["import_confidence"] == {"a/Duplicate.cs": "ambiguous"}
 
 
 def test_csharp_short_type_names_are_not_matched(tmp_path):

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -114,6 +114,35 @@ def test_build_module_graph_java_source_root_inferred_from_package(tmp_path):
     ) in edges
 
 
+def test_build_module_graph_java_ambiguous_import_is_flagged_inferred(tmp_path):
+    # Two independent source trees (no shared src/main/java prefix, so each
+    # contributes its own distinct root) each declare com.example.Shared -
+    # a real multi-root tiebreak, resolved deterministically (moduleA sorts
+    # before moduleB) but flagged, not silently presented as certain.
+    repo = tmp_path / "repo"
+    module_a = repo / "moduleA" / "com" / "example"
+    module_b = repo / "moduleB" / "com" / "example"
+    module_a.mkdir(parents=True)
+    module_b.mkdir(parents=True)
+    (module_a / "Shared.java").write_text(
+        "package com.example;\n\npublic class Shared {\n    public int x;\n}\n"
+    )
+    (module_b / "Shared.java").write_text(
+        "package com.example;\n\npublic class Shared {\n    public int x;\n}\n"
+    )
+    (module_a / "User.java").write_text(
+        "package com.example;\n\nimport com.example.Shared;\n\n"
+        "public class User {\n    private Shared s;\n}\n"
+    )
+
+    modules, _dependency_graph, _unparseable = build_module_graph(repo)
+    by_path = {m["path"]: m for m in modules}
+
+    user = by_path["moduleA/com/example/User.java"]
+    assert user["imports"] == ["moduleA/com/example/Shared.java"]
+    assert user["import_confidence"] == {"moduleA/com/example/Shared.java": "inferred"}
+
+
 def test_build_module_graph_java_direct_import_resolves(tmp_path):
     repo = make_java_repo(tmp_path)
     _, dependency_graph, _ = build_module_graph(repo)

--- a/src/tests/test_graph_php.py
+++ b/src/tests/test_graph_php.py
@@ -94,6 +94,30 @@ def test_build_module_graph_php_psr4_use_resolves(tmp_path):
     assert ("main.php", "src/Handlers/Handler.php") in edges
 
 
+def test_build_module_graph_php_psr4_ambiguous_prefix_is_flagged_inferred(tmp_path):
+    # Two registered PSR-4 prefixes both match "App\Extra\Foo" ("App\" -> src/
+    # and the more specific "App\Extra\" -> extra/) - PSR-4's own
+    # longest-prefix-wins rule resolves it deterministically, but that's still
+    # a real choice among multiple registered candidates, not a certainty.
+    repo = tmp_path / "repo"
+    (repo / "extra").mkdir(parents=True)
+    (repo / "composer.json").write_text(
+        '{"name": "example/webservice", '
+        '"autoload": {"psr-4": {"App\\\\": "src/", "App\\\\Extra\\\\": "extra/"}}}'
+    )
+    (repo / "extra" / "Foo.php").write_text(
+        "<?php\n\nnamespace App\\Extra;\n\nclass Foo\n{\n}\n"
+    )
+    (repo / "main.php").write_text("<?php\n\nuse App\\Extra\\Foo;\n")
+
+    modules, _dependency_graph, _unparseable = build_module_graph(repo)
+    by_path = {m["path"]: m for m in modules}
+
+    main = by_path["main.php"]
+    assert main["imports"] == ["extra/Foo.php"]
+    assert main["import_confidence"] == {"extra/Foo.php": "inferred"}
+
+
 def test_build_module_graph_php_dir_concat_require_resolves(tmp_path):
     repo = make_php_repo(tmp_path)
     _, dependency_graph, _ = build_module_graph(repo)

--- a/src/tests/test_wiki_diagrams.py
+++ b/src/tests/test_wiki_diagrams.py
@@ -85,3 +85,36 @@ def test_build_subsystem_diagram_only_draws_edges_within_the_cluster():
 def test_build_subsystem_diagram_handles_empty_cluster():
     diagram = build_subsystem_diagram(make_evidence(), {"id": 5, "modules": []})
     assert diagram == "flowchart TD"
+
+
+def test_build_subsystem_diagram_excludes_ambiguous_edges():
+    # A diagram is a stronger claim than a citable-but-uncertain evidence
+    # edge ("this file depends on that one," not "probably, among a few
+    # candidates") - an edge flagged "ambiguous" in import_confidence
+    # (currently only C# type-reference edges - see scanner/graph.py's
+    # _csharp_type_reference_targets) stays in the underlying evidence but
+    # must not be drawn.
+    evidence = make_evidence()
+    evidence["repository"]["modules"][0]["import_confidence"] = {"auth/tokens.py": "ambiguous"}
+    cluster = evidence["architecture"]["clusters"][0]
+    diagram = build_subsystem_diagram(evidence, cluster)
+    assert "N0 --> N1" not in diagram
+    assert diagram.count("-->") == 0
+
+
+def test_build_subsystem_diagram_draws_inferred_edges_normally():
+    # "inferred" (a source-root/prefix tiebreak among multiple real
+    # candidates, generally still correct) is a materially different kind
+    # of uncertainty from "ambiguous" - only the latter is excluded.
+    evidence = make_evidence()
+    evidence["repository"]["modules"][0]["import_confidence"] = {"auth/tokens.py": "inferred"}
+    cluster = evidence["architecture"]["clusters"][0]
+    diagram = build_subsystem_diagram(evidence, cluster)
+    assert "N0 --> N1" in diagram
+
+
+def test_build_overview_diagram_excludes_ambiguous_cross_cluster_edges():
+    evidence = make_evidence()
+    evidence["repository"]["modules"][0]["import_confidence"] = {"db/session.py": "ambiguous"}
+    diagram = build_overview_diagram(evidence)
+    assert "C0 --> C1" not in diagram


### PR DESCRIPTION
## Summary
- Adapted from researching Graphify (github.com/Graphify-Labs/graphify, YC S26): they tag every graph edge EXTRACTED/INFERRED/AMBIGUOUS. New optional `repository.modules[].import_confidence` map does the same for Aletheore's own resolvers - omitted entirely for the common exact-resolution case and for the six languages whose resolvers are never ambiguous (js/ts, go, rust, ruby, c/cpp), so this costs nothing in evidence-packet size for the large majority of edges.
- Python/Java (multi-source-root) and PHP (PSR-4 longest-prefix) tag a resolved edge `"inferred"` when a tiebreak among genuinely multiple candidates picked the winner.
- C# is the only language with a second edge type (type-reference). It previously **dropped** an edge outright on ambiguity - now it keeps the edge (deterministically chosen owner) and tags it `"ambiguous"` instead of losing the information entirely. Measured on real AutoMapper: 738 such edges that used to vanish silently are now kept.
- Found and fixed a real bug while wiring this up: Java's multi-source-root tiebreak picked whichever root came first in raw filesystem walk order (not stable across runs/platforms) - now sorted the same deterministic way Python's roots already were.
- AIR schema bumped 0.4.0 -> 0.5.0 per `docs/AIR-SCHEMA.md`'s migration rules.

## Benchmark
Measured against real, pinned per-language corpora (same ones `aletheore-benchmarks` uses):

| language | repo | edges | inferred | ambiguous | non-exact % |
|---|---|---|---|---|---|
| python | flask | 315 | 0 | 0 | 0.0% |
| go | gin | 230 | 0 | 0 | 0.0% |
| php | slim | 305 | 54 | 0 | 17.7% |
| rust | serde | 323 | 0 | 0 | 0.0% |
| ruby | jekyll | 23 | 0 | 0 | 0.0% |
| typescript | zod | 528 | 0 | 0 | 0.0% |
| java | gson | 1085 | 0 | 0 | 0.0% |
| javascript | axios | 293 | 0 | 0 | 0.0% |
| c | jq | 159 | 0 | 0 | 0.0% |
| cpp | fmt | 60 | 0 | 0 | 0.0% |
| csharp | automapper | 2860 | 152 | 738 | 31.1% |

6 of 11 languages correctly show 0% (never-ambiguous resolvers, by design). Python/Java's 0% here is a property of these single-source-root corpora, not the mechanism - proven correct by targeted unit tests, and even Veridion's own genuine multi-root Python layout has no actual name collision between its two projects (checked directly, also 0%).

## Test plan
- [x] Full `src/` suite: 1407 passed.
- [x] New targeted tests: Python multi-root ambiguity + the zero-cost unambiguous case, Java multi-root ambiguity, PHP PSR-4 ambiguity, C# using-prefix ambiguity, C# type-reference ambiguity (kept-and-flagged, replacing the old dropped-silently test).
- [x] Found and fixed a real regression during review: `endpoints.py` called `_resolve_python_from_import` directly and needed updating for the new tuple return.