### PR TITLE
feat: add MCP server instructions for connecting agents

### DIFF
--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -83,6 +83,51 @@ def read_evidence(repo_path: Path) -> dict:
     return evidence
 
 
+# Surfaced in the MCP `initialize` handshake itself - every client shows
+# this to the connecting agent before any tool is called, unlike a resource
+# the agent would have to separately think to fetch. Content sourced from
+# real, measured facts rather than generic advice: the vocabulary claim is
+# our own benchmark's finding (aletheore-benchmarks, "Where we lose" -
+# several corpora scored below 35% top-1 under vocabulary-avoiding phrasing,
+# recovering 20-47 points when the same questions used the project's own
+# terms), not a guess. Kept to what changes agent behavior, not a full tool
+# catalog - each tool's own docstring is already visible to the client.
+SERVER_INSTRUCTIONS = """Aletheore is a deterministic, evidence-grounded code intelligence tool for \
+this repository - every result cites a real file:line, nothing is invented.
+
+Getting started on an unfamiliar repo: call aletheore_overview first. If no \
+evidence exists yet, run aletheore_scan once - the deterministic parse and \
+dependency-graph pass every other tool reads from. aletheore_search_codebase \
+and aletheore_answer additionally require aletheore_index to have run first \
+(builds the semantic index on top of scan evidence); every other tool works \
+straight off scan evidence alone.
+
+Timing: aletheore_scan and aletheore_index both report live progress while \
+running, not a silent hang - a small repo finishes in seconds, a large \
+monorepo can take several minutes. Don't assume either has failed just \
+because it's still running; check the reported progress before retrying.
+
+Question phrasing matters more than for most tools. aletheore_search_codebase \
+and aletheore_answer are semantic, but our own published benchmark measured \
+real, large accuracy drops when a question avoids the codebase's own \
+vocabulary in favor of generic or paraphrased terms - several corpora scored \
+under 35% top-1 accuracy on vocabulary-avoiding phrasing, recovering 20-47 \
+points when the same question used the project's own terms instead. Prefer \
+this repo's actual identifiers, file names, and terminology over a \
+paraphrase. aletheore_overview, aletheore_symbols, and aletheore_list can \
+surface real names to query with when you're unsure of the vocabulary.
+
+Prefer exact tools when the target is already known: aletheore_imports, \
+aletheore_imported_by, aletheore_symbols, aletheore_symbol_source, \
+aletheore_neighborhood, and the aletheore_find_evidence_for_* tools are \
+exact (not approximate) and need no semantic index. So are the security/ \
+quality tools (aletheore_secrets, aletheore_vulnerabilities, \
+aletheore_licenses, aletheore_dead_code, aletheore_hotspots, \
+aletheore_layer_violations) and aletheore_search (literal/regex text \
+search, not semantic). Reach for the semantic tools only for open-ended \
+"how does this work" questions the exact tools can't answer directly."""
+
+
 def _toon_result(data: object) -> str:
     # Every tool result is TOON-encoded rather than returned as a plain dict
     # (which MCPServer would otherwise auto-serialize to JSON) - this is the
@@ -719,7 +764,7 @@ def build_server(
     """
     effects = allowed_effects(os.environ.get(_ALLOW_ENV_VAR)) if allow is None else allow
 
-    mcp_instance = MCPServer("aletheore")
+    mcp_instance = MCPServer("aletheore", instructions=SERVER_INSTRUCTIONS)
     _register_query_wrapper_tools(mcp_instance, repo_path)
     _register_changes_tool(mcp_instance, repo_path)
     _register_neighborhood_tool(mcp_instance, repo_path)

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -268,6 +268,19 @@ async def test_build_server_registers_expected_tools(tmp_path):
     assert "aletheore_answer" not in names
 
 
+def test_build_server_surfaces_instructions_in_the_handshake(tmp_path):
+    # Unlike a resource the connecting agent would have to separately think
+    # to fetch, `instructions` is surfaced in the MCP `initialize` handshake
+    # itself - every client shows it to the agent before any tool is called.
+    repo = make_repo_with_evidence(tmp_path)
+
+    server = build_server(repo)
+
+    assert server.instructions
+    assert "aletheore_overview" in server.instructions
+    assert "vocabulary" in server.instructions.lower()
+
+
 @pytest.mark.asyncio
 async def test_dynamic_query_tools_have_distinct_non_generic_descriptions(tmp_path):
     # Before this fix, every one of these 16 tools shared the same templated


### PR DESCRIPTION
## Summary
- `MCPServer.__init__` supports a real `instructions` parameter (verified via introspection before writing anything) that's surfaced in the MCP `initialize` handshake itself - shown to every connecting agent before any tool call, unlike a resource the agent would have to separately think to fetch.
- Content is sourced from real, measured facts:
  - Vocabulary-phrasing guidance cites our own published benchmark's finding (several corpora scored under 35% top-1 accuracy on vocabulary-avoiding phrasing, recovering 20-47 points when the same questions used the project's own terms).
  - Timing guidance is qualitative rather than a specific number - scan/index throughput has moved with several perf fixes this session, and a stale precise figure would mislead worse than none would - points instead at the live progress reporting both tools already emit.
- Kept to what actually changes agent behavior (getting-started order, timing expectations, phrasing, when to reach for exact vs. semantic tools), not a full tool catalog - every tool's own docstring is already visible to the client.

## Test plan
- [x] Full `src/` suite: 1403 passed.
- [x] New test asserts `build_server(...)` produces a server whose `.instructions` mentions the getting-started tool and the vocabulary guidance.