### PR TITLE
fix: managed_audit crashes on its first call whenever Luna is the resolved model

### DIFF
--- a/src/aletheore/adapters/openai_compatible.py
+++ b/src/aletheore/adapters/openai_compatible.py
@@ -390,10 +390,26 @@ class OpenAICompatibleAdapter(AgentAdapter):
         finished = False
         consecutive_no_tool_calls = 0
 
+        # gpt-5.6-luna rejects function tools on /v1/chat/completions unless
+        # reasoning_effort is explicitly "none" - a hard API requirement for
+        # tool use (confirmed directly: tools+tool_choice="required" only
+        # succeeds with this present; fails identically without it,
+        # regardless of tool_choice). This is NOT the same knob as
+        # model_tiers.AIRVIEW_REASONING - that's an opt-in cost-saving
+        # toggle for simple_completion's prose calls, off by default, so
+        # self._extra_body can't be relied on to carry it here. invoke() is
+        # the only caller in this codebase that ever sends tools (see
+        # report.py's single call site), so forcing this is unconditional
+        # and scoped to exactly the call shape that needs it.
+        tool_call_extra_body = dict(self._extra_body)
+        if self.name == "OpenAI":
+            tool_call_extra_body["reasoning_effort"] = "none"
+
         create_kwargs = {
             "model": self._model,
             "tools": TOOLS,
             "timeout": self._request_timeout_seconds,
+            **({"extra_body": tool_call_extra_body} if tool_call_extra_body else {}),
         }
         if self._supports_tool_choice:
             create_kwargs["tool_choice"] = "required"

--- a/src/tests/test_openai_compatible_adapter.py
+++ b/src/tests/test_openai_compatible_adapter.py
@@ -713,3 +713,63 @@ def test_supports_tool_choice_true_by_default(mock_openai_class, tmp_path):
 
     first_call = mock_client.chat.completions.create.call_args_list[0]
     assert first_call.kwargs["tool_choice"] == "required"
+
+
+@patch("aletheore.adapters.openai_compatible.OpenAI")
+def test_invoke_forces_reasoning_effort_none_for_openai_provider(mock_openai_class, tmp_path):
+    # Regression: gpt-5.6-luna rejects function tools on /v1/chat/completions
+    # unless reasoning_effort is explicitly "none" - confirmed directly
+    # against the real API (tools+tool_choice="required" only succeeds with
+    # this present). extra_body defaults to {} (model_tiers._reasoning_body
+    # only returns a real value behind the opt-in AIRVIEW_REASONING=off
+    # toggle), so this can't rely on the caller having configured extra_body -
+    # invoke() must force it unconditionally for the OpenAI-named provider,
+    # since it's the only place that ever sends tools.
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.chat.completions.create.side_effect = _write_all_sections_then_finish_responses()
+
+    adapter = _adapter(tmp_path, name="OpenAI", needs_key=False)
+    adapter.invoke("audit this repo", cwd=str(repo))
+
+    first_call = mock_client.chat.completions.create.call_args_list[0]
+    assert first_call.kwargs["extra_body"] == {"reasoning_effort": "none"}
+
+
+@patch("aletheore.adapters.openai_compatible.OpenAI")
+def test_invoke_merges_reasoning_effort_with_existing_extra_body_for_openai(mock_openai_class, tmp_path):
+    # If a caller already configured extra_body (e.g. AIRVIEW_REASONING=off
+    # threading the same value through), the forced override must not
+    # clobber other keys that might be present alongside it.
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.chat.completions.create.side_effect = _write_all_sections_then_finish_responses()
+
+    adapter = _adapter(
+        tmp_path, name="OpenAI", needs_key=False, extra_body={"reasoning_effort": "none", "other_flag": True}
+    )
+    adapter.invoke("audit this repo", cwd=str(repo))
+
+    first_call = mock_client.chat.completions.create.call_args_list[0]
+    assert first_call.kwargs["extra_body"] == {"reasoning_effort": "none", "other_flag": True}
+
+
+@patch("aletheore.adapters.openai_compatible.OpenAI")
+def test_invoke_does_not_force_reasoning_effort_for_non_openai_provider(mock_openai_class, tmp_path):
+    # DeepSeek uses a different disabled-reasoning shape entirely
+    # ({"thinking": {"type": "disabled"}}, not reasoning_effort) and has no
+    # documented requirement that tools always need it disabled - forcing
+    # an OpenAI-specific field onto every provider would be wrong, not just
+    # unnecessary.
+    repo = _make_repo_with_evidence(tmp_path, {"repository": {"modules": []}})
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.chat.completions.create.side_effect = _write_all_sections_then_finish_responses()
+
+    adapter = _adapter(tmp_path, name="DeepSeek", needs_key=False)
+    adapter.invoke("audit this repo", cwd=str(repo))
+
+    first_call = mock_client.chat.completions.create.call_args_list[0]
+    assert "extra_body" not in first_call.kwargs


### PR DESCRIPTION
## Summary

`OpenAICompatibleAdapter.invoke()` - the tool-calling agent loop `run_managed_audit`'s reasoning phase uses, its only caller anywhere in the codebase (`report.py:77`) - never passed `extra_body` to the API, unlike `simple_completion()` which does. `gpt-5.6-luna` rejects function tools on `/v1/chat/completions` unless `reasoning_effort` is explicitly `"none"`.

Since `OPENAI_API_KEY` is configured in production and `writing_adapter_for` defaults to preferring Luna whenever it's available, **every real managed-audit run has been crashing on its very first LLM call.** This explains why `audit_reports` is completely empty across every installation, ever, and `managed_audit_rate_limits` has exactly one row in the entire table.

## How this was found

Investigating a real question ("what does managed_audit actually cost per run") - no historical cost data existed anywhere (empty `audit_reports`, one stale `managed_audit_rate_limits` row) so I triggered a real run against a freshly-cloned, freshly-scanned copy of this repo. It failed immediately with:

```
openai.BadRequestError: Error code: 400 - Function tools with reasoning_effort are not
supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use
/v1/responses or set reasoning_effort to 'none'.
```

## The fix, and why the first attempt wasn't enough

My first instinct - just pass `self._extra_body` through in `invoke()`, mirroring `simple_completion()` - did not resolve it. `model_tiers._reasoning_body()` only returns a real value behind an opt-in `AIRVIEW_REASONING=off` toggle (meant for `simple_completion`'s prose-writing calls, to save reasoning-token cost) - off by default, so `self._extra_body` is `{}` in production regardless. `invoke()` is the *only* caller that ever sends `tools`, so it needs to force `reasoning_effort: "none"` unconditionally for the OpenAI-named provider, merged with (not replacing) whatever `extra_body` the caller already configured - DeepSeek uses an entirely different disabled-reasoning shape (`{"thinking": {"type": "disabled"}}`) and has no documented equivalent requirement, so this is scoped to exactly the provider that needs it.

Isolated the exact failing combination with a direct probe against the real API before settling on this fix - `tools` + `reasoning_effort=none` succeeds regardless of `tool_choice`; `tools` without it fails identically regardless of `tool_choice`.

## Verification

**Live, after the fix**: a full managed-audit run against this repository completed successfully - 6 rounds, $0.15, `gpt-5.6-luna`, produced a real 23k-character evidence-grounded report. (Also ran the same audit forced onto `deepseek-v4-pro` for comparison: 14 rounds, $1.15, more thorough in places - e.g. caught a real circular import Luna's run missed - but 7.5x the cost and 2.5x the time. Not part of this fix, just confirms the fix produces a genuinely working, quality report on both providers.)

## Test plan
- [x] 3 new regression tests: forces `reasoning_effort: "none"` for the OpenAI-named provider; merges with (doesn't clobber) an existing `extra_body`; does *not* force it for a non-OpenAI provider (DeepSeek)
- [x] Full `src/tests` suite: 1421/1421 passing
- [x] Live-verified: real managed-audit run against this repo succeeds post-fix (failed identically pre-fix)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>