### PR TITLE
fix: cap aletheore_search's result to a total character budget

### DIFF
--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -216,6 +216,19 @@ _SEARCH_MATCH_CAP = 200
 # what happened rather than returning results.
 _SEARCH_TIMEOUT_SECONDS = 5.0
 
+# _SEARCH_MATCH_CAP alone doesn't bound the result's total size - 200
+# matches of long lines (a minified bundle, a generated file, a single huge
+# JSON line) can still produce an oversized result even under the count
+# cap. Confirmed live: an unscoped literal search on a common word returned
+# a result the calling MCP client rejected outright for exceeding its own
+# ~390,000-char limit, with 200 matches well under the count cap. Both caps
+# below exist because either alone is insufficient - a handful of huge
+# lines defeats the count cap (this repro: 200 matches x 3000-char lines =
+# ~600,000 chars), and a huge number of merely-long lines would defeat a
+# per-line cap without an aggregate budget too.
+_SEARCH_LINE_MAX_CHARS = 500
+_SEARCH_TOTAL_CHAR_BUDGET = 100_000
+
 
 def _search_files(repo_path: Path, pattern: str, regex: bool, path_glob: str | None) -> dict:
     """The actual search. Literal (non-regex) mode has no backtracking risk
@@ -224,6 +237,7 @@ def _search_files(repo_path: Path, pattern: str, regex: bool, path_glob: str | N
     compiled = re.compile(pattern) if regex else None
     matches: list[dict] = []
     truncated = False
+    total_chars = 0
     ignored_paths = load_repo_config(repo_path)["ignored_paths"]
 
     for path in iter_all_files(repo_path, ignored_paths):
@@ -238,10 +252,16 @@ def _search_files(repo_path: Path, pattern: str, regex: bool, path_glob: str | N
         for line_no, line in enumerate(text.splitlines(), start=1):
             found = compiled.search(line) is not None if compiled else pattern in line
             if found:
-                if len(matches) >= _SEARCH_MATCH_CAP:
+                if len(matches) >= _SEARCH_MATCH_CAP or total_chars >= _SEARCH_TOTAL_CHAR_BUDGET:
                     truncated = True
                     break
-                matches.append({"path": rel_path, "line": line_no, "text": line})
+                line_text = (
+                    line[:_SEARCH_LINE_MAX_CHARS] + "... (line truncated)"
+                    if len(line) > _SEARCH_LINE_MAX_CHARS
+                    else line
+                )
+                matches.append({"path": rel_path, "line": line_no, "text": line_text})
+                total_chars += len(line_text)
         if truncated:
             break
 

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -934,6 +934,46 @@ async def test_aletheore_search_caps_at_200_and_flags_truncated(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aletheore_search_truncates_a_single_very_long_matched_line(tmp_path):
+    # A minified bundle or a huge generated JSON line can match once and
+    # still blow well past a reasonable result size on its own - the
+    # 200-match count cap does nothing to stop this since it's one match,
+    # not many.
+    long_line = "MATCH_ME " + ("x" * 3000)
+    repo = make_repo_with_files(tmp_path, {"bundle.min.js": long_line})
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_search", {"pattern": "MATCH_ME"})
+
+    matches = tool_result_body(result)["result"]["matches"]
+    assert len(matches) == 1
+    assert len(matches[0]["text"]) < len(long_line)
+    assert matches[0]["text"].startswith("MATCH_ME")
+    assert matches[0]["text"].endswith("(line truncated)")
+
+
+@pytest.mark.asyncio
+async def test_aletheore_search_stops_early_on_total_char_budget_even_under_the_match_cap(tmp_path):
+    # Confirmed live: an unscoped search on a common word returned a result
+    # an MCP client rejected for exceeding its own size limit, well under
+    # the 200-match count cap (200 matches x long lines = ~600,000 chars in
+    # this exact repro). The count cap alone can't catch this - only an
+    # aggregate character budget does.
+    long_line = "MATCH_ME " + ("x" * 3000)
+    content = "\n".join(long_line for _ in range(200))
+    repo = make_repo_with_files(tmp_path, {"big.js": content})
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_search", {"pattern": "MATCH_ME"})
+
+    result_body = tool_result_body(result)["result"]
+    total_chars = sum(len(m["text"]) for m in result_body["matches"])
+    assert len(result_body["matches"]) < 200
+    assert total_chars < 110_000
+    assert result_body["truncated"] is True
+
+
+@pytest.mark.asyncio
 async def test_aletheore_search_respects_repo_config_ignored_paths(tmp_path):
     repo = make_repo_with_evidence(tmp_path)
     (repo / "vendor").mkdir()


### PR DESCRIPTION
## Summary

Follow-up on veridion-fa's A/B-testing finding on PR #442/#444's SERVER_INSTRUCTIONS: an unscoped `aletheore_search` on a common word returned a result the calling MCP client rejected for exceeding its own ~390,000-char limit, even though the result was well under `_SEARCH_MATCH_CAP` (200 matches).

Root cause, confirmed by reading the code: `_SEARCH_MATCH_CAP` bounds the *number* of matches but nothing bounds their *combined size* - each match includes the full matched line's text with no per-line or aggregate limit. 200 matches of long lines (a minified bundle, a generated file, a single huge JSON line) can produce an oversized result while the count cap does nothing to stop it.

Confirmed this is aletheore's own gap, not something to just document: `_toon_result` (the encoding step every tool result goes through) is a pure encoder with zero size limiting of its own. Reproduced directly before fixing: 200 matches of realistic long lines (3000 chars each) produced ~600,000 combined chars against the unmodified code.

## Fix

Two independent guards in `_search_files`, since either alone is insufficient:
- `_SEARCH_LINE_MAX_CHARS` (500): truncates one absurdly long matched line on its own - the match-count cap does nothing here since it's a single match.
- `_SEARCH_TOTAL_CHAR_BUDGET` (100,000): stops the search early and flags `truncated: true` once the aggregate result size crosses this - reuses the exact same truncation signal already returned for the match-count cap. A huge number of merely-long lines would defeat a per-line cap alone, which is why both exist.

100,000 chars is comfortably under the ~390,000-char limit observed live, while still returning a substantial, useful result.

## Why this branches off #444, not master

This branch is based on `fix/mcp-instructions-and-tool-docs` (#444, still open) rather than master - that PR's diff sits right next to `aletheore_search`'s docstring, and this change touches the function body immediately below it. Branching here avoids a conflict regardless of merge order; rebase onto master after #444 lands, or merge this into that branch first, whichever you prefer.

## Test plan
- [x] Reproduced the bug directly against the pre-fix code (200 matches x 3000-char lines = ~600,000 chars)
- [x] 2 new regression tests added - both confirmed to fail against the pre-fix code (single huge line, and 200-line aggregate)
- [x] Full `src/` suite: 1418 passed, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr