### PR TITLE
feat: reply-based dismissal for Flash Review findings

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -14,6 +14,27 @@ async def create_pool(dsn: str) -> asyncpg.Pool:
     return await asyncpg.create_pool(dsn)
 
 
+async def get_flash_review_finding_comment_by_github_id(
+    pool: asyncpg.Pool, github_comment_id: int
+) -> dict | None:
+    """Reverse lookup for the reply-based dismissal webhook
+    (webhooks/pull_request_review_comment.py): a reply's payload only ever
+    carries in_reply_to_id, the real GitHub comment id of the finding
+    comment being replied to - this is the only path back to which
+    installation/repo/PR/finding that comment actually tracks. See
+    migration 059's flash_review_finding_comments_by_github_id index,
+    added specifically for this query."""
+    row = await pool.fetchrow(
+        """
+        SELECT installation_id, repo_full_name, pr_number, finding_type, identity_key
+        FROM flash_review_finding_comments
+        WHERE github_comment_id = $1
+        """,
+        github_comment_id,
+    )
+    return dict(row) if row else None
+
+
 async def upsert_installation(pool: asyncpg.Pool, installation_id: int, account_login: str) -> None:
     await pool.execute(
         """

--- a/github-app/app_server/dismissed_findings.py
+++ b/github-app/app_server/dismissed_findings.py
@@ -1,4 +1,46 @@
+import hashlib
+import re
+
 import asyncpg
+
+# Unlike a secret (path+pattern+match_preview) or a vulnerability
+# (ecosystem+package+advisory_id), a Flash Review finding has no natural
+# unique id - "issue" is free-text a model wrote, and the same underlying
+# bug can come back reworded (different phrasing, different word order)
+# across two independent generations of the same diff. Hashing the raw
+# text would treat any rewording as a brand-new finding, silently
+# resurrecting something a user already dismissed. Hashing file+line alone
+# would go too far the other way: two genuinely different bugs that happen
+# to land on the same line across two unrelated pushes (rare, but not
+# impossible - a fixed bug's line later hosting an unrelated new one) would
+# collapse into one identity.
+#
+# The middle ground here: normalize the issue text (lowercase, strip
+# punctuation, drop a short stopword list, collapse to a set of the
+# remaining significant words) and hash that set rather than the raw
+# string. A set - not a sequence - so word-order changes ("the null check
+# was removed" vs "removed the null check") don't change the key, while
+# genuinely different wording (different nouns/verbs describing a
+# different problem) does. This is a considered design choice, not a
+# verified one: there is no real corpus of "same bug, reworded across two
+# independent re-reviews of the same diff" available to test it against,
+# so its resilience to real model rewording is untested past the
+# synthetic cases in test_dismissed_findings.py. Line is still exact-match
+# (consistent with how secret/vulnerability identity already works, no
+# fuzzy tolerance there either) - a finding that shifts by even one line
+# because of an unrelated edit above it gets a fresh identity, a known,
+# accepted limitation shared with the other two finding types.
+_STOPWORDS = frozenset(
+    "a an and are as at be but by for from has have if in into is it its "
+    "of on or that the this to was were will with".split()
+)
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _issue_fingerprint(issue: str) -> str:
+    words = {w for w in _WORD_RE.findall(issue.lower()) if w not in _STOPWORDS}
+    normalized = "\x1e".join(sorted(words))
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
 
 
 def finding_identity_key(finding_type: str, finding: dict) -> str:
@@ -20,11 +62,19 @@ def finding_identity_key(finding_type: str, finding: dict) -> str:
     the cleanup this fired once already, and repeat that pattern (a
     migration that purges now-unreachable rows, not a data migration) if the
     preview format changes again.
+
+    flash_review_llm and flash_review_semantic (Flash Review's model-
+    generated and deterministic findings respectively - kept as two
+    distinct types rather than one, so dismissal-rate comparisons between
+    them stay possible) use file+line+_issue_fingerprint(issue) - see that
+    function's docstring for why a fingerprint rather than the raw text.
     """
     if finding_type == "secret":
         return f"{finding['path']}\x1f{finding['pattern']}\x1f{finding['match_preview']}"
     if finding_type == "vulnerability":
         return f"{finding['ecosystem']}\x1f{finding['package']}\x1f{finding['advisory_id']}"
+    if finding_type in ("flash_review_llm", "flash_review_semantic"):
+        return f"{finding['file']}\x1f{finding['line']}\x1f{_issue_fingerprint(finding['issue'])}"
     raise ValueError(f"unknown finding_type: {finding_type!r}")
 
 
@@ -36,16 +86,26 @@ def filter_dismissed(findings: list[dict], finding_type: str, dismissed_keys: se
     return [f for f in findings if finding_identity_key(finding_type, f) not in dismissed_keys]
 
 
-async def dismiss_finding(
+async def dismiss_finding_by_identity_key(
     pool: asyncpg.Pool,
     installation_id: int,
     repo_full_name: str,
     finding_type: str,
-    finding: dict,
+    identity_key: str,
     dismissed_by: str,
     reason: str | None = None,
 ) -> None:
-    identity_key = finding_identity_key(finding_type, finding)
+    """Same INSERT as dismiss_finding, but takes an already-known
+    identity_key directly instead of a finding dict to recompute it from.
+
+    Exists for the reply-based dismissal webhook
+    (webhooks/pull_request_review_comment.py): a reply's payload only
+    carries in_reply_to_id, resolved (via
+    get_flash_review_finding_comment_by_github_id) straight to a stored
+    identity_key - there is no original finding dict (file/line/issue) to
+    reconstruct at that point, and fabricating one just to feed it back
+    through finding_identity_key would be pointless indirection for a
+    value already on hand."""
     await pool.execute(
         """
         INSERT INTO dismissed_findings
@@ -59,6 +119,21 @@ async def dismiss_finding(
         identity_key,
         dismissed_by,
         reason,
+    )
+
+
+async def dismiss_finding(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    repo_full_name: str,
+    finding_type: str,
+    finding: dict,
+    dismissed_by: str,
+    reason: str | None = None,
+) -> None:
+    identity_key = finding_identity_key(finding_type, finding)
+    await dismiss_finding_by_identity_key(
+        pool, installation_id, repo_full_name, finding_type, identity_key, dismissed_by, reason
     )
 
 
@@ -94,7 +169,12 @@ async def get_dismissed_identity_keys(
         installation_id,
         repo_full_name,
     )
-    result: dict[str, set[str]] = {"secret": set(), "vulnerability": set()}
+    result: dict[str, set[str]] = {
+        "secret": set(),
+        "vulnerability": set(),
+        "flash_review_llm": set(),
+        "flash_review_semantic": set(),
+    }
     for row in rows:
         result[row["finding_type"]].add(row["identity_key"])
     return result

--- a/github-app/app_server/main.py
+++ b/github-app/app_server/main.py
@@ -213,6 +213,12 @@ async def webhook(request: Request):
             from app_server.webhooks.issue_comment import handle_issue_comment_event
 
             await handle_issue_comment_event(payload, pool, settings.redis_url)
+        elif event == "pull_request_review_comment":
+            from app_server.webhooks.pull_request_review_comment import (
+                handle_pull_request_review_comment_event,
+            )
+
+            await handle_pull_request_review_comment_event(payload, pool, settings.redis_url)
     except Exception:
         # Hand the GUID back before failing, or GitHub's retry of this same
         # delivery would be treated as a duplicate and dropped - turning a

--- a/github-app/app_server/webhooks/pull_request_review_comment.py
+++ b/github-app/app_server/webhooks/pull_request_review_comment.py
@@ -1,0 +1,129 @@
+import asyncio
+import logging
+
+from app_server.config import get_settings
+from app_server.db import get_flash_review_finding_comment_by_github_id, is_repo_hidden
+from app_server.dismissed_findings import dismiss_finding_by_identity_key
+from app_server.github_auth import generate_app_jwt, get_installation_token, get_repo_permission_for_user
+
+logger = logging.getLogger(__name__)
+
+DISMISS_COMMAND = "/dismiss"
+
+# Same reasoning as issue_comment.py's AUDIT_COMMAND gate: anyone who can
+# push to the repo can already suppress a finding by editing the code
+# around it or disabling the check entirely - write/admin is the same bar
+# an outside PR commenter (who this exists to stop) sits below.
+AUTHORIZED_PERMISSIONS = ("admin", "write")
+
+
+def _verify_commenter_permission_sync(
+    installation_id: int, app_jwt: str, repo_full_name: str, commenter: str
+) -> str:
+    token = get_installation_token(installation_id, app_jwt)
+    return get_repo_permission_for_user(repo_full_name, commenter, token)
+
+
+def _dismiss_reason(body: str) -> str | None:
+    """Whatever follows /dismiss on its own line, trimmed - None if the
+    command is bare (no reason given). Only the first matching line is
+    used; a reply is one short comment, not a document."""
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(DISMISS_COMMAND):
+            reason = stripped[len(DISMISS_COMMAND):].strip()
+            return reason or None
+    return None
+
+
+async def handle_pull_request_review_comment_event(payload: dict, pool, redis_url: str, queue=None) -> None:
+    """Reply-based dismissal: a user replies /dismiss to one of Flash
+    Review's inline finding comments (see jobs.py's
+    _flash_review_comment_body, which tells them to). GitHub fires this
+    event for every reply to a review comment - in_reply_to_id is only
+    ever set on a reply, never a top-level review comment, which is what
+    scopes this to actual replies without needing to distinguish by
+    content first.
+
+    Deliberately does not verify this is a reply to specifically a Flash
+    Review comment before doing the permission check - a reply to some
+    unrelated review comment simply won't resolve via
+    get_flash_review_finding_comment_by_github_id below and this returns
+    quietly, same cost either way. Checking permission first would only
+    save one DB query on the common case of "not our comment", not worth
+    reordering for.
+    """
+    if payload.get("action") != "created":
+        return
+    comment = payload.get("comment", {})
+    if comment.get("in_reply_to_id") is None:
+        return  # not a reply - a top-level review comment, nothing to dismiss
+    if comment.get("user", {}).get("type") == "Bot":
+        return  # never act on our own resolution-edit comments or any other bot's reply
+    body = comment.get("body", "")
+    if not any(line.strip().startswith(DISMISS_COMMAND) for line in body.splitlines()):
+        return
+
+    installation_id = payload["installation"]["id"]
+    repo_full_name = payload["repository"]["full_name"]
+    commenter = payload["comment"]["user"]["login"]
+    in_reply_to_id = comment["in_reply_to_id"]
+
+    if await is_repo_hidden(pool, installation_id, repo_full_name):
+        return
+
+    tracked = await get_flash_review_finding_comment_by_github_id(pool, in_reply_to_id)
+    if tracked is None:
+        # A reply to a review comment we don't track (not one of Flash
+        # Review's own finding comments, or the tracking row was never
+        # written) - nothing to dismiss.
+        return
+    if tracked["installation_id"] != installation_id or tracked["repo_full_name"] != repo_full_name:
+        # The tracked row belongs to a different installation/repo than
+        # this webhook payload claims - in_reply_to_id is a GitHub-wide
+        # comment id, not scoped to one installation, so this is the
+        # cross-check that stops a payload from one installation acting on
+        # another's dismissal state. Should never happen in practice (a
+        # reply's own repository IS the comment's repository), but the
+        # check is cheap and the alternative (trusting the id blindly) is
+        # not.
+        logger.warning(
+            "flash review dismiss: in_reply_to_id=%s tracked row belongs to a different "
+            "installation/repo than the webhook payload (%s/%s) - refusing to act",
+            in_reply_to_id, installation_id, repo_full_name,
+        )
+        return
+
+    settings = get_settings()
+    try:
+        app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
+        permission = await asyncio.to_thread(
+            _verify_commenter_permission_sync, installation_id, app_jwt, repo_full_name, commenter
+        )
+    except Exception:
+        # Fail closed, same as issue_comment.py's audit trigger: an API
+        # hiccup here should silently drop a legitimate dismissal (the
+        # user can just reply again) rather than let an unverified
+        # commenter through because the check itself errored.
+        logger.warning(
+            "failed to verify commenter permission for %s on %s; refusing to record dismissal",
+            commenter, repo_full_name, exc_info=True,
+        )
+        return
+
+    if permission not in AUTHORIZED_PERMISSIONS:
+        logger.info(
+            "ignoring '%s' from %s on %s: permission=%r, need write or admin",
+            DISMISS_COMMAND, commenter, repo_full_name, permission,
+        )
+        return
+
+    await dismiss_finding_by_identity_key(
+        pool,
+        installation_id,
+        repo_full_name,
+        tracked["finding_type"],
+        tracked["identity_key"],
+        dismissed_by=commenter,
+        reason=_dismiss_reason(body),
+    )

--- a/github-app/migrations/058_flash_review_dismissal_types.sql
+++ b/github-app/migrations/058_flash_review_dismissal_types.sql
@@ -1,0 +1,39 @@
+-- dismissed_findings.finding_type was CHECK-constrained to ('secret',
+-- 'vulnerability') only (see migration 033). Flash Review findings (both
+-- LLM-generated and the free deterministic semantic checks) now reuse this
+-- same table rather than a parallel dismissal system - see
+-- app_server/dismissed_findings.py's finding_identity_key() for the two new
+-- types' identity-key shape. Kept as two distinct types, not one generic
+-- "flash_review", because a deterministic finding is pattern-matched
+-- against real code (effectively proven) while an LLM finding is a model's
+-- claim already passed through grounding - collapsing them would make it
+-- impossible to later ask "do users dismiss deterministic findings at a
+-- different rate than LLM ones", which is the whole reason this feedback
+-- loop is being built.
+--
+-- The original CHECK was added inline in CREATE TABLE (migration 033) with
+-- no explicit name, so Postgres auto-generated one. Looked up here via
+-- information_schema rather than hardcoding the conventional
+-- "dismissed_findings_finding_type_check" name - no live Postgres was
+-- available to confirm that guess against this project's actual migration
+-- history before shipping this, and a wrong hardcoded name fails loudly
+-- (DROP CONSTRAINT errors if the name doesn't exist) rather than silently,
+-- but there is no reason to guess when the real name can be found instead.
+DO $$
+DECLARE
+    constraint_name text;
+BEGIN
+    SELECT con.conname INTO constraint_name
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    WHERE rel.relname = 'dismissed_findings'
+      AND con.contype = 'c'
+      AND pg_get_constraintdef(con.oid) LIKE '%finding_type%';
+
+    IF constraint_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE dismissed_findings DROP CONSTRAINT %I', constraint_name);
+    END IF;
+
+    ALTER TABLE dismissed_findings ADD CONSTRAINT dismissed_findings_finding_type_check
+        CHECK (finding_type IN ('secret', 'vulnerability', 'flash_review_llm', 'flash_review_semantic'));
+END $$;

--- a/github-app/migrations/059_flash_review_finding_comments.sql
+++ b/github-app/migrations/059_flash_review_finding_comments.sql
@@ -1,0 +1,50 @@
+-- Maps a Flash Review finding's identity (see app_server/dismissed_findings.py's
+-- finding_identity_key for flash_review_llm/flash_review_semantic) to the
+-- real GitHub inline review-comment id that finding was posted as, per PR.
+--
+-- Scoped by pr_number (unlike dismissed_findings, which is repo-wide) - a
+-- finding's dismissal should follow the underlying bug across every PR on
+-- the repo, but a comment is inherently one PR's artifact; the same
+-- identity_key can have a different github_comment_id on two different
+-- PRs, and needs to.
+--
+-- Needed because posting moved from one upserted issue-comment
+-- (jobs.py's FLASH_REVIEW_MARKER pattern - a single comment, trivially
+-- reconciled by re-fetching and matching a marker string) to one inline
+-- review comment per finding: a re-review has to know which of N existing
+-- comments corresponds to which of this push's findings, so a still-
+-- present finding gets left untouched (not reposted/duplicated) and only
+-- genuinely new findings get a new comment.
+--
+-- resolved_at is set (once) the first time a re-review's finding list no
+-- longer includes this identity_key - the comment itself is left in place
+-- and edited to say so (see run_flash_review_job), never deleted: a human
+-- may have already replied to it, and deleting a comment with real replies
+-- attached destroys that thread. NULL until then; once set, a further
+-- re-review that also doesn't detect the finding does not re-edit the
+-- comment again (checked before editing, not just before this row's
+-- write) - the edit itself is a one-time transition, not resynced on every
+-- subsequent silent push.
+CREATE TABLE IF NOT EXISTS flash_review_finding_comments (
+    id                BIGSERIAL PRIMARY KEY,
+    installation_id   BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name    TEXT NOT NULL,
+    pr_number         INT NOT NULL,
+    finding_type      TEXT NOT NULL CHECK (finding_type IN ('flash_review_llm', 'flash_review_semantic')),
+    identity_key      TEXT NOT NULL,
+    github_comment_id BIGINT NOT NULL,
+    last_seen_sha     TEXT NOT NULL,
+    resolved_at       TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (installation_id, repo_full_name, pr_number, finding_type, identity_key)
+);
+
+CREATE INDEX IF NOT EXISTS flash_review_finding_comments_lookup
+    ON flash_review_finding_comments (installation_id, repo_full_name, pr_number);
+
+-- The reply-webhook path (pull_request_review_comment, in_reply_to_id set)
+-- only ever has the real GitHub comment id to start from, not the
+-- installation/repo/pr/identity_key tuple - this is the lookup that path
+-- needs.
+CREATE INDEX IF NOT EXISTS flash_review_finding_comments_by_github_id
+    ON flash_review_finding_comments (github_comment_id);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -618,7 +618,12 @@ def get_dismissed_identity_keys(dsn: str, installation_id: int, repo_full_name: 
                 """,
                 (installation_id, repo_full_name),
             )
-            result: dict[str, set[str]] = {"secret": set(), "vulnerability": set()}
+            result: dict[str, set[str]] = {
+                "secret": set(),
+                "vulnerability": set(),
+                "flash_review_llm": set(),
+                "flash_review_semantic": set(),
+            }
             for finding_type, identity_key in cur.fetchall():
                 result[finding_type].add(identity_key)
             return result
@@ -1439,6 +1444,125 @@ def record_flash_review_cache_hit(dsn: str, row_id: int) -> None:
                 (row_id,),
             )
         conn.commit()
+
+
+def get_flash_review_finding_comments(
+    dsn: str, installation_id: int, repo_full_name: str, pr_number: int
+) -> dict[tuple[str, str], dict]:
+    """Every tracked inline comment for this PR, keyed by (finding_type,
+    identity_key) so run_flash_review_job can tell, per finding in this
+    push's results, whether it already has a real GitHub comment (edit/
+    leave alone) or needs a new one (see migration 059's docstring for why
+    this replaced the old single-upserted-comment reconciliation)."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT id, finding_type, identity_key, github_comment_id, resolved_at
+                FROM flash_review_finding_comments
+                WHERE installation_id = %s AND repo_full_name = %s AND pr_number = %s
+                """,
+                (installation_id, repo_full_name, pr_number),
+            )
+            return {(row["finding_type"], row["identity_key"]): row for row in cur.fetchall()}
+
+
+def insert_flash_review_finding_comment(
+    dsn: str,
+    installation_id: int,
+    repo_full_name: str,
+    pr_number: int,
+    finding_type: str,
+    identity_key: str,
+    github_comment_id: int,
+    head_sha: str,
+) -> None:
+    """Records a newly posted inline comment for a finding this PR has
+    never seen before. ON CONFLICT DO NOTHING rather than upsert: this is
+    only ever called after get_flash_review_finding_comments already
+    confirmed no row exists for this (finding_type, identity_key) - a
+    conflict here would mean a real race (two review runs for the same PR
+    overlapping), and silently keeping the first writer's github_comment_id
+    is correct, not a bug to paper over with a last-writer-wins update."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO flash_review_finding_comments
+                    (installation_id, repo_full_name, pr_number, finding_type,
+                     identity_key, github_comment_id, last_seen_sha)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (installation_id, repo_full_name, pr_number, finding_type, identity_key)
+                DO NOTHING
+                """,
+                (
+                    installation_id,
+                    repo_full_name,
+                    pr_number,
+                    finding_type,
+                    identity_key,
+                    github_comment_id,
+                    head_sha,
+                ),
+            )
+        conn.commit()
+
+
+def touch_flash_review_finding_comment(
+    dsn: str, row_id: int, head_sha: str, resolved: bool | None = None
+) -> None:
+    """A finding still present on this push - no new comment (usually no
+    edit either), just records that this sha re-confirmed it
+    (last_seen_sha), separate from resolved_at so a finding that
+    disappears and later comes back (a revert, or the same bug
+    reintroduced) has a real last-seen trail.
+
+    resolved=False clears resolved_at in the same UPDATE - used when a
+    finding reappears after having been marked resolved (see
+    _post_flash_review_finding_comments), so un-resolving is one state
+    transition, not a separate DB function on top of this one. resolved=True
+    is never passed here - mark_flash_review_finding_comment_resolved
+    exists specifically because that transition needs to know whether it
+    was the one that made it (its RETURNING id), which a plain UPDATE
+    ignoring rowcount can't distinguish from "was already resolved"."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            if resolved is False:
+                cur.execute(
+                    "UPDATE flash_review_finding_comments "
+                    "SET last_seen_sha = %s, resolved_at = NULL WHERE id = %s",
+                    (head_sha, row_id),
+                )
+            else:
+                cur.execute(
+                    "UPDATE flash_review_finding_comments SET last_seen_sha = %s WHERE id = %s",
+                    (head_sha, row_id),
+                )
+        conn.commit()
+
+
+def mark_flash_review_finding_comment_resolved(dsn: str, row_id: int) -> bool:
+    """Sets resolved_at the first time a re-review no longer detects this
+    finding. Returns whether this call actually made the transition (True)
+    vs the row was already resolved (False) - the caller uses this to
+    decide whether to PATCH the real GitHub comment: the edit is a one-time
+    transition, not resynced on every subsequent push that also doesn't
+    detect the finding (WHERE resolved_at IS NULL makes a second call on an
+    already-resolved row a no-op update, RETURNING id then coming back
+    empty)."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE flash_review_finding_comments SET resolved_at = now()
+                WHERE id = %s AND resolved_at IS NULL
+                RETURNING id
+                """,
+                (row_id,),
+            )
+            made_transition = cur.fetchone() is not None
+        conn.commit()
+        return made_transition
 
 
 def delete_expired_flash_review_cache(dsn: str, retention_days: int = 30) -> int:

--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -973,13 +973,40 @@ def _verify_findings_with_second_model(
 
 
 def _merge_semantic_findings(model_findings: list[dict], semantic_findings: list[dict]) -> list[dict]:
-    """Prefer an evidence-only finding over a model finding at that location."""
+    """Prefer an evidence-only finding over a model finding at that location.
+
+    Also the one guaranteed choke point every finding passes through
+    regardless of code path (fresh generation, or a cache hit re-merging
+    stored model findings with a fresh semantic pass - see review_diff's
+    cache_lookup branch), so it's where "source" gets tagged
+    ("semantic"/"llm") rather than at each of the several individual
+    origin points (semantic_checks.py's _finding(), or the two raw
+    json.loads() sites for a fresh LLM response) - tagging here is the only
+    way to guarantee every finding that ever leaves review_diff carries it,
+    which app_server/dismissed_findings.py's finding_identity_key needs to
+    pick flash_review_llm vs flash_review_semantic. New dicts, not mutated
+    in place - callers elsewhere hold references to the same finding dicts
+    (e.g. the similarity cache writes model_findings verbatim) and must not
+    see a "source" key appear on them as a side effect of this call.
+
+    Tagging uses .get("source", default) - not an unconditional overwrite -
+    because model_findings is not always genuinely fresh, untagged LLM
+    output: on a cache hit, review_diff calls this again with the cache's
+    stored findings as model_findings, and those already carry whatever
+    "source" this function gave them the first time (a cache write stores
+    findings from a prior call to this same function). A finding that was
+    originally "semantic" must keep reading as "semantic" after surviving
+    into a cache hit, not get silently relabeled "llm" just because it's
+    sitting in the model_findings argument on this call.
+    """
+    tagged_semantic = [{**finding, "source": finding.get("source", "semantic")} for finding in semantic_findings]
     semantic_locations = {(finding["file"], finding["line"]) for finding in semantic_findings}
-    return semantic_findings + [
-        finding
+    tagged_model = [
+        {**finding, "source": finding.get("source", "llm")}
         for finding in model_findings
         if (finding["file"], finding["line"]) not in semantic_locations
     ]
+    return tagged_semantic + tagged_model
 
 
 def review_diff(

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -56,6 +56,77 @@ def upsert_pr_comment(
     response.raise_for_status()
 
 
+def create_pr_review_comment(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    pr_number: int,
+    commit_id: str,
+    path: str,
+    line: int,
+    body: str,
+) -> dict:
+    """Posts one inline PR review comment anchored to a real file:line -
+    the .../pulls/{pr}/comments endpoint, distinct from upsert_pr_comment's
+    .../issues/{pr}/comments (a plain, unanchored PR-level comment). side
+    is always RIGHT: line is always a new-file line number (see
+    flash_review.py's _diff_valid_lines), matching the new/head version of
+    the diff GitHub anchors RIGHT-side comments against.
+
+    Returns the created comment's JSON (id is what callers persist in
+    flash_review_finding_comments to track it across re-reviews).
+
+    A path/line GitHub's own review-comment validation rejects (not part
+    of the diff's added/context lines - can happen if the same finding's
+    citation drifted between grounding and posting, though grounding
+    should already prevent this) surfaces as a real 422 from raise_for_status
+    - deliberately not swallowed here, since a caller silently losing a
+    finding it meant to post is worse than a visible failure.
+    """
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    response = client.post(
+        f"/repos/{repo_full_name}/pulls/{pr_number}/comments",
+        headers=headers,
+        json={
+            "body": body,
+            "commit_id": commit_id,
+            "path": path,
+            "line": line,
+            "side": "RIGHT",
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def edit_pr_review_comment(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    comment_id: int,
+    body: str,
+) -> None:
+    """Edits an existing inline review comment in place - used both to
+    update a still-present finding's body across re-reviews (if its issue
+    text changed) and to mark one no longer detected without deleting it
+    (see run_flash_review_job's resolution handling: a reply thread a human
+    already engaged with must stay intact, so this edits rather than
+    deletes)."""
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    response = client.patch(
+        f"/repos/{repo_full_name}/pulls/comments/{comment_id}",
+        headers=headers,
+        json={"body": body},
+    )
+    response.raise_for_status()
+
+
 def create_check_run(
     client: httpx.Client,
     token: str,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -37,7 +37,7 @@ from aletheore.healthcheck import run_healthcheck
 from aletheore.signature_diff import find_regression_fence_violations
 from app_server.config import get_settings
 from app_server.db import MAX_SCANNED_REPOS_PER_MONTH
-from app_server.dismissed_findings import filter_dismissed
+from app_server.dismissed_findings import filter_dismissed, finding_identity_key
 from app_server.error_alerts import send_error_alert
 from app_server.github_auth import generate_app_jwt, get_installation_token
 from app_server.http_client import get_github_api_client
@@ -66,6 +66,7 @@ from scan_worker.db import (
     delete_wiki_subsystems_not_in,
     email_already_sent,
     get_dismissed_identity_keys,
+    get_flash_review_finding_comments,
     managed_audit_definitely_still_cooling_down,
     get_docs_repo_commit_settings,
     get_endpoint_health_summary,
@@ -80,6 +81,7 @@ from scan_worker.db import (
     get_seconds_since_last_health_check,
     insert_audit_report,
     insert_endpoint_health,
+    insert_flash_review_finding_comment,
     insert_repo_history,
     installation_spend_lock,
     release_flash_review_count_reservation,
@@ -95,6 +97,7 @@ from scan_worker.db import (
     list_recent_endpoint_incidents,
     list_repos_for_installation,
     list_wiki_subsystems,
+    mark_flash_review_finding_comment_resolved,
     record_digest_sent,
     record_docs_catchup_swept,
     record_docs_repo_commit,
@@ -105,6 +108,7 @@ from scan_worker.db import (
     set_docs_build_status,
     set_last_reviewed_sha,
     set_wiki_build_status,
+    touch_flash_review_finding_comment,
     upsert_docs_symbol,
     upsert_wiki_overview,
     upsert_wiki_subsystem,
@@ -130,6 +134,8 @@ from scan_worker.github_api import (
     MAX_CONTEXT_FILE_BYTES,
     MAX_CONTEXT_FILES,
     create_check_run,
+    create_pr_review_comment,
+    edit_pr_review_comment,
     fetch_default_branch_head_sha,
     fetch_file_content,
     fetch_pr_changed_files,
@@ -1591,6 +1597,134 @@ def run_flash_review_job(
                 release_llm_spend_reservation(settings.database_url, installation_id, reserved_spend)
 
 
+def _flash_review_finding_type(finding: dict) -> str:
+    return "flash_review_llm" if finding.get("source") == "llm" else "flash_review_semantic"
+
+
+def _flash_review_comment_body(finding: dict) -> str:
+    lines = [finding["issue"]]
+    suggestion = finding.get("suggestion")
+    if suggestion:
+        lines.append(f"```\n{suggestion}\n```")
+    lines.append(
+        "\n_Reply `/dismiss` (optionally with a reason) if this isn't helpful - Aletheore won't "
+        "raise it again on this repo._"
+    )
+    return "\n\n".join(lines)
+
+
+_RESOLVED_PREFIX = "✅ _No longer detected as of `{sha}`._\n\n---\n\n"
+
+
+def _post_flash_review_finding_comments(
+    settings,
+    client,
+    token: str,
+    installation_id: int,
+    repo_full_name: str,
+    pr_number: int,
+    head_sha: str,
+    findings_to_post: list[dict],
+) -> None:
+    """Posts one inline PR review comment per finding (anchored to its real
+    file:line via create_pr_review_comment) instead of the old single
+    upserted issue-comment listing every finding as a bullet - each
+    finding needs its own comment for reply-based dismissal (a webhook
+    fires per-comment, not per-PR) and its own tracked identity across
+    re-reviews (see migration 059's docstring).
+
+    A finding already tracked for this PR is left untouched except for
+    last_seen_sha (no repost, no duplicate) - or, if it had previously been
+    marked resolved and has now reappeared (a revert, or the same bug
+    reintroduced), the comment is edited back to its normal body and
+    resolved_at is cleared. A tracked finding NOT present in
+    findings_to_post is presumed fixed: its comment is edited (not
+    deleted - see migration 059's docstring on why a human's existing
+    reply thread must survive) to note it's no longer detected, and only
+    on the first push that doesn't detect it (resolved_at is a one-time
+    transition, not resynced every subsequent silent push).
+    """
+    dsn = settings.database_url
+    existing = get_flash_review_finding_comments(dsn, installation_id, repo_full_name, pr_number)
+    seen_keys: set[tuple[str, str]] = set()
+
+    for finding in findings_to_post:
+        finding_type = _flash_review_finding_type(finding)
+        identity_key = finding_identity_key(finding_type, finding)
+        seen_keys.add((finding_type, identity_key))
+        row = existing.get((finding_type, identity_key))
+
+        if row is None:
+            try:
+                comment = create_pr_review_comment(
+                    client, token, repo_full_name, pr_number, head_sha,
+                    finding["file"], finding["line"], _flash_review_comment_body(finding),
+                )
+            except Exception:
+                # A finding whose citation GitHub's own diff-position
+                # validation rejects (see create_pr_review_comment's
+                # docstring) must not take down the rest of this PR's
+                # findings with it - one bad anchor posting nothing is
+                # better than the whole review silently posting none.
+                logging.getLogger("scan_worker.jobs").warning(
+                    "failed to post flash review inline comment for %s:%s on %s#%s",
+                    finding["file"], finding["line"], repo_full_name, pr_number, exc_info=True,
+                )
+                continue
+            insert_flash_review_finding_comment(
+                dsn, installation_id, repo_full_name, pr_number,
+                finding_type, identity_key, comment["id"], head_sha,
+            )
+        elif row["resolved_at"] is not None:
+            # Reappeared after being marked resolved - restore the normal
+            # comment body (dropping the "no longer detected" prefix) and
+            # clear resolved_at so a future disappearance can transition
+            # again. clear_flash_review_finding_comment_resolved isn't a
+            # separate DB call: touch_flash_review_finding_comment already
+            # updates last_seen_sha unconditionally, so resolved_at is
+            # cleared inline in the same UPDATE rather than adding a fifth
+            # DB function for what's really one state transition.
+            try:
+                edit_pr_review_comment(
+                    client, token, repo_full_name, row["github_comment_id"], _flash_review_comment_body(finding)
+                )
+            except Exception:
+                logging.getLogger("scan_worker.jobs").warning(
+                    "failed to un-resolve flash review comment %s on %s#%s",
+                    row["github_comment_id"], repo_full_name, pr_number, exc_info=True,
+                )
+            touch_flash_review_finding_comment(dsn, row["id"], head_sha, resolved=False)
+        else:
+            touch_flash_review_finding_comment(dsn, row["id"], head_sha)
+
+    for (finding_type, identity_key), row in existing.items():
+        if (finding_type, identity_key) in seen_keys or row["resolved_at"] is not None:
+            continue
+        if not mark_flash_review_finding_comment_resolved(dsn, row["id"]):
+            continue  # lost a race with another concurrent transition - do not double-edit
+        try:
+            # The tracking row has no copy of the finding's own text (only
+            # its identity_key, a one-way hash - see dismissed_findings.py)
+            # so the original comment body can't be reconstructed here.
+            # Prepending is enough: it doesn't need to restate the finding,
+            # just mark the thread resolved above whatever's already there.
+            current = client.get(
+                f"/repos/{repo_full_name}/pulls/comments/{row['github_comment_id']}",
+                headers={"Authorization": f"token {token}", "Accept": "application/vnd.github+json"},
+            )
+            current.raise_for_status()
+            original_body = current.json()["body"]
+            edit_pr_review_comment(
+                client, token, repo_full_name, row["github_comment_id"],
+                _RESOLVED_PREFIX.format(sha=head_sha[:12]) + original_body,
+            )
+        except Exception:
+            logging.getLogger("scan_worker.jobs").warning(
+                "failed to mark flash review comment %s resolved on %s#%s",
+                row["github_comment_id"], repo_full_name, pr_number, exc_info=True,
+            )
+
+
 def _run_flash_review(
     settings,
     installation_id: int,
@@ -1845,14 +1979,46 @@ def _run_flash_review(
     proposed = grounding_result.get("proposed", 0)
     kept = grounding_result.get("kept", 0)
 
-    if findings:
-        lines = [f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n"]
-        for finding in findings:
-            lines.append(f"- `{finding['file']}:{finding['line']}` — {finding['issue']}")
-            suggestion = finding.get("suggestion")
-            if suggestion:
-                lines.append(f"  ```\n  {suggestion}\n  ```")
-        body = "\n".join(lines)
+    # Dismissal, applied here (not upstream in review_diff) for the same
+    # reason the diff-comment path already filters secrets/vulnerabilities
+    # this late: proposed/kept above describe what the grounding/
+    # verification pipeline technically validated, independent of whether
+    # a user already said "not helpful" on this exact bug. A dismissed
+    # finding still counts toward those stats - dismissal is a posting
+    # decision, not a re-judgment of the pipeline's own accuracy.
+    dismissed = get_dismissed_identity_keys(settings.database_url, installation_id, repo_full_name)
+    llm_findings = filter_dismissed(
+        [f for f in findings if f.get("source") == "llm"], "flash_review_llm", dismissed["flash_review_llm"]
+    )
+    semantic_findings_for_posting = filter_dismissed(
+        [f for f in findings if f.get("source") == "semantic"],
+        "flash_review_semantic",
+        dismissed["flash_review_semantic"],
+    )
+    findings_to_post = semantic_findings_for_posting + llm_findings
+
+    _post_flash_review_finding_comments(
+        settings, client, token, installation_id, repo_full_name, pr_number, head_sha, findings_to_post,
+    )
+
+    if findings_to_post:
+        body = (
+            f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n\n"
+            f"{len(findings_to_post)} finding(s) posted as inline review comment(s) below."
+        )
+    elif findings:
+        # findings (raw, pre-dismissal) is non-empty but findings_to_post
+        # is empty - every surviving finding was already dismissed by a
+        # user. Distinct from the two branches below (kept/proposed
+        # describe the grounding/verification pipeline, which ran before
+        # dismissal and doesn't know about it) - without this branch, an
+        # all-dismissed review would fall into "no issues held up under
+        # verification", which is simply false: they held up fine, a human
+        # already said not to show them.
+        body = (
+            f"{FLASH_REVIEW_MARKER}\n### Aletheore Flash review\n\n"
+            f"{len(findings)} finding(s) held up but were already dismissed on a previous review."
+        )
     elif kept:
         # Grounding accepted findings (kept > 0), but the independent
         # second-model verification step then rejected every one of them

--- a/github-app/tests/test_dismissed_findings.py
+++ b/github-app/tests/test_dismissed_findings.py
@@ -49,6 +49,96 @@ def test_filter_dismissed_does_not_mutate_input_list():
     assert findings == [SECRET_FINDING]
 
 
+def test_finding_identity_key_flash_review_llm_and_semantic_can_share_a_raw_key():
+    # The raw identity_key string is NOT required to differ between the two
+    # flash_review finding_types for the same file/line/issue - finding_type
+    # is tracked as its own column (dismissed_findings' UNIQUE constraint is
+    # on (installation_id, repo_full_name, finding_type, identity_key)) and
+    # its own dict bucket in get_dismissed_identity_keys, so a raw-key
+    # collision across the two types is harmless: dismissing the LLM
+    # finding never marks the semantic one (or vice versa) as dismissed.
+    # See test_get_dismissed_identity_keys_groups_rows_by_finding_type for
+    # the actual scoping guarantee this depends on.
+    finding = {"file": "a.py", "line": 10, "issue": "removed the null check"}
+    llm_key = finding_identity_key("flash_review_llm", finding)
+    semantic_key = finding_identity_key("flash_review_semantic", finding)
+    assert llm_key == semantic_key
+
+
+def test_finding_identity_key_flash_review_survives_word_reordering():
+    reworded = {"file": "a.py", "line": 10, "issue": "the null check was removed"}
+    original = {"file": "a.py", "line": 10, "issue": "removed the null check"}
+    assert finding_identity_key("flash_review_llm", reworded) == finding_identity_key(
+        "flash_review_llm", original
+    )
+
+
+def test_finding_identity_key_flash_review_survives_punctuation_and_case_changes():
+    a = {"file": "a.py", "line": 10, "issue": "Removed the null check!"}
+    b = {"file": "a.py", "line": 10, "issue": "removed the null check"}
+    assert finding_identity_key("flash_review_llm", a) == finding_identity_key("flash_review_llm", b)
+
+
+def test_finding_identity_key_flash_review_different_line_differs():
+    a = {"file": "a.py", "line": 10, "issue": "removed the null check"}
+    b = {"file": "a.py", "line": 11, "issue": "removed the null check"}
+    assert finding_identity_key("flash_review_llm", a) != finding_identity_key("flash_review_llm", b)
+
+
+def test_finding_identity_key_flash_review_different_file_differs():
+    a = {"file": "a.py", "line": 10, "issue": "removed the null check"}
+    b = {"file": "b.py", "line": 10, "issue": "removed the null check"}
+    assert finding_identity_key("flash_review_llm", a) != finding_identity_key("flash_review_llm", b)
+
+
+def test_finding_identity_key_flash_review_genuinely_different_issue_differs():
+    a = {"file": "a.py", "line": 10, "issue": "removed the null check"}
+    b = {"file": "a.py", "line": 10, "issue": "introduced a SQL injection risk"}
+    assert finding_identity_key("flash_review_llm", a) != finding_identity_key("flash_review_llm", b)
+
+
+class _FakePool:
+    """Minimal stand-in for asyncpg.Pool - get_dismissed_identity_keys only
+    ever calls .fetch() on it, so this only needs to satisfy that one call
+    with rows shaped the way asyncpg would return them (mapping-like, keyed
+    by column name)."""
+
+    def __init__(self, rows: list[dict]):
+        self._rows = rows
+
+    async def fetch(self, query, *args):
+        return self._rows
+
+
+@pytest.mark.asyncio
+async def test_get_dismissed_identity_keys_seeds_all_four_types_with_zero_rows():
+    # Always seeds all four known finding_type keys even with zero rows, so
+    # a caller building a dict comprehension over its result (e.g. jobs.py's
+    # dismissed["flash_review_llm"]) never KeyErrors on an installation
+    # with no dismissals of that type yet.
+    result = await get_dismissed_identity_keys(_FakePool([]), 1, "owner/repo")
+    assert result == {
+        "secret": set(),
+        "vulnerability": set(),
+        "flash_review_llm": set(),
+        "flash_review_semantic": set(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_dismissed_identity_keys_groups_rows_by_finding_type():
+    rows = [
+        {"finding_type": "flash_review_llm", "identity_key": "k1"},
+        {"finding_type": "flash_review_semantic", "identity_key": "k2"},
+        {"finding_type": "secret", "identity_key": "k3"},
+    ]
+    result = await get_dismissed_identity_keys(_FakePool(rows), 1, "owner/repo")
+    assert result["flash_review_llm"] == {"k1"}
+    assert result["flash_review_semantic"] == {"k2"}
+    assert result["secret"] == {"k3"}
+    assert result["vulnerability"] == set()
+
+
 @pytest.mark.asyncio
 async def test_dismiss_finding_then_get_dismissed_identity_keys(pool):
     await upsert_installation(pool, 1, "octocat")

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -439,7 +439,7 @@ def test_review_diff_parses_valid_findings(mock_adapter_class):
     findings = review_diff("--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')")
 
     assert findings == [
-        {"file": "app.py", "line": 42, "issue": "unclosed file handle, never calls .close()"}
+        {"file": "app.py", "line": 42, "issue": "unclosed file handle, never calls .close()", "source": "llm"}
     ]
 
 
@@ -463,7 +463,7 @@ def test_review_diff_drops_findings_missing_required_fields(mock_adapter_class):
 
     findings = review_diff("--- b.py ---\n@@ -1,1 +3,1 @@\n+something")
 
-    assert findings == [{"file": "b.py", "line": 3, "issue": "this one is valid"}]
+    assert findings == [{"file": "b.py", "line": 3, "issue": "this one is valid", "source": "llm"}]
 
 
 @patch("scan_worker.flash_review.writing_adapter_for")
@@ -498,7 +498,7 @@ def test_review_diff_drops_a_hallucinated_finding_outside_the_diff(mock_adapter_
 
     findings = review_diff("--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')")
 
-    assert findings == [{"file": "app.py", "line": 42, "issue": "real, inside the diff"}]
+    assert findings == [{"file": "app.py", "line": 42, "issue": "real, inside the diff", "source": "llm"}]
 
 
 # ── adapter_chain (free-tier cascading fallback) integration ────────────
@@ -526,7 +526,7 @@ def test_review_diff_falls_back_to_the_next_adapter_in_the_chain_on_failure():
         adapter_chain=[first, second],
     )
 
-    assert findings == [{"file": "app.py", "line": 42, "issue": "found by the second provider"}]
+    assert findings == [{"file": "app.py", "line": 42, "issue": "found by the second provider", "source": "llm"}]
     first.simple_completion.assert_called_once()
     second.simple_completion.assert_called_once()
 
@@ -552,7 +552,9 @@ def test_review_diff_treats_non_json_output_as_a_failure_and_tries_the_next_adap
         adapter_chain=[weak_model, strong_model],
     )
 
-    assert findings == [{"file": "app.py", "line": 42, "issue": "real finding from the working adapter"}]
+    assert findings == [
+        {"file": "app.py", "line": 42, "issue": "real finding from the working adapter", "source": "llm"}
+    ]
 
 
 def test_review_diff_treats_non_json_list_as_a_failure_and_tries_the_next_adapter():
@@ -644,7 +646,7 @@ def test_review_diff_serves_validated_cache_hit_without_calling_the_model():
         findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
 
     mock_adapter_class.assert_not_called()
-    assert findings == cached_findings
+    assert findings == [{**cached_findings[0], "source": "llm"}]
 
 
 def test_review_diff_revalidates_cache_hit_against_current_diff():
@@ -658,7 +660,7 @@ def test_review_diff_revalidates_cache_hit_against_current_diff():
         findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
 
     mock_adapter_class.assert_not_called()
-    assert findings == [{"file": "app.py", "line": 42, "issue": "still valid"}]
+    assert findings == [{"file": "app.py", "line": 42, "issue": "still valid", "source": "llm"}]
 
 
 @patch("scan_worker.flash_review.writing_adapter_for")
@@ -672,7 +674,7 @@ def test_review_diff_falls_through_to_model_call_on_cache_miss(mock_adapter_clas
 
     findings = review_diff(diff_text, cache_lookup=lambda diff: None)
 
-    assert findings == [{"file": "app.py", "line": 42, "issue": "fresh finding"}]
+    assert findings == [{"file": "app.py", "line": 42, "issue": "fresh finding", "source": "llm"}]
 
 
 @patch("scan_worker.flash_review.writing_adapter_for")
@@ -693,7 +695,11 @@ def test_review_diff_writes_to_cache_after_a_fresh_call(mock_adapter_class):
     )
 
     assert written == [
-        (diff_text, [{"file": "app.py", "line": 42, "issue": "fresh finding"}], "deepseek-v4-flash")
+        (
+            diff_text,
+            [{"file": "app.py", "line": 42, "issue": "fresh finding", "source": "llm"}],
+            "deepseek-v4-flash",
+        )
     ]
 
 
@@ -831,7 +837,13 @@ def test_review_diff_parses_optional_suggestion_field(mock_adapter_class):
     findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
     assert findings == [
-        {"file": "a.py", "line": 3, "issue": "off-by-one", "suggestion": "for i in range(n):"}
+        {
+            "file": "a.py",
+            "line": 3,
+            "issue": "off-by-one",
+            "suggestion": "for i in range(n):",
+            "source": "llm",
+        }
     ]
 
 
@@ -845,7 +857,7 @@ def test_review_diff_suggestion_field_is_optional(mock_adapter_class):
 
     findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
-    assert findings == [{"file": "a.py", "line": 3, "issue": "off-by-one"}]
+    assert findings == [{"file": "a.py", "line": 3, "issue": "off-by-one", "source": "llm"}]
 
 
 def test_names_referenced_in_diff_extracts_identifiers_from_added_and_context_lines():
@@ -1660,7 +1672,7 @@ def test_review_diff_drops_only_the_suggestion_when_it_smuggles_a_fence(mock_ada
 
     findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
-    assert findings == [{"file": "a.py", "line": 3, "issue": "real, benign issue text"}]
+    assert findings == [{"file": "a.py", "line": 3, "issue": "real, benign issue text", "source": "llm"}]
 
 
 @patch("scan_worker.flash_review.writing_adapter_for")
@@ -1685,7 +1697,7 @@ def test_review_diff_ignores_unexpected_fields_on_a_finding(mock_adapter_class):
 
     findings = review_diff("--- a.py ---\n@@ -1,1 +3,1 @@\n+thing")
 
-    assert findings == [{"file": "a.py", "line": 3, "issue": "real issue"}]
+    assert findings == [{"file": "a.py", "line": 3, "issue": "real issue", "source": "llm"}]
 
 
 def test_fetch_review_file_context_stops_at_max_files(monkeypatch):
@@ -2448,7 +2460,9 @@ def test_review_diff_falls_through_to_next_provider_on_malformed_json():
 
     assert first.calls == 1
     assert second.calls == 1
-    assert findings == [{"file": "app.py", "line": 1, "issue": "real issue from the second provider"}]
+    assert findings == [
+        {"file": "app.py", "line": 1, "issue": "real issue from the second provider", "source": "llm"}
+    ]
 
 
 def test_review_diff_falls_through_to_next_provider_on_non_list_json():
@@ -2465,7 +2479,9 @@ def test_review_diff_falls_through_to_next_provider_on_non_list_json():
 
     assert first.calls == 1
     assert second.calls == 1
-    assert findings == [{"file": "app.py", "line": 1, "issue": "real issue from the second provider"}]
+    assert findings == [
+        {"file": "app.py", "line": 1, "issue": "real issue from the second provider", "source": "llm"}
+    ]
 
 
 def test_review_diff_uses_first_providers_valid_json_without_falling_through():
@@ -2482,7 +2498,7 @@ def test_review_diff_uses_first_providers_valid_json_without_falling_through():
 
     assert first.calls == 1
     assert second.calls == 0
-    assert findings == [{"file": "app.py", "line": 1, "issue": "found by the first provider"}]
+    assert findings == [{"file": "app.py", "line": 1, "issue": "found by the first provider", "source": "llm"}]
 
 
 def test_review_diff_returns_empty_findings_when_every_chain_provider_fails():
@@ -2661,7 +2677,7 @@ def test_review_diff_skips_verification_by_default(mock_verification_adapter, mo
 
     findings = review_diff("--- app.py ---\n@@ -1,1 +1,1 @@\n+x = 1")
 
-    assert findings == [{"file": "app.py", "line": 1, "issue": "a real problem"}]
+    assert findings == [{"file": "app.py", "line": 1, "issue": "a real problem", "source": "llm"}]
     mock_verification_adapter.assert_not_called()
 
 
@@ -2680,7 +2696,7 @@ def test_review_diff_never_reverifies_a_cache_hit(mock_verification_adapter):
         verify_with_second_model=True,
     )
 
-    assert findings == cached_findings
+    assert findings == [{**cached_findings[0], "source": "llm"}]
     mock_verification_adapter.assert_not_called()
 
 
@@ -2712,7 +2728,9 @@ def test_review_diff_never_sends_a_semantic_finding_to_the_llm_verifier(
     ):
         findings = review_diff(diff_text, verify_with_second_model=True)
 
-    assert findings == [{"file": "app.py", "line": 2, "issue": "bare except silently swallows all errors"}]
+    assert findings == [
+        {"file": "app.py", "line": 2, "issue": "bare except silently swallows all errors", "source": "semantic"}
+    ]
     mock_verifier.simple_completion.assert_not_called()
 
 
@@ -2742,5 +2760,7 @@ def test_review_diff_verifies_model_findings_but_not_semantic_findings_in_the_sa
     ):
         findings = review_diff(diff_text, verify_with_second_model=True)
 
-    assert findings == [{"file": "app.py", "line": 2, "issue": "bare except silently swallows all errors"}]
+    assert findings == [
+        {"file": "app.py", "line": 2, "issue": "bare except silently swallows all errors", "source": "semantic"}
+    ]
     mock_verifier.simple_completion.assert_called_once()

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1699,6 +1699,20 @@ def test_flash_review_job_routes_free_tier_to_free_tier_path(monkeypatch):
     )
 
     from scan_worker.jobs import run_flash_review_job
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     # The free-tier chain's adapter was really called - proves the free-tier
@@ -1749,6 +1763,20 @@ def test_flash_review_job_reserves_the_free_tier_monthly_count_atomically(monkey
     monkeypatch.setattr("scan_worker.jobs._run_flash_review", lambda *a, **k: True)
 
     from scan_worker.jobs import run_flash_review_job
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert reserve_calls == [(1, MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH)]
@@ -1772,6 +1800,20 @@ def test_flash_review_job_skips_when_over_the_free_tier_monthly_cap(monkeypatch)
     )
 
     from scan_worker.jobs import run_flash_review_job
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert run_called == []
@@ -1841,6 +1883,20 @@ def test_flash_review_job_alerts_ops_when_all_free_tier_providers_fail(monkeypat
     )
 
     from scan_worker.jobs import run_flash_review_job
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert len(ops_alert_calls) == 1
@@ -1916,6 +1972,20 @@ def test_flash_review_does_not_post_or_advance_sha_when_free_tier_exhausted(monk
     )
 
     from scan_worker.jobs import run_flash_review_job
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert comment_calls == []
@@ -1935,6 +2005,20 @@ def test_flash_review_job_skips_when_debounced(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert llm_called == []
@@ -1965,6 +2049,20 @@ def test_flash_review_job_skips_when_spend_cap_reached(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert llm_called == []
@@ -1993,6 +2091,20 @@ def test_flash_review_job_skips_when_monthly_review_count_reached(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert llm_called == []
@@ -2034,6 +2146,20 @@ def test_flash_review_job_skips_model_call_for_lockfile_only_diff(monkeypatch):
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert llm_called == []
@@ -2062,7 +2188,7 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
         lambda diff_text, file_context="", **kwargs: [
-            {"file": "app.py", "line": 1, "issue": "real problem"}
+            {"file": "app.py", "line": 1, "issue": "real problem", "source": "llm"}
         ],
     )
     recorded_spend = []
@@ -2088,10 +2214,35 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     )
     from scan_worker.jobs import FLASH_REVIEW_MARKER, run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    inline_comments = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda client, token, repo, pr, commit_id, path, line, body: inline_comments.append(
+            (path, line, body)
+        )
+        or {"id": 999001},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
-    assert "app.py:1" in posted["body"]
-    assert "real problem" in posted["body"]
+    # The finding itself now posts as its own inline review comment
+    # (create_pr_review_comment) anchored to app.py:1, not listed inside
+    # the summary issue-comment (upsert_pr_comment) - see
+    # _post_flash_review_finding_comments.
+    assert len(inline_comments) == 1
+    assert inline_comments[0][0] == "app.py"
+    assert inline_comments[0][1] == 1
+    assert "real problem" in inline_comments[0][2]
+    assert "1 finding(s) posted as inline review comment(s) below" in posted["body"]
     assert posted["marker"] == FLASH_REVIEW_MARKER
     assert set_sha_calls == ["bbb"]
     # True-up delta, not the raw total: real cost (0.0 - review_diff is
@@ -2136,7 +2287,7 @@ def test_flash_review_job_reserves_the_cap_before_running_the_review(monkeypatch
 
     def _review_diff(diff_text, file_context="", **kwargs):
         call_order.append("review_diff")
-        return [{"file": "app.py", "line": 1, "issue": "x"}]
+        return [{"file": "app.py", "line": 1, "issue": "x", "source": "llm"}]
 
     monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", _reserve_flash_review_count)
     monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
@@ -2147,6 +2298,20 @@ def test_flash_review_job_reserves_the_cap_before_running_the_review(monkeypatch
 
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert call_order == ["reserve_count", "reserve_spend", "review_diff"]
@@ -2184,6 +2349,20 @@ def test_flash_review_job_releases_reservation_when_the_review_never_runs(monkey
 
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     # Free tier has no dollar reservation (reserved_spend stays 0.0), so
@@ -2217,7 +2396,7 @@ def test_flash_review_job_does_not_release_reservation_after_a_successful_review
     monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
-        lambda diff_text, file_context="", **kwargs: [{"file": "app.py", "line": 1, "issue": "x"}],
+        lambda diff_text, file_context="", **kwargs: [{"file": "app.py", "line": 1, "issue": "x", "source": "llm"}],
     )
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
@@ -2225,6 +2404,20 @@ def test_flash_review_job_does_not_release_reservation_after_a_successful_review
 
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert released == {"count": False, "spend": False}
@@ -2248,7 +2441,7 @@ def test_flash_review_job_posts_grounding_note_when_some_findings_are_dropped(mo
 
     def fake_review_diff(diff_text, file_context="", **kwargs):
         kwargs["on_grounding_result"]({"proposed": 2, "kept": 1})
-        return [{"file": "app.py", "line": 1, "issue": "real problem"}]
+        return [{"file": "app.py", "line": 1, "issue": "real problem", "source": "llm"}]
 
     monkeypatch.setattr("scan_worker.jobs.review_diff", fake_review_diff)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
@@ -2264,6 +2457,20 @@ def test_flash_review_job_posts_grounding_note_when_some_findings_are_dropped(mo
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert "Grounding: 1 of 2 proposed finding(s) held up" in posted["body"]
@@ -2303,6 +2510,20 @@ def test_flash_review_job_reports_zero_grounded_distinctly_from_no_issues_found(
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert "No issues held up under grounding (3 proposed, 0 grounded" in posted["body"]
@@ -2353,6 +2574,20 @@ def test_flash_review_job_reports_zero_confirmed_distinctly_from_zero_grounded(m
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert "No issues held up under independent verification (3 grounded, 0 confirmed" in posted["body"]
@@ -2401,6 +2636,20 @@ def test_flash_review_job_discloses_files_it_never_reviewed(monkeypatch):
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert "No issues found in this diff." in posted["body"]
@@ -2442,6 +2691,20 @@ def test_flash_review_job_adds_no_coverage_note_when_every_file_was_read(monkeyp
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert "not included in this review" not in posted["body"]
@@ -2483,6 +2746,20 @@ def test_flash_review_job_posts_failure_comment_instead_of_raising(monkeypatch):
     )
     from scan_worker.jobs import FLASH_REVIEW_MARKER, run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert posted["marker"] == FLASH_REVIEW_MARKER
@@ -2556,6 +2833,20 @@ def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkey
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert "admin.py:_github_http_client" in captured["referenced_symbol_context"]
@@ -2603,6 +2894,20 @@ def test_flash_review_job_passes_changed_file_contents_to_review_diff(monkeypatc
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert captured["file_contents"] == {"app.py": "real content of app.py"}
@@ -2640,6 +2945,20 @@ def test_flash_review_job_requests_second_model_verification_on_paid_plan(monkey
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert captured["verify_with_second_model"] is True
@@ -2701,6 +3020,20 @@ def test_flash_review_job_does_not_request_second_model_verification_on_free_tie
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert captured["verify_with_second_model"] is False
@@ -2753,6 +3086,20 @@ def test_flash_review_job_never_sends_the_raw_file_context_blob_to_review_diff(m
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert captured["file_context"] == ""
@@ -2781,7 +3128,7 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
     monkeypatch.setattr(
         "scan_worker.jobs.review_diff",
         lambda diff_text, file_context="", **kwargs: [
-            {"file": "app.py", "line": 1, "issue": "unclosed handle", "suggestion": "f.close()"}
+            {"file": "app.py", "line": 1, "issue": "unclosed handle", "suggestion": "f.close()", "source": "llm"}
         ],
     )
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
@@ -2797,10 +3144,30 @@ def test_flash_review_job_renders_suggestion_as_plain_fence_not_github_suggestio
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    inline_comments = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda client, token, repo, pr, commit_id, path, line, body: inline_comments.append(body)
+        or {"id": 999001},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
-    assert "f.close()" in posted["body"]
-    assert "```suggestion" not in posted["body"]
+    # The suggestion now lives in the finding's own inline review comment
+    # (create_pr_review_comment), not the summary issue-comment
+    # (upsert_pr_comment) - see _post_flash_review_finding_comments.
+    assert len(inline_comments) == 1
+    assert "f.close()" in inline_comments[0]
+    assert "```suggestion" not in inline_comments[0]
 
 
 def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch):
@@ -2836,6 +3203,20 @@ def test_flash_review_job_posts_no_issues_found_when_findings_empty(monkeypatch)
     )
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert "no issues found" in posted["body"].lower()
@@ -5001,6 +5382,20 @@ def test_flash_review_job_skips_paid_repo_past_monthly_scan_cap(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda *a, **k: llm_called.append(True))
     from scan_worker.jobs import run_flash_review_job
 
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.create_pr_review_comment",
+        lambda *a, **k: {"id": 999000 + len(a)},
+    )
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert attempted == []

--- a/github-app/tests/test_pull_request_review_comment_webhook.py
+++ b/github-app/tests/test_pull_request_review_comment_webhook.py
@@ -1,0 +1,293 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from app_server.db import hide_repo, upsert_installation
+from app_server.dismissed_findings import get_dismissed_identity_keys
+from app_server.webhooks.pull_request_review_comment import handle_pull_request_review_comment_event
+
+
+def _payload(
+    body: str,
+    in_reply_to_id: int | None = 555,
+    commenter: str = "someuser",
+    commenter_type: str = "User",
+    installation_id: int = 111,
+    repo_full_name: str = "octocat/hello-world",
+):
+    comment = {"body": body, "user": {"login": commenter, "type": commenter_type}}
+    if in_reply_to_id is not None:
+        comment["in_reply_to_id"] = in_reply_to_id
+    return {
+        "action": "created",
+        "installation": {"id": installation_id},
+        "repository": {"full_name": repo_full_name},
+        "comment": comment,
+    }
+
+
+def _mock_permission_check(monkeypatch, permission: str | None, raises: bool = False):
+    monkeypatch.setattr(
+        "app_server.webhooks.pull_request_review_comment.generate_app_jwt", lambda *a, **k: "fake-jwt"
+    )
+    monkeypatch.setattr(
+        "app_server.webhooks.pull_request_review_comment.get_installation_token",
+        MagicMock(return_value="fake-token"),
+    )
+    if raises:
+
+        def _raise(*a, **k):
+            raise RuntimeError("GitHub API unavailable")
+
+        monkeypatch.setattr(
+            "app_server.webhooks.pull_request_review_comment.get_repo_permission_for_user", _raise
+        )
+    else:
+        monkeypatch.setattr(
+            "app_server.webhooks.pull_request_review_comment.get_repo_permission_for_user",
+            lambda *a, **k: permission,
+        )
+
+
+async def _seed_installation(pool, installation_id: int = 111, account_login: str = "octocat"):
+    await upsert_installation(pool, installation_id, account_login)
+
+
+async def _seed_tracked_comment(
+    pool,
+    installation_id: int = 111,
+    repo_full_name: str = "octocat/hello-world",
+    pr_number: int = 42,
+    finding_type: str = "flash_review_llm",
+    identity_key: str = "app.py\x1f10\x1fabc123",
+    github_comment_id: int = 555,
+):
+    await pool.execute(
+        """
+        INSERT INTO flash_review_finding_comments
+            (installation_id, repo_full_name, pr_number, finding_type, identity_key,
+             github_comment_id, last_seen_sha)
+        VALUES ($1, $2, $3, $4, $5, $6, 'deadbeef')
+        """,
+        installation_id,
+        repo_full_name,
+        pr_number,
+        finding_type,
+        identity_key,
+        github_comment_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_from_a_write_collaborator_records_dismissal(pool, monkeypatch):
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(_payload("/dismiss"), pool, "redis://unused")
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert "app.py\x1f10\x1fabc123" in dismissed["flash_review_llm"]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_from_an_admin_also_records(pool, monkeypatch):
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "admin")
+
+    await handle_pull_request_review_comment_event(_payload("/dismiss"), pool, "redis://unused")
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert "app.py\x1f10\x1fabc123" in dismissed["flash_review_llm"]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_captures_the_reason_text(pool, monkeypatch):
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismiss this is a false positive"), pool, "redis://unused"
+    )
+
+    row = await pool.fetchrow(
+        "SELECT reason FROM dismissed_findings WHERE installation_id = $1 AND identity_key = $2",
+        111,
+        "app.py\x1f10\x1fabc123",
+    )
+    assert row["reason"] == "this is a false positive"
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_from_a_read_only_commenter_does_not_record(pool, monkeypatch):
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "read")
+
+    await handle_pull_request_review_comment_event(_payload("/dismiss"), pool, "redis://unused")
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert dismissed["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_from_a_non_collaborator_does_not_record(pool, monkeypatch):
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "none")
+
+    await handle_pull_request_review_comment_event(_payload("/dismiss"), pool, "redis://unused")
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert dismissed["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_does_not_record_when_permission_check_itself_fails(pool, monkeypatch):
+    # Fails closed: an API error while verifying the commenter's permission
+    # must not be treated as authorization to proceed.
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, None, raises=True)
+
+    await handle_pull_request_review_comment_event(_payload("/dismiss"), pool, "redis://unused")
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert dismissed["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_non_reply_comment_does_not_record(pool, monkeypatch):
+    # in_reply_to_id absent - a top-level review comment, not a reply.
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismiss", in_reply_to_id=None), pool, "redis://unused"
+    )
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert dismissed["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_bot_reply_does_not_record(pool, monkeypatch):
+    # Never act on our own resolution-edit comments or any other bot reply.
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismiss", commenter_type="Bot"), pool, "redis://unused"
+    )
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert dismissed["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_reply_without_dismiss_command_does_not_record(pool, monkeypatch):
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("thanks, fixing this now"), pool, "redis://unused"
+    )
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert dismissed["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_reply_to_an_untracked_comment_does_not_record_and_does_not_crash(pool, monkeypatch):
+    # in_reply_to_id doesn't match any row in flash_review_finding_comments
+    # - a reply to some other, non-Flash-Review review comment.
+    await _seed_installation(pool)
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismiss", in_reply_to_id=999999), pool, "redis://unused"
+    )
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert dismissed["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_untracked_comment_never_reaches_the_permission_check(pool, monkeypatch):
+    await _seed_installation(pool)
+    permission_check = MagicMock()
+    monkeypatch.setattr(
+        "app_server.webhooks.pull_request_review_comment.get_repo_permission_for_user", permission_check
+    )
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismiss", in_reply_to_id=999999), pool, "redis://unused"
+    )
+
+    permission_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_on_a_hidden_repo_does_not_reach_the_permission_check(pool, monkeypatch):
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    await hide_repo(pool, 111, "octocat/hello-world")
+    permission_check = MagicMock()
+    monkeypatch.setattr(
+        "app_server.webhooks.pull_request_review_comment.get_repo_permission_for_user", permission_check
+    )
+
+    await handle_pull_request_review_comment_event(_payload("/dismiss"), pool, "redis://unused")
+
+    permission_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tracked_comment_belonging_to_a_different_installation_is_refused(pool, monkeypatch):
+    # in_reply_to_id is a GitHub-wide comment id, not scoped to one
+    # installation - a payload claiming installation 111 must not act on a
+    # tracked row that actually belongs to installation 222.
+    await _seed_installation(pool, installation_id=111, account_login="octocat")
+    await _seed_installation(pool, installation_id=222, account_login="someorg")
+    await _seed_tracked_comment(pool, installation_id=222, repo_full_name="someorg/other-repo")
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismiss", installation_id=111, repo_full_name="octocat/hello-world"),
+        pool,
+        "redis://unused",
+    )
+
+    dismissed_111 = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    dismissed_222 = await get_dismissed_identity_keys(pool, 222, "someorg/other-repo")
+    assert dismissed_111["flash_review_llm"] == set()
+    assert dismissed_222["flash_review_llm"] == set()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_reply_only_affects_the_specific_finding_type_replied_to(pool, monkeypatch):
+    # Same identity_key can exist under both flash_review_llm and
+    # flash_review_semantic (see dismissed_findings.py's docstring on why
+    # a raw-key collision across the two types is harmless) - dismissing
+    # one must not dismiss the other.
+    await _seed_installation(pool)
+    await _seed_tracked_comment(
+        pool, finding_type="flash_review_llm", identity_key="shared\x1fkey", github_comment_id=1
+    )
+    await _seed_tracked_comment(
+        pool, finding_type="flash_review_semantic", identity_key="shared\x1fkey", github_comment_id=2
+    )
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismiss", in_reply_to_id=1), pool, "redis://unused"
+    )
+
+    dismissed = await get_dismissed_identity_keys(pool, 111, "octocat/hello-world")
+    assert "shared\x1fkey" in dismissed["flash_review_llm"]
+    assert "shared\x1fkey" not in dismissed["flash_review_semantic"]

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -1761,7 +1761,12 @@ async def test_get_dismissed_identity_keys_sync_returns_empty_sets_when_none_dis
 
     dismissed = get_dismissed_identity_keys(TEST_DATABASE_URL, 810, "co/repo")
 
-    assert dismissed == {"secret": set(), "vulnerability": set()}
+    assert dismissed == {
+        "secret": set(),
+        "vulnerability": set(),
+        "flash_review_llm": set(),
+        "flash_review_semantic": set(),
+    }
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -25,6 +25,10 @@ from scan_worker.db import (
     email_already_sent,
     get_dismissed_identity_keys,
     get_endpoint_health_summary,
+    get_flash_review_finding_comments,
+    insert_flash_review_finding_comment,
+    mark_flash_review_finding_comment_resolved,
+    touch_flash_review_finding_comment,
     get_extra_seats,
     get_last_endpoint_health,
     get_last_reviewed_sha,
@@ -1758,6 +1762,93 @@ async def test_get_dismissed_identity_keys_sync_returns_empty_sets_when_none_dis
     dismissed = get_dismissed_identity_keys(TEST_DATABASE_URL, 810, "co/repo")
 
     assert dismissed == {"secret": set(), "vulnerability": set()}
+
+
+@pytest.mark.asyncio
+async def test_insert_and_get_flash_review_finding_comment(pool):
+    await _insert_installation(pool, 812, "co")
+
+    insert_flash_review_finding_comment(
+        TEST_DATABASE_URL, 812, "co/repo", 42, "flash_review_llm", "a.py\x1f10\x1fabc123", 999001, "sha1"
+    )
+
+    comments = get_flash_review_finding_comments(TEST_DATABASE_URL, 812, "co/repo", 42)
+
+    key = ("flash_review_llm", "a.py\x1f10\x1fabc123")
+    assert key in comments
+    assert comments[key]["github_comment_id"] == 999001
+    assert comments[key]["resolved_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_flash_review_finding_comments_scoped_per_pr(pool):
+    await _insert_installation(pool, 813, "co")
+    insert_flash_review_finding_comment(
+        TEST_DATABASE_URL, 813, "co/repo", 1, "flash_review_llm", "a.py\x1f10\x1fabc", 1, "sha1"
+    )
+    insert_flash_review_finding_comment(
+        TEST_DATABASE_URL, 813, "co/repo", 2, "flash_review_llm", "a.py\x1f10\x1fabc", 2, "sha1"
+    )
+
+    pr1 = get_flash_review_finding_comments(TEST_DATABASE_URL, 813, "co/repo", 1)
+    pr2 = get_flash_review_finding_comments(TEST_DATABASE_URL, 813, "co/repo", 2)
+
+    assert pr1[("flash_review_llm", "a.py\x1f10\x1fabc")]["github_comment_id"] == 1
+    assert pr2[("flash_review_llm", "a.py\x1f10\x1fabc")]["github_comment_id"] == 2
+
+
+@pytest.mark.asyncio
+async def test_insert_flash_review_finding_comment_conflict_keeps_first_writer(pool):
+    # ON CONFLICT DO NOTHING - see the function's own docstring on why a
+    # second insert for the same identity must not clobber the first
+    # writer's github_comment_id.
+    await _insert_installation(pool, 814, "co")
+    insert_flash_review_finding_comment(
+        TEST_DATABASE_URL, 814, "co/repo", 1, "flash_review_llm", "a.py\x1f10\x1fabc", 111, "sha1"
+    )
+    insert_flash_review_finding_comment(
+        TEST_DATABASE_URL, 814, "co/repo", 1, "flash_review_llm", "a.py\x1f10\x1fabc", 222, "sha2"
+    )
+
+    comments = get_flash_review_finding_comments(TEST_DATABASE_URL, 814, "co/repo", 1)
+
+    assert comments[("flash_review_llm", "a.py\x1f10\x1fabc")]["github_comment_id"] == 111
+
+
+@pytest.mark.asyncio
+async def test_touch_flash_review_finding_comment_updates_last_seen_sha(pool):
+    await _insert_installation(pool, 815, "co")
+    insert_flash_review_finding_comment(
+        TEST_DATABASE_URL, 815, "co/repo", 1, "flash_review_llm", "a.py\x1f10\x1fabc", 1, "sha1"
+    )
+    row_id = get_flash_review_finding_comments(TEST_DATABASE_URL, 815, "co/repo", 1)[
+        ("flash_review_llm", "a.py\x1f10\x1fabc")
+    ]["id"]
+
+    touch_flash_review_finding_comment(TEST_DATABASE_URL, row_id, "sha2")
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT last_seen_sha FROM flash_review_finding_comments WHERE id = $1", row_id
+        )
+    assert row["last_seen_sha"] == "sha2"
+
+
+@pytest.mark.asyncio
+async def test_mark_flash_review_finding_comment_resolved_is_one_time_transition(pool):
+    await _insert_installation(pool, 816, "co")
+    insert_flash_review_finding_comment(
+        TEST_DATABASE_URL, 816, "co/repo", 1, "flash_review_llm", "a.py\x1f10\x1fabc", 1, "sha1"
+    )
+    row_id = get_flash_review_finding_comments(TEST_DATABASE_URL, 816, "co/repo", 1)[
+        ("flash_review_llm", "a.py\x1f10\x1fabc")
+    ]["id"]
+
+    first_call = mark_flash_review_finding_comment_resolved(TEST_DATABASE_URL, row_id)
+    second_call = mark_flash_review_finding_comment_resolved(TEST_DATABASE_URL, row_id)
+
+    assert first_call is True
+    assert second_call is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Flash Review findings (LLM-generated and the free deterministic semantic checks) had zero feedback loop - unlike secrets/vulnerabilities, there was no way to tell Aletheore a finding wasn't helpful. This adds one, built around **inline PR review comments (one per finding)** instead of the old single issue-comment listing every finding as a bullet - GitHub only fires a webhook on a *reply* to a review comment, not on a reaction to any comment (confirmed: no reaction webhook exists, it's an open GitHub feature request), so reply-based dismissal is the only real-time-capable design.

- **Migration 058**: extends `dismissed_findings.finding_type` to accept `flash_review_llm`/`flash_review_semantic` (two distinct types, not one, so dismissal-rate comparisons between deterministic and model-generated findings stay possible later).
- **Migration 059**: new `flash_review_finding_comments` table mapping a finding's identity to its real GitHub comment id, per PR - needed because a re-review now reconciles N existing comments against this push's findings instead of upserting one.
- **Identity key**: file + line (exact) + a hash of a *normalized* issue-text fingerprint (lowercased, punctuation-stripped, stopwords dropped, word-order-independent) so minor rewording of the same bug across re-reviews collapses to the same key. Flagged honestly as a design choice, not a verified one - no real corpus of "same bug reworded across two independent re-reviews" exists to test against.
- **Source tagging**: `_merge_semantic_findings` now tags every finding's origin ("llm"/"semantic"), including correctly on a cache hit (preserves a previously-tagged finding's real source instead of overwriting it - a real bug caught and fixed during implementation, not shipped).
- **Posting**: findings are filtered through dismissal before posting; each survivor gets its own inline comment, tracked across re-reviews (untouched if still present). A finding no longer detected gets its comment *edited* (never deleted - a human may have replied) to note it's resolved, once.
- **New webhook** (`pull_request_review_comment`): a reply containing `/dismiss` (optional reason) from a write/admin collaborator records the dismissal. Fails closed on a permission-check error, ignores bot replies, and cross-checks that a resolved comment's tracked row actually belongs to the requesting installation/repo before acting.

## Real, disclosed limitation
No live Postgres was available in this development environment (no local install, Docker daemon not running) - the new webhook handler's tests and the DB-layer tests are written against this project's own established `pool`-fixture convention (same pattern as every other async DB test here) and collect/skip cleanly, but were never executed against a real database. **Recommend verifying in CI before merging.**

## Test plan
- [x] Identity-key properties real-tested: exact match, word-reordering, punctuation/case tolerance, different line/file/issue all produce different keys, cross-type (llm vs semantic) raw-key collision confirmed harmless.
- [x] Source-tagging cache-hit bug found and fixed before shipping (tagging is `.get(..., default)`, not an unconditional overwrite).
- [x] 14 new webhook-handler tests covering: write/admin success, read-only/none-permission refusal, permission-check-failure fail-closed, non-reply filtering, bot-reply filtering, missing-command filtering, untracked-comment no-op, hidden-repo short-circuit, cross-installation guard, dismiss-reason parsing, and finding-type isolation on a shared identity key.
- [x] Full local suite: 374 passed, 0 failed, 139 skipped (all DB-dependent, environment limitation above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr