### PR TITLE
fix: 8 scanner import-resolution bugs (audit findings 21, 27, 28, 29, 31, 32, 33, 35)

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -401,7 +401,16 @@ def _extract_django_routes(root: Node, source: bytes, rel_path: str) -> list[dic
     entries: list[dict] = []
 
     def walk(n: Node) -> None:
-        if n.type == "assignment":
+        # "urlpatterns += [...]" (splitting the list across an initial
+        # assignment plus one or more extensions - an ordinary, documented
+        # Django organizing pattern) parses to augmented_assignment, a
+        # distinct node type from plain assignment - the unconditional
+        # recursion below already walks into it, but nothing matched it
+        # for extraction, so every route declared this way was silently
+        # missing from the endpoint inventory with no indication anything
+        # was skipped (audit finding 27). Both node types use the same
+        # left/right field names in this grammar, confirmed directly.
+        if n.type in ("assignment", "augmented_assignment"):
             left = n.child_by_field_name("left")
             right = n.child_by_field_name("right")
             is_urlpatterns = (

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -666,6 +666,26 @@ def _extract_javascript(node: Node, source: bytes) -> tuple[list[str], list[dict
                 if source_node is not None:
                     raw = source[source_node.start_byte:source_node.end_byte].decode(errors="ignore")
                     imports.append(raw.strip("'\""))
+                else:
+                    # Import-equals ("import foo = require('./foo');") is
+                    # still an import_statement node, but has no "source"
+                    # field - the path lives inside a nested
+                    # import_require_clause instead, a declaration form
+                    # distinct from (and not caught by) the
+                    # call_expression-based require() handling below.
+                    # Confirmed present in real code (3 occurrences in the
+                    # axios repo) - without this, the whole statement
+                    # silently produced zero imports (audit finding 32).
+                    require_clause = next(
+                        (c for c in n.children if c.type == "import_require_clause"), None
+                    )
+                    if require_clause is not None:
+                        string_node = next(
+                            (c for c in require_clause.children if c.type == "string"), None
+                        )
+                        specifier = string_literal(string_node)
+                        if specifier is not None:
+                            imports.append(specifier)
             elif n.type == "export_statement":
                 # Re-export barrels ("export { x } from './x'", "export * from
                 # './x'") get their own export_statement node type with a
@@ -935,10 +955,29 @@ def _rust_use_paths(node: Node, source: bytes) -> list[str]:
         # "crate::foo::{Bar, Baz}" - both names share the same prefix module; each
         # becomes prefix::name so the existing crate/self/super resolver can treat
         # them exactly like any other full path.
+        #
+        # A list item can itself be a nested group ("crate::foo::{Bar,
+        # baz::{Qux, self}}") or an aliased entry ("Bar as MyBar") rather
+        # than a bare identifier/self leaf - recursing for those instead of
+        # only accepting leaves is what makes nested use grouping
+        # (idiomatic, rustfmt's default output in many configs) resolve at
+        # all, instead of silently dropping everything below the first
+        # brace level. Confirmed directly: "use std::{fmt, io::{self,
+        # Write}};" only ever produced "std::fmt" - io and io::Write both
+        # vanished (audit finding 33). Each recursive result is already
+        # fully qualified relative to ITS OWN nested prefix (e.g.
+        # "io::Write"), so prepending this level's prefix once, the same
+        # as for a leaf name, is enough to cascade correctly through any
+        # depth of nesting.
         prefix_node = node.children[0]
         list_node = node.children[-1]
         prefix = text(prefix_node)
-        names = [text(c) for c in list_node.children if c.type in ("identifier", "self")]
+        names: list[str] = []
+        for c in list_node.children:
+            if c.type in ("identifier", "self"):
+                names.append(text(c))
+            elif c.type in ("scoped_use_list", "use_as_clause"):
+                names.extend(_rust_use_paths(c, source))
         return [f"{prefix}::{name}" for name in names]
 
     if node.type == "use_list":
@@ -994,9 +1033,16 @@ def _extract_rust(node: Node, source: bytes) -> tuple[list[str], list[dict], lis
             n = stack.pop()
             if n.type == "use_declaration":
                 # use_declaration's single meaningful child is whichever path-shaped
-                # node follows the "use" keyword and precedes the ";".
+                # node follows the "use" keyword and precedes the ";" - a "pub"/
+                # "pub(crate)" use_declaration also carries a leading
+                # visibility_modifier child, which must be skipped too or it's
+                # mistaken for the path itself: confirmed directly,
+                # "pub use crate::foo::Bar;" produced imports: ['pub'] instead
+                # of the real target, silently dropping the dependency (audit
+                # finding 21 - pub use is the standard idiom for a crate's
+                # public re-export surface, not a corner case).
                 for child in n.children:
-                    if child.type not in ("use", ";"):
+                    if child.type not in ("use", ";", "visibility_modifier"):
                         imports.extend(_rust_use_paths(child, source))
                         break
             elif n.type == "mod_item" and not any(
@@ -1325,21 +1371,38 @@ def _resolve_java_import(
     if not segments:
         return [], False
 
-    if is_wildcard:
-        # dotted is a package path with no class name - every .java file directly
-        # in that package's directory is what a wildcard import pulls in, the same
-        # "import the whole package" fan-out Go's package-level imports need.
+    if is_static:
+        # "import static a.b.C.MEMBER" - MEMBER is a field or method, not a
+        # class; the file that actually exists is a.b.C.java. A static
+        # WILDCARD import ("import static a.b.C.*;") is different: its
+        # dotted text is already just "a.b.C" - the "*" isn't part of
+        # dotted at all, tracked separately via is_wildcard - so there is
+        # no extra trailing segment to trim here; trimming it anyway would
+        # cut the real class name "C" itself. Confirmed directly against
+        # the real tree-sitter-java grammar: the scoped_identifier for
+        # "a.b.C.*" is "a.b.C" (3 segments), for "a.b.C.MEMBER" it's
+        # "a.b.C.MEMBER" (4 segments).
+        #
+        # Checked before is_wildcard, unlike before - a static wildcard
+        # used to fall into that branch first and get treated exactly like
+        # a plain (non-static) wildcard import, looking for a directory
+        # a/b/C/ that doesn't exist, since C is a class file, not a
+        # package. Confirmed: "import static a.b.C.*;" always returned []
+        # even when C was local to the repo (audit finding 29).
+        if not is_wildcard:
+            segments = segments[:-1]
+            if not segments:
+                return [], False
+    elif is_wildcard:
+        # dotted is a package path with no class name - only reached here
+        # for a plain, non-static wildcard now. Every .java file directly
+        # in that package's directory is what a wildcard import pulls in,
+        # the same "import the whole package" fan-out Go's package-level
+        # imports need.
         matching_roots = [root for root in source_roots if root.joinpath(*segments).is_dir()]
         if not matching_roots:
             return [], False
         return sorted(matching_roots[0].joinpath(*segments).glob("*.java")), len(matching_roots) > 1
-
-    if is_static:
-        # "import static a.b.C.MEMBER" - MEMBER is a field or method, not a class;
-        # the file that actually exists is a.b.C.java.
-        segments = segments[:-1]
-        if not segments:
-            return [], False
 
     matches = [target for root in source_roots if (target := _java_class_file(root, segments)) is not None]
     if matches:
@@ -1535,11 +1598,44 @@ def _extract_php(node: Node, source: bytes) -> tuple[list[tuple[str, str]], list
                             imports.append(("include", path))
                         break
             elif n.type == "namespace_use_declaration":
-                for clause in n.children:
-                    if clause.type == "namespace_use_clause":
-                        for grandchild in clause.children:
-                            if grandchild.type in ("qualified_name", "name"):
-                                imports.append(("use", text(grandchild)))
+                # A single unprefixed clause ("use Foo\Bar;" or "use Foo\Bar
+                # as Baz;") is a direct namespace_use_clause child. A
+                # grouped statement ("use Foo\Bar\{ClassA, ClassB as B};")
+                # nests its clauses one level deeper instead, inside a
+                # namespace_use_group sibling that carries the shared
+                # prefix from the declaration's own namespace_name - neither
+                # is a namespace_use_declaration's direct child, so scanning
+                # only direct namespace_use_clause children silently dropped
+                # the entire grouped statement (audit finding 28). Grouped
+                # use is valid PHP 7+ syntax and common enough that zeroing
+                # it out entirely is a real gap, not a corner case.
+                prefix = ""
+                clauses: list[Node] = []
+                for child in n.children:
+                    if child.type == "namespace_use_clause":
+                        clauses.append(child)
+                    elif child.type == "namespace_name":
+                        prefix = text(child)
+                    elif child.type == "namespace_use_group":
+                        clauses.extend(c for c in child.children if c.type == "namespace_use_clause")
+                for clause in clauses:
+                    # "use Foo\Bar as Baz;"'s alias target is also a bare
+                    # "name" node - the same node type as an unaliased
+                    # import's own path - so matching on type alone appended
+                    # a second, phantom "Baz" entry alongside the real path
+                    # every time an alias was used, grouped or not (audit
+                    # finding 31). child_by_field_name("alias") is how the
+                    # grammar itself distinguishes the two.
+                    alias_node = clause.child_by_field_name("alias")
+                    for grandchild in clause.children:
+                        if grandchild is alias_node:
+                            continue
+                        if grandchild.type in ("qualified_name", "name"):
+                            clause_path = text(grandchild)
+                            imports.append(
+                                ("use", f"{prefix}\\{clause_path}" if prefix else clause_path)
+                            )
+                            break
             elif n.type in ("function_definition", "method_declaration"):
                 name_node = n.child_by_field_name("name")
                 if name_node is not None:
@@ -2260,9 +2356,18 @@ def _extract_module(
     if language_name == "python":
         plain_imports, from_imports, functions, classes, constants = _extract_python(tree.root_node, source)
 
+        # target != rel_path is applied here and in the from-import loop
+        # below - every other language branch already guards against a
+        # file importing itself this way; Python's didn't (audit finding
+        # 35). dead_code.py's unreachable-file test is
+        # `if not module.get("imported_by", [])`, so a Python file that
+        # happens to statically self-import (an absolute `import pkg.mod`
+        # from inside pkg/mod.py itself) got a non-empty imported_by purely
+        # from itself and silently escaped dead-code detection even if
+        # genuinely unused by everything else.
         for dotted in plain_imports:
             target, ambiguous = _resolve_python_module(repo_path, dotted, path, python_source_roots)
-            if target is not None:
+            if target is not None and target != rel_path:
                 resolved_imports.append(target)
                 if ambiguous:
                     import_confidence[target] = "inferred"
@@ -2274,13 +2379,13 @@ def _extract_module(
                     target, ambiguous = _resolve_python_from_import(
                         repo_path, module_name, name, path, python_source_roots
                     )
-                    if target is not None:
+                    if target is not None and target != rel_path:
                         targets.add(target)
                         if ambiguous:
                             import_confidence[target] = "inferred"
             else:
                 target, ambiguous = _resolve_python_module(repo_path, module_name, path, python_source_roots)
-                if target is not None:
+                if target is not None and target != rel_path:
                     targets.add(target)
                     if ambiguous:
                         import_confidence[target] = "inferred"
@@ -2366,7 +2471,12 @@ def _extract_module(
         raw_imports, functions, classes = _extract_javascript(tree.root_node, source)
         for spec in raw_imports:
             target = _resolve_js_import(repo_path, path, spec)
-            if target is not None:
+            # Same target != rel_path guard every other language branch
+            # already has - see the Python branch's comment above (audit
+            # finding 35). A JS file require()-ing or importing its own
+            # path is the same false-negative risk for dead_code.py's
+            # `imported_by` check.
+            if target is not None and target != rel_path:
                 resolved_imports.append(target)
 
     module: dict = {

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -429,6 +429,29 @@ def test_extract_django_path_call():
     ]
 
 
+def test_extract_django_augmented_assignment_urlpatterns_is_not_skipped():
+    # audit finding 27: "urlpatterns += [...]" - splitting the list across
+    # an initial assignment plus one or more extensions is an ordinary,
+    # documented Django organizing pattern. It parses to
+    # augmented_assignment, a distinct node type from plain assignment -
+    # only the initial "urlpatterns = [...]" used to be matched, so every
+    # route declared via "+=" was silently missing from the endpoint
+    # inventory with no indication anything was skipped.
+    root, source = parse_python(
+        "urlpatterns = [\n"
+        "    path('home/', views.home),\n"
+        "]\n"
+        "urlpatterns += [\n"
+        "    path('api/', views.api),\n"
+        "]\n"
+    )
+
+    entries = _extract_django_routes(root, source, "app/urls.py")
+
+    paths = {entry["path"] for entry in entries}
+    assert paths == {"home/", "api/"}
+
+
 def test_extract_django_re_path_call():
     root, source = parse_python("urlpatterns = [re_path(r'^items/$', views.list_items)]\n")
 

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -257,6 +257,66 @@ def test_build_module_graph_extracts_javascript_imports(tmp_path):
     assert unparseable == []
 
 
+def test_build_module_graph_typescript_import_equals_require_resolves(tmp_path):
+    # audit finding 32: "import foo = require('./foo');" (TypeScript's
+    # import-equals form) is still an import_statement node, but has no
+    # "source" field at all - the path lives inside a nested
+    # import_require_clause instead, a declaration form distinct from the
+    # separate call_expression-based require() handling. Without this, the
+    # whole statement silently produced zero imports.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "utils.ts").write_text("export function add(a: number, b: number) { return a + b; }\n")
+    (repo / "index.ts").write_text(
+        "import utils = require('./utils');\n\nfunction main() { return utils.add(1, 2); }\n"
+    )
+
+    modules, dependency_graph, unparseable = build_module_graph(repo)
+    by_path = {m["path"]: m for m in modules}
+
+    assert "utils.ts" in by_path["index.ts"]["imports"]
+    assert ["index.ts", "utils.ts"] in dependency_graph["edges"]
+    assert unparseable == []
+
+
+def test_build_module_graph_python_file_that_imports_itself_is_not_its_own_dependent(tmp_path):
+    # audit finding 35: dead_code.py's unreachable-file test is
+    # `if not module.get("imported_by", [])` - a Python file that happens
+    # to statically self-import (an absolute "import pkg.mod" from inside
+    # pkg/mod.py itself) used to get a non-empty imported_by purely from
+    # itself, silently escaping dead-code detection even if genuinely
+    # unused by everything else. Every other language branch already
+    # guards against this; Python's didn't.
+    repo = tmp_path / "repo"
+    (repo / "pkg").mkdir(parents=True)
+    (repo / "pkg" / "__init__.py").write_text("")
+    (repo / "pkg" / "mod.py").write_text("import pkg.mod\n\ndef helper():\n    pass\n")
+
+    modules, dependency_graph, unparseable = build_module_graph(repo)
+    mod = next(m for m in modules if m["path"] == "pkg/mod.py")
+
+    assert mod["imports"] == []
+    assert mod["imported_by"] == []
+    assert dependency_graph["edges"] == []
+    assert unparseable == []
+
+
+def test_build_module_graph_javascript_file_that_requires_itself_is_not_its_own_dependent(tmp_path):
+    # Same guard as the Python case just above, for the JS/TS branch - see
+    # its comment for the dead_code.py consequence (audit finding 35).
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "self.js").write_text("const me = require('./self');\n\nfunction helper() {}\n")
+
+    modules, dependency_graph, unparseable = build_module_graph(repo)
+    mod = next(m for m in modules if m["path"] == "self.js")
+
+    assert mod["imports"] == []
+    assert mod["imported_by"] == []
+    assert dependency_graph["edges"] == []
+    assert unparseable == []
+
+
 def test_build_module_graph_extracts_commonjs_reexports_and_dynamic_imports(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -215,6 +215,45 @@ def test_build_module_graph_java_static_import_resolves_to_the_class_not_the_mem
     ) in edges
 
 
+def test_build_module_graph_java_static_wildcard_import_resolves_to_the_class(tmp_path):
+    # audit finding 29: "import static com.example.util.Constants.*;" used
+    # to be checked against is_wildcard before is_static, treating every
+    # segment - including the trailing class name "Constants" - as a
+    # package-directory component and looking for a directory
+    # .../util/Constants/ that doesn't exist (the real file is
+    # Constants.java). A static wildcard's dotted text is already just the
+    # class path (no member/"*" segment appended, unlike a static
+    # non-wildcard import), so it needs the same class-file lookup the
+    # test right above this one already exercises for a named static
+    # member - never the plain-wildcard package-directory lookup.
+    repo = tmp_path / "repo"
+    base = repo / "src" / "main" / "java" / "com" / "example"
+    (base / "util").mkdir(parents=True)
+    (base / "util" / "Constants.java").write_text(
+        "package com.example.util;\n\n"
+        "public class Constants {\n"
+        "    public static final int MAX_SIZE = 100;\n"
+        "}\n"
+    )
+    (base / "Main.java").write_text(
+        "package com.example;\n\n"
+        "import static com.example.util.Constants.*;\n\n"
+        "public class Main {\n"
+        "    public static void main(String[] args) {\n"
+        "        int x = MAX_SIZE;\n"
+        "    }\n"
+        "}\n"
+    )
+
+    _, dependency_graph, _ = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert (
+        "src/main/java/com/example/Main.java",
+        "src/main/java/com/example/util/Constants.java",
+    ) in edges
+
+
 def test_build_module_graph_java_no_package_declaration_still_scans_the_file(tmp_path):
     # A class in the unnamed/default package can't actually be imported by name at
     # all - javac rejects a bare "import Helper;" outright ("'.' expected", verified

--- a/src/tests/test_graph_php.py
+++ b/src/tests/test_graph_php.py
@@ -1,7 +1,16 @@
 from pathlib import Path
 
-from aletheore.scanner.graph import build_module_graph
+from tree_sitter import Parser
+
+from aletheore.scanner.graph import PHP_LANGUAGE, _extract_php, build_module_graph
 from conftest import symbol_names
+
+
+def parse_php(source: str):
+    parser = Parser()
+    parser.language = PHP_LANGUAGE
+    encoded = source.encode()
+    return parser.parse(encoded).root_node, encoded
 
 
 def make_php_repo(tmp_path: Path) -> Path:
@@ -116,6 +125,64 @@ def test_build_module_graph_php_psr4_ambiguous_prefix_is_flagged_inferred(tmp_pa
     main = by_path["main.php"]
     assert main["imports"] == ["extra/Foo.php"]
     assert main["import_confidence"] == {"extra/Foo.php": "inferred"}
+
+
+def test_build_module_graph_php_grouped_use_resolves_every_clause(tmp_path):
+    # audit finding 28: "use Foo\Bar\{ClassA, ClassB};" nests its clauses
+    # inside a namespace_use_group one level deeper than a plain
+    # unprefixed clause - neither is a namespace_use_declaration's direct
+    # child, so scanning only direct namespace_use_clause children
+    # silently dropped the entire grouped statement, real code that
+    # `use`s two sibling classes under one shared namespace got zero
+    # resolved dependencies for either.
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "composer.json").write_text(
+        '{"name": "example/webservice", "autoload": {"psr-4": {"App\\\\": "src/"}}}'
+    )
+    (repo / "src" / "ClassA.php").write_text("<?php\n\nnamespace App;\n\nclass ClassA\n{\n}\n")
+    (repo / "src" / "ClassB.php").write_text("<?php\n\nnamespace App;\n\nclass ClassB\n{\n}\n")
+    (repo / "main.php").write_text("<?php\n\nuse App\\{ClassA, ClassB};\n")
+
+    _, dependency_graph, _ = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert ("main.php", "src/ClassA.php") in edges
+    assert ("main.php", "src/ClassB.php") in edges
+
+
+def test_extract_php_aliased_use_does_not_also_extract_the_bare_alias():
+    # audit finding 31: "use Foo\Bar as Baz;" - the alias target ("Baz")
+    # and the real path ("Foo\Bar") are both bare "name" nodes to
+    # tree-sitter-php, the same node type - matching on type alone
+    # appended a second, phantom entry for the alias string itself
+    # alongside the real path.
+    #
+    # This has to be checked at the raw extraction level, before PSR-4
+    # resolution: a bare, unprefixed alias string can never resolve
+    # through _resolve_php_use regardless of whether the extraction bug is
+    # fixed (its matching requires an exact or prefix+"\\" match against a
+    # registered namespace prefix, which a bare name never has), so a
+    # build_module_graph-level test would pass identically whether the
+    # phantom entry was extracted or not - it always silently disappears
+    # during resolution either way, exactly the "usually harmless noise"
+    # the finding itself describes.
+    root, source = parse_php("<?php\n\nuse Foo\\Bar as Baz;\n")
+
+    imports, _functions, _classes = _extract_php(root, source)
+
+    assert imports == [("use", "Foo\\Bar")]
+
+
+def test_extract_php_grouped_aliased_use_does_not_also_extract_the_bare_alias():
+    # Same check as above, for an aliased clause inside a grouped use
+    # statement - the alias exclusion has to apply there too, not just to
+    # a top-level unprefixed clause.
+    root, source = parse_php("<?php\n\nuse Foo\\Bar\\{ClassA, ClassB as B};\n")
+
+    imports, _functions, _classes = _extract_php(root, source)
+
+    assert imports == [("use", "Foo\\Bar\\ClassA"), ("use", "Foo\\Bar\\ClassB")]
 
 
 def test_build_module_graph_php_dir_concat_require_resolves(tmp_path):

--- a/src/tests/test_graph_rust.py
+++ b/src/tests/test_graph_rust.py
@@ -148,6 +148,60 @@ def test_build_module_graph_rust_std_import_does_not_resolve(tmp_path):
     assert dependency_graph["edges"] == []
 
 
+def test_build_module_graph_rust_pub_use_resolves(tmp_path):
+    # audit finding 21: "pub use" is the standard idiom for constructing a
+    # crate's public re-export surface, not a corner case - a
+    # use_declaration with a leading visibility_modifier ("pub"/
+    # "pub(crate)") child used to have that modifier mistaken for the path
+    # itself (the first non-"use"/";" child), producing an import of the
+    # literal string "pub" - which then failed to resolve and silently
+    # dropped the real dependency.
+    #
+    # The target has to be reachable ONLY via the "pub use" itself, not
+    # also via a "mod" declaration - main.rs "mod foo;"-ing foo.rs directly
+    # would produce the same edge regardless of whether "pub use" resolved
+    # correctly, silently passing even against the pre-fix code. Nesting
+    # the real target one level deeper (foo::bar, reached only through
+    # "pub use crate::foo::bar::Something;", never through "mod foo;"
+    # alone) is what isolates the fix.
+    repo = tmp_path / "repo"
+    (repo / "src" / "foo").mkdir(parents=True)
+    (repo / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+    (repo / "src" / "foo.rs").write_text("mod bar;\n")
+    (repo / "src" / "foo" / "bar.rs").write_text("pub struct Something;\n")
+    (repo / "src" / "main.rs").write_text(
+        "mod foo;\n\npub use crate::foo::bar::Something;\n\nfn main() {}\n"
+    )
+
+    _, dependency_graph, _ = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert ("src/main.rs", "src/foo/bar.rs") in edges
+
+
+def test_build_module_graph_rust_nested_grouped_use_resolves_every_level(tmp_path):
+    # audit finding 33: "use std::{fmt, io::{self, Write}};" - a group item
+    # can itself be a nested group, not just a bare identifier/self leaf.
+    # The old code only accepted identifier/self children, so a nested
+    # scoped_use_list matched neither type and was dropped along with
+    # everything inside it - here, foo::{Bar, baz::{Qux}} must resolve
+    # Bar (one level deep) AND Qux (two levels deep), not just Bar.
+    repo = tmp_path / "repo"
+    (repo / "src" / "foo").mkdir(parents=True)
+    (repo / "Cargo.toml").write_text('[package]\nname = "x"\nversion = "0.1.0"\n')
+    (repo / "src" / "foo.rs").write_text("mod baz;\npub struct Bar;\n")
+    (repo / "src" / "foo" / "baz.rs").write_text("pub struct Qux;\n")
+    (repo / "src" / "main.rs").write_text(
+        "mod foo;\n\nuse crate::foo::{Bar, baz::{Qux}};\n\nfn main() {}\n"
+    )
+
+    _, dependency_graph, _ = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert ("src/main.rs", "src/foo.rs") in edges
+    assert ("src/main.rs", "src/foo/baz.rs") in edges
+
+
 def test_build_module_graph_rust_grouped_use_resolves_both_names(tmp_path):
     repo = tmp_path / "repo"
     (repo / "src").mkdir(parents=True)


### PR DESCRIPTION
## Summary

Batches 8 findings from `docs/audits/Claude_Audit.md`, all independently confirmed still open via a verification sweep, each reproduced directly against the real tree-sitter grammar before fixing. All are scanner-side import/endpoint-resolution bugs - each one silently drops or mis-extracts a real dependency edge for a specific, real language pattern.

| # | Language | Bug |
|---|----------|-----|
| 21 | Rust | `pub use crate::foo::Bar;` mistook the leading `visibility_modifier` for the path itself, extracting the literal string `"pub"` instead of the real target - the standard idiom for a crate's public re-export surface, silently broken. |
| 33 | Rust | `use std::{fmt, io::{self, Write}};` - a nested `scoped_use_list` group item wasn't recursed into, only bare `identifier`/`self` leaves were accepted, dropping everything below the first brace level. |
| 28 | PHP | `use Foo\Bar\{ClassA, ClassB};` (grouped use) nests its clauses one level deeper than a plain clause - scanning only direct children silently dropped the entire grouped statement. |
| 31 | PHP | `use Foo\Bar as Baz;` - the alias target and the real path are both bare `"name"` nodes to tree-sitter-php, so matching on type alone appended a phantom second entry for the alias string itself. |
| 29 | Java | `import static a.b.C.*;` was checked against `is_wildcard` before `is_static`, treating the trailing class name as a package-directory component and looking for a directory that doesn't exist. |
| 32 | TypeScript | `import foo = require('./foo');` (import-equals) is still an `import_statement` node but has no `"source"` field - the path lives inside a nested `import_require_clause`, silently producing zero imports. |
| 27 | Django | `urlpatterns += [...]` parses to `augmented_assignment`, a distinct node type from plain `assignment` that was never matched for extraction - every route declared this ordinary, documented way was missing. |
| 35 | Python/JS/TS | 7 of 9 language branches in the main resolution loop already guard against a file importing itself (`target != rel_path`); Python's and JS/TS's didn't, letting a self-importing file's non-empty `imported_by` silently defeat `dead_code.py`'s unreachable-file test. |

## Test discipline

Each fix verified independently against real tree-sitter parsing before writing its regression test. Two tests needed redesigning after an initial version passed even against the pre-fix code, for reasons unrelated to the actual bug:
- The Rust `pub use` test's target edge already existed via a separate `mod` declaration in the same file - masking whether `pub use` itself worked. Redesigned so the target is reachable *only* through the `pub use`.
- The PHP aliased-use phantom entry always fails PSR-4 resolution regardless of extraction correctness (a bare unprefixed name can never match a registered namespace prefix) - a `build_module_graph`-level test couldn't distinguish pre/post-fix. Redesigned to check the raw `_extract_php` output directly, before resolution.

Caught both by explicitly reverting the fix and re-running before trusting either test - the same discipline applied to the other 8.

## Test plan
- [x] 10 regression tests total (finding 35 split into Python + JS/TS), every one confirmed to fail against the pre-fix code
- [x] Full `src/` suite: 1432 passed, 0 failed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr