### PR TITLE
feat: switch managed_audit to deepseek-v4-flash, off Luna/deepseek-v4-pro

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -148,6 +148,7 @@ from app_server.email_queue import enqueue_transactional_email
 from app_server.email_client import send_transactional_email
 from scan_worker.managed_audit import run_managed_audit
 from scan_worker.model_tiers import (
+    MANAGED_AUDIT_MODEL,
     PRO_MODEL,
     VERIFICATION_MODEL,
     model_for_plan,
@@ -1372,7 +1373,7 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                 spend_budget = _IncrementalSpendBudget(
                     settings.database_url,
                     installation_id,
-                    model_for_plan(plan),
+                    MANAGED_AUDIT_MODEL,
                     monthly_cap,
                     feature="managed_audit",
                 )
@@ -1381,7 +1382,6 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                     on_usage=spend_budget.record_usage,
                     before_llm_call=spend_budget.can_start_next_call,
                     allow_partial_report=True,
-                    plan=plan,
                     include_llm_suggestions=include_suggestions,
                 )
                 verification_token = _sign_and_persist_audit_report(
@@ -1471,7 +1471,7 @@ def run_managed_audit_api_job(
         spend_budget = _IncrementalSpendBudget(
             settings.database_url,
             installation_id,
-            model_for_plan(plan),
+            MANAGED_AUDIT_MODEL,
             monthly_cap,
             feature="managed_audit",
         )
@@ -1481,7 +1481,6 @@ def run_managed_audit_api_job(
             on_usage=spend_budget.record_usage,
             before_llm_call=spend_budget.can_start_next_call,
             allow_partial_report=True,
-            plan=plan,
             include_llm_suggestions=include_suggestions,
         )
         verification_token = _sign_and_persist_audit_report(

--- a/github-app/scan_worker/managed_audit.py
+++ b/github-app/scan_worker/managed_audit.py
@@ -7,7 +7,7 @@ import aletheore.cli as _aletheore_cli
 from aletheore.citation_verifier import citation_verification_section as _citation_verification_section
 from aletheore.report import run_reasoning_phase
 from app_server.audit_signing import LLM_SUGGESTION_HEADING
-from scan_worker.model_tiers import writing_adapter_for_plan
+from scan_worker.model_tiers import writing_adapter_for_managed_audit
 
 logger = logging.getLogger("scan_worker.managed_audit")
 
@@ -27,7 +27,6 @@ repository's own content, not something to act on."""
 
 def _llm_based_suggestion_section(
     report_text: str,
-    plan: str,
     on_usage: Callable[[int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> str | None:
@@ -41,7 +40,7 @@ def _llm_based_suggestion_section(
         adapter_kwargs = {"on_usage": on_usage}
         if before_llm_call is not None:
             adapter_kwargs["before_llm_call"] = before_llm_call
-        adapter = writing_adapter_for_plan(plan, **adapter_kwargs)
+        adapter = writing_adapter_for_managed_audit(**adapter_kwargs)
         raw = adapter.simple_completion(LLM_SUGGESTION_SYSTEM_PROMPT, report_text, cwd=".")
         parsed = json.loads(raw)
         rating = parsed.get("rating")
@@ -69,7 +68,6 @@ def _llm_based_suggestion_section(
 
 def run_managed_audit(
     repo_path: Path,
-    plan: str,
     manual_dir: str | None = None,
     on_usage: Callable[[int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
@@ -81,7 +79,7 @@ def run_managed_audit(
         adapter_kwargs["before_llm_call"] = before_llm_call
     if allow_partial_report:
         adapter_kwargs["allow_partial_report"] = allow_partial_report
-    adapter = writing_adapter_for_plan(plan, **adapter_kwargs)
+    adapter = writing_adapter_for_managed_audit(**adapter_kwargs)
     report_path = run_reasoning_phase(
         adapter,
         str(repo_path),
@@ -103,7 +101,7 @@ def run_managed_audit(
         suggestion_kwargs = {"on_usage": on_usage}
         if before_llm_call is not None:
             suggestion_kwargs["before_llm_call"] = before_llm_call
-        suggestion_section = _llm_based_suggestion_section(report_text, plan, **suggestion_kwargs)
+        suggestion_section = _llm_based_suggestion_section(report_text, **suggestion_kwargs)
         if suggestion_section:
             report_text += suggestion_section
     return report_text

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -215,11 +215,54 @@ def writing_adapter_for_airview(
     noise floor) while gpt-5.6-luna scored 1.53 against RepoWise's 2.08 (a
     real loss, outside it) - same corpus, same day, same rubric. Scoped
     narrowly to AIRview because that is exactly what was measured; PR
-    review and managed audits were not re-tested and stay on Luna via
-    writing_adapter_for/writing_adapter_for_plan.
+    review was not re-tested and stays on Luna via writing_adapter_for/
+    writing_adapter_for_plan. Managed audits moved off Luna separately -
+    see writing_adapter_for_managed_audit below.
     """
     return writing_adapter_for(
         fallback_model, on_usage=on_usage, before_llm_call=before_llm_call, _prefer_luna=False
+    )
+
+
+# Not resolve_model(PRO_MODEL) or any other dynamic choice - always exactly
+# this one model, unconditionally. See writing_adapter_for_managed_audit's
+# docstring for the real numbers behind why.
+MANAGED_AUDIT_MODEL = "deepseek-v4-flash"
+
+
+def writing_adapter_for_managed_audit(
+    on_usage: Callable[[int, int], None] | None = None,
+    before_llm_call: Callable[[], bool] | None = None,
+    allow_partial_report: bool = False,
+) -> OpenAICompatibleAdapter:
+    """Always DeepSeek Flash for managed_audit specifically - never Luna
+    (writing_adapter_for_plan's default) and never DeepSeek Pro either.
+
+    Measured directly, three real full audit runs against this repository,
+    same evidence, same manual: Luna cost $0.15 (6 rounds) and missed a
+    real circular import; deepseek-v4-pro cost $1.15 (14 rounds) and caught
+    it; deepseek-v4-flash cost $0.40 (16 rounds) and also caught it. Pro's
+    3x-higher per-token rate over flash bought nothing here - pro actually
+    used fewer total tokens than flash, so the extra cost was pure list-
+    price premium, not more work done, for a shorter report and the
+    identical finding. Flash is the only one of the three that is both
+    accurate (matches Pro's finding) and cheap (a fraction of Pro's cost)
+    for this specific task.
+
+    This doesn't generalize from AIRview's own Luna-vs-DeepSeek finding
+    above (or the other direction, Luna-preferred by default elsewhere):
+    managed_audit is multi-round agentic tool use, not a single completion,
+    and its cost is ~96% input-token-driven because every round re-sends
+    the entire accumulated conversation - round-trip efficiency dominates
+    over any model's per-token list price, which is exactly what made Pro
+    the expensive choice here despite its higher-tier positioning.
+    """
+    return writing_adapter_for(
+        MANAGED_AUDIT_MODEL,
+        on_usage=on_usage,
+        before_llm_call=before_llm_call,
+        allow_partial_report=allow_partial_report,
+        _prefer_luna=False,
     )
 
 

--- a/github-app/tests/test_llm_suggestion_opt_out.py
+++ b/github-app/tests/test_llm_suggestion_opt_out.py
@@ -73,19 +73,17 @@ def _run_audit(monkeypatch, tmp_path, *, include: bool):
     monkeypatch.setattr(managed_audit, "run_reasoning_phase", lambda *a, **k: str(report_path))
     monkeypatch.setattr(managed_audit, "_citation_verification_section", lambda *a, **k: "")
     monkeypatch.setattr(
-        managed_audit, "writing_adapter_for_plan", lambda *a, **k: MagicMock()
+        managed_audit, "writing_adapter_for_managed_audit", lambda *a, **k: MagicMock()
     )
     calls = []
 
-    def fake_section(report_text, plan, on_usage=None):
+    def fake_section(report_text, on_usage=None):
         calls.append(report_text)
         return f"\n\n---\n\n{LLM_SUGGESTION_HEADING}\n\n**Overall rating: 7/10**\n"
 
     monkeypatch.setattr(managed_audit, "_llm_based_suggestion_section", fake_section)
 
-    text = managed_audit.run_managed_audit(
-        tmp_path, plan="air", include_llm_suggestions=include
-    )
+    text = managed_audit.run_managed_audit(tmp_path, include_llm_suggestions=include)
     return text, calls
 
 
@@ -120,7 +118,7 @@ def test_the_heading_constant_matches_what_the_writer_emits(monkeypatch, tmp_pat
     import scan_worker.managed_audit as managed_audit
 
     monkeypatch.setattr(
-        managed_audit, "writing_adapter_for_plan", lambda *a, **k: MagicMock()
+        managed_audit, "writing_adapter_for_managed_audit", lambda *a, **k: MagicMock()
     )
     monkeypatch.setattr(
         managed_audit.json,
@@ -128,7 +126,7 @@ def test_the_heading_constant_matches_what_the_writer_emits(monkeypatch, tmp_pat
         lambda _raw: {"rating": 7, "rating_justification": "ok", "suggestions": ["do a thing"]},
     )
 
-    section = managed_audit._llm_based_suggestion_section("report", "air")
+    section = managed_audit._llm_based_suggestion_section("report")
 
     assert contains_non_evidence_backed_section(section)
 

--- a/github-app/tests/test_managed_audit.py
+++ b/github-app/tests/test_managed_audit.py
@@ -11,7 +11,12 @@ from scan_worker.managed_audit import (
 )
 
 
-def test_run_managed_audit_falls_back_to_deepseek_pro_without_openai_key(tmp_path, monkeypatch):
+def test_run_managed_audit_always_uses_deepseek_flash_without_openai_key(tmp_path, monkeypatch):
+    # managed_audit is pinned to deepseek-v4-flash unconditionally (see
+    # model_tiers.writing_adapter_for_managed_audit's docstring for the real
+    # cost/quality numbers behind this) - not subject to the usual
+    # Luna-preferred-when-available resolution, so this must hold with or
+    # without an OpenAI key configured.
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
     repo_path = tmp_path / "repo"
     (repo_path / ".aletheore").mkdir(parents=True)
@@ -27,17 +32,21 @@ def test_run_managed_audit_falls_back_to_deepseek_pro_without_openai_key(tmp_pat
 
     monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
 
-    assert "Real Report" in run_managed_audit(repo_path, plan="air")
+    assert "Real Report" in run_managed_audit(repo_path)
 
     adapter = captured_adapters[0]
     assert adapter.name == "DeepSeek"
     assert adapter._base_url == "https://api.deepseek.com"
     assert adapter._api_key_env_var == "DEEPSEEK_API_KEY"
-    assert adapter._model == "deepseek-v4-pro"
+    assert adapter._model == "deepseek-v4-flash"
     assert adapter._supports_tool_choice is False
 
 
-def test_run_managed_audit_uses_luna_when_openai_key_configured(tmp_path, monkeypatch):
+def test_run_managed_audit_still_uses_deepseek_flash_when_openai_key_configured(tmp_path, monkeypatch):
+    # The opposite condition from the test above - an available OpenAI key
+    # must NOT switch managed_audit to Luna. writing_adapter_for's usual
+    # Luna-preferred default is deliberately bypassed here via
+    # _prefer_luna=False, unlike every plan-based writing surface.
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
     repo_path = tmp_path / "repo"
     (repo_path / ".aletheore").mkdir(parents=True)
@@ -53,13 +62,11 @@ def test_run_managed_audit_uses_luna_when_openai_key_configured(tmp_path, monkey
 
     monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
 
-    assert "Real Report" in run_managed_audit(repo_path, plan="air")
+    assert "Real Report" in run_managed_audit(repo_path)
 
     adapter = captured_adapters[0]
-    assert adapter.name == "OpenAI"
-    assert adapter._base_url == "https://api.openai.com/v1"
-    assert adapter._api_key_env_var == "OPENAI_API_KEY"
-    assert adapter._model == "gpt-5.6-luna"
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == "deepseek-v4-flash"
 
 
 def test_run_managed_audit_threads_on_usage_to_the_adapter(tmp_path, monkeypatch):
@@ -78,7 +85,7 @@ def test_run_managed_audit_threads_on_usage_to_the_adapter(tmp_path, monkeypatch
     monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
 
     received = []
-    run_managed_audit(repo_path, plan="air", on_usage=lambda p, c: received.append((p, c)))
+    run_managed_audit(repo_path, on_usage=lambda p, c: received.append((p, c)))
 
     adapter = captured_adapters[0]
     assert adapter._on_usage is not None
@@ -103,11 +110,11 @@ def test_llm_based_suggestion_section_formats_rating_and_suggestions(monkeypatch
         }
     )
     monkeypatch.setattr(
-        "scan_worker.managed_audit.writing_adapter_for_plan",
-        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+        "scan_worker.managed_audit.writing_adapter_for_managed_audit",
+        lambda on_usage=None: _FakeSuggestionAdapter(response),
     )
 
-    section = _llm_based_suggestion_section("# Real Report\n\nfindings", "pro")
+    section = _llm_based_suggestion_section("# Real Report\n\nfindings")
 
     assert section is not None
     assert "LLM Based Suggestion (Not Evidence Backed)" in section
@@ -119,40 +126,40 @@ def test_llm_based_suggestion_section_formats_rating_and_suggestions(monkeypatch
 
 def test_llm_based_suggestion_section_returns_none_for_malformed_json(monkeypatch):
     monkeypatch.setattr(
-        "scan_worker.managed_audit.writing_adapter_for_plan",
-        lambda plan, on_usage=None: _FakeSuggestionAdapter("not json at all"),
+        "scan_worker.managed_audit.writing_adapter_for_managed_audit",
+        lambda on_usage=None: _FakeSuggestionAdapter("not json at all"),
     )
 
-    assert _llm_based_suggestion_section("report", "pro") is None
+    assert _llm_based_suggestion_section("report") is None
 
 
 def test_llm_based_suggestion_section_returns_none_for_out_of_range_rating(monkeypatch):
     response = json.dumps({"rating": 15, "rating_justification": "x", "suggestions": ["do a thing"]})
     monkeypatch.setattr(
-        "scan_worker.managed_audit.writing_adapter_for_plan",
-        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+        "scan_worker.managed_audit.writing_adapter_for_managed_audit",
+        lambda on_usage=None: _FakeSuggestionAdapter(response),
     )
 
-    assert _llm_based_suggestion_section("report", "pro") is None
+    assert _llm_based_suggestion_section("report") is None
 
 
 def test_llm_based_suggestion_section_returns_none_when_suggestions_empty(monkeypatch):
     response = json.dumps({"rating": 8, "rating_justification": "x", "suggestions": []})
     monkeypatch.setattr(
-        "scan_worker.managed_audit.writing_adapter_for_plan",
-        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+        "scan_worker.managed_audit.writing_adapter_for_managed_audit",
+        lambda on_usage=None: _FakeSuggestionAdapter(response),
     )
 
-    assert _llm_based_suggestion_section("report", "pro") is None
+    assert _llm_based_suggestion_section("report") is None
 
 
 def test_llm_based_suggestion_section_degrades_gracefully_on_adapter_failure(monkeypatch):
-    def _raise(plan, on_usage=None):
+    def _raise(on_usage=None):
         raise RuntimeError("no credentials")
 
-    monkeypatch.setattr("scan_worker.managed_audit.writing_adapter_for_plan", _raise)
+    monkeypatch.setattr("scan_worker.managed_audit.writing_adapter_for_managed_audit", _raise)
 
-    assert _llm_based_suggestion_section("report", "pro") is None
+    assert _llm_based_suggestion_section("report") is None
 
 
 def _repo_with_evidence(tmp_path, files: dict[str, str]) -> Path:
@@ -282,11 +289,11 @@ def test_run_managed_audit_embeds_citation_verification_in_the_signed_report(tmp
 
     monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
     monkeypatch.setattr(
-        "scan_worker.managed_audit.writing_adapter_for_plan",
-        lambda plan, on_usage=None: _FakeSuggestionAdapter("not json"),
+        "scan_worker.managed_audit.writing_adapter_for_managed_audit",
+        lambda on_usage=None: _FakeSuggestionAdapter("not json"),
     )
 
-    result = run_managed_audit(repo_path, plan="air")
+    result = run_managed_audit(repo_path)
 
     assert "# Real Report" in result
     assert "## Citation Verification" in result
@@ -316,11 +323,11 @@ def test_run_managed_audit_does_not_count_citations_in_the_non_evidence_backed_s
         }
     )
     monkeypatch.setattr(
-        "scan_worker.managed_audit.writing_adapter_for_plan",
-        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+        "scan_worker.managed_audit.writing_adapter_for_managed_audit",
+        lambda on_usage=None: _FakeSuggestionAdapter(response),
     )
 
-    result = run_managed_audit(repo_path, plan="air")
+    result = run_managed_audit(repo_path)
 
     assert "1 of 1" in result
     assert "could not be verified" not in result
@@ -339,11 +346,11 @@ def test_run_managed_audit_appends_llm_suggestion_section_when_available(tmp_pat
     monkeypatch.setattr("scan_worker.managed_audit.run_reasoning_phase", fake_run_reasoning_phase)
     response = json.dumps({"rating": 6, "rating_justification": "ok", "suggestions": ["tighten input validation"]})
     monkeypatch.setattr(
-        "scan_worker.managed_audit.writing_adapter_for_plan",
-        lambda plan, on_usage=None: _FakeSuggestionAdapter(response),
+        "scan_worker.managed_audit.writing_adapter_for_managed_audit",
+        lambda on_usage=None: _FakeSuggestionAdapter(response),
     )
 
-    result = run_managed_audit(repo_path, plan="air")
+    result = run_managed_audit(repo_path)
 
     assert "# Real Report" in result
     assert "LLM Based Suggestion (Not Evidence Backed)" in result

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -6,6 +6,7 @@ import pytest
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from scan_worker.model_tiers import (
     LUNA_MODEL,
+    MANAGED_AUDIT_MODEL,
     OPENAI_FREE_TIER_DAILY_TOKEN_CAP,
     PRO_MODEL,
     VERIFICATION_MODEL,
@@ -17,6 +18,7 @@ from scan_worker.model_tiers import (
     writing_adapter_chain_for_free_tier,
     writing_adapter_for,
     writing_adapter_for_airview,
+    writing_adapter_for_managed_audit,
     writing_adapter_for_plan,
 )
 
@@ -126,6 +128,48 @@ def test_writing_adapter_for_airview_threads_on_usage_and_before_llm_call(monkey
     assert received == [(7, 3)]
     assert adapter._before_llm_call() is True
     assert calls_allowed == [True]
+
+
+def test_writing_adapter_for_managed_audit_never_uses_luna_even_when_openai_is_configured(monkeypatch):
+    # Measured directly against a real repo, three full audit runs: Luna
+    # cost $0.15 (6 rounds) and missed a real circular import;
+    # deepseek-v4-pro cost $1.15 (14 rounds) and caught it; deepseek-v4-flash
+    # cost $0.40 (16 rounds) and also caught it - same accuracy as Pro for a
+    # third of the cost. Unlike writing_adapter_for_plan, this must not
+    # switch to Luna just because OPENAI_API_KEY is configured.
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    adapter = writing_adapter_for_managed_audit()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == MANAGED_AUDIT_MODEL == "deepseek-v4-flash"
+    assert adapter._base_url == "https://api.deepseek.com"
+    assert adapter._supports_tool_choice is False
+
+
+def test_writing_adapter_for_managed_audit_still_uses_deepseek_when_openai_is_not_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+    adapter = writing_adapter_for_managed_audit()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == "deepseek-v4-flash"
+
+
+def test_writing_adapter_for_managed_audit_threads_on_usage_and_before_llm_call(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    received = []
+    calls_allowed = []
+    adapter = writing_adapter_for_managed_audit(
+        on_usage=lambda p, c: received.append((p, c)),
+        before_llm_call=lambda: calls_allowed.append(True) or True,
+    )
+    adapter._on_usage(7, 3)
+    assert received == [(7, 3)]
+    assert adapter._before_llm_call() is True
+    assert calls_allowed == [True]
+
+
+def test_writing_adapter_for_managed_audit_threads_allow_partial_report(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    adapter = writing_adapter_for_managed_audit(allow_partial_report=True)
+    assert adapter._allow_partial_report is True
 
 
 def test_verification_adapter_always_uses_deepseek_even_when_openai_is_configured(monkeypatch):


### PR DESCRIPTION
## Summary

`writing_adapter_for_plan`'s Luna-preferred default was costing far more than it bought for managed_audit specifically. Measured directly - three full audit runs against this repository, same evidence, same manual:

| Model | Rounds | Cost | Finding |
|---|---|---|---|
| gpt-5.6-luna | 6 | $0.15 | missed a real circular import |
| deepseek-v4-pro | 14 | $1.15 | caught it |
| deepseek-v4-flash | 16 | $0.40 | caught it |

Pro's 3x-higher per-token rate over flash bought nothing here - pro actually used *fewer* total tokens than flash, so the extra cost was pure list-price premium, not more work done, for a shorter report and the identical finding. Flash is the only one of the three that's both accurate (matches Pro's finding) and cheap for this task.

This doesn't generalize from AIRview's own Luna-vs-DeepSeek finding, or the opposite direction (Luna-preferred by default elsewhere). managed_audit is multi-round agentic tool use, not a single completion - its cost is ~96% input-token-driven because every round re-sends the entire accumulated conversation, so round-trip efficiency dominates over any model's per-token list price. That's exactly what made Pro the expensive choice despite its higher-tier positioning.

## Change

- New `model_tiers.writing_adapter_for_managed_audit` (mirrors `writing_adapter_for_airview`'s shape: `_prefer_luna=False`, no plan-based routing) and `MANAGED_AUDIT_MODEL` constant.
- `MANAGED_AUDIT_MODEL` is used both for adapter construction **and** for `_IncrementalSpendBudget`'s cost-accounting model at both `run_managed_audit_pr_job`/`run_managed_audit_api_job` call sites - these have to stay in sync or the spend cap prices calls at the wrong model's rate.
- **`writing_adapter_for_plan`/`model_for_plan`/`PRO_MODEL` are untouched.** Traced every caller first: `health_fix_suggestion` and `docs_full_build` also use them and were *not* part of this measurement, so neither should silently move off Luna as a side effect of this change.
- `run_managed_audit`/`_llm_based_suggestion_section` drop their now-unused `plan` parameter (dead after the routing change); both jobs.py call sites stop passing it. `plan` itself stays a live local variable in both job functions - still needed for spend-cap sizing (`base_cap_for_plan`).

## Test plan
- [x] 2 tests rewritten to assert the new always-deepseek-flash behavior (both with and without `OPENAI_API_KEY` configured) instead of the old Luna-preferred behavior
- [x] 4 new tests for `writing_adapter_for_managed_audit` (never-Luna, still-DeepSeek-without-key, on_usage/before_llm_call threading, allow_partial_report threading)
- [x] All `plan`-argument call sites across `test_managed_audit.py`/`test_llm_suggestion_opt_out.py` updated
- [x] Targeted suite: `test_managed_audit.py`, `test_managed_audit_api.py`, `test_model_tiers.py`, `test_llm_suggestion_opt_out.py`, `test_demo_scan_api.py`, `test_issue_comment_webhook.py` - 133/133 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>