### PR TITLE
fix: stop a repo-existence oracle in the admin/dashboard ownership check (audit finding 34)

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -201,7 +201,7 @@ def _github_http_client() -> httpx.Client:
     return get_github_api_client()
 
 
-async def _repo_installation_id(pool, org: str, repo: str) -> int:
+async def _repo_installation_id(pool, org: str, repo: str) -> int | None:
     # A GitHub App installation covers exactly one account (org or user) -
     # a repo's owner in the URL is always that same account - so this
     # resolves without ever touching repo_history, which used to be the
@@ -212,6 +212,13 @@ async def _repo_installation_id(pool, org: str, repo: str) -> int:
     # never be reached, since this raised first). repo_history stays as
     # a fallback for account_login drift (e.g. a GitHub account rename
     # landing after this row was written), not the primary path anymore.
+    #
+    # Returns None rather than raising 404 itself - a genuinely nonexistent
+    # repo and one that exists but the caller doesn't administer need to
+    # produce the identical response (see both callers' merged not-found
+    # check), or the status code alone is a repo-existence oracle for any
+    # authenticated user, not just an admin of the target org
+    # (docs/audits/Claude_Audit.md finding 34).
     row = await pool.fetchrow(
         "SELECT installation_id FROM installations WHERE account_login = $1",
         org,
@@ -227,9 +234,7 @@ async def _repo_installation_id(pool, org: str, repo: str) -> int:
         """,
         f"{org}/{repo}",
     )
-    if row is None:
-        raise HTTPException(status_code=404, detail="no such repo")
-    return row["installation_id"]
+    return row["installation_id"] if row is not None else None
 
 
 def _fetch_administered_installation_ids(github_token: str) -> set[int]:
@@ -469,8 +474,15 @@ async def _require_authorized_installation(request: Request, org: str, repo: str
     pool = request.app.state.db_pool
     installation_id = await _repo_installation_id(pool, org, repo)
     administered_ids = await _administered_installation_ids_for_session_or_401(pool, session)
-    if installation_id not in administered_ids:
-        raise HTTPException(status_code=403, detail="you do not administer this installation")
+    # A real repo the caller doesn't administer and a repo that's never been
+    # connected at all get the identical 404 - neither status code nor body
+    # reveals which one it is to an authenticated caller who isn't an admin
+    # of the target org (docs/audits/Claude_Audit.md finding 34). The repo
+    # lookup above still has to happen before ownership can be checked
+    # against it - that ordering isn't what changed, only what a caller who
+    # fails the check gets told.
+    if installation_id is None or installation_id not in administered_ids:
+        raise HTTPException(status_code=404, detail="no such repo")
 
     installation = await get_installation(pool, installation_id)
     if installation is None:

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -183,8 +183,15 @@ async def list_my_repos(request: Request):
 
 
 async def _require_dashboard_installation(request: Request, org: str, repo: str) -> tuple[dict, int]:
-    # Session + ownership check first, before any repo lookup - an unauthenticated
-    # caller should not learn whether a given org/repo has scan history at all.
+    # Session first - an unauthenticated caller learns nothing. The repo
+    # lookup below still has to run before ownership can be checked against
+    # it (_repo_installation_id is what resolves org/repo to an
+    # installation_id in the first place); what's closed is the response
+    # itself: a real repo the caller doesn't administer and a repo that's
+    # never been connected at all now get the identical 404, so an
+    # authenticated-but-unauthorized caller can't use the status code to
+    # learn which org/repos this product has ever seen
+    # (docs/audits/Claude_Audit.md finding 34).
     session = await get_current_session(request)
     if session is None:
         raise HTTPException(status_code=401, detail="login required")
@@ -193,8 +200,8 @@ async def _require_dashboard_installation(request: Request, org: str, repo: str)
     installation_id = await _repo_installation_id(pool, org, repo)
 
     administered_ids = await _administered_installation_ids_for_session_or_401(pool, session)
-    if installation_id not in administered_ids:
-        raise HTTPException(status_code=403, detail="you do not administer this installation")
+    if installation_id is None or installation_id not in administered_ids:
+        raise HTTPException(status_code=404, detail="no such repo")
 
     installation = await get_installation(pool, installation_id)
     if installation is not None:

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -1132,6 +1132,29 @@ async def test_first_admin_to_arrive_is_auto_seated(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_admin_page_rejects_an_unadministered_installation_with_the_same_404_as_a_nonexistent_repo(
+    pool, monkeypatch
+):
+    # A real repo (installation 100, octocat/hello-world) the caller's
+    # GitHub account genuinely doesn't administer at all - distinct from
+    # test_second_github_admin_without_a_seat_is_rejected below, where the
+    # caller *does* administer it on GitHub but hasn't been seated yet (a
+    # different check, still correctly 403). 404, not 403, here: a real
+    # repo the caller doesn't administer must be indistinguishable from a
+    # repo that was never connected at all, or the status code alone is a
+    # repo-existence oracle for any authenticated user
+    # (docs/audits/Claude_Audit.md finding 34).
+    await _logged_in_client(pool, monkeypatch)  # sets up installation 100 + real repo_history
+    await _mock_github_installations(monkeypatch, [999])  # this session administers 999, not 100
+
+    signed = sign_session_id("sess-1", "test-session-secret")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test", cookies={"session": signed}) as client:
+        response = await client.get("/admin/octocat/hello-world")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_second_github_admin_without_a_seat_is_rejected(pool, monkeypatch):
     first = await _logged_in_client(pool, monkeypatch)
     async with first:
@@ -1649,8 +1672,9 @@ async def test_repo_installation_id_falls_back_to_repo_history(pool):
 
 
 @pytest.mark.asyncio
-async def test_repo_installation_id_raises_404_when_truly_unresolvable(pool):
-    with pytest.raises(HTTPException) as exc_info:
-        await _repo_installation_id(pool, "no-such-account", "no-such-repo")
-
-    assert exc_info.value.status_code == 404
+async def test_repo_installation_id_returns_none_when_truly_unresolvable(pool):
+    # Returns None rather than raising - the caller merges this with the
+    # ownership check into a single 404, so a nonexistent repo and one the
+    # caller doesn't administer are indistinguishable (see
+    # test_admin_page_rejects_an_unadministered_installation_with_the_same_404_as_a_nonexistent_repo).
+    assert await _repo_installation_id(pool, "no-such-account", "no-such-repo") is None

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -564,7 +564,9 @@ async def test_dashboard_returns_404_for_unknown_repo(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_dashboard_rejects_unadministered_installation(pool, monkeypatch):
+async def test_dashboard_rejects_unadministered_installation_with_the_same_404_as_a_nonexistent_repo(
+    pool, monkeypatch
+):
     await upsert_installation(pool, 1, "octocat")
     await insert_repo_history(
         pool,
@@ -575,11 +577,16 @@ async def test_dashboard_rejects_unadministered_installation(pool, monkeypatch):
     )
     # The caller is logged in, but their GitHub account administers a
     # different installation (999), not the one that owns this repo (1) -
-    # this is the exact cross-tenant case the fix closes.
+    # this is the exact cross-tenant case the fix closes. 404, not 403: a
+    # real repo the caller doesn't administer must be indistinguishable
+    # from a repo that was never connected at all (see
+    # test_dashboard_returns_404_for_unknown_repo just above) - otherwise
+    # the status code alone is a repo-existence oracle for any
+    # authenticated user (docs/audits/Claude_Audit.md finding 34).
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[999])
     async with client:
         response = await client.get("/app/octocat/hello-world")
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -1160,6 +1167,8 @@ async def test_dashboard_health_history_respects_limit(pool, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_dashboard_health_history_rejects_unadministered_installation(pool, monkeypatch):
+    # 404, not 403 - see test_dashboard_rejects_unadministered_installation_
+    # with_the_same_404_as_a_nonexistent_repo for why (finding 34).
     await upsert_installation(pool, 506, "octocat")
     await insert_repo_history(
         pool, 506, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
@@ -1169,11 +1178,13 @@ async def test_dashboard_health_history_rejects_unadministered_installation(pool
         response = await client.get(
             "/app/octocat/hello-world/health/history", params={"method": "GET", "path": "/api/users"}
         )
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_dashboard_health_rejects_unadministered_installation(pool, monkeypatch):
+    # 404, not 403 - see test_dashboard_rejects_unadministered_installation_
+    # with_the_same_404_as_a_nonexistent_repo for why (finding 34).
     await upsert_installation(pool, 501, "octocat")
     await insert_repo_history(
         pool,
@@ -1193,7 +1204,7 @@ async def test_dashboard_health_rejects_unadministered_installation(pool, monkey
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[999])
     async with client:
         response = await client.get("/app/octocat/hello-world/health")
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_data_deletion.py
+++ b/github-app/tests/test_data_deletion.py
@@ -325,9 +325,13 @@ async def test_delete_all_data_route_works_on_the_free_plan(pool, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_delete_all_data_route_rejects_non_administrator(pool, monkeypatch):
-    # 403 fires inside _require_authorized_installation, before the OTP is
-    # ever looked at - "000000" just needs to be syntactically valid so
-    # Pydantic doesn't 422 the request before that check even runs.
+    # 404, not 403, fires inside _require_authorized_installation, before
+    # the OTP is ever looked at - "000000" just needs to be syntactically
+    # valid so Pydantic doesn't 422 the request before that check even
+    # runs. A real installation the caller doesn't administer must be
+    # indistinguishable from one that doesn't exist at all
+    # (docs/audits/Claude_Audit.md finding 34) - otherwise the status code
+    # is a repo-existence oracle for any authenticated user.
     client = await _logged_in_client(pool, monkeypatch, installation_id=100)
     # A second installation this session does not administer - the mocked
     # GitHub /user/installations response only ever returns id 100.
@@ -338,7 +342,7 @@ async def test_delete_all_data_route_rejects_non_administrator(pool, monkeypatch
             json={"confirm": "globex", "otp_code": "000000"},
         )
 
-    assert response.status_code == 403
+    assert response.status_code == 404
     assert await get_installation(pool, 101) is not None
 
 

--- a/github-app/tests/test_data_export.py
+++ b/github-app/tests/test_data_export.py
@@ -18,6 +18,9 @@ async def test_export_requires_login(pool, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_export_rejects_non_administrator(pool, monkeypatch):
+    # 404, not 403 - a real installation the caller doesn't administer must
+    # be indistinguishable from one that doesn't exist at all
+    # (docs/audits/Claude_Audit.md finding 34).
     from app_server.db import upsert_installation
 
     client = await _logged_in_client(pool, monkeypatch, installation_id=100)
@@ -25,7 +28,7 @@ async def test_export_rejects_non_administrator(pool, monkeypatch):
     async with client:
         response = await client.get("/admin/globex/web/export-data")
 
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_deletion_otp.py
+++ b/github-app/tests/test_deletion_otp.py
@@ -18,6 +18,9 @@ async def test_request_otp_requires_login(pool, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_request_otp_rejects_non_administrator(pool, monkeypatch):
+    # 404, not 403 - a real installation the caller doesn't administer must
+    # be indistinguishable from one that doesn't exist at all
+    # (docs/audits/Claude_Audit.md finding 34).
     from app_server.db import upsert_installation
 
     client = await _logged_in_client(pool, monkeypatch, installation_id=100)
@@ -25,7 +28,7 @@ async def test_request_otp_rejects_non_administrator(pool, monkeypatch):
     async with client:
         response = await client.post("/admin/globex/web/delete-all-data/request-otp")
 
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`docs/audits/Claude_Audit.md` finding 34: a real repo the caller's GitHub account doesn't administer returned `403 "you do not administer this installation"`, while a repo that's never been connected to the product at all returned `404 "no such repo"` - two distinguishable responses for any authenticated user (anyone who's completed the app's own GitHub OAuth login, not necessarily an admin of the target org), letting them probe whether an arbitrary org/repo has ever been scanned before ownership was ever checked.

The codebase already treats exactly this pattern as worth engineering around elsewhere. Here the comment on `_require_dashboard_installation` claimed the same care ("Session + ownership check first, before any repo lookup"), but the code never actually had that ordering - `_repo_installation_id` always ran first, since it's literally what resolves org/repo into the installation_id ownership gets checked against. As the audit itself notes, that ordering can't be fully avoided; what can be fixed is what a failed check tells the caller.

## Fix

`_repo_installation_id` now returns `None` instead of raising 404 itself. Both `_require_authorized_installation` (admin.py) and `_require_dashboard_installation` (dashboard.py) merge that `None` check with the ownership check into a single `404 "no such repo"` - a real repo the caller doesn't administer and one that was never connected at all are now genuinely indistinguishable, not just superficially similar.

## Test changes

Updated 6 existing tests across 5 files from expecting 403 to expecting 404 - each confirmed via direct reading to be exercising this real ownership-check path, not one of the other, unrelated 403s in `admin.py` (seat-limit checks, the CLI-token route's direct-installation-id check, `_has_real_admin_permission` checks) which are untouched and still correctly return 403. Added 2 new regression tests covering the merged-404 behavior directly.

**Severity: low** - tenant-existence info disclosure only, not data, and requires just a self-service GitHub OAuth login to reach.

## Test plan
- [x] Targeted suite (test_admin.py, test_dashboard.py, test_data_deletion.py, test_deletion_otp.py, test_data_export.py): 209 passed
- [x] Full github-app suite: 1571 passed, 8 skipped, 0 failed (one test_jobs.py test flaked once under unrelated concurrent test-DB contamination during a run, confirmed to pass cleanly in isolation with a clear DB - not a regression from this change)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr