### PR TITLE
fix: strengthen the CLI's free-to-paid nudge, add a support contact

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -245,10 +245,11 @@ def _free_pr_review_nudge() -> str:
     # place for this to live, on the general principle, not that specific
     # example.)
     return (
-        "\n[dim]You're on the free tier - Aletheore also does free, "
-        "evidence-grounded PR reviews on your pull requests, globally "
-        "rate-limited and subject to availability. Install the app: "
-        "https://github.com/apps/aletheore/installations/new[/dim]"
+        "\n[bold]Want this on every pull request automatically?[/bold] Aletheore's "
+        "free tier reviews PRs with the same evidence-grounded findings this run just "
+        "used. Install the GitHub App: "
+        "[bold cyan]https://github.com/apps/aletheore/installations/new[/bold cyan]\n"
+        "[dim](free tier is globally rate-limited)[/dim]"
     )
 
 
@@ -314,6 +315,8 @@ def _banner_panel() -> Panel:
     footer.append("aletheore <command> --help", style="bold cyan")
     footer.append(" for details on any command.\n")
     footer.append("https://github.com/Aletheore/Aletheore", style="dim underline")
+    footer.append("\nIssues or suggestions? ")
+    footer.append("support@aletheore.com", style="dim underline")
 
     return Panel(
         Group(intro, commands, Text(""), footer),

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -186,6 +186,14 @@ def test_main_with_no_command_shows_banner_and_exits_cleanly():
     assert "scan" in result.output and "audit" in result.output
 
 
+def test_main_with_no_command_shows_support_contact():
+    with patch("aletheore.cli._check_for_update", return_value="up to date"):
+        result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "support@aletheore.com" in result.output
+
+
 def test_main_with_no_command_prints_update_notice_when_available():
     with patch("aletheore.cli._check_for_update", return_value="update available: 9.9.9"):
         result = runner.invoke(app, [])
@@ -706,6 +714,18 @@ def test_scan_command_nudges_free_tier_users_toward_the_github_app(tmp_path):
 
     assert result.exit_code == 0
     assert "github.com/apps/aletheore/installations/new" in result.output
+
+
+def test_scan_command_nudge_stays_honest_about_the_rate_limit(tmp_path):
+    # The install CTA itself shouldn't lead with the hedge (that undercuts
+    # the ask), but the rate-limit disclosure must still be there somewhere -
+    # softer placement isn't license to drop it.
+    (tmp_path / "main.py").write_text("x = 1\n")
+
+    result = runner.invoke(app, ["scan", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "rate-limited" in result.output
 
 
 def test_scan_command_does_not_nudge_after_a_git_analysis_error(tmp_path):


### PR DESCRIPTION
## Summary

Two small CLI conversion/discoverability improvements, prompted by a real gap: 9,488 pip downloads over 6 weeks but only 4 total hosted GitHub App installations (one of which is our own dogfooding account) - the funnel breaks well before "free to paid" even becomes relevant.

- **`_free_pr_review_nudge()` reframed.** Previously led with a hedge ("globally rate-limited and subject to availability") right at the install CTA, and was styled fully `[dim]`. Now leads with the value prop and a bold install link; the honest rate-limit disclosure is kept, just moved to a smaller trailing line instead of leading the pitch.
- **Added a `support@aletheore.com` line to the banner** shown on every bare `aletheore` invocation - previously the only in-CLI pointer was the GitHub repo link, no direct channel for a bug report or suggestion.

## Test plan

- [x] `pytest tests/test_cli.py` - 165 passed
- [x] New test confirms the banner shows the support email
- [x] New test confirms the nudge still discloses the rate limit (softer placement isn't license to drop the honesty)
- [x] Existing nudge/banner tests unchanged and still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)