### PR TITLE
fix: DeepSeek V4 pro/flash spend-cap rates are stale by a real repricing

### DIFF
--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -10,8 +10,17 @@ logger = logging.getLogger(__name__)
 # provider's own pricing page - not a promise the price hasn't moved
 # since, just an honest record of how stale it might be.
 MODEL_RATES_PER_MILLION_USD = {
-    "deepseek-v4-pro": {"input": 0.435, "output": 0.87, "verified_at": "2026-07-23"},
-    "deepseek-v4-flash": {"input": 0.14, "output": 0.28, "verified_at": "2026-07-23"},
+    # Peak-hour, cache-miss rate - DeepSeek repriced 2026-08-16 (confirmed
+    # against api-docs.deepseek.com/quick_start/pricing) and now publishes
+    # four real rates per model: peak/off-peak x cache-hit/cache-miss. Peak
+    # cache-miss is the worst case of the four, matching this table's own
+    # "overestimate is the safe direction" rule above - a real DeepSeek call
+    # is very often billed at the much cheaper cache-hit rate (managed_audit
+    # measured 96% cache hit on its shared, append-only conversation prefix
+    # in a real test), so this constant is deliberately a ceiling, not an
+    # estimate of typical real cost.
+    "deepseek-v4-pro": {"input": 1.32, "output": 3.96, "verified_at": "2026-08-29"},
+    "deepseek-v4-flash": {"input": 0.44, "output": 1.32, "verified_at": "2026-08-29"},
     "gpt-5.6-luna": {"input": 0.20, "output": 1.20, "verified_at": "2026-08-09"},
     # Embeddings bill on input only, so output is 0 rather than absent -
     # cost_for_usage multiplies both, and a missing key would KeyError

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -15,13 +15,13 @@ from app_server.llm_cost import (
 
 def test_cost_for_usage_deepseek_v4_pro():
     assert cost_for_usage("deepseek-v4-pro", 1_000_000, 1_000_000) == pytest.approx(
-        0.435 + 0.87
+        1.32 + 3.96
     )
 
 
 def test_cost_for_usage_deepseek_v4_flash():
     assert cost_for_usage("deepseek-v4-flash", 1_000_000, 1_000_000) == pytest.approx(
-        0.14 + 0.28
+        0.44 + 1.32
     )
 
 
@@ -32,7 +32,7 @@ def test_cost_for_usage_gpt_5_6_luna():
 
 
 def test_cost_for_usage_small_real_call():
-    expected = (2_000 * 0.14 + 300 * 0.28) / 1_000_000
+    expected = (2_000 * 0.44 + 300 * 1.32) / 1_000_000
     assert cost_for_usage("deepseek-v4-flash", 2_000, 300) == pytest.approx(expected)
 
 


### PR DESCRIPTION
## Summary

`MODEL_RATES_PER_MILLION_USD`'s `deepseek-v4-pro`/`deepseek-v4-flash` entries were last verified 2026-07-23, before DeepSeek's real repricing on 2026-08-16 (confirmed directly against api-docs.deepseek.com/quick_start/pricing). The 90-day staleness warning never caught this since it's a discrete pricing event, not gradual staleness a date-diff check can see.

Both constants updated to the peak-hour, cache-miss rate, the worst case of DeepSeek's four real published rates (peak/off-peak x cache-hit/cache-miss), matching this table's own documented "overestimate is the safe direction" rule for a hard spend cap.

Real-world context: a DeepSeek call is very often billed at the far cheaper cache-hit rate in practice. Measured directly against `managed_audit`'s real conversation (append-only, stable prefix, ideal shape for provider-side prefix caching): 93.3% cache hit rate across 14 real calls, real cost $0.0855/run off-peak or $0.171/run peak, well under what even this corrected conservative constant implies for a worst-case ceiling.

## Test plan

- [x] `pytest tests/test_llm_cost.py` - 18 passed
- [x] `pytest tests/test_correlation.py tests/test_jobs.py tests/test_model_tiers.py` - 245 passed, 6 skipped (no other test file references these rates directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)