### PR TITLE
fix: bound Java/C# scanner pre-pass peak memory (audit finding 15)

### DIFF
--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -2737,11 +2737,20 @@ def build_module_graph(
     # pre-parse before any of them can have their imports resolved.
     java_source_roots: list[Path] = []
     oversized_paths: set[Path] = set()
-    # Reused by the main loop below so every .java file is parsed once per
-    # scan, not twice - this pre-pass already has to parse it to read the
-    # package declaration, and tree-sitter parsing is the expensive part of
-    # this whole function.
-    java_pre_parsed: dict[Path, tuple[bytes, Tree]] = {}
+    # Every .java file's (source, Tree) used to be kept alive here for the
+    # main loop below to reuse, parsing each file once per scan instead of
+    # twice - real, but the wrong trade for a hosted worker: it means every
+    # tree in the repo is held simultaneously the moment this pre-pass
+    # finishes, before the main loop has consumed even one of them.
+    # tree-sitter trees run ~37x their source size; scan-worker/scan-worker-2
+    # are capped at a 1GB container memory limit (docker-compose.yml), so a
+    # large enough Java repo could OOM-crash the whole scan right here,
+    # before any partial result exists to fall back to - a strictly worse
+    # failure mode than the extra CPU cost of parsing twice (audit finding
+    # 15). Nothing here is retained past its own loop iteration now - each
+    # file's tree is parsed, its package read, and then falls out of scope
+    # to be freed before the next file's parse even starts, so peak memory
+    # stays roughly one file's tree, not every file's.
     pre_parser = Parser()
     pre_parser.language = JAVA_LANGUAGE
     for path in _iter_source_files(repo_path, ignored_paths):
@@ -2753,7 +2762,6 @@ def build_module_graph(
             continue
         pre_source = path.read_bytes()
         tree = pre_parser.parse(pre_source)
-        java_pre_parsed[path] = (pre_source, tree)
         package = _extract_java_package(tree.root_node, pre_source)
         root = _java_source_root_for(path, package)
         if root is not None and root not in java_source_roots:
@@ -2778,8 +2786,9 @@ def build_module_graph(
     csharp_source_paths: list[Path] = []
     # Which file declares each type name, for the type-reference edges below.
     csharp_type_owners: dict[str, set[Path]] = {}
-    # Same reasoning as java_pre_parsed above.
-    csharp_pre_parsed: dict[Path, tuple[bytes, Tree]] = {}
+    # Same reasoning as java_source_roots' pre-pass above - nothing here is
+    # retained past its own loop iteration either, for the same audit
+    # finding 15 memory-peak reason.
     cs_pre_parser = Parser()
     cs_pre_parser.language = CSHARP_LANGUAGE
     for path in _iter_source_files(repo_path, ignored_paths):
@@ -2792,7 +2801,6 @@ def build_module_graph(
         csharp_source_paths.append(path)
         pre_source = path.read_bytes()
         tree = cs_pre_parser.parse(pre_source)
-        csharp_pre_parsed[path] = (pre_source, tree)
         namespace = _extract_csharp_namespace(tree.root_node, pre_source)
         result = _csharp_prefix_and_root_for(path, namespace)
         if result is not None:
@@ -2837,29 +2845,14 @@ def build_module_graph(
             unparseable.append({"path": rel_path, "reason": "file exceeds size limit"})
             continue
 
-        if language_name == "java" and path in java_pre_parsed:
-            # pop, not a plain lookup: java_pre_parsed/csharp_pre_parsed hold
-            # the full (source, Tree) for every .java/.cs file simultaneously
-            # once the pre-pass above finishes - unavoidable, since the
-            # pre-pass needs every file's package/namespace before it can
-            # infer a source root at all. But nothing forces this loop to
-            # keep holding a file's entry once it's been consumed here -
-            # tree-sitter trees run roughly 37x their source size, so on a
-            # large Java/C# repo this loop's the rest of its run (every
-            # other-language file remaining) previously held every already-
-            # consumed tree alive for no reason. Popping lets each entry's
-            # memory free as soon as this loop passes it, instead of only
-            # when build_module_graph returns.
-            source, tree = java_pre_parsed.pop(path)
-        elif language_name == "csharp" and path in csharp_pre_parsed:
-            source, tree = csharp_pre_parsed.pop(path)
-        elif language_name in ("java", "csharp"):
-            # Rare: the pre-pass above and this walk saw different
-            # filesystem state (e.g. the file appeared/disappeared between
-            # the two _iter_source_files calls). Falls back to a fresh
-            # parse right here, exactly like every file did before this
-            # function had a parallel path at all - never routed through
-            # paths_needing_parse/the worker pool.
+        if language_name in ("java", "csharp"):
+            # Re-parsed here rather than reusing a tree the pre-pass above
+            # held onto - see that pre-pass's own comment (audit finding
+            # 15). The pre-pass already had to parse every .java/.cs file
+            # once to read its package/namespace before any of them could
+            # have a source root inferred at all; this is deliberately a
+            # second parse per file, trading CPU for never holding more
+            # than about one file's tree in memory at a time.
             parser.language = ts_language
             source = path.read_bytes()
             tree = parser.parse(source)

--- a/src/tests/test_graph_csharp.py
+++ b/src/tests/test_graph_csharp.py
@@ -5,6 +5,85 @@ from aletheore.scanner.graph import build_module_graph
 from conftest import symbol_names
 
 
+def _write_synthetic_csharp_repo(repo: Path, file_count: int) -> None:
+    # Real class bodies, not one-liners - tree-sitter tree size scales with
+    # source complexity, so trivial fixtures under-report the memory this
+    # test is trying to measure (verified on the Java equivalent of this
+    # fixture: one-line classes never surfaced a measurable gap between the
+    # cached and uncached pre-pass; classes this size reliably do).
+    for i in range(file_count):
+        fields = "\n".join(f"    private int field{j} = {j};" for j in range(40))
+        methods = "\n".join(
+            f"""
+    public int Method{j}(int a, int b) {{
+        int total = 0;
+        for (int k = 0; k < 10; k++) {{
+            if (k % 2 == 0) {{
+                total += a * k + field{j % 40};
+            }} else {{
+                total -= b - k;
+            }}
+        }}
+        return total;
+    }}"""
+            for j in range(60)
+        )
+        (repo / f"C{i}.cs").write_text(
+            f"namespace Example.Pkg{i};\n\nusing System.Collections.Generic;\n\n"
+            f"public class C{i} {{\n{fields}\n{methods}\n}}\n"
+        )
+
+
+def _measure_boundary_rss_for_csharp_repo(file_count: int, out_queue) -> None:
+    # Runs inside its own subprocess so ru_maxrss - a whole-process
+    # high-water-mark that can't be reset mid-process - reflects only this
+    # one scan, not whatever the pytest process had already touched before
+    # this test ran.
+    import resource
+    import sys
+    import tempfile
+    from pathlib import Path as _Path
+
+    from aletheore.scanner import graph as _graph_module
+
+    baseline = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    boundary: dict[str, int] = {}
+    original_rel = _graph_module._rel
+
+    def tracking_rel(repo_path, path):
+        # _rel(repo_path, path) is the first thing the main loop does for
+        # each file, so its first-ever call lands right at the boundary
+        # between the pre-pass finishing (every .cs file already parsed)
+        # and the main loop starting to consume anything - the instant a
+        # whole-repo cache would be at its fullest.
+        if "value" not in boundary:
+            boundary["value"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return original_rel(repo_path, path)
+
+    _graph_module._rel = tracking_rel
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _Path(tmp)
+        _write_synthetic_csharp_repo(repo, file_count)
+        _graph_module.build_module_graph(repo)
+
+    # ru_maxrss is bytes on macOS, KB on Linux.
+    scale = 1 if sys.platform == "darwin" else 1024
+    out_queue.put((boundary["value"] - baseline) * scale)
+
+
+def _boundary_rss_delta_for_csharp_repo(file_count: int) -> int:
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    out_queue: multiprocessing.Queue = ctx.Queue()
+    process = ctx.Process(target=_measure_boundary_rss_for_csharp_repo, args=(file_count, out_queue))
+    process.start()
+    result = out_queue.get()
+    process.join()
+    return result
+
+
 def make_csharp_repo(tmp_path: Path) -> Path:
     # Mirrors a real project verified by actually compiling AND running it with
     # `dotnet run` before this fixture was written - a <RootNamespace>App</RootNamespace>
@@ -205,17 +284,19 @@ def test_build_module_graph_csharp_using_escaping_repo_root_does_not_crash(tmp_p
     assert dependency_graph["edges"] == []
 
 
-def test_build_module_graph_reuses_the_csharp_prepass_parse_in_the_main_loop(tmp_path):
-    # Real regression this guards: the namespace/type pre-pass already reads
-    # and parses every .cs file to extract its namespace and declared type
-    # names - the main loop used to read and parse each one again from
-    # scratch instead of reusing that (source, tree) pair, doubling
-    # tree-sitter parse cost for every C# file in a scan for no benefit
-    # (the pre-parsed tree is consumed by the main loop moments later in
-    # the same function call, not retained for the scan's whole lifetime,
-    # so caching it costs nothing extra in memory - the "reparse for
-    # bounded memory" framing this test used to encode was never a real
-    # trade-off).
+def test_build_module_graph_reparses_each_csharp_file_in_the_main_loop(tmp_path):
+    # Documents the deliberate trade-off behind audit finding 15: the
+    # namespace/type pre-pass already has to read and parse every .cs file
+    # to extract its namespace and declared type names, but nothing from
+    # that parse is cached for the main loop to reuse anymore - each file
+    # is read and parsed a second time there. That's real, avoidable CPU
+    # cost, traded away on purpose because the alternative (a dict caching
+    # every file's (source, Tree) between the two passes) pins every tree
+    # in the repo in memory at once - real risk on a hosted worker capped
+    # at 1GB (scan-worker/scan-worker-2's mem_limit in docker-compose.yml).
+    # If a future change reintroduces that cache, this test's count drops
+    # back to 1 and should be revisited alongside the memory trade-off,
+    # not just updated to match.
     repo = make_csharp_repo(tmp_path)
 
     real_read_bytes = Path.read_bytes
@@ -230,18 +311,20 @@ def test_build_module_graph_reuses_the_csharp_prepass_parse_in_the_main_loop(tmp
         build_module_graph(repo)
 
     assert read_counts
-    assert all(count == 1 for count in read_counts.values())
+    assert all(count == 2 for count in read_counts.values())
 
 
-def test_build_module_graph_releases_a_csharp_prepass_tree_once_the_main_loop_consumes_it(tmp_path, monkeypatch):
+def test_build_module_graph_never_holds_every_csharp_files_tree_at_once(tmp_path, monkeypatch):
     # C# equivalent of the identically-named Java test in test_graph_java.py
-    # - see that test's comment for the full reasoning. csharp_pre_parsed
-    # has the same shape (dict[Path, tuple[bytes, Tree]]) and the same
-    # main-loop consumption site as java_pre_parsed.
+    # - see that test's comment for the full reasoning, including why this
+    # inspects build_module_graph's own frame locals directly rather than
+    # inferring retention from sys.getrefcount() (which turned out unable
+    # to reliably distinguish the cached and uncached implementations).
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "AFirst.cs").write_text("namespace Example { class AFirst {} }\n")
-    (repo / "ZLater.js").write_text("const x = 1;\n")
+    file_count = 12
+    for i in range(file_count):
+        (repo / f"C{i}.cs").write_text(f"namespace Example {{ class C{i} {{}} }}\n")
 
     import sys
 
@@ -249,31 +332,45 @@ def test_build_module_graph_releases_a_csharp_prepass_tree_once_the_main_loop_co
 
     from aletheore.scanner import graph as graph_module
 
-    captured: dict[str, object] = {}
-    original_parse = tree_sitter.Parser.parse
-
-    def tracking_parse(self, source, *a, **k):
-        tree = original_parse(self, source, *a, **k)
-        if b"AFirst" in source:
-            captured["tree"] = tree
-        return tree
-
-    monkeypatch.setattr(tree_sitter.Parser, "parse", tracking_parse)
-
-    refcounts: dict[str, int] = {}
+    peak_trees_in_one_local: dict[str, int] = {"value": 0}
     original_rel = graph_module._rel
 
     def tracking_rel(repo_path, path):
-        if path.name == "ZLater.js" and "tree" in captured:
-            refcounts["value"] = sys.getrefcount(captured["tree"])
+        frame = sys._getframe(1)
+        if frame.f_code.co_name == "build_module_graph":
+            for value in frame.f_locals.values():
+                if isinstance(value, dict):
+                    n = sum(
+                        1
+                        for v in value.values()
+                        if isinstance(v, tuple) and any(isinstance(x, tree_sitter.Tree) for x in v)
+                    )
+                elif isinstance(value, (list, set)):
+                    n = sum(1 for v in value if isinstance(v, tree_sitter.Tree))
+                else:
+                    n = 0
+                peak_trees_in_one_local["value"] = max(peak_trees_in_one_local["value"], n)
         return original_rel(repo_path, path)
 
     monkeypatch.setattr(graph_module, "_rel", tracking_rel)
 
     graph_module.build_module_graph(repo)
 
-    assert "value" in refcounts
-    assert refcounts["value"] <= 3
+    # A reintroduced whole-pre-pass cache would show up here as a single
+    # local holding all file_count trees at once (verified against the
+    # Java equivalent's dict-caching implementation: it showed 12/12).
+    assert peak_trees_in_one_local["value"] < file_count
+
+
+def test_build_module_graph_csharp_prepass_boundary_rss_does_not_scale_with_repo_size(tmp_path):
+    # Secondary, corroborating check for the same invariant the frame-
+    # inspection test above proves directly - see the Java equivalent in
+    # test_graph_java.py for the real before/after numbers this threshold
+    # is calibrated against (same fixture shape, same mechanism, same
+    # mem_limit: 1g production constraint).
+    boundary_delta = _boundary_rss_delta_for_csharp_repo(600)
+
+    assert boundary_delta < 60 * 1024 * 1024
 
 
 def test_csharp_extracts_summary_from_xmldoc(tmp_path):

--- a/src/tests/test_graph_java.py
+++ b/src/tests/test_graph_java.py
@@ -5,6 +5,85 @@ from aletheore.scanner.graph import build_module_graph
 from conftest import symbol_names
 
 
+def _write_synthetic_java_repo(repo: Path, file_count: int) -> None:
+    # Real class bodies, not one-liners - tree-sitter tree size scales with
+    # source complexity, so trivial fixtures under-report the memory this
+    # test is trying to measure (verified: one-line classes never surfaced
+    # a measurable gap between the cached and uncached pre-pass; classes
+    # this size reliably do).
+    for i in range(file_count):
+        fields = "\n".join(f"    private int field{j} = {j};" for j in range(40))
+        methods = "\n".join(
+            f"""
+    public int method{j}(int a, int b) {{
+        int total = 0;
+        for (int k = 0; k < 10; k++) {{
+            if (k % 2 == 0) {{
+                total += a * k + field{j % 40};
+            }} else {{
+                total -= b - k;
+            }}
+        }}
+        return total;
+    }}"""
+            for j in range(60)
+        )
+        (repo / f"C{i}.java").write_text(
+            f"package com.example.pkg{i};\n\nimport java.util.List;\nimport java.util.Map;\n\n"
+            f"public class C{i} {{\n{fields}\n{methods}\n}}\n"
+        )
+
+
+def _measure_boundary_rss_for_java_repo(file_count: int, out_queue) -> None:
+    # Runs inside its own subprocess so ru_maxrss - a whole-process
+    # high-water-mark that can't be reset mid-process - reflects only this
+    # one scan, not whatever the pytest process had already touched before
+    # this test ran.
+    import resource
+    import sys
+    import tempfile
+    from pathlib import Path as _Path
+
+    from aletheore.scanner import graph as _graph_module
+
+    baseline = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    boundary: dict[str, int] = {}
+    original_rel = _graph_module._rel
+
+    def tracking_rel(repo_path, path):
+        # _rel(repo_path, path) is the first thing the main loop does for
+        # each file, so its first-ever call lands right at the boundary
+        # between the pre-pass finishing (every .java file already parsed)
+        # and the main loop starting to consume anything - the instant a
+        # whole-repo cache would be at its fullest.
+        if "value" not in boundary:
+            boundary["value"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return original_rel(repo_path, path)
+
+    _graph_module._rel = tracking_rel
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = _Path(tmp)
+        _write_synthetic_java_repo(repo, file_count)
+        _graph_module.build_module_graph(repo)
+
+    # ru_maxrss is bytes on macOS, KB on Linux.
+    scale = 1 if sys.platform == "darwin" else 1024
+    out_queue.put((boundary["value"] - baseline) * scale)
+
+
+def _boundary_rss_delta_for_java_repo(file_count: int) -> int:
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    out_queue: multiprocessing.Queue = ctx.Queue()
+    process = ctx.Process(target=_measure_boundary_rss_for_java_repo, args=(file_count, out_queue))
+    process.start()
+    result = out_queue.get()
+    process.join()
+    return result
+
+
 def make_java_repo(tmp_path: Path) -> Path:
     # Mirrors a real Maven-layout project verified with `javac` before this fixture
     # was written - Main.java at com.example, importing across com.example.handlers
@@ -293,16 +372,19 @@ def test_build_module_graph_java_import_escaping_repo_root_does_not_crash(tmp_pa
     assert dependency_graph["edges"] == []
 
 
-def test_build_module_graph_reuses_the_java_prepass_parse_in_the_main_loop(tmp_path):
-    # Real regression this guards: the source-root pre-pass already reads
-    # and parses every .java file to extract its package declaration - the
-    # main loop used to read and parse each one again from scratch instead
-    # of reusing that (source, tree) pair, doubling tree-sitter parse cost
-    # for every Java file in a scan for no benefit (the pre-parsed tree is
-    # consumed by the main loop moments later in the same function call,
-    # not retained for the scan's whole lifetime, so caching it costs
-    # nothing extra in memory - the "reparse for bounded memory" framing
-    # this test used to encode was never a real trade-off).
+def test_build_module_graph_reparses_each_java_file_in_the_main_loop(tmp_path):
+    # Documents the deliberate trade-off behind audit finding 15: the
+    # source-root pre-pass already has to read and parse every .java file
+    # to extract its package declaration, but nothing from that parse is
+    # cached for the main loop to reuse anymore - each file is read and
+    # parsed a second time there. That's real, avoidable CPU cost, traded
+    # away on purpose because the alternative (a dict caching every file's
+    # (source, Tree) between the two passes) pins every tree in the repo
+    # in memory at once - real risk on a hosted worker capped at 1GB
+    # (scan-worker/scan-worker-2's mem_limit in docker-compose.yml). If a
+    # future change reintroduces that cache, this test's count drops back
+    # to 1 and should be revisited alongside the memory trade-off, not
+    # just updated to match.
     repo = make_java_repo(tmp_path)
 
     real_read_bytes = Path.read_bytes
@@ -317,30 +399,34 @@ def test_build_module_graph_reuses_the_java_prepass_parse_in_the_main_loop(tmp_p
         build_module_graph(repo)
 
     assert read_counts
-    assert all(count == 1 for count in read_counts.values())
+    assert all(count == 2 for count in read_counts.values())
 
 
-def test_build_module_graph_releases_a_java_prepass_tree_once_the_main_loop_consumes_it(tmp_path, monkeypatch):
-    # Real regression this guards: java_pre_parsed holds every .java file's
-    # (source, Tree) simultaneously once the pre-pass finishes - tree-sitter
-    # trees run ~37x their source size, so on a large Java repo this is real
-    # memory (measured independently at 82MB RSS on a 512-file C# repo, the
-    # same shape). The main loop used to keep each entry alive via a plain
-    # dict lookup even after consuming it, so the whole cache stayed pinned
-    # until build_module_graph returned - i.e. until every other file in the
-    # repo (every language, not just Java) had also been processed. Popping
-    # instead of indexing releases each entry's memory as soon as the main
-    # loop passes it.
+def test_build_module_graph_never_holds_every_java_files_tree_at_once(tmp_path, monkeypatch):
+    # Real regression this guards: java_pre_parsed used to hold every
+    # .java file's (source, Tree) simultaneously once the pre-pass
+    # finished - tree-sitter trees run ~37x their source size, so on a
+    # large Java repo this is real memory (measured independently at
+    # 82MB RSS on a 512-file C# repo, the same shape), and it was pinned
+    # until the main loop got around to consuming each entry. The fix
+    # doesn't cache at all: each file's (source, Tree) falls out of scope
+    # at the end of its own pre-pass iteration, before the next file is
+    # even read.
     #
-    # Refcount, not RSS: RSS is real but flaky/slow to assert on directly in
-    # a unit test. sys.getrefcount() on the specific Tree object is a direct,
-    # reliable proxy for "is java_pre_parsed still holding a reference to
-    # this" - verified by hand that reverting the pop() fix changes the
-    # count this asserts (4 without the fix, 3 with it).
+    # Inspects build_module_graph's own frame locals directly rather than
+    # inferring retention from sys.getrefcount(): getrefcount on a single
+    # captured tree turned out to fluctuate for reasons unrelated to
+    # caching (other locals briefly holding it during unrelated
+    # processing), which made it unable to reliably tell the cached and
+    # uncached implementations apart. Scanning every local collection in
+    # the frame for how many Tree objects it holds at once has no such
+    # ambiguity - a name-agnostic version of "did anything just accumulate
+    # one entry per file".
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "AFirst.java").write_text("package com.example;\nclass AFirst {}\n")
-    (repo / "ZLater.js").write_text("const x = 1;\n")
+    file_count = 12
+    for i in range(file_count):
+        (repo / f"C{i}.java").write_text(f"package com.example;\nclass C{i} {{}}\n")
 
     import sys
 
@@ -348,38 +434,56 @@ def test_build_module_graph_releases_a_java_prepass_tree_once_the_main_loop_cons
 
     from aletheore.scanner import graph as graph_module
 
-    captured: dict[str, object] = {}
-    original_parse = tree_sitter.Parser.parse
-
-    def tracking_parse(self, source, *a, **k):
-        tree = original_parse(self, source, *a, **k)
-        if b"AFirst" in source:
-            captured["tree"] = tree
-        return tree
-
-    monkeypatch.setattr(tree_sitter.Parser, "parse", tracking_parse)
-
-    refcounts: dict[str, int] = {}
+    peak_trees_in_one_local: dict[str, int] = {"value": 0}
     original_rel = graph_module._rel
 
     def tracking_rel(repo_path, path):
-        # _rel(repo_path, path) is the first thing the main loop does for
-        # each file - by the time it's called for ZLater.js, AFirst.java's
-        # own main-loop iteration (including the java_pre_parsed.pop()) has
-        # already completed.
-        if path.name == "ZLater.js" and "tree" in captured:
-            refcounts["value"] = sys.getrefcount(captured["tree"])
+        frame = sys._getframe(1)
+        if frame.f_code.co_name == "build_module_graph":
+            for value in frame.f_locals.values():
+                if isinstance(value, dict):
+                    n = sum(
+                        1
+                        for v in value.values()
+                        if isinstance(v, tuple) and any(isinstance(x, tree_sitter.Tree) for x in v)
+                    )
+                elif isinstance(value, (list, set)):
+                    n = sum(1 for v in value if isinstance(v, tree_sitter.Tree))
+                else:
+                    n = 0
+                peak_trees_in_one_local["value"] = max(peak_trees_in_one_local["value"], n)
         return original_rel(repo_path, path)
 
     monkeypatch.setattr(graph_module, "_rel", tracking_rel)
 
     graph_module.build_module_graph(repo)
 
-    assert "value" in refcounts
-    # Baseline references at this point: captured["tree"] itself, the local
-    # `tree` parameter inside sys.getrefcount()'s own call frame. Anything
-    # higher means java_pre_parsed is still holding a third reference alive.
-    assert refcounts["value"] <= 3
+    # A reintroduced whole-pre-pass cache would show up here as a single
+    # local holding all file_count trees at once (verified: this exact
+    # test found java_pre_parsed holding 12/12 when run against the
+    # dict-caching implementation this fix replaces).
+    assert peak_trees_in_one_local["value"] < file_count
+
+
+def test_build_module_graph_java_prepass_boundary_rss_does_not_scale_with_repo_size(tmp_path):
+    # Secondary, corroborating check for the same invariant the frame-
+    # inspection test above proves directly: peak process memory at the
+    # boundary between the pre-pass finishing and the main loop starting
+    # should stay roughly flat as file count grows, not scale with it.
+    # Real production constraint this guards: scan-worker/scan-worker-2 are
+    # both capped at mem_limit: 1g in docker-compose.yml.
+    #
+    # Calibrated against real measurements on this exact fixture shape, in
+    # an isolated subprocess so ru_maxrss - a whole-process high-water-mark
+    # that can't be reset mid-process - reflects only this one scan:
+    # dict-caching (pre-fix) scaled the boundary delta close to linearly
+    # with file count (~7MB at 10 files, ~406MB at 600 files); this fix
+    # stays flat regardless of file count (~1-3MB at both). 60MB leaves
+    # roughly 20x headroom above the fix's real measured delta while
+    # sitting comfortably below the pre-fix number it needs to catch.
+    boundary_delta = _boundary_rss_delta_for_java_repo(600)
+
+    assert boundary_delta < 60 * 1024 * 1024
 
 
 def test_java_extracts_javadoc_and_return_type(tmp_path):


### PR DESCRIPTION
## Summary

`java_pre_parsed`/`csharp_pre_parsed` in `build_module_graph` held every `.java`/`.cs` file's parsed `Tree` simultaneously once the source-root pre-pass finished, before the main loop had consumed any of them. tree-sitter trees run roughly 37x their source size, and `scan-worker`/`scan-worker-2` are both capped at `mem_limit: 1g` in `docker-compose.yml` — a large enough Java/C# repo could OOM-crash the whole scan at that point, before any partial result exists to fall back to.

Removes the cache entirely rather than shrinking its retention window: each file's `(source, Tree)` now falls out of scope at the end of its own pre-pass loop iteration, and the main loop re-parses each Java/C# file from scratch instead of reusing a cached tree. This trades doubled tree-sitter parse CPU for never holding more than about one file's tree in memory at a time.

## Verification (real before/after measurement, not just "doesn't crash")

Isolated-subprocess measurement (`resource.getrusage`, 600-file synthetic Java repo with realistic multi-method classes) at the boundary between the pre-pass finishing and the main loop starting — the instant a whole-repo cache is at its fullest:

| File count | Before (dict cache) | After (this fix) |
|---|---|---|
| 10 | ~7 MB | ~1.5 MB |
| 200 | ~136 MB | ~3 MB |
| 600 | ~406 MB | ~3.3 MB |

Also added a frame-inspection regression test that directly checks every local collection in `build_module_graph`'s own frame for how many `Tree` objects it holds at once (not refcount inference, which turned out to fluctuate for reasons unrelated to caching and couldn't reliably tell the two implementations apart) — confirmed it finds `java_pre_parsed`/`csharp_pre_parsed` holding all 12/12 trees against the pre-fix code, and 0 against this fix.

Both the frame-inspection test and the RSS-boundary test are confirmed to fail against the pre-fix code (via `git stash` on just the source file) and pass against this fix, for both Java and C#.

## Test plan

- [x] `test_build_module_graph_reparses_each_java_file_in_the_main_loop` / C# equivalent — documents the intentional CPU/memory trade-off (each file parsed twice now, not once)
- [x] `test_build_module_graph_never_holds_every_java_files_tree_at_once` / C# equivalent — frame-inspection proof no local collection retains every file's tree
- [x] `test_build_module_graph_java_prepass_boundary_rss_does_not_scale_with_repo_size` / C# equivalent — real RSS measurement on a 600-file synthetic repo, calibrated against real before/after numbers
- [x] Full `test_graph*.py` + `test_code_graph_diff.py` suite (211 tests) passes
- [x] All 6 new/rewritten tests confirmed to fail against pre-fix code via `git stash`, pass against the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr