### PR TITLE
fix: resolve the advisory-lock namespace-3 collision (audit finding 30)

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -493,17 +493,29 @@ async def insert_repo_history(
 # enforce the same cap against the same monthly_scanned_repos table.
 MAX_SCANNED_REPOS_PER_MONTH = 10
 # Advisory locks use the same Postgres global key space across app-server and
-# scan-worker connections. Keep this namespace value identical in both files;
-# the second key is the installation id.
+# scan-worker connections - pg_advisory_lock/pg_advisory_xact_lock key on the
+# literal (namespace, key) pair regardless of which function or file took
+# the lock, so every namespace value claimed in either file must stay
+# disjoint from every namespace claimed in the other, not just internally
+# consistent within one file. Live-verified: two unrelated locks sharing a
+# namespace genuinely block each other whenever their second key (an
+# installation id here, hashtext(f"{installation_id}:{repo}") in
+# scan_worker's REPO_CHECKOUT_LOCK_NAMESPACE) happens to collide.
+#
+# scan_worker/db.py claims 1 (SCAN_SLOT_LOCK_NAMESPACE, shared/intentional -
+# the same monthly-scan-slot reservation, taken from either process) and 2
+# (SPEND_LOCK_NAMESPACE). 3 used to be claimed by both SEAT_LOCK_NAMESPACE
+# here and scan_worker's REPO_CHECKOUT_LOCK_NAMESPACE - an independent,
+# unintentional collision (docs/audits/Claude_Audit.md finding 30,
+# confirmed live: a held checkout lock made a concurrent seat-admission
+# call block for its full lock_timeout and then fail). Moved to 6, the
+# first value neither file had claimed, rather than reusing 4 or 5 below
+# (chosen after the collision was found, specifically to avoid it for new
+# locks - but never applied to the original clash until now).
 SCAN_SLOT_LOCK_NAMESPACE = 1
-SEAT_LOCK_NAMESPACE = 3
-# scan_worker/db.py separately claims 1 (shared, intentional - see above), 2
-# (SPEND_LOCK_NAMESPACE), and 3 (REPO_CHECKOUT_LOCK_NAMESPACE, an
-# independent, unintentional collision with SEAT_LOCK_NAMESPACE above - see
-# docs/audits/Claude_Audit.md finding 30). 4 and 5 chosen here specifically
-# because neither file has claimed them yet.
 HEALTH_CHECK_TARGET_LOCK_NAMESPACE = 4
 API_TOKEN_LOCK_NAMESPACE = 5
+SEAT_LOCK_NAMESPACE = 6
 ADVISORY_LOCK_TIMEOUT = "5s"
 
 

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -16,8 +16,19 @@ from app_server.llm_cost import WARN_FRACTION_OF_CAP, crossed_spend_warning_thre
 logger = logging.getLogger(__name__)
 
 # Advisory locks share one Postgres key space across app-server and
-# scan-worker. Keep namespace 1 identical to app_server.db; namespace 2 is
-# reserved for the session-scoped spend lock. The installation id is key 2.
+# scan-worker - pg_advisory_lock/pg_advisory_xact_lock key on the literal
+# (namespace, key) pair regardless of which file took the lock, so every
+# namespace value claimed here must stay disjoint from every namespace
+# app_server.db claims too, not just internally consistent within this
+# file. Keep namespace 1 identical to app_server.db (the same monthly-scan-
+# slot reservation, taken from either process); namespace 2 is reserved for
+# the session-scoped spend lock. app_server.db currently claims 1 (shared,
+# see above), 4 (HEALTH_CHECK_TARGET_LOCK_NAMESPACE), 5
+# (API_TOKEN_LOCK_NAMESPACE), and 6 (SEAT_LOCK_NAMESPACE) - 3 used to be an
+# independent, unintentional collision with SEAT_LOCK_NAMESPACE
+# (docs/audits/Claude_Audit.md finding 30, confirmed live: a held checkout
+# lock made a concurrent seat-admission call block for its full
+# lock_timeout and then fail), fixed by moving SEAT_LOCK_NAMESPACE to 6.
 SCAN_SLOT_LOCK_NAMESPACE = 1
 SPEND_LOCK_NAMESPACE = 2
 # Namespace 3 is reserved for the per-repo checkout lock (see

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -1167,6 +1167,40 @@ async def test_scan_slot_lock_does_not_collide_with_spend_lock(pool):
         ) is True
 
 
+def test_seat_lock_and_repo_checkout_lock_namespaces_are_disjoint():
+    # docs/audits/Claude_Audit.md finding 30, confirmed live before this
+    # fix: SEAT_LOCK_NAMESPACE (app_server.db) and REPO_CHECKOUT_LOCK_NAMESPACE
+    # (here) both used to be 3 - pg_advisory_lock/pg_advisory_xact_lock key on
+    # the literal (namespace, key) pair regardless of which file took the
+    # lock, so a held repo-checkout lock genuinely blocked (then failed) a
+    # concurrent seat-admission call whenever their second keys collided.
+    # A static equality check, not a live-blocking repro - the live behavior
+    # is exactly what test_scan_slot_lock_does_not_collide_with_spend_lock
+    # below already demonstrates for a different namespace pair.
+    from app_server.db import SEAT_LOCK_NAMESPACE
+
+    assert SEAT_LOCK_NAMESPACE != REPO_CHECKOUT_LOCK_NAMESPACE
+
+
+def test_every_advisory_lock_namespace_is_disjoint_across_both_files():
+    # Broader guard than the seat/checkout pair above: every namespace value
+    # either file claims must stay disjoint from every namespace the other
+    # claims, except SCAN_SLOT_LOCK_NAMESPACE (deliberately shared - the same
+    # monthly-scan-slot reservation, taken from either process). A future
+    # namespace added to either file without checking the other would
+    # otherwise reintroduce this exact bug class silently.
+    from app_server.db import (
+        API_TOKEN_LOCK_NAMESPACE,
+        HEALTH_CHECK_TARGET_LOCK_NAMESPACE,
+        SEAT_LOCK_NAMESPACE,
+    )
+
+    app_server_only = {API_TOKEN_LOCK_NAMESPACE, HEALTH_CHECK_TARGET_LOCK_NAMESPACE, SEAT_LOCK_NAMESPACE}
+    scan_worker_only = {SPEND_LOCK_NAMESPACE, REPO_CHECKOUT_LOCK_NAMESPACE}
+
+    assert app_server_only.isdisjoint(scan_worker_only)
+
+
 @pytest.mark.asyncio
 async def test_scan_slot_lock_still_serializes_same_purpose(pool):
     import psycopg


### PR DESCRIPTION
## Summary

A real bug that was already found and documented (`docs/audits/Claude_Audit.md`, finding 30) but never actually fixed - later namespace additions (`HEALTH_CHECK_TARGET_LOCK_NAMESPACE`, `API_TOKEN_LOCK_NAMESPACE`) dodged the same collision for *new* locks without ever renumbering the *original* clash.

`app_server/db.py`'s `SEAT_LOCK_NAMESPACE` and `scan_worker/db.py`'s `REPO_CHECKOUT_LOCK_NAMESPACE` were both `3`. Postgres advisory locks key on the literal `(namespace, key)` pair regardless of which file or function took the lock, so a held repo-checkout lock (deliberately blocking, no timeout, held for as long as a checkout+scan takes) and a concurrent seat-admission call (5s `lock_timeout`) genuinely contend whenever `hashtext(installation_id:repo)` collides with a real installation id - surfacing as an inexplicable, intermittent failure to add a team member with no discoverable connection to the actual cause.

## Verification

Live-verified before fixing, with two raw psycopg connections against a real Postgres instance:
- One holds `pg_advisory_lock(3, 12345)`.
- The other attempts `pg_advisory_xact_lock(3, 12345)` under a short `lock_timeout` - blocks for the full timeout, then fails with `LockNotAvailable`, matching the audit's documented failure scenario exactly.
- A control case on namespace 6 (the fix) acquires immediately under the same held lock, confirming the fix actually eliminates the contention rather than just moving the number around.

## Fix

Moved `SEAT_LOCK_NAMESPACE` to `6` - the first value neither file had claimed (`1, 2, 3, 4, 5` were all taken across the two files). Added cross-referencing comments in both files listing every namespace claimed in the other, per the audit finding's own proposed fix.

Added a broader regression test than just this one pair: every namespace constant across both files is checked pairwise disjoint (except `SCAN_SLOT_LOCK_NAMESPACE`, deliberately shared - the same monthly-scan-slot reservation, taken from either process), so a future namespace added to either file without checking the other can't silently reintroduce this bug class.

## Test plan
- [x] Live cross-connection repro against real Postgres (see above)
- [x] 2 new regression tests in `test_scan_worker_db.py` - both confirmed to fail against the pre-fix code
- [x] Full github-app suite: 1553 passed, 8 skipped, 0 failed (1359/8 skipped in the bulk suite, 194 in test_jobs.py + test_postgres_graph_store.py)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr