### PR TITLE
feat: switch live-docs full build off Luna onto deepseek-v4-flash

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -148,6 +148,7 @@ from app_server.email_queue import enqueue_transactional_email
 from app_server.email_client import send_transactional_email
 from scan_worker.managed_audit import run_managed_audit
 from scan_worker.model_tiers import (
+    DOCS_FULL_BUILD_MODEL,
     MANAGED_AUDIT_MODEL,
     PRO_MODEL,
     VERIFICATION_MODEL,
@@ -155,6 +156,7 @@ from scan_worker.model_tiers import (
     resolve_model,
     writing_adapter_for,
     writing_adapter_for_airview,
+    writing_adapter_for_docs_full_build,
     writing_adapter_for_plan,
 )
 from scan_worker.packet_cache import lookup_cached_result, store_result
@@ -3775,9 +3777,9 @@ MAX_DOCS_FULL_BUILD_FILES = 50
 
 
 def _live_docs_full_build_writing_adapter(
-    plan: str, on_usage: Callable[[int, int], None] | None = None
+    on_usage: Callable[[int, int], None] | None = None
 ) -> OpenAICompatibleAdapter:
-    return writing_adapter_for_plan(plan, on_usage=on_usage)
+    return writing_adapter_for_docs_full_build(on_usage=on_usage)
 
 
 def _live_docs_update_writing_adapter(
@@ -4037,9 +4039,8 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         )
         return
 
-    full_build_model = model_for_plan(plan)
     spend_budget = _IncrementalSpendBudget(
-        dsn, installation_id, full_build_model, monthly_cap,
+        dsn, installation_id, DOCS_FULL_BUILD_MODEL, monthly_cap,
         feature="docs_full_build",
     )
 
@@ -4047,7 +4048,7 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         spend_budget.record_usage(prompt_tokens, completion_tokens)
 
     try:
-        writing_adapter = _live_docs_full_build_writing_adapter(plan, on_usage=_on_usage)
+        writing_adapter = _live_docs_full_build_writing_adapter(on_usage=_on_usage)
     except Exception as exc:  # noqa: BLE001
         logging.getLogger("scan_worker.jobs").warning(
             "live docs full build could not start for installation=%s repo=%s (%s)",

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -284,6 +284,41 @@ def writing_adapter_for_plan(
     )
 
 
+# Not resolve_model(PRO_MODEL) - always exactly this one model,
+# unconditionally, matching MANAGED_AUDIT_MODEL's own reasoning above.
+DOCS_FULL_BUILD_MODEL = "deepseek-v4-flash"
+
+
+def writing_adapter_for_docs_full_build(
+    on_usage: Callable[[int, int], None] | None = None,
+    before_llm_call: Callable[[], bool] | None = None,
+    allow_partial_report: bool = False,
+) -> OpenAICompatibleAdapter:
+    """Always DeepSeek Flash for a live-docs full build specifically - never
+    Luna (writing_adapter_for_plan's default, and what a full build actually
+    ran on before this, since OPENAI_API_KEY is configured in production)
+    and never DeepSeek Pro either.
+
+    A full build processes every module/symbol in the repo at once (2,814
+    real symbols on this repo alone as of 2026-08-29) - this is the same
+    "writing quality holds up on Flash, at a fraction of the cost" finding
+    already established for managed_audit and AIRview, applied to the one
+    remaining writing surface still defaulting to the expensive tier. Live
+    docs' own incremental update path (writing_adapter_for's caller in
+    _maybe_update_live_docs) already uses live_docs.FLASH_MODEL directly -
+    this brings the one-time full build in line with what incremental
+    updates already do, rather than leaving the more expensive model on
+    just the highest-volume of the two call sites.
+    """
+    return writing_adapter_for(
+        DOCS_FULL_BUILD_MODEL,
+        on_usage=on_usage,
+        before_llm_call=before_llm_call,
+        allow_partial_report=allow_partial_report,
+        _prefer_luna=False,
+    )
+
+
 def verification_adapter(
     on_usage: Callable[[int, int], None] | None = None,
 ) -> OpenAICompatibleAdapter:

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -5794,7 +5794,7 @@ def test_run_live_docs_full_build_job_skips_llm_call_when_spend_cap_reached(monk
     adapter_calls = []
     monkeypatch.setattr(
         "scan_worker.jobs._live_docs_full_build_writing_adapter",
-        lambda plan, on_usage=None: adapter_calls.append(True),
+        lambda on_usage=None: adapter_calls.append(True),
     )
     status_calls = []
     monkeypatch.setattr(
@@ -5825,7 +5825,7 @@ def test_run_live_docs_full_build_job_survives_one_module_failing(monkeypatch):
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
     monkeypatch.setattr(
-        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan, on_usage=None: object()
+        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda on_usage=None: object()
     )
 
     def fake_fetch(client, token, repo, path, ref):
@@ -5884,7 +5884,7 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
 
     monkeypatch.setattr(
         "scan_worker.jobs._live_docs_full_build_writing_adapter",
-        lambda plan, on_usage=None: FakeAdapter(on_usage),
+        lambda on_usage=None: FakeAdapter(on_usage),
     )
     stored_for = []
 
@@ -5941,7 +5941,7 @@ def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(mon
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
     monkeypatch.setattr(
-        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan, on_usage=None: object()
+        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda on_usage=None: object()
     )
     monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: "source")
 
@@ -5983,7 +5983,7 @@ def test_run_live_docs_full_build_job_reports_failed_when_every_fetch_returns_no
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
     monkeypatch.setattr(
-        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda plan, on_usage=None: object()
+        "scan_worker.jobs._live_docs_full_build_writing_adapter", lambda on_usage=None: object()
     )
     monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: None)
     status_calls = []

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -5,6 +5,7 @@ import pytest
 
 from aletheore.adapters.openai_compatible import OpenAICompatibleAdapter
 from scan_worker.model_tiers import (
+    DOCS_FULL_BUILD_MODEL,
     LUNA_MODEL,
     MANAGED_AUDIT_MODEL,
     OPENAI_FREE_TIER_DAILY_TOKEN_CAP,
@@ -18,6 +19,7 @@ from scan_worker.model_tiers import (
     writing_adapter_chain_for_free_tier,
     writing_adapter_for,
     writing_adapter_for_airview,
+    writing_adapter_for_docs_full_build,
     writing_adapter_for_managed_audit,
     writing_adapter_for_plan,
 )
@@ -169,6 +171,47 @@ def test_writing_adapter_for_managed_audit_threads_on_usage_and_before_llm_call(
 def test_writing_adapter_for_managed_audit_threads_allow_partial_report(monkeypatch):
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
     adapter = writing_adapter_for_managed_audit(allow_partial_report=True)
+    assert adapter._allow_partial_report is True
+
+
+def test_writing_adapter_for_docs_full_build_never_uses_luna_even_when_openai_is_configured(monkeypatch):
+    # A full build processes every module in the repo at once (2,814 real
+    # symbols measured on this repo alone) - previously ran on Luna by
+    # default (writing_adapter_for_plan's _prefer_luna=True, and
+    # OPENAI_API_KEY is configured in production), now always Flash, same
+    # "writing quality holds on Flash for a fraction of the cost" finding
+    # already established for managed_audit and AIRview.
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    adapter = writing_adapter_for_docs_full_build()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == DOCS_FULL_BUILD_MODEL == "deepseek-v4-flash"
+    assert adapter._base_url == "https://api.deepseek.com"
+
+
+def test_writing_adapter_for_docs_full_build_still_uses_deepseek_when_openai_is_not_configured(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: False)
+    adapter = writing_adapter_for_docs_full_build()
+    assert adapter.name == "DeepSeek"
+    assert adapter._model == "deepseek-v4-flash"
+
+
+def test_writing_adapter_for_docs_full_build_threads_on_usage_and_before_llm_call(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    received = []
+    calls_allowed = []
+    adapter = writing_adapter_for_docs_full_build(
+        on_usage=lambda p, c: received.append((p, c)),
+        before_llm_call=lambda: calls_allowed.append(True) or True,
+    )
+    adapter._on_usage(7, 3)
+    assert received == [(7, 3)]
+    assert adapter._before_llm_call() is True
+    assert calls_allowed == [True]
+
+
+def test_writing_adapter_for_docs_full_build_threads_allow_partial_report(monkeypatch):
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    adapter = writing_adapter_for_docs_full_build(allow_partial_report=True)
     assert adapter._allow_partial_report is True
 
 


### PR DESCRIPTION
## Summary

`run_live_docs_full_build_job` was routed through `writing_adapter_for_plan`, which defaults to `_prefer_luna=True` - since `OPENAI_API_KEY` is configured in production, a full build actually ran on **Luna**, not the `deepseek-v4-pro` fallback the naming suggested. A full build processes every module in the repo at once (2,814 real symbols measured on this repo alone), making it the highest-volume writing surface still on the expensive default - and a strong real candidate for where this month's dogfooding spend concentrated.

Adds `writing_adapter_for_docs_full_build` (mirrors `writing_adapter_for_managed_audit`'s pattern exactly): always `deepseek-v4-flash`, never Luna, never Pro. Live docs' own incremental update path already uses `live_docs.FLASH_MODEL` directly - this brings the one-time full build in line with what incremental updates already do, rather than leaving the expensive model on just the highest-volume call site.

`writing_adapter_for_plan`/`model_for_plan`/`PRO_MODEL` are left untouched - still shared with `health_fix_suggestion`, which this change doesn't touch or have data on.

## Test plan

- [x] `pytest tests/test_model_tiers.py tests/test_jobs.py` - 231 passed, 2 skipped
- [x] New tests confirm `writing_adapter_for_docs_full_build` never uses Luna (mirrors managed_audit's own test), threads `on_usage`/`before_llm_call`/`allow_partial_report` correctly
- [x] Existing `test_run_live_docs_full_build_job_*` tests updated for the new (no-`plan`) adapter-factory signature, all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)