### PR TITLE
fix: swallowed-exception check ignored comment-only mentions of raise/log

### DIFF
--- a/github-app/scan_worker/semantic_checks.py
+++ b/github-app/scan_worker/semantic_checks.py
@@ -525,8 +525,14 @@ def _swallowed_exception_findings(file: str, source: str, hunks: list[_Hunk]) ->
             non_comment = [b for b in body if not b.startswith("#")]
             if non_comment != ["pass"]:
                 continue  # body has real handling (or more than just pass) - not a swallow
-            if any(_LOG_OR_RERAISE_RE.search(b) for b in body):
-                continue  # defensive, in case a future body shape sneaks a log/raise into a comment line
+            # Scoped to non_comment, not body: a comment merely mentioning
+            # "raise"/"log"/"warn" ("# used to raise, now silently
+            # ignored") is commentary, not real handling, and must not
+            # suppress a genuine swallow - confirmed as a real false
+            # negative, not theoretical, by a standalone before/after
+            # check against this exact shape.
+            if any(_LOG_OR_RERAISE_RE.search(b) for b in non_comment):
+                continue  # defensive, in case a future body shape sneaks a log/raise into real code
 
             findings.append(
                 _finding(

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -2173,6 +2173,35 @@ def test_semantic_checker_does_not_flag_an_except_that_logs():
     assert findings == []
 
 
+def test_semantic_checker_flags_a_swallow_even_with_a_comment_mentioning_raise():
+    """Real false-negative, found by an independent review pass: the body
+    is genuinely just `pass` - a comment merely mentioning "raise"/"log"
+    is commentary, not real handling, and must not suppress the finding.
+    The log/re-raise check must scope to non-comment lines only."""
+    source = (
+        "def close_quietly(self):\n"
+        "    try:\n"
+        "        self.conn.close()\n"
+        "    except Exception:\n"
+        "        # note: this used to raise, now silently ignored\n"
+        "        pass\n"
+    )
+    diff = (
+        "--- sessions.py ---\n"
+        "@@ -1,1 +1,5 @@\n"
+        " def close_quietly(self):\n"
+        "+    try:\n"
+        "+        self.conn.close()\n"
+        "+    except Exception:\n"
+        "+        # note: this used to raise, now silently ignored\n"
+        "+        pass\n"
+    )
+
+    findings = find_semantic_regressions(diff, {"sessions.py": source}, "")
+
+    assert len(findings) == 1
+
+
 def test_semantic_checker_does_not_flag_a_narrow_except_with_pass():
     """A specific exception type, not a bare/broad catch-all, is a
     deliberate narrow suppression - a different risk profile from the


### PR DESCRIPTION
## Summary
Follow-up to #462 (already merged): `_swallowed_exception_findings`' log/re-raise check ran against every body line, including comments - a comment merely mentioning "raise"/"log"/"warn" ("# used to raise, now silently ignored") suppressed a genuine swallowed-exception finding even though the real body was just `pass`.

Found by an independent review pass (thanks veridion-aa), confirmed as a real false negative via direct execution, not theoretical.

A second, larger gap was found in the same review - the check only fires on a newly-added except line, so it misses an existing except block whose body gets weakened from real handling to bare pass with the except line itself untouched (context, not part of the diff). That one needs new detection logic (matching removed-body content against added-body content when the except header itself is unchanged) and deserves its own design pass rather than being rushed into this fix - tracking it separately.

## Test plan
- [x] New regression test reproducing the exact false-negative shape
- [x] `test_flash_review.py` + `test_github_api.py`: 191 passed
- [x] Real 25-case corpus check (`evaluate_semantic_checks.py`): 6/21 recall, 0/4 false positives - unchanged, none of the corpus cases hit this specific shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)