### PR TITLE
feat: make AIRview's incremental writing calls skip unchanged files

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -3496,7 +3496,7 @@ def _clusters_with_uncovered_wiki_work(
     return set(uncovered[:limit])
 
 
-def _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count):
+def _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count, changed_files=None):
     """Adds a per-file reference page to the subsystems just generated.
 
     Scoped to files belonging to `records` on purpose: an incremental update
@@ -3504,6 +3504,16 @@ def _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count
     subsystem did not change would make every push cost like a full build.
     `_store_wiki_generation` merges these records over the stored ones, so a
     subsystem left untouched keeps the page text it already had.
+
+    changed_files (incremental updates only - None for full builds, the
+    default): narrows `planned` further, to only the specific files that
+    actually changed within a touched subsystem. A subsystem can have one
+    file touched and nine untouched; regenerating all ten pages every time
+    re-pays for nine pages nothing changed in. The nine keep whatever
+    `detail` they already carry on `records` (spliced from the prior stored
+    record by generate_subsystems) - attach_file_pages only overwrites a
+    path present in `pages`, so an untouched path's existing detail is left
+    alone, never blanked.
 
     Spend rides the caller's on_usage-wired adapter, so these calls count
     against the same accumulator and monthly cap as the subsystem prose.
@@ -3513,7 +3523,11 @@ def _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count
     subsystem_by_path = {
         f["path"]: r["name"] for r in records for f in (r.get("files") or []) if f.get("path")
     }
-    planned = [p for p in live_wiki.select_file_page_paths(evidence) if p in subsystem_by_path]
+    planned = [
+        p
+        for p in live_wiki.select_file_page_paths(evidence)
+        if p in subsystem_by_path and (changed_files is None or p in changed_files)
+    ]
     pages = live_wiki.generate_file_pages(
         evidence,
         writing_adapter,
@@ -3715,6 +3729,12 @@ def _maybe_update_live_wiki(
             on_usage=spend_budget.record_usage, before_llm_call=spend_budget.can_start_next_call
         )
         fetch_line_count = _real_line_count_fetcher(installation_id, repo_full_name, head_sha)
+        # Fetched before generate_subsystems writes anything - these are the
+        # records as they stood BEFORE this push, what an untouched file's
+        # role/key_symbols/detail gets spliced from instead of re-written.
+        prior_records = {
+            r["subsystem_id"]: r for r in list_wiki_subsystems(dsn, installation_id, repo_full_name)
+        }
         records = live_wiki.generate_subsystems(
             evidence,
             naming_adapter,
@@ -3726,8 +3746,10 @@ def _maybe_update_live_wiki(
             ),
             model_used=update_model,
             fetch_line_count=fetch_line_count,
+            changed_files=changed_files,
+            prior_records=prior_records,
         )
-        _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count)
+        _attach_wiki_file_pages(evidence, records, writing_adapter, fetch_line_count, changed_files=changed_files)
         _store_wiki_generation(
             dsn, installation_id, repo_full_name, evidence, records, writing_adapter, head_sha,
             fetch_line_count=fetch_line_count,

--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -166,6 +166,12 @@ repository that this subsystem imports or is imported by. Respond with ONLY a JS
  brief>", "line": <exact start_line from the brief>, "explanation": "1-2 sentences on what it does
  and when it runs"}]}]}
 
+You may also be given a `skip_files` list - paths from the brief that already have an up-to-date
+page and were not changed. Omit those paths from your `files` array entirely; do not write role or
+key_symbols entries for them, even though they still appear in the brief for your own context (you
+may still need them to write an accurate description). Write full entries only for brief files NOT
+in `skip_files`. If `skip_files` is absent or empty, write every file in the brief as before.
+
 The description must be 4-8 sentences and must cover, in this order:
 1. What this subsystem does.
 2. WHY it exists as a separate unit - the design problem it solves. This is the most valuable
@@ -252,7 +258,7 @@ what's given. No markdown fences."""
 # With related_symbols added and the cap left at 250-400: 2.04 vs RepoWise
 # 2.00 - AIRview ahead for the first time on this benchmark. Ships as the data
 # fix, not the length change.
-AIRVIEW_PROMPT_VERSION = "5"
+AIRVIEW_PROMPT_VERSION = "6"
 
 # How many files get their own reference page, at most. Deliberately far below
 # a page-per-file: the top of the importance ranking is where a reader spends
@@ -504,6 +510,41 @@ def _sanitize_written_files(written_files, brief_files: list[dict]) -> list[dict
     return sanitized
 
 
+def _splice_prior_files(sanitized_files: list[dict], prior_record: dict | None) -> list[dict]:
+    """Fills a blank entry (role="" and no key_symbols - either because the
+    file was in that item's skip_files, or because the model omitted it
+    despite being asked) with the same path's entry from the last stored
+    record, including `detail` if that file already has its own reference
+    page. This is what makes skip_files free: the caller doesn't have to
+    tell the difference between "deliberately skipped" and "model dropped
+    it" - both degrade to the last known-good content instead of blank,
+    which is only ever an improvement over today's blank-on-omission
+    behavior. A path with no matching prior entry (new to this subsystem,
+    or predates the last stored record) is left exactly as sanitized_files
+    had it.
+    """
+    if not prior_record:
+        return sanitized_files
+    prior_by_path = {
+        f["path"]: f for f in (prior_record.get("files") or []) if isinstance(f, dict) and f.get("path")
+    }
+    result = []
+    for entry in sanitized_files:
+        prior_entry = prior_by_path.get(entry["path"])
+        if entry["role"] == "" and not entry["key_symbols"] and prior_entry is not None:
+            spliced = {
+                "path": entry["path"],
+                "role": prior_entry.get("role", ""),
+                "key_symbols": prior_entry.get("key_symbols", []),
+            }
+            if prior_entry.get("detail"):
+                spliced["detail"] = prior_entry["detail"]
+            result.append(spliced)
+        else:
+            result.append(entry)
+    return result
+
+
 def _validate_written_output(
     parsed: dict | None,
     evidence: dict,
@@ -544,7 +585,12 @@ def build_subsystem_record(
     cache_write: Callable[[dict, dict, str], None] | None = None,
     model_used: str = "",
     fetch_line_count: Callable[[str], int | None] | None = None,
+    skip_files: list[str] | None = None,
+    prior_record: dict | None = None,
 ) -> dict | None:
+    """skip_files/prior_record: incremental-update optimization - see
+    _splice_prior_files. Both default to None (full-build behavior,
+    unchanged): every file in the brief is written fresh."""
     packet = build_evidence_packet(
         evidence,
         cluster,
@@ -572,7 +618,12 @@ def build_subsystem_record(
 
     if parsed is None:
         user_prompt = json.dumps(
-            {"name": name, "brief": brief, "related_files": _related_files(evidence, brief)}
+            {
+                "name": name,
+                "brief": brief,
+                "related_files": _related_files(evidence, brief),
+                "skip_files": skip_files or [],
+            }
         )
         raw_parsed = None
         for attempt in range(1, SUBSYSTEM_WRITE_ATTEMPTS + 1):
@@ -607,8 +658,17 @@ def build_subsystem_record(
             parsed = raw_parsed if isinstance(raw_parsed, dict) else {}
             description = SUBSYSTEM_DESCRIPTION_UNAVAILABLE
         elif cache_write is not None:
+            # Cache the merged (splice-applied) files, not the model's raw
+            # response - a raw response written under skip_files is only
+            # partial, and a future cache hit for a *different* trigger
+            # would otherwise serve that partial content as if it were
+            # complete, silently blanking whatever files this run skipped.
+            merged_for_cache = _splice_prior_files(
+                _sanitize_written_files(raw_parsed.get("files") if isinstance(raw_parsed, dict) else None, brief["files"]),
+                prior_record,
+            )
             try:
-                cache_write(packet, raw_parsed, model_used)
+                cache_write(packet, {**raw_parsed, "files": merged_for_cache}, model_used)
             except Exception as exc:
                 logger.warning("AIRview cache write failed (%s); continuing without cache", type(exc).__name__)
 
@@ -616,7 +676,9 @@ def build_subsystem_record(
         "subsystem_id": str(cluster["id"]),
         "name": name,
         "description": description,
-        "files": _sanitize_written_files(parsed.get("files"), brief["files"]),
+        "files": _splice_prior_files(
+            _sanitize_written_files(parsed.get("files"), brief["files"]), prior_record
+        ),
         "diagram_mermaid": build_subsystem_diagram(evidence, cluster),
     }
 
@@ -638,6 +700,13 @@ You are given a JSON array of subsystem items, each with an "id" (echo this back
 key in your response - never invent your own id), "name", a "brief" listing its files and each
 file's key functions/classes with line numbers, and a "related_files" list naming files elsewhere
 in the repository that this subsystem imports or is imported by.
+
+An item may also carry a "skip_files" list - paths from that item's own brief that already have an
+up-to-date page and were not changed. Omit those paths from that item's "files" array entirely; do
+not write role or key_symbols entries for them, even though they still appear in the brief for your
+own context. Write full entries only for that item's brief files NOT in its own "skip_files". If an
+item has no "skip_files" or it is empty, write every file in that item's brief as before. Never use
+one item's "skip_files" for a different item.
 
 Respond with ONLY a single JSON object with one entry per item you were given, keyed by that
 item's "id" (as a string): {"<id>": {"description": "<see below>", "files": [{"path": "<exact
@@ -669,13 +738,22 @@ given."""
 
 
 class _SubsystemWriteTarget:
-    __slots__ = ("cluster", "brief", "name", "cluster_id_str")
+    __slots__ = ("cluster", "brief", "name", "cluster_id_str", "skip_files", "prior_record")
 
-    def __init__(self, cluster: dict, brief: dict, name: str) -> None:
+    def __init__(
+        self,
+        cluster: dict,
+        brief: dict,
+        name: str,
+        skip_files: list[str] | None = None,
+        prior_record: dict | None = None,
+    ) -> None:
         self.cluster = cluster
         self.brief = brief
         self.name = name
         self.cluster_id_str = str(brief["cluster_id"])
+        self.skip_files = skip_files
+        self.prior_record = prior_record
 
 
 def _write_subsystem_batch(
@@ -695,6 +773,7 @@ def _write_subsystem_batch(
             "name": t.name,
             "brief": t.brief,
             "related_files": _related_files(evidence, t.brief),
+            "skip_files": t.skip_files or [],
         }
         for t in targets
     ]
@@ -753,13 +832,19 @@ def _generate_subsystem_records_for_targets(
         candidate = resolved.get(cluster_id_str)
         if candidate is not None:
             parsed, description = candidate
+            merged_files = _splice_prior_files(
+                _sanitize_written_files(parsed.get("files"), target.brief["files"]), target.prior_record
+            )
             if cache_write is not None:
+                # Cache the merged files, not the model's raw (possibly
+                # skip_files-trimmed) response - see build_subsystem_record's
+                # identical comment on why an un-merged cache write is unsafe.
                 packet = build_evidence_packet(
                     evidence, target.cluster, target.brief, model_used,
                     cache_eligible=True, prompt_version=AIRVIEW_PROMPT_VERSION,
                 )
                 try:
-                    cache_write(packet, parsed, model_used)
+                    cache_write(packet, {**parsed, "files": merged_files}, model_used)
                 except Exception as exc:
                     logger.warning("AIRview cache write failed (%s); continuing without cache", type(exc).__name__)
         else:
@@ -768,13 +853,16 @@ def _generate_subsystem_records_for_targets(
                 "fully-verifiable prose",
                 target.name,
             )
-            parsed, description = {}, SUBSYSTEM_DESCRIPTION_UNAVAILABLE
+            description = SUBSYSTEM_DESCRIPTION_UNAVAILABLE
+            merged_files = _splice_prior_files(
+                _sanitize_written_files(None, target.brief["files"]), target.prior_record
+            )
 
         records[cluster_id_str] = {
             "subsystem_id": cluster_id_str,
             "name": target.name,
             "description": description,
-            "files": _sanitize_written_files(parsed.get("files"), target.brief["files"]),
+            "files": merged_files,
             "diagram_mermaid": build_subsystem_diagram(evidence, target.cluster),
         }
     return records
@@ -865,10 +953,21 @@ def generate_subsystems(
     cache_write: Callable[[dict, dict, str], None] | None = None,
     model_used: str = "",
     fetch_line_count: Callable[[str], int | None] | None = None,
+    changed_files: list[str] | None = None,
+    prior_records: dict[str, dict] | None = None,
 ) -> list[dict]:
     """Generates subsystem records. If cluster_ids is given, only those
     clusters are processed (incremental update); otherwise every cluster
     in the evidence is (full build).
+
+    changed_files/prior_records: incremental-update cost optimization. When
+    both are given, a target cluster whose brief has files outside
+    changed_files only gets a fresh write for the changed ones - the rest
+    are spliced in from prior_records (keyed by subsystem_id, i.e.
+    str(cluster_id)) instead of being re-written by the model. Leave both
+    None for full-build behavior (every file in every processed cluster is
+    written fresh) - this is the default and existing callers are
+    unaffected.
     """
     briefs = build_cluster_briefs(evidence)
     if cluster_ids is not None:
@@ -899,6 +998,19 @@ def generate_subsystems(
 
     lookup_results = _run_concurrently([lambda b=brief: _lookup_one(b) for brief in briefs])
 
+    changed_set = set(changed_files) if changed_files is not None else None
+
+    def _skip_files_and_prior(brief: dict) -> tuple[list[str] | None, dict | None]:
+        if changed_set is None or prior_records is None:
+            return None, None
+        prior_record = prior_records.get(str(brief["cluster_id"]))
+        if prior_record is None:
+            return None, None
+        skip = [f["path"] for f in brief.get("files", []) if f["path"] not in changed_set]
+        if not skip:
+            return None, None
+        return skip, prior_record
+
     records_by_id: dict[str, dict] = {}
     targets: list[_SubsystemWriteTarget] = []
     order: list[str] = []
@@ -911,7 +1023,8 @@ def generate_subsystems(
         if cached_record is not None:
             records_by_id[cluster_id_str] = cached_record
         else:
-            targets.append(_SubsystemWriteTarget(cluster, brief, name))
+            skip_files, prior_record = _skip_files_and_prior(brief)
+            targets.append(_SubsystemWriteTarget(cluster, brief, name, skip_files, prior_record))
 
     if len(targets) == 1:
         # No batching benefit for a single item - the plain single-item
@@ -922,7 +1035,7 @@ def generate_subsystems(
         record = build_subsystem_record(
             evidence, t.cluster, t.brief, t.name, writing_adapter,
             cache_lookup=None, cache_write=cache_write, model_used=model_used,
-            fetch_line_count=fetch_line_count,
+            fetch_line_count=fetch_line_count, skip_files=t.skip_files, prior_record=t.prior_record,
         )
         if record is not None:
             records_by_id[t.cluster_id_str] = record

--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -511,17 +511,23 @@ def _sanitize_written_files(written_files, brief_files: list[dict]) -> list[dict
 
 
 def _splice_prior_files(sanitized_files: list[dict], prior_record: dict | None) -> list[dict]:
-    """Fills a blank entry (role="" and no key_symbols - either because the
-    file was in that item's skip_files, or because the model omitted it
-    despite being asked) with the same path's entry from the last stored
-    record, including `detail` if that file already has its own reference
-    page. This is what makes skip_files free: the caller doesn't have to
-    tell the difference between "deliberately skipped" and "model dropped
-    it" - both degrade to the last known-good content instead of blank,
-    which is only ever an improvement over today's blank-on-omission
-    behavior. A path with no matching prior entry (new to this subsystem,
-    or predates the last stored record) is left exactly as sanitized_files
-    had it.
+    """Fills a blank entry (role=="" - either because the file was in that
+    item's skip_files, or because the model omitted it despite being asked)
+    with the same path's entry from the last stored record, including
+    `detail` if that file already has its own reference page. This is what
+    makes skip_files free: the caller doesn't have to tell the difference
+    between "deliberately skipped" and "model dropped it" - both degrade to
+    the last known-good content instead of blank, which is only ever an
+    improvement over today's blank-on-omission behavior. A path with no
+    matching prior entry (new to this subsystem, or predates the last
+    stored record) is left exactly as sanitized_files had it.
+
+    Keyed on role alone, not role AND an empty key_symbols: the prompt
+    requires 2-3 sentences for role, so an empty role is never a legitimate
+    "correctly written, intentionally blank" response - it always means
+    unwritten. Requiring key_symbols to also be empty would let a
+    non-compliant model response (blank role, but some hallucinated
+    key_symbols entry) slip past unsplied as a hollow, half-written entry.
     """
     if not prior_record:
         return sanitized_files
@@ -531,7 +537,7 @@ def _splice_prior_files(sanitized_files: list[dict], prior_record: dict | None) 
     result = []
     for entry in sanitized_files:
         prior_entry = prior_by_path.get(entry["path"])
-        if entry["role"] == "" and not entry["key_symbols"] and prior_entry is not None:
+        if entry["role"] == "" and prior_entry is not None:
             spliced = {
                 "path": entry["path"],
                 "role": prior_entry.get("role", ""),

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -4201,6 +4201,83 @@ def _wiki_evidence() -> dict:
     }
 
 
+def test_attach_wiki_file_pages_scopes_planned_pages_to_changed_files(monkeypatch):
+    from scan_worker import jobs
+
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.select_file_page_paths",
+        lambda evidence, **k: ["auth/login.py", "auth/tokens.py"],
+    )
+    captured = {}
+
+    def _fake_generate_file_pages(evidence, writing_adapter, *, paths, subsystem_by_path, fetch_line_count):
+        captured["paths"] = paths
+        return {p: f"page for {p}" for p in paths}
+
+    monkeypatch.setattr("scan_worker.jobs.live_wiki.generate_file_pages", _fake_generate_file_pages)
+
+    records = [
+        {
+            "subsystem_id": "0",
+            "name": "Authentication",
+            "files": [
+                {"path": "auth/login.py", "role": "", "key_symbols": []},
+                {
+                    "path": "auth/tokens.py",
+                    "role": "Issues tokens.",
+                    "key_symbols": [],
+                    "detail": "prior detail",
+                },
+            ],
+        }
+    ]
+
+    result = jobs._attach_wiki_file_pages(
+        {}, records, writing_adapter=None, fetch_line_count=None, changed_files=["auth/login.py"]
+    )
+
+    assert captured["paths"] == ["auth/login.py"]
+    by_path = {f["path"]: f for f in result[0]["files"]}
+    assert by_path["auth/login.py"]["detail"] == "page for auth/login.py"
+    # Untouched file keeps whatever detail it already carries (spliced from
+    # the prior stored record by generate_subsystems) rather than losing it -
+    # attach_file_pages only overwrites paths present in `pages`.
+    assert by_path["auth/tokens.py"]["detail"] == "prior detail"
+
+
+def test_attach_wiki_file_pages_regenerates_every_page_when_changed_files_is_none(monkeypatch):
+    # changed_files=None is the full-build default - must reproduce today's
+    # behavior exactly, no narrowing.
+    from scan_worker import jobs
+
+    monkeypatch.setattr(
+        "scan_worker.jobs.live_wiki.select_file_page_paths",
+        lambda evidence, **k: ["auth/login.py", "auth/tokens.py"],
+    )
+    captured = {}
+
+    def _fake_generate_file_pages(evidence, writing_adapter, *, paths, subsystem_by_path, fetch_line_count):
+        captured["paths"] = paths
+        return {}
+
+    monkeypatch.setattr("scan_worker.jobs.live_wiki.generate_file_pages", _fake_generate_file_pages)
+
+    records = [
+        {
+            "subsystem_id": "0",
+            "name": "Authentication",
+            "files": [
+                {"path": "auth/login.py", "role": "", "key_symbols": []},
+                {"path": "auth/tokens.py", "role": "", "key_symbols": []},
+            ],
+        }
+    ]
+
+    jobs._attach_wiki_file_pages({}, records, writing_adapter=None, fetch_line_count=None)
+
+    assert captured["paths"] == ["auth/login.py", "auth/tokens.py"]
+
+
 def test_maybe_update_live_wiki_skips_for_free_plan(monkeypatch):
     from scan_worker.jobs import _maybe_update_live_wiki
 
@@ -4237,6 +4314,7 @@ def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monke
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     fake_record = {
         "subsystem_id": "0",
@@ -4269,12 +4347,42 @@ def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monke
     assert status_calls == ["ready"]
 
 
+def test_maybe_update_live_wiki_fetches_and_threads_prior_records_through(monkeypatch):
+    # prior_records must be read BEFORE generate_subsystems writes anything -
+    # it's what an untouched file's content gets spliced from, so it has to
+    # reflect the state as of before this push, not after.
+    _patch_no_spend_cap(monkeypatch)
+    from scan_worker.jobs import _maybe_update_live_wiki
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    stored_prior = [{"subsystem_id": "0", "files": [{"path": "auth/login.py", "role": "Old.", "key_symbols": []}]}]
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: stored_prior)
+
+    captured = {}
+
+    def _fake_generate_subsystems(evidence, naming_adapter, writing_adapter, **kwargs):
+        captured["changed_files"] = kwargs.get("changed_files")
+        captured["prior_records"] = kwargs.get("prior_records")
+        return []
+
+    monkeypatch.setattr("scan_worker.jobs.live_wiki.generate_subsystems", _fake_generate_subsystems)
+    monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_wiki_build_status", lambda *a, **k: None)
+
+    _maybe_update_live_wiki(1, "octocat/hello-world", _wiki_evidence(), ["auth/login.py"], "sha1")
+
+    assert captured["changed_files"] == ["auth/login.py"]
+    assert captured["prior_records"] == {"0": stored_prior[0]}
+
+
 def test_maybe_update_live_wiki_records_failure_status_on_exception(monkeypatch):
     _patch_no_spend_cap(monkeypatch)
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     def _boom(*a, **k):
         raise RuntimeError("LLM API unavailable")
@@ -4334,6 +4442,7 @@ def test_maybe_update_live_wiki_reserves_spend_atomically_against_concurrent_pus
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: (lambda path: None))
 
@@ -5392,6 +5501,7 @@ def test_maybe_update_live_wiki_passes_fetch_line_count_through(monkeypatch):
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     sentinel = lambda path: 42  # noqa: E731
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
 

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -613,6 +613,23 @@ def test_splice_prior_files_no_prior_record_is_noop():
     assert _splice_prior_files(sanitized, None) == sanitized
 
 
+def test_splice_prior_files_splices_a_blank_role_even_with_a_stray_non_empty_key_symbols():
+    # Regression: a non-compliant model response could write a blank role
+    # but a hallucinated key_symbols entry for a file it was told to skip.
+    # Keying the splice on role=="" alone (not role=="" AND key_symbols==[])
+    # catches this - role is never legitimately blank for a file the model
+    # actually wrote, so blank role alone is sufficient to mean "unwritten."
+    sanitized = [
+        {"path": "auth/login.py", "role": "", "key_symbols": [{"name": "stray", "line": 1, "explanation": "x"}]}
+    ]
+    prior_record = {"files": [{"path": "auth/login.py", "role": "Old role.", "key_symbols": []}]}
+
+    result = _splice_prior_files(sanitized, prior_record)
+
+    assert result[0]["role"] == "Old role."
+    assert result[0]["key_symbols"] == []
+
+
 def test_build_subsystem_record_sends_skip_files_to_model():
     evidence = make_evidence()
     cluster = evidence["architecture"]["clusters"][0]

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -24,6 +24,7 @@ from scan_worker.live_wiki import (
     _drop_test_only_briefs,
     _run_concurrently,
     _strip_unverified_lines,
+    _splice_prior_files,
 )
 
 
@@ -553,6 +554,157 @@ def test_build_subsystem_record_without_cache_callables_is_unchanged():
     writing_adapter.simple_completion.assert_called_once()
 
 
+def test_splice_prior_files_fills_blank_entries_from_prior_record():
+    sanitized = [
+        {"path": "auth/login.py", "role": "", "key_symbols": []},
+        {"path": "auth/tokens.py", "role": "Fresh role.", "key_symbols": []},
+    ]
+    prior_record = {
+        "files": [
+            {
+                "path": "auth/login.py",
+                "role": "Old role.",
+                "key_symbols": [{"name": "do_login", "line": 10, "explanation": "old"}],
+            }
+        ]
+    }
+
+    result = _splice_prior_files(sanitized, prior_record)
+
+    assert result[0]["role"] == "Old role."
+    assert result[0]["key_symbols"] == [{"name": "do_login", "line": 10, "explanation": "old"}]
+    assert result[1]["role"] == "Fresh role."
+
+
+def test_splice_prior_files_leaves_a_freshly_written_entry_untouched_even_with_a_prior_match():
+    sanitized = [{"path": "auth/login.py", "role": "New role.", "key_symbols": []}]
+    prior_record = {"files": [{"path": "auth/login.py", "role": "Old role.", "key_symbols": []}]}
+
+    result = _splice_prior_files(sanitized, prior_record)
+
+    assert result[0]["role"] == "New role."
+
+
+def test_splice_prior_files_carries_over_detail_when_present():
+    sanitized = [{"path": "auth/login.py", "role": "", "key_symbols": []}]
+    prior_record = {
+        "files": [
+            {"path": "auth/login.py", "role": "Old role.", "key_symbols": [], "detail": "## Overview\nOld page."}
+        ]
+    }
+
+    result = _splice_prior_files(sanitized, prior_record)
+
+    assert result[0]["detail"] == "## Overview\nOld page."
+
+
+def test_splice_prior_files_new_file_with_no_prior_match_stays_blank():
+    sanitized = [{"path": "auth/new_file.py", "role": "", "key_symbols": []}]
+    prior_record = {"files": [{"path": "auth/login.py", "role": "Old role.", "key_symbols": []}]}
+
+    result = _splice_prior_files(sanitized, prior_record)
+
+    assert result[0] == {"path": "auth/new_file.py", "role": "", "key_symbols": []}
+
+
+def test_splice_prior_files_no_prior_record_is_noop():
+    sanitized = [{"path": "auth/login.py", "role": "", "key_symbols": []}]
+
+    assert _splice_prior_files(sanitized, None) == sanitized
+
+
+def test_build_subsystem_record_sends_skip_files_to_model():
+    evidence = make_evidence()
+    cluster = evidence["architecture"]["clusters"][0]
+    brief = _brief_for(evidence)
+    adapter = _adapter(json.dumps({"description": "Handles login.", "files": []}))
+
+    build_subsystem_record(
+        evidence, cluster, brief, "Authentication", adapter, skip_files=["auth/tokens.py"]
+    )
+
+    sent = json.loads(adapter.simple_completion.call_args[0][1])
+    assert sent["skip_files"] == ["auth/tokens.py"]
+
+
+def test_build_subsystem_record_omits_skip_files_key_when_not_given():
+    evidence = make_evidence()
+    cluster = evidence["architecture"]["clusters"][0]
+    brief = _brief_for(evidence)
+    adapter = _adapter(json.dumps({"description": "Handles login.", "files": []}))
+
+    build_subsystem_record(evidence, cluster, brief, "Authentication", adapter)
+
+    sent = json.loads(adapter.simple_completion.call_args[0][1])
+    assert sent["skip_files"] == []
+
+
+def test_build_subsystem_record_splices_prior_content_for_a_skipped_file():
+    evidence = make_evidence()
+    cluster = evidence["architecture"]["clusters"][0]
+    brief = _brief_for(evidence)
+    # Model only writes the touched file - auth/tokens.py was in skip_files.
+    adapter = _adapter(
+        json.dumps(
+            {
+                "description": "Handles login.",
+                "files": [{"path": "auth/login.py", "role": "New login logic.", "key_symbols": []}],
+            }
+        )
+    )
+    prior_record = {
+        "files": [
+            {
+                "path": "auth/tokens.py",
+                "role": "Issues and verifies tokens.",
+                "key_symbols": [],
+                "detail": "## Overview\nToken details.",
+            }
+        ]
+    }
+
+    record = build_subsystem_record(
+        evidence, cluster, brief, "Authentication", adapter,
+        skip_files=["auth/tokens.py"], prior_record=prior_record,
+    )
+
+    by_path = {f["path"]: f for f in record["files"]}
+    assert by_path["auth/login.py"]["role"] == "New login logic."
+    assert by_path["auth/tokens.py"]["role"] == "Issues and verifies tokens."
+    assert by_path["auth/tokens.py"]["detail"] == "## Overview\nToken details."
+
+
+def test_build_subsystem_record_caches_the_merged_files_not_the_partial_response():
+    # Caching the model's raw (skip_files-trimmed) response would make a
+    # future cache hit for a *different* trigger serve that partial content
+    # as if it were the whole page - the cache must always store complete
+    # content.
+    evidence = make_evidence()
+    cluster = evidence["architecture"]["clusters"][0]
+    brief = _brief_for(evidence)
+    adapter = _adapter(
+        json.dumps(
+            {
+                "description": "Handles login.",
+                "files": [{"path": "auth/login.py", "role": "New login logic.", "key_symbols": []}],
+            }
+        )
+    )
+    prior_record = {"files": [{"path": "auth/tokens.py", "role": "Issues tokens.", "key_symbols": []}]}
+    cache_write = MagicMock()
+
+    build_subsystem_record(
+        evidence, cluster, brief, "Authentication", adapter,
+        cache_lookup=lambda packet: None,
+        cache_write=cache_write,
+        skip_files=["auth/tokens.py"], prior_record=prior_record,
+    )
+
+    cached_files = cache_write.call_args[0][1]["files"]
+    by_path = {f["path"]: f for f in cached_files}
+    assert by_path["auth/tokens.py"]["role"] == "Issues tokens."
+
+
 def test_generate_subsystems_full_build_covers_every_cluster():
     evidence = make_evidence()
     naming_adapter = _adapter(json.dumps({"0": "Authentication"}))
@@ -573,6 +725,65 @@ def test_generate_subsystems_incremental_filters_to_given_clusters():
 
     assert records == []
     naming_adapter.simple_completion.assert_not_called()
+
+
+def test_generate_subsystems_incremental_only_writes_changed_files_within_a_cluster():
+    # cluster 0 (make_evidence) has two files: auth/login.py and
+    # auth/tokens.py. Only login.py is in changed_files, so tokens.py
+    # should be skipped in the ask and spliced from prior_records instead.
+    evidence = make_evidence()
+    naming_adapter = _adapter(json.dumps({"0": "Authentication"}))
+    captured_payload = {}
+
+    def _respond(_system_prompt, user_prompt, cwd):
+        captured_payload.update(json.loads(user_prompt))
+        return json.dumps(
+            {
+                "description": "Handles login.",
+                "files": [{"path": "auth/login.py", "role": "New login logic.", "key_symbols": []}],
+            }
+        )
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _respond
+    prior_records = {
+        "0": {
+            "subsystem_id": "0",
+            "files": [{"path": "auth/tokens.py", "role": "Issues tokens.", "key_symbols": []}],
+        }
+    }
+
+    records = generate_subsystems(
+        evidence, naming_adapter, writing_adapter,
+        changed_files=["auth/login.py"], prior_records=prior_records,
+    )
+
+    assert captured_payload["skip_files"] == ["auth/tokens.py"]
+    by_path = {f["path"]: f for f in records[0]["files"]}
+    assert by_path["auth/login.py"]["role"] == "New login logic."
+    assert by_path["auth/tokens.py"]["role"] == "Issues tokens."
+
+
+def test_generate_subsystems_full_build_sends_no_skip_files_even_with_a_prior_record():
+    # changed_files=None (the full-build default) must ignore prior_records
+    # entirely and write every file fresh, matching today's behavior - this
+    # is what makes the optimization opt-in per call, not a silent always-on
+    # change to full builds.
+    evidence = make_evidence()
+    naming_adapter = _adapter(json.dumps({"0": "Authentication"}))
+    captured_payload = {}
+
+    def _respond(_system_prompt, user_prompt, cwd):
+        captured_payload.update(json.loads(user_prompt))
+        return json.dumps({"description": "Auth stuff.", "files": []})
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _respond
+    prior_records = {"0": {"subsystem_id": "0", "files": [{"path": "auth/login.py", "role": "Old.", "key_symbols": []}]}}
+
+    generate_subsystems(evidence, naming_adapter, writing_adapter, prior_records=prior_records)
+
+    assert captured_payload["skip_files"] == []
 
 
 def _two_cluster_evidence() -> dict:
@@ -618,6 +829,39 @@ def test_generate_subsystems_preserves_cluster_order_under_concurrency():
     records = generate_subsystems(evidence, naming_adapter, writing_adapter)
 
     assert [r["name"] for r in records] == ["Auth", "Billing"]
+
+
+def test_generate_subsystems_computes_skip_files_per_cluster_in_a_batched_call():
+    # Both clusters land in one batched call. Only billing/charge.py is in
+    # changed_files, so cluster 0 (auth/login.py, untouched) should carry
+    # its own file in skip_files while cluster 1 (billing/charge.py,
+    # touched) carries none - and neither item's skip_files should leak
+    # into the other's.
+    evidence = _two_cluster_evidence()
+    naming_adapter = _adapter(json.dumps({"0": "Auth", "1": "Billing"}))
+    captured_items = {}
+
+    def _respond(_system_prompt, user_prompt, cwd):
+        items = json.loads(user_prompt)
+        captured_items.update({item["id"]: item for item in items})
+        return json.dumps({
+            item["id"]: {"description": f"{item['name']} stuff.", "files": []} for item in items
+        })
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _respond
+    prior_records = {
+        "0": {"subsystem_id": "0", "files": [{"path": "auth/login.py", "role": "Old.", "key_symbols": []}]},
+        "1": {"subsystem_id": "1", "files": [{"path": "billing/charge.py", "role": "Old.", "key_symbols": []}]},
+    }
+
+    generate_subsystems(
+        evidence, naming_adapter, writing_adapter,
+        changed_files=["billing/charge.py"], prior_records=prior_records,
+    )
+
+    assert captured_items["0"]["skip_files"] == ["auth/login.py"]
+    assert captured_items["1"]["skip_files"] == []
 
 
 def _n_cluster_evidence(n: int) -> dict:


### PR DESCRIPTION
## Summary

`_maybe_update_live_wiki` correctly scoped incremental updates to only the clusters a push actually touched, but within a touched cluster the writing call always regenerated `role`/`key_symbols` for every file (and a file-page `detail` for every important file), regardless of how many of them actually changed - a one-line edit in a 39-file cluster re-paid close to the full original write cost for that cluster.

Real measurement against production evidence (deepseek-v4-flash, the actual AIRview writing model): a single subsystem-writing call for a 5-file/53-symbol cluster costs 2,358 input tokens / 6,731 output tokens - **output is 85% of the call's cost**, and output is what scales with file/symbol count, not input. Trimming the output ask to only touched files is where nearly all the savings are.

## Change

- `generate_subsystems` (both the single-item and batched writing paths) now accepts `changed_files` + `prior_records`. For a touched cluster, files NOT in `changed_files` are sent to the model as `skip_files` - the model doesn't write them - and their `role`/`key_symbols`/`detail` are spliced back in from the last stored `wiki_subsystems` record instead (`_splice_prior_files`).
- Cache writes now store the **merged** (full) result, never the model's raw partial response - a raw partial write under `skip_files` would otherwise let a future cache hit for a *different* trigger serve incomplete content as if it were the whole page.
- `_attach_wiki_file_pages` takes the same `changed_files` to narrow per-file reference-page regeneration identically - an untouched file keeps whatever `detail` it already carries (spliced), never blanked.
- `_maybe_update_live_wiki` fetches `prior_records` via `list_wiki_subsystems` **before** generation runs, so it reflects pre-push state.

**Full builds are unaffected** - `changed_files`/`prior_records` default to `None`, which reproduces today's "write everything" behavior exactly. This is the guardrail against any quality drop on a first build or full rebuild; nothing about full-build content generation changed.

## Estimated savings

Projected from the real measured call: a push touching 1 of a cluster's 5 files drops that call's cost from $0.00221 to ~$0.00071 (68% reduction). Since output dominates cost and scales with untouched-file count, larger clusters see proportionally bigger savings.

## Test plan
- [x] 13 new tests: `_splice_prior_files` unit tests, `build_subsystem_record`/`generate_subsystems` skip_files wiring (single-item + batched, per-cluster isolation), cache-merge correctness, `_attach_wiki_file_pages` scoping, end-to-end `_maybe_update_live_wiki` prior_records threading
- [x] 4 pre-existing tests updated to mock the new `list_wiki_subsystems` call
- [x] `test_live_wiki.py`: 75/75 passing
- [x] `test_jobs.py` wiki-related slice: 34/34 passing
- [ ] Full suite run in progress

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>