### PR TITLE
fix: isolate vulnerability check-run test from the real, persistent OSV cache

### DIFF
--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -766,13 +766,32 @@ def test_check_run_failure_on_new_secret(bare_repo_with_two_commits, monkeypatch
 
 
 def test_vulnerability_check_run_fails_on_real_known_cve_bump(
-    bare_repo_with_dependency_bump, monkeypatch
+    bare_repo_with_dependency_bump, monkeypatch, tmp_path
 ):
     """Real end-to-end: bumps requirements.txt to pyyaml==5.3.1 (a real,
     live-queried OSV.dev advisory - see the fixture) and asserts the new
     vulnerability check run fires failure. Makes a real network call to
     OSV.dev, same as production; not mocked, so this only proves the
-    wiring if OSV.dev is reachable when the suite runs."""
+    wiring if OSV.dev is reachable when the suite runs.
+
+    Real flakiness this fixed: check_vulnerabilities' default cache_path
+    (aletheore.vulnerabilities.DEFAULT_VULNERABILITY_CACHE_PATH) is
+    ~/.cache/aletheore/vulnerability-cache.json - a real file, shared and
+    persistent across every test run and every branch/PR on the same
+    machine, with a 24-hour TTL. Without isolating it, a single spurious-
+    but-200 OSV.dev response (not even a real outage - just one
+    momentarily incomplete/empty result) gets cached as "no vulnerabilities
+    found" for pyyaml==5.3.1 and silently poisons every subsequent test run
+    for up to a day, on any branch. Confirmed as the real root cause of a
+    live CI failure on an unrelated PR (#463) whose only connection to this
+    test was running on the same CI runner. The module's own comment on
+    check_vulnerabilities ("resolved inside the function body so a test
+    monkeypatching DEFAULT_VULNERABILITY_CACHE_PATH actually takes effect")
+    already anticipated exactly this - this test just never did it."""
+    monkeypatch.setattr(
+        "aletheore.vulnerabilities.DEFAULT_VULNERABILITY_CACHE_PATH",
+        tmp_path / "vulnerability-cache.json",
+    )
     bare_path, base_sha, head_sha = bare_repo_with_dependency_bump
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- `test_vulnerability_check_run_fails_on_real_known_cve_bump` (added in #462) never overrode `check_vulnerabilities`' default `cache_path` - a real file at `~/.cache/aletheore/vulnerability-cache.json`, shared and persistent across every test run, every branch, and real production usage on the same machine, with a 24-hour TTL.
- Root cause of a real, live CI failure on unrelated PR #463: a single spurious-but-200 OSV.dev response for `pyyaml==5.3.1` (not even a real outage, just one momentarily incomplete result) gets cached as "no vulnerabilities found" and silently poisons every subsequent run of this test for up to a day, on any branch - confirmed by re-querying OSV.dev directly afterward and finding the real advisory data unchanged.
- The module's own comment on `check_vulnerabilities` already anticipated exactly this ("resolved inside the function body so a test monkeypatching `DEFAULT_VULNERABILITY_CACHE_PATH` actually takes effect") - the test just never did it.
- Fix: monkeypatch `DEFAULT_VULNERABILITY_CACHE_PATH` to a per-test `tmp_path` so each test run gets its own isolated cache, eliminating both the flakiness and the cross-branch pollution risk entirely (a retry would not have fixed this - the underlying issue is a *cached* stale result, not a transient per-call failure, so a retry within the same poisoned-cache window would hit the same stale cache entry and fail identically).

## Test plan
- [x] `test_vulnerability_check_run_fails_on_real_known_cve_bump` and `test_vulnerability_check_run_succeeds_when_no_new_vulnerability` both pass with the isolated cache path.
- [x] Confirmed the real, production cache file at `~/.cache/aletheore/vulnerability-cache.json` is untouched by this change (checked before/after, no diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr