### PR TITLE
fix: endpoint cache doesn't invalidate on cross-file router-mount changes (audit finding 20, high severity)

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -1361,10 +1361,29 @@ def map_api_endpoints(
         for key, prefixes in collected.items():
             cross_file_router_mounts.setdefault(key, []).extend(prefixes)
 
+    # A router-defining file's composed endpoint paths depend on every
+    # include_router(..., prefix=...) call that targets it, which can live
+    # in a different file entirely - this loop is unconditional above (no
+    # unchanged_endpoints check), so cross_file_router_mounts is always
+    # fresh, but the cache-reuse skip below used to trust a defining file's
+    # own hash/diff as if that were the whole story. Confirmed live: bumping
+    # app.py's include_router prefix from /api/v1 to /api/v2 while
+    # routers/users.py stayed byte-identical left the cached, now-stale
+    # /api/v1/users path in place, since routers/users.py alone "looked"
+    # unchanged. Excluding every defining file from cache-reuse trades a
+    # little incremental-scan speed for those specific files for
+    # correctness that doesn't depend on tracking which mounting file
+    # changed - see docs/audits/Claude_Audit.md finding 20.
+    cross_file_mount_defining_files = {defining_file for defining_file, _router in cross_file_router_mounts}
+
     for path in _iter_source_files(repo_path, ignored_paths):
         rel_path = _rel(repo_path, path)
 
-        if unchanged_endpoints is not None and rel_path in unchanged_endpoints:
+        if (
+            unchanged_endpoints is not None
+            and rel_path in unchanged_endpoints
+            and rel_path not in cross_file_mount_defining_files
+        ):
             endpoints.extend(unchanged_endpoints[rel_path])
             continue
 

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -199,6 +199,43 @@ def test_map_api_endpoints_composes_fastapi_prefix_from_another_file(tmp_path):
     assert route["path"] == "/api/v1/users/{user_id}"
 
 
+def test_map_api_endpoints_reparses_a_router_file_when_only_the_mounting_file_changed(tmp_path):
+    # docs/audits/Claude_Audit.md finding 20, confirmed live before the fix:
+    # cross_file_router_mounts is recomputed fresh every call (the pre-pass
+    # loop above has no unchanged_endpoints check), but the per-file
+    # cache-reuse skip below used to trust users.py's own hash/diff as the
+    # whole story - so bumping main.py's include_router prefix while
+    # users.py stayed byte-identical left the cached, now-stale /api/v1
+    # path in place. users.py must be excluded from cache-reuse because its
+    # composed path depends on a DIFFERENT file's include_router call, not
+    # because its own content changed.
+    (tmp_path / "users.py").write_text(
+        'router = APIRouter()\n'
+        '@router.get("/list")\n'
+        'def list_users():\n    pass\n'
+    )
+    (tmp_path / "main.py").write_text(
+        "from users import router\n"
+        'app.include_router(router, prefix="/api/v1")\n'
+    )
+
+    first = map_api_endpoints(tmp_path)
+    cached_users_endpoint = next(e for e in first["endpoints"] if e["file"] == "users.py")
+    assert cached_users_endpoint["path"] == "/api/v1/list"
+
+    # Only main.py changes (prefix bumped to /api/v2) - users.py is passed
+    # as unchanged, exactly as evidence.py/scan_worker.jobs would build it
+    # from a real hash/diff comparison.
+    (tmp_path / "main.py").write_text(
+        "from users import router\n"
+        'app.include_router(router, prefix="/api/v2")\n'
+    )
+
+    second = map_api_endpoints(tmp_path, unchanged_endpoints={"users.py": [cached_users_endpoint]})
+    users_endpoint = next(e for e in second["endpoints"] if e["file"] == "users.py")
+    assert users_endpoint["path"] == "/api/v2/list"
+
+
 def test_map_api_endpoints_does_not_double_count_a_same_file_include_router_prefix(tmp_path):
     (tmp_path / "api.py").write_text(
         'router = APIRouter(prefix="/api/v1/users")\n'


### PR DESCRIPTION
## Summary

`docs/audits/Claude_Audit.md` finding 20 - **high severity, live on the production per-push/per-PR scan path.**

`cross_file_router_mounts` is recomputed fresh on every `map_api_endpoints` call (the pre-pass loop that collects it has no `unchanged_endpoints` check at all), but the per-file cache-reuse skip trusted a router-defining file's own content hash/diff as the whole story. A router's composed endpoint path can depend on a *different* file's `include_router(..., prefix=...)` call, which a file-level diff has no way to see.

## Reproduction

Confirmed live before fixing: bumping a mounting file's `include_router` prefix from `/api/v1` to `/api/v2` while the router-defining file stayed byte-identical left the cached, now-stale `/api/v1` path in place across the "incremental" scan.

Concretely: a PR that only touches `app.py` (changing an `include_router` prefix) leaves the router-definition file out of the diff, so its previously-persisted composed path gets reused verbatim in the new evidence/endpoint inventory - on every push/PR scan of that repo from then on, until the router file itself changes for an unrelated reason. This silently corrupts endpoint evidence for any repo using this common FastAPI pattern (a router defined in one file, mounted with a prefix in another).

## Fix

Excludes every file that appears as a `defining_file` in `cross_file_router_mounts` from `unchanged_endpoints` reuse, unconditionally - not just when the specific mounting file that targets it also changed. This is the audit's proposed "fix option 2": simpler than tracking which mounting file changed (which would need diffing that file's *previous* version too, not just its current one), still fully correct, and contained entirely inside `map_api_endpoints`.

`evidence.py` and `scan_worker/jobs.py` (the two cache producers the audit names) both just pass `unchanged_endpoints` through to `map_api_endpoints` unchanged - neither needed any changes, since the fix lives entirely in the shared function both of them call into.

## Test plan
- [x] Reproduced the bug directly against the pre-fix code
- [x] 1 new regression test, confirmed to fail against the pre-fix code
- [x] Full `src/` suite: 1422 passed, 0 failed
- [x] `test_endpoints.py` specifically: 63 passed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr