### PR TITLE
fix: make Paddle webhook plan-change writes atomic (audit finding 11)

### DIFF
--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -148,29 +148,11 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         )
         return
 
-    transitioned_to_paid = False
-    if plan != "free":
-        transitioned_to_paid = await claim_free_to_paid_plan(pool, installation_id, plan)
-        if not transitioned_to_paid:
-            await set_paid_installation_plan(pool, installation_id, plan)
-    else:
-        await set_installation_plan(pool, installation_id, plan)
-
-    # Deliberately independent of transitioned_to_paid: if a crash lands
-    # between that write committing and the one-time setup below actually
-    # running, a Paddle retry finds plan already non-free, so
-    # claim_free_to_paid_plan correctly returns False on the retry - but
-    # setup still never ran once. This claim is what actually decides
-    # whether to run it, so a crash-then-retry still runs it exactly once
-    # instead of silently skipping it forever.
-    should_run_paid_setup = plan != "free" and await claim_paid_setup(pool, installation_id)
-    if "id" in data and "customer_id" in data:
-        await add_paddle_ids_to_installation(pool, installation_id, data["id"], data["customer_id"])
-
     # The extra-seat line item's quantity is the source of truth for billed
     # seats - reconciled here, the same way the plan itself is, rather than
     # trusting the buy/remove-seat button's own optimism about what Paddle
-    # actually charged.
+    # actually charged. Computed before the transaction below since it only
+    # reads `items`/`plan`, already available.
     extra_seats = (
         sum(
             item.get("quantity", 0)
@@ -180,7 +162,42 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         if plan != "free"
         else 0
     )
-    await set_extra_seats(pool, installation_id, extra_seats)
+
+    # One transaction, not three independent writes: a crash between any two
+    # of these previously left the installation on the new plan with stale
+    # extra_seats, or upgraded with no Paddle IDs recorded - a state that
+    # persisted until a Paddle retry happened to land outside
+    # claim_webhook_delivery's 15-minute reclaim window (see
+    # docs/audits/Claude_Audit.md finding 11; confirmed live by injecting a
+    # crash between add_paddle_ids_to_installation and set_extra_seats - the
+    # plan and Paddle IDs committed, extra_seats never did). Rolling back
+    # together means a crash here now looks identical to never having
+    # started, from any later retry's point of view - no partial state to
+    # reason about, whether the retry is immediate or 15 minutes later.
+    transitioned_to_paid = False
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            if plan != "free":
+                transitioned_to_paid = await claim_free_to_paid_plan(conn, installation_id, plan)
+                if not transitioned_to_paid:
+                    await set_paid_installation_plan(conn, installation_id, plan)
+            else:
+                await set_installation_plan(conn, installation_id, plan)
+
+            if "id" in data and "customer_id" in data:
+                await add_paddle_ids_to_installation(conn, installation_id, data["id"], data["customer_id"])
+
+            await set_extra_seats(conn, installation_id, extra_seats)
+
+    # Deliberately independent of transitioned_to_paid, and deliberately
+    # outside the transaction above: if a crash lands between that
+    # transaction committing and the one-time setup below actually running,
+    # a Paddle retry finds plan already non-free, so claim_free_to_paid_plan
+    # correctly returns False on the retry - but setup still never ran once.
+    # This claim is what actually decides whether to run it, so a
+    # crash-then-retry still runs it exactly once instead of silently
+    # skipping it forever.
+    should_run_paid_setup = plan != "free" and await claim_paid_setup(pool, installation_id)
 
     # One-time Live Wiki build, mirroring the GitHub Marketplace path in
     # webhooks/marketplace.py - fires exactly once, on the free -> paid

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -5,7 +5,7 @@ import json
 import logging
 import time
 from decimal import Decimal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -470,6 +470,49 @@ async def test_paid_to_paid_change_does_not_retrigger_live_wiki_full_build(pool)
     installation = await get_installation(pool, 201)
     assert installation["plan"] == "air"
     fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_crash_between_writes_rolls_back_the_plan_change_atomically(pool):
+    # docs/audits/Claude_Audit.md finding 11: the plan write, Paddle-id
+    # write, and extra-seats write used to be three independent awaits - a
+    # crash between any two of them left the installation on the new plan
+    # with stale extra_seats, or upgraded with no Paddle IDs recorded, a
+    # state no near-term retry could see coming since claim_webhook_delivery
+    # already thinks this event was claimed. Confirmed live before the fix:
+    # injecting a crash right before set_extra_seats left plan='air' and
+    # paddle_subscription_id='sub_repro' committed with extra_seats never
+    # applied. One transaction means the crash now rolls back everything,
+    # not just some of it.
+    import app_server.webhooks.paddle as paddle_mod
+
+    await upsert_installation(pool, 206, "acme")  # defaults to plan='free'
+    payload = {
+        "event_id": "evt_crash_mid_write",
+        "event_type": "subscription.created",
+        "data": {
+            "id": "sub_should_not_persist",
+            "customer_id": "ctm_should_not_persist",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(206)},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 2},
+            ],
+        },
+    }
+
+    async def _crash(*a, **k):
+        raise RuntimeError("simulated crash: pod killed here")
+
+    with patch.object(paddle_mod, "set_extra_seats", _crash):
+        with pytest.raises(RuntimeError):
+            await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=MagicMock())
+
+    installation = await get_installation(pool, 206)
+    assert installation["plan"] == "free"
+    assert installation["paddle_subscription_id"] is None
+    assert await get_extra_seats(pool, 206) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`docs/audits/Claude_Audit.md` finding 11: the plan write (`claim_free_to_paid_plan`/`set_paid_installation_plan`/`set_installation_plan`), `add_paddle_ids_to_installation`, and `set_extra_seats` in `handle_paddle_webhook_event` were three independent `await` calls, not one transaction. A crash between any two of them left the installation on the new plan with stale `extra_seats`, or upgraded with no Paddle IDs recorded - a state no near-term retry could correct, since `claim_webhook_delivery` already treats the event as claimed for the next 15 minutes.

## Verification

Confirmed live before fixing: injected a crash right before `set_extra_seats` and got exactly the predicted outcome - `plan='air'` and `paddle_subscription_id` committed independently, `extra_seats` never applied.

## Fix

Acquire one connection and wrap the three writes in a single transaction, so a crash anywhere in that sequence rolls back everything instead of some of it - the retry (immediate or 15 minutes later, either way) sees a clean unclaimed-equivalent state rather than a partial one.

`claim_paid_setup` is deliberately left outside the transaction, unchanged - its own atomic one-time claim already reasons correctly about running exactly once across a crash-then-retry (see its existing comment), and folding it in would change intentional, already-correct behavior for no benefit.

The five DB functions used inside the transaction all just call `.execute()`/`.fetchrow()`/`.fetchval()` on whatever pool object they're given, so passing the acquired connection instead of the pool works transparently - no signature changes needed.

## Test plan
- [x] Reproduced the bug directly against the pre-fix code (crash before `set_extra_seats` left `plan='air'` + `paddle_subscription_id` committed)
- [x] 1 new regression test, confirmed to fail against the pre-fix code
- [x] Full github-app suite: 1571 passed, 8 skipped, 0 failed (1374 passed/8 skipped in the bulk suite, 197 in test_jobs.py + test_postgres_graph_store.py)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr