### PR TITLE
feat: real plan-tier entitlement gating for the flash tier + live Paddle wiring

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -496,8 +496,11 @@ async def _require_authorized_installation(request: Request, org: str, repo: str
 
 async def _require_admin_installation(request: Request, org: str, repo: str) -> dict:
     session, installation = await _require_authorized_installation(request, org, repo)
-    if installation["plan"] == "free":
-        raise HTTPException(status_code=402, detail="this feature requires a paid plan")
+    # AIR-exclusive - the flash plan doesn't include a managed dashboard
+    # at all, same as free (self-service only: CLI, GitHub Action, free
+    # GitHub App usage).
+    if installation["plan"] != "air":
+        raise HTTPException(status_code=402, detail="this feature requires the AIR plan")
     pool = request.app.state.db_pool
     await _require_seat_if_paid(pool, installation, session["github_login"], f"{org}/{repo}")
     return installation
@@ -1326,8 +1329,10 @@ async def create_cli_token(request: Request, body: CreateCliTokenRequest):
     installation = await get_installation(pool, installation_id)
     if installation is None:
         raise HTTPException(status_code=404, detail="installation not found")
-    if installation["plan"] == "free":
-        raise HTTPException(status_code=402, detail="this feature requires a paid plan")
+    # AIR-exclusive - same "no dashboard/admin surface at all" rule as
+    # _require_admin_installation.
+    if installation["plan"] != "air":
+        raise HTTPException(status_code=402, detail="this feature requires the AIR plan")
 
     max_tokens = await get_max_tokens(pool, installation_id)
     raw_token = secrets.token_urlsafe(32)

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -149,8 +149,10 @@ async def list_my_repos(request: Request):
         # ever touching a shared web view. Listing a free installation's
         # repos here would let every GitHub admin on that org click into a
         # full managed dashboard for free - exactly the team-collaboration
-        # capability AIR itself sells.
-        if row["plan"] == "free":
+        # capability AIR itself sells. The flash plan doesn't get a
+        # managed dashboard either - same self-service-only shape as
+        # free, just with paid PR-review limits.
+        if row["plan"] != "air":
             continue
         # repo_full_name is the source of truth for the org/repo split used
         # in every /app/{org}/{repo} route - account_login is a display
@@ -168,7 +170,8 @@ async def list_my_repos(request: Request):
 
     for installation_id in administered_ids:
         installation = await get_installation(pool, installation_id)
-        if installation is None or installation["plan"] == "free":
+        # AIR-exclusive - no managed dashboard for flash either.
+        if installation is None or installation["plan"] != "air":
             continue
         known = known_by_installation.get(installation_id, set())
         scanned_this_month = await count_monthly_scanned_repos(pool, installation_id)
@@ -205,8 +208,9 @@ async def _require_dashboard_installation(request: Request, org: str, repo: str)
 
     installation = await get_installation(pool, installation_id)
     if installation is not None:
-        if installation["plan"] == "free":
-            raise HTTPException(status_code=402, detail="the managed dashboard requires a paid plan")
+        # AIR-exclusive - no managed dashboard for flash either.
+        if installation["plan"] != "air":
+            raise HTTPException(status_code=402, detail="the managed dashboard requires the AIR plan")
         await _require_seat_if_paid(pool, installation, session["github_login"], f"{org}/{repo}")
 
     return session, installation_id

--- a/github-app/app_server/embeddings_api.py
+++ b/github-app/app_server/embeddings_api.py
@@ -146,11 +146,13 @@ async def create_embeddings(request: Request, body: EmbeddingsRequest):
     installation = await _authenticated_installation(request)
     installation_id = installation["installation_id"]
 
-    if installation["plan"] == "free":
+    # AIR-exclusive, not "any paid plan" - the flash plan doesn't include
+    # hosted embeddings/MCP.
+    if installation["plan"] != "air":
         raise HTTPException(
             status_code=402,
             detail=(
-                "hosted embeddings require a paid plan - run 'aletheore index' with a local "
+                "hosted embeddings require the AIR plan - run 'aletheore index' with a local "
                 "Ollama or your own OPENAI_API_KEY instead, which is free"
             ),
         )

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -479,7 +479,8 @@ function escapeHtml(s) {
   });
 }
 function planDisplayName(plan) {
-  return plan === 'free' ? 'Aletheore Community' : 'Aletheore AIR';
+  var names = { free: 'Aletheore Community', flash: 'Aletheore Flash', air: 'Aletheore AIR' };
+  return names[plan] || names.air;
 }
 // Minimal markdown for AIRview file pages. The text is model-written from
 // repository content, so it is escaped FIRST and only then are a handful of
@@ -2349,12 +2350,24 @@ def _no_store_html(content: str) -> HTMLResponse:
     return HTMLResponse(content, headers={"Cache-Control": "no-store"})
 
 
-_VALID_PLANS = ("air",)
+_VALID_PLANS = ("air", "flash")
 _VALID_INTERVALS = ("month", "year")
 
 
+_PLAN_DISPLAY_NAMES = {
+    "free": "Aletheore Community",
+    "flash": "Aletheore Flash",
+    "air": "Aletheore AIR",
+}
+
+
 def _plan_display_name(plan: str) -> str:
-    return "Aletheore Community" if plan == "free" else "Aletheore AIR"
+    # Falls back to AIR for an unrecognized value rather than raising -
+    # matches this function's pre-existing fail-open shape (a binary
+    # free/else check used to mean "anything that isn't literally 'free'
+    # is AIR"), now explicit about the values it knows rather than
+    # accidentally correct only by omission.
+    return _PLAN_DISPLAY_NAMES.get(plan, _PLAN_DISPLAY_NAMES["air"])
 
 
 def _subscribe_page(title: str, body: str) -> str:
@@ -2449,7 +2462,7 @@ document.getElementById("continue-checkout").addEventListener("click", (event) =
     settings: {{
       displayMode: "overlay",
       variant: "one-page",
-      successUrl: "https://app.aletheore.com/dashboard",
+      successUrl: "{"https://app.aletheore.com/dashboard" if plan == "air" else "https://www.aletheore.com/?subscribed=flash"}",
     }},
   }});
 }});
@@ -2459,7 +2472,16 @@ document.getElementById("continue-checkout").addEventListener("click", (event) =
 
 @frontend_router.get("/subscribe", response_class=HTMLResponse)
 async def subscribe_page(request: Request, plan: str = "", interval: str = ""):
+    # Validated against the real (plan, interval) -> price_id mapping
+    # directly, not plan and interval as two independent sets - flash
+    # only has a monthly price (no annual yet), so "flash" being in
+    # _VALID_PLANS and "year" being in _VALID_INTERVALS would otherwise
+    # both pass while resolve_price_id_for_plan("flash", "year") returns
+    # None, sending a customer to a checkout page with no real price
+    # attached instead of a clean 400.
     if plan not in _VALID_PLANS or interval not in _VALID_INTERVALS:
+        raise HTTPException(status_code=400, detail="invalid plan or interval")
+    if resolve_price_id_for_plan(plan, interval) is None:
         raise HTTPException(status_code=400, detail="invalid plan or interval")
 
     next_path = f"/subscribe?plan={plan}&interval={interval}"

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -50,6 +50,18 @@ EXTRA_SEAT_LLM_CAP_USD = 3.00
 # spend cap is a monthly rolling figure either way.
 PLAN_MONTHLY_PRICE_USD = {
     "air": 29.99,
+    "flash": 6.00,
+}
+
+# flash's real spend cap is a deliberately looser fraction of its price
+# than the shared 50% default below (~67%, $4 of $6) - real worst-case
+# cost for 1000 reviews of solo Luna generation (no dual-agent
+# verification, compact + trimmed diff) measured at ~$4.34, small enough
+# in absolute dollars that the tighter formula wasn't worth applying
+# here. See jobs.py's MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH for the real
+# review-count cap (800) this was checked against.
+PLAN_CAP_OVERRIDE_USD = {
+    "flash": 4.00,
 }
 
 # Deliberately generous: this is a worst-case abuse/runaway-cost ceiling, not
@@ -89,6 +101,8 @@ def cost_for_usage(model: str, prompt_tokens: int, completion_tokens: int) -> fl
 
 
 def base_cap_for_plan(plan: str) -> float:
+    if plan in PLAN_CAP_OVERRIDE_USD:
+        return PLAN_CAP_OVERRIDE_USD[plan]
     price = PLAN_MONTHLY_PRICE_USD.get(plan)
     if price is None:
         return 0.0

--- a/github-app/app_server/managed_audit_api.py
+++ b/github-app/app_server/managed_audit_api.py
@@ -97,8 +97,10 @@ async def _authenticate_token(request: Request) -> tuple[dict, str]:
 async def start_managed_audit(request: Request, body: StartManagedAuditRequest):
     installation, token_hash = await _authenticate_token(request)
     pool = request.app.state.db_pool
-    if installation["plan"] == "free":
-        raise HTTPException(status_code=402, detail="managed audits require a paid plan")
+    # AIR-exclusive, not "any paid plan" - the flash plan doesn't include
+    # managed audits.
+    if installation["plan"] != "air":
+        raise HTTPException(status_code=402, detail="managed audits require the AIR plan")
 
     if not body.repo_full_name:
         raise HTTPException(status_code=400, detail="repo_full_name is required")

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -14,9 +14,15 @@
 # bundle into the base $29.99/mo price.
 EXTRA_SEAT_PRICE_ID = "pri_01m123rwvvtgbm6bmmxcbav4hh"
 
+# The flash plan's real Paddle product (pro_01m1754jf8nkvhrn3sbaj9rmyq,
+# "Aletheore Flash") and its one price - monthly only, no annual yet,
+# matching what was actually validated ($6/mo, real cost/recall data
+# checked against an 800-review cap). Created live via the Paddle MCP,
+# not a placeholder - real, chargeable as of 2026-08-29.
 PADDLE_PRICE_TO_PLAN: dict[str, str] = {
     "pri_01kyhevc8bkcghfpwjymz16y2h": "air",
     "pri_01kyhevc9xn6z2nghmy8057jvp": "air",
+    "pri_01m1754jr5msg62grry49kjhw5": "flash",
 }
 
 
@@ -27,6 +33,7 @@ def resolve_plan_for_price_id(price_id: str) -> str | None:
 PLAN_INTERVAL_TO_PRICE_ID: dict[tuple[str, str], str] = {
     ("air", "month"): "pri_01kyhevc8bkcghfpwjymz16y2h",
     ("air", "year"): "pri_01kyhevc9xn6z2nghmy8057jvp",
+    ("flash", "month"): "pri_01m1754jr5msg62grry49kjhw5",
 }
 
 

--- a/github-app/app_server/runtime_events.py
+++ b/github-app/app_server/runtime_events.py
@@ -83,8 +83,10 @@ def _enforce_runtime_event_rate_limit(installation_id: int) -> None:
 @runtime_events_router.post("/v1/runtime-events")
 async def report_runtime_event(request: Request, body: RuntimeEventRequest):
     installation, token_hash = await _authenticate_token(request)
-    if installation["plan"] == "free":
-        raise HTTPException(status_code=402, detail="runtime event correlation requires a paid plan")
+    # AIR-exclusive, not "any paid plan" - the flash plan doesn't include
+    # runtime event correlation.
+    if installation["plan"] != "air":
+        raise HTTPException(status_code=402, detail="runtime event correlation requires the AIR plan")
 
     _enforce_runtime_event_rate_limit(installation["installation_id"])
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -251,6 +251,13 @@ MAX_FLASH_REVIEWS_PER_MONTH = 500
 # above) - free tier is meant to stay generous and reach more people, not
 # track paid 1:1.
 MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH = 150
+# The "flash" plan's own cap - real, validated separately from AIR's 500,
+# not just a bigger/smaller multiple of it. 800/mo is the number this
+# tier's whole real cost/recall validation (compact + trimmed diff,
+# solo Luna generation, no dual-agent verification) was run against - see
+# model_tiers.py's plan-specific adapter choice and the real worst-case
+# cost figures that number was checked against before committing to it.
+MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH = 800
 DEFAULT_LLM_NEXT_CALL_RESERVE_USD = 0.001
 
 # Conservative flat reserve for one paid-tier Flash Review, used by
@@ -617,7 +624,11 @@ def _maybe_send_slack_alert(
 ) -> None:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    if installation is None or installation["plan"] == "free":
+    # AIR-exclusive, not "any paid plan" - a notification convenience
+    # bundled into AIR's price, not a PR-review feature the flash plan's
+    # pitch includes. "!= air" (not "== free") deliberately, so this stays
+    # correct if a future plan value shows up too.
+    if installation is None or installation["plan"] != "air":
         return
     webhook_url = installation.get("webhook_url")
     if not webhook_url:
@@ -1124,12 +1135,13 @@ def run_initial_scan_job(installation_id: int, repo_full_name: str) -> None:
         _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
         _insert_history(installation_id, repo_full_name, evidence)
 
-        # A repo added to an already-paid installation should get its
+        # A repo added to an already-AIR installation should get its
         # AIRview build right away too, rather than waiting for enough
         # incremental pushes to slowly build clusters one at a time - the
         # same gap the Paddle subscription.created wiki-build trigger
-        # closed for brand-new upgrades.
-        if installation is not None and installation["plan"] != "free":
+        # closed for brand-new upgrades. AIR-exclusive, not "any paid
+        # plan" - the flash plan doesn't include AIRview/Docs at all.
+        if installation is not None and installation["plan"] == "air":
             try:
                 run_live_wiki_full_build_job(installation_id, repo_full_name)
             except Exception:  # noqa: BLE001
@@ -1195,7 +1207,9 @@ def run_push_scan_job(
         _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
         history_id = _insert_history(installation_id, repo_full_name, evidence)
 
-        if installation is not None and installation["plan"] != "free":
+        # AIR-exclusive - see the identical note on run_initial_scan_job's
+        # full-build trigger above.
+        if installation is not None and installation["plan"] == "air":
             # Enqueued as their own jobs, not called inline - see
             # run_live_wiki_incremental_update_job's docstring.
             try:
@@ -1601,8 +1615,18 @@ def run_flash_review_job(
         # that itself needs cross-process atomicity.
         extra_seats = get_extra_seats(settings.database_url, installation_id)
         monthly_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
+        # flash's own real, separately-validated cap (800), not AIR's 500 -
+        # see MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH. Any other non-free
+        # plan value falls back to the AIR cap, matching this codebase's
+        # existing "only free is special-cased, everything else defaults
+        # to the paid shape" convention elsewhere.
+        review_count_cap = (
+            MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH
+            if installation["plan"] == "flash"
+            else MAX_FLASH_REVIEWS_PER_MONTH
+        )
         if not reserve_flash_review_count(
-            settings.database_url, installation_id, MAX_FLASH_REVIEWS_PER_MONTH
+            settings.database_url, installation_id, review_count_cap
         ):
             return
         reserved_spend = FLASH_REVIEW_SPEND_RESERVE_USD
@@ -1615,6 +1639,7 @@ def run_flash_review_job(
         review_ran = _run_flash_review(
             settings, installation_id, repo_full_name, pr_number, base_sha, head_sha, monthly_cap,
             reserved_spend, is_free_tier=is_free_tier,
+            verify_with_second_model=(installation["plan"] == "air"),
         )
     except Exception as exc:  # noqa: BLE001
         try:
@@ -1647,6 +1672,7 @@ def _run_flash_review(
     reserved_spend: float,
     *,
     is_free_tier: bool = False,
+    verify_with_second_model: bool = False,
 ) -> bool:
     """Returns True if a real review actually ran and its spend/count
     reservation (see run_flash_review_job) was trued up to reflect it -
@@ -1856,10 +1882,17 @@ def _run_flash_review(
             diff_patches=diff_patches,
             adapter_chain=free_tier_chain,
             on_free_tier_exhausted=_on_free_tier_exhausted,
-            # Paid-tier only (see _on_verification_usage) - free tier's
-            # own generation quality/cost tradeoffs are a separate,
-            # already-pooled budget this doesn't touch.
-            verify_with_second_model=not is_free_tier,
+            # AIR-tier only (see _on_verification_usage) - explicit, not
+            # derived from is_free_tier, because "paid" no longer means
+            # "AIR" now that the flash plan exists: flash's whole real
+            # cost/recall validation (see MAX_FLASH_TIER_FLASH_REVIEWS_
+            # PER_MONTH) was run on solo generation, no second-model
+            # check - `not is_free_tier` would have silently given flash
+            # dual-agent verification for free, the exact cost this plan
+            # doesn't have room for. Free tier's own generation quality/
+            # cost tradeoffs are a separate, already-pooled budget this
+            # doesn't touch either way.
+            verify_with_second_model=verify_with_second_model,
             on_verification_usage=_on_verification_usage,
         )
     # Every free-tier provider failed mid-review (see
@@ -2401,7 +2434,9 @@ def run_runtime_event_job(
     """
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    if installation is None or installation["plan"] == "free":
+    # AIR-exclusive - endpoint/runtime monitoring is a premium convenience
+    # unrelated to PR-review value, not part of the flash plan's pitch.
+    if installation is None or installation["plan"] != "air":
         return
 
     if not (
@@ -3735,7 +3770,8 @@ def _maybe_update_live_wiki(
 ) -> None:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    if installation is None or installation["plan"] == "free":
+    # AIR-exclusive - AIRview isn't part of the flash plan's pitch.
+    if installation is None or installation["plan"] != "air":
         return
 
     cluster_ids = live_wiki.affected_cluster_ids(evidence, changed_files)
@@ -4193,7 +4229,8 @@ def _maybe_update_live_docs(
 ) -> None:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    if installation is None or installation["plan"] == "free":
+    # AIR-exclusive - Docs isn't part of the flash plan's pitch.
+    if installation is None or installation["plan"] != "air":
         return
 
     modules_by_path = {m["path"]: m for m in evidence["repository"]["modules"]}

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -981,7 +981,7 @@ async def test_my_installations_requires_bearer_token(pool):
 @pytest.mark.asyncio
 async def test_create_cli_token_mints_token_for_administered_paid_installation(pool, monkeypatch):
     await upsert_installation(pool, 100, "acme")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     await _mock_github_installations(monkeypatch, [100])
 
     app.state.db_pool = pool
@@ -1036,7 +1036,7 @@ async def test_create_cli_token_rejects_free_plan(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_create_cli_token_enforces_seat_cap(pool, monkeypatch):
     await upsert_installation(pool, 100, "acme")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     await _mock_github_installations(monkeypatch, [100])
 
     app.state.db_pool = pool

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -198,9 +198,9 @@ async def test_list_my_repos_requires_login(pool):
 @pytest.mark.asyncio
 async def test_list_my_repos_returns_repos_across_administered_installations(pool, monkeypatch):
     await upsert_installation(pool, 701, "octocat")
-    await set_installation_plan(pool, 701, "indie")
+    await set_installation_plan(pool, 701, "air")
     await upsert_installation(pool, 702, "another-org")
-    await set_installation_plan(pool, 702, "indie")
+    await set_installation_plan(pool, 702, "air")
     await insert_repo_history(
         pool, 701, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -224,8 +224,8 @@ async def test_list_my_repos_returns_repos_across_administered_installations(poo
     by_name = {r["repo_full_name"]: r for r in repos}
     assert by_name["octocat/hello-world"]["org"] == "octocat"
     assert by_name["octocat/hello-world"]["repo"] == "hello-world"
-    assert by_name["octocat/hello-world"]["plan"] == "indie"
-    assert by_name["another-org/service-b"]["plan"] == "indie"
+    assert by_name["octocat/hello-world"]["plan"] == "air"
+    assert by_name["another-org/service-b"]["plan"] == "air"
 
 
 @pytest.mark.asyncio
@@ -254,7 +254,7 @@ async def test_list_my_repos_excludes_a_hidden_repo(pool, monkeypatch):
     # hide_repo) must disappear from the dashboard immediately, without
     # its scan history being deleted.
     await upsert_installation(pool, 705, "octocat")
-    await set_installation_plan(pool, 705, "indie")
+    await set_installation_plan(pool, 705, "air")
     await insert_repo_history(
         pool, 705, "octocat/kept", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -280,7 +280,7 @@ async def test_list_my_repos_includes_uninitialized_repos_with_no_scan_yet(pool,
     # paid for their personal-account installation and the dashboard kept
     # showing nothing for it.
     await upsert_installation(pool, 801, "some-user")
-    await set_installation_plan(pool, 801, "team")
+    await set_installation_plan(pool, 801, "air")
 
     monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
 
@@ -325,7 +325,7 @@ async def test_list_my_repos_includes_uninitialized_repos_with_no_scan_yet(pool,
         "org": "some-user",
         "repo": "proctor-browser",
         "repo_full_name": "some-user/proctor-browser",
-        "plan": "team",
+        "plan": "air",
         "initialized": False,
         "scan_limit_reached": False,
     }]
@@ -334,7 +334,7 @@ async def test_list_my_repos_includes_uninitialized_repos_with_no_scan_yet(pool,
 @pytest.mark.asyncio
 async def test_list_my_repos_flags_uninitialized_repos_when_monthly_scan_cap_reached(pool, monkeypatch):
     await upsert_installation(pool, 802, "some-user")
-    await set_installation_plan(pool, 802, "team")
+    await set_installation_plan(pool, 802, "air")
     for i in range(10):
         await pool.execute(
             """
@@ -387,7 +387,7 @@ async def test_list_my_repos_flags_uninitialized_repos_when_monthly_scan_cap_rea
         "org": "some-user",
         "repo": "proctor-browser",
         "repo_full_name": "some-user/proctor-browser",
-        "plan": "team",
+        "plan": "air",
         "initialized": False,
         "scan_limit_reached": True,
     }]
@@ -399,7 +399,7 @@ async def test_list_my_repos_does_not_duplicate_already_scanned_repos(pool, monk
     # "uninitialized" duplicate just because it's still covered by the
     # installation's real GitHub repo list.
     await upsert_installation(pool, 802, "some-user")
-    await set_installation_plan(pool, 802, "team")
+    await set_installation_plan(pool, 802, "air")
     await insert_repo_history(
         pool, 802, "some-user/already-scanned", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -447,7 +447,7 @@ async def test_list_my_repos_does_not_duplicate_already_scanned_repos(pool, monk
         "org": "some-user",
         "repo": "already-scanned",
         "repo_full_name": "some-user/already-scanned",
-        "plan": "team",
+        "plan": "air",
         "initialized": True,
     }]
 
@@ -620,7 +620,7 @@ async def test_dashboard_health_requires_paid_plan(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_returns_data_for_known_repo(pool, monkeypatch):
     await upsert_installation(pool, 1, "octocat")
-    await set_installation_plan(pool, 1, "indie")
+    await set_installation_plan(pool, 1, "air")
     await insert_repo_history(
         pool,
         1,
@@ -640,7 +640,7 @@ async def test_dashboard_returns_data_for_known_repo(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_returns_empty_dismissed_finding_keys_by_default(pool, monkeypatch):
     await upsert_installation(pool, 1, "octocat")
-    await set_installation_plan(pool, 1, "indie")
+    await set_installation_plan(pool, 1, "air")
     await insert_repo_history(
         pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -666,7 +666,7 @@ async def test_dismiss_finding_route_requires_login(pool):
 @pytest.mark.asyncio
 async def test_dismiss_finding_route_rejects_unknown_finding_type(pool, monkeypatch):
     await upsert_installation(pool, 1, "octocat")
-    await set_installation_plan(pool, 1, "indie")
+    await set_installation_plan(pool, 1, "air")
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
     async with client:
         response = await client.post(
@@ -679,7 +679,7 @@ async def test_dismiss_finding_route_rejects_unknown_finding_type(pool, monkeypa
 @pytest.mark.asyncio
 async def test_dismiss_finding_route_rejects_finding_missing_required_field(pool, monkeypatch):
     await upsert_installation(pool, 1, "octocat")
-    await set_installation_plan(pool, 1, "indie")
+    await set_installation_plan(pool, 1, "air")
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
     async with client:
         response = await client.post(
@@ -692,7 +692,7 @@ async def test_dismiss_finding_route_rejects_finding_missing_required_field(pool
 @pytest.mark.asyncio
 async def test_dismiss_finding_route_then_get_dashboard_reflects_it(pool, monkeypatch):
     await upsert_installation(pool, 1, "octocat")
-    await set_installation_plan(pool, 1, "indie")
+    await set_installation_plan(pool, 1, "air")
     await insert_repo_history(
         pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -717,7 +717,7 @@ async def test_dismiss_finding_route_then_get_dashboard_reflects_it(pool, monkey
 @pytest.mark.asyncio
 async def test_undismiss_finding_route_removes_it(pool, monkeypatch):
     await upsert_installation(pool, 1, "octocat")
-    await set_installation_plan(pool, 1, "indie")
+    await set_installation_plan(pool, 1, "air")
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
     finding = {"ecosystem": "PyPI", "package": "requests", "advisory_id": "GHSA-1"}
     async with client:
@@ -1038,7 +1038,7 @@ async def test_dashboard_health_keeps_results_separate_per_target(pool, monkeypa
     # targets checking the exact same method+path collapse into one row
     # and one target's result silently vanishes.
     await upsert_installation(pool, 503, "octocat")
-    await set_installation_plan(pool, 503, "indie")
+    await set_installation_plan(pool, 503, "air")
     await insert_repo_history(
         pool, 503, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -1093,7 +1093,7 @@ async def test_dashboard_health_history_requires_login(pool):
 @pytest.mark.asyncio
 async def test_dashboard_health_history_returns_checks_newest_first(pool, monkeypatch):
     await upsert_installation(pool, 504, "octocat")
-    await set_installation_plan(pool, 504, "indie")
+    await set_installation_plan(pool, 504, "air")
     await insert_repo_history(
         pool, 504, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -1139,7 +1139,7 @@ async def test_dashboard_health_history_returns_checks_newest_first(pool, monkey
 @pytest.mark.asyncio
 async def test_dashboard_health_history_respects_limit(pool, monkeypatch):
     await upsert_installation(pool, 505, "octocat")
-    await set_installation_plan(pool, 505, "indie")
+    await set_installation_plan(pool, 505, "air")
     await insert_repo_history(
         pool, 505, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
     )
@@ -1210,7 +1210,7 @@ async def test_dashboard_health_rejects_unadministered_installation(pool, monkey
 @pytest.mark.asyncio
 async def test_dashboard_health_includes_evidence_resolution(pool, monkeypatch):
     await upsert_installation(pool, 502, "octocat")
-    await set_installation_plan(pool, 502, "indie")
+    await set_installation_plan(pool, 502, "air")
     await insert_repo_history(
         pool,
         502,
@@ -1257,7 +1257,7 @@ async def test_dashboard_health_includes_evidence_resolution(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
     await upsert_installation(pool, 504, "octocat")
-    await set_installation_plan(pool, 504, "indie")
+    await set_installation_plan(pool, 504, "air")
     await insert_repo_history(
         pool,
         504,
@@ -1308,7 +1308,7 @@ async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_health_omits_stale_endpoints_with_recent_success(pool, monkeypatch):
     await upsert_installation(pool, 505, "octocat")
-    await set_installation_plan(pool, 505, "indie")
+    await set_installation_plan(pool, 505, "air")
     await insert_repo_history(
         pool,
         505,
@@ -1379,7 +1379,7 @@ async def test_dashboard_wiki_requires_paid_plan(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_wiki_returns_overview_and_subsystems(pool, monkeypatch):
     await upsert_installation(pool, 602, "octocat")
-    await set_installation_plan(pool, 602, "indie")
+    await set_installation_plan(pool, 602, "air")
     await insert_repo_history(
         pool,
         602,
@@ -1407,7 +1407,7 @@ async def test_dashboard_wiki_returns_overview_and_subsystems(pool, monkeypatch)
 @pytest.mark.asyncio
 async def test_dashboard_wiki_returns_null_overview_when_not_yet_generated(pool, monkeypatch):
     await upsert_installation(pool, 603, "octocat")
-    await set_installation_plan(pool, 603, "indie")
+    await set_installation_plan(pool, 603, "air")
     await insert_repo_history(
         pool,
         603,
@@ -1433,7 +1433,7 @@ async def test_dashboard_wiki_surfaces_failed_build_status(pool, monkeypatch):
     # from "hasn't been built yet" - the customer had no way to tell a
     # transient in-progress state apart from a build that's never coming.
     await upsert_installation(pool, 605, "octocat")
-    await set_installation_plan(pool, 605, "indie")
+    await set_installation_plan(pool, 605, "air")
     await insert_repo_history(
         pool,
         605,
@@ -1461,7 +1461,7 @@ async def test_dashboard_wiki_surfaces_failed_status_alongside_existing_overview
     # drop it just because an overview now exists), so the dashboard can
     # tell the customer their AIRview content may be stale.
     await upsert_installation(pool, 606, "octocat")
-    await set_installation_plan(pool, 606, "indie")
+    await set_installation_plan(pool, 606, "air")
     await insert_repo_history(
         pool,
         606,
@@ -1495,7 +1495,7 @@ async def test_dashboard_wiki_subsystem_requires_login(pool):
 @pytest.mark.asyncio
 async def test_dashboard_wiki_subsystem_returns_detail(pool, monkeypatch):
     await upsert_installation(pool, 604, "octocat")
-    await set_installation_plan(pool, 604, "indie")
+    await set_installation_plan(pool, 604, "air")
     await insert_repo_history(
         pool,
         604,
@@ -1521,7 +1521,7 @@ async def test_dashboard_wiki_subsystem_returns_detail(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_wiki_file_returns_structural_fallback_for_unpaged_module(pool, monkeypatch):
     await upsert_installation(pool, 607, "octocat")
-    await set_installation_plan(pool, 607, "indie")
+    await set_installation_plan(pool, 607, "air")
     await insert_repo_history(
         pool,
         607,
@@ -1568,7 +1568,7 @@ async def test_dashboard_wiki_file_returns_structural_fallback_for_unpaged_modul
 @pytest.mark.asyncio
 async def test_dashboard_wiki_file_fetches_unindexed_file_without_llm(pool, monkeypatch):
     await upsert_installation(pool, 608, "octocat")
-    await set_installation_plan(pool, 608, "indie")
+    await set_installation_plan(pool, 608, "air")
     await insert_repo_history(
         pool,
         608,
@@ -1594,7 +1594,7 @@ async def test_dashboard_wiki_file_fetches_unindexed_file_without_llm(pool, monk
 @pytest.mark.asyncio
 async def test_dashboard_wiki_subsystem_404s_for_unknown_id(pool, monkeypatch):
     await upsert_installation(pool, 605, "octocat")
-    await set_installation_plan(pool, 605, "indie")
+    await set_installation_plan(pool, 605, "air")
     await insert_repo_history(
         pool,
         605,
@@ -1633,7 +1633,7 @@ async def test_dashboard_docs_requires_paid_plan(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_docs_renders_verbatim_docstring_with_no_ai_marker(pool, monkeypatch):
     await upsert_installation(pool, 702, "octocat")
-    await set_installation_plan(pool, 702, "indie")
+    await set_installation_plan(pool, 702, "air")
     await insert_repo_history(
         pool, 702, "octocat/hello-world", datetime.now(timezone.utc),
         _evidence_with_module("a.py", "add", "Adds two numbers."),
@@ -1653,7 +1653,7 @@ async def test_dashboard_docs_renders_verbatim_docstring_with_no_ai_marker(pool,
 @pytest.mark.asyncio
 async def test_dashboard_docs_merges_ai_generated_description_for_undocumented_symbol(pool, monkeypatch):
     await upsert_installation(pool, 703, "octocat")
-    await set_installation_plan(pool, 703, "indie")
+    await set_installation_plan(pool, 703, "air")
     await insert_repo_history(
         pool, 703, "octocat/hello-world", datetime.now(timezone.utc),
         _evidence_with_module("a.py", "add", None),
@@ -1673,7 +1673,7 @@ async def test_dashboard_docs_merges_ai_generated_description_for_undocumented_s
 @pytest.mark.asyncio
 async def test_dashboard_docs_returns_empty_modules_when_nothing_scanned_yet(pool, monkeypatch):
     await upsert_installation(pool, 704, "octocat")
-    await set_installation_plan(pool, 704, "indie")
+    await set_installation_plan(pool, 704, "air")
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[704])
     async with client:
         response = await client.get("/app/octocat/hello-world/docs")
@@ -1687,7 +1687,7 @@ async def test_dashboard_docs_returns_empty_modules_when_nothing_scanned_yet(poo
 @pytest.mark.asyncio
 async def test_dashboard_docs_surfaces_failed_build_status(pool, monkeypatch):
     await upsert_installation(pool, 705, "octocat")
-    await set_installation_plan(pool, 705, "indie")
+    await set_installation_plan(pool, 705, "air")
     await insert_repo_history(
         pool, 705, "octocat/hello-world", datetime.now(timezone.utc),
         _evidence_with_module("a.py", "add", None),
@@ -1729,7 +1729,7 @@ async def test_dashboard_docs_export_requires_paid_plan(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_dashboard_docs_export_returns_combined_markdown_with_toc(pool, monkeypatch):
     await upsert_installation(pool, 707, "octocat")
-    await set_installation_plan(pool, 707, "indie")
+    await set_installation_plan(pool, 707, "air")
     await insert_repo_history(
         pool, 707, "octocat/hello-world", datetime.now(timezone.utc),
         _evidence_with_module("a.py", "add", "Adds two numbers."),
@@ -1751,7 +1751,7 @@ async def test_dashboard_docs_export_returns_combined_markdown_with_toc(pool, mo
 @pytest.mark.asyncio
 async def test_dashboard_docs_export_handles_no_modules_yet(pool, monkeypatch):
     await upsert_installation(pool, 708, "octocat")
-    await set_installation_plan(pool, 708, "indie")
+    await set_installation_plan(pool, 708, "air")
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[708])
     async with client:
         response = await client.get("/app/octocat/hello-world/docs/export")
@@ -1769,7 +1769,7 @@ async def test_dashboard_docs_export_sanitizes_unsafe_characters_in_filename(poo
     # can. A raw '"' here would otherwise break the Content-Disposition
     # header's quoting.
     await upsert_installation(pool, 709, "octocat")
-    await set_installation_plan(pool, 709, "indie")
+    await set_installation_plan(pool, 709, "air")
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[709])
     async with client:
         response = await client.get('/app/octocat/weird%22repo/docs/export')

--- a/github-app/tests/test_frontend_subscribe.py
+++ b/github-app/tests/test_frontend_subscribe.py
@@ -7,7 +7,24 @@ from httpx import ASGITransport, AsyncClient
 
 from app_server.auth import encrypt_access_token, sign_session_id, unsign_checkout_installation_id
 from app_server.db import add_paddle_ids_to_installation, create_session, upsert_installation
+from app_server.frontend import _plan_display_name
 from app_server.main import app
+
+
+def test_plan_display_name_covers_all_three_plans():
+    # Real bug found by an independent audit pass: this used to be a bare
+    # binary (free vs "else AIR"), which silently mislabeled a flash-plan
+    # installation as "Aletheore AIR" in the UI - a real, misleading
+    # billing-adjacent bug, not cosmetic.
+    assert _plan_display_name("free") == "Aletheore Community"
+    assert _plan_display_name("flash") == "Aletheore Flash"
+    assert _plan_display_name("air") == "Aletheore AIR"
+
+
+def test_plan_display_name_falls_back_to_air_for_unrecognized_value():
+    # Matches this function's original fail-open shape (anything not
+    # literally "free" used to read as AIR) - now explicit, not accidental.
+    assert _plan_display_name("some-future-plan") == "Aletheore AIR"
 
 
 async def _logged_in_client(pool, monkeypatch, administered_ids):

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2734,6 +2734,56 @@ def test_flash_review_job_requests_second_model_verification_on_paid_plan(monkey
     assert cost_calls == ["deepseek-v4-flash"]
 
 
+def test_flash_review_job_does_not_request_second_model_verification_on_flash_tier(monkeypatch):
+    # The real bug this guards: verify_with_second_model used to be
+    # `not is_free_tier`, which would have silently given the flash plan
+    # dual-agent verification for free the moment it existed as a plan
+    # value - flash's real cost/recall validation was run on solo
+    # generation only, and has no room in its cap for that. Also confirms
+    # flash gets its own, separately-validated review-count cap (800),
+    # not AIR's 500.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "flash"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n@@ -1,1 +1,1 @@\n+broken"
+    )
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+    captured = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.review_diff",
+        lambda diff_text, file_context="", **kwargs: captured.update(kwargs) or [],
+    )
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    reserve_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.reserve_flash_review_count",
+        lambda dsn, installation_id, cap: reserve_calls.append(cap) or True,
+    )
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    from scan_worker.jobs import MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH, run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert captured["verify_with_second_model"] is False
+    assert reserve_calls == [MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH]
+    assert MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH == 800
+
+
 def test_flash_review_job_does_not_request_second_model_verification_on_free_tier(monkeypatch):
     from unittest.mock import MagicMock
 

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -45,6 +45,13 @@ def test_base_cap_for_plan_free_or_unknown_plan_has_no_budget():
     assert base_cap_for_plan("not-a-real-plan") == 0.0
 
 
+def test_base_cap_for_plan_flash_uses_its_own_explicit_override_not_the_shared_fraction():
+    # Real, deliberate: $4, not $6 * CAP_FRACTION_OF_PRICE (0.5) = $3 -
+    # flash's real worst-case cost data justified a looser fraction than
+    # the shared default, so it's a real override, not derived from price.
+    assert base_cap_for_plan("flash") == 4.00
+
+
 def test_monthly_cap_for_installation_base_only():
     assert monthly_cap_for_installation(7.00, 0) == pytest.approx(7.00)
 

--- a/github-app/tests/test_managed_audit_api.py
+++ b/github-app/tests/test_managed_audit_api.py
@@ -165,7 +165,7 @@ async def test_managed_audit_returns_422_for_missing_evidence(pool):
 @pytest.mark.asyncio
 async def test_managed_audit_requires_repo_full_name(pool):
     await upsert_installation(pool, 100, "octocat")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
     app.state.db_pool = pool
@@ -219,7 +219,7 @@ async def test_managed_audit_rejects_malformed_air_before_reserving_quota(monkey
 @pytest.mark.asyncio
 async def test_managed_audit_enqueues_job_for_paid_token(pool, monkeypatch):
     await upsert_installation(pool, 100, "octocat")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
     fake_job = MagicMock(id="job-123")
@@ -249,7 +249,7 @@ async def test_managed_audit_enqueues_job_for_paid_token(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_managed_audit_blocks_second_request_within_cooldown(pool, monkeypatch):
     await upsert_installation(pool, 100, "octocat")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
     fake_queue = MagicMock()
@@ -274,7 +274,7 @@ async def test_managed_audit_blocks_second_request_within_cooldown(pool, monkeyp
 @pytest.mark.asyncio
 async def test_managed_audit_rate_limit_is_independent_per_repo(pool, monkeypatch):
     await upsert_installation(pool, 100, "octocat")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
     fake_queue = MagicMock()
@@ -302,7 +302,7 @@ async def test_managed_audit_rate_limit_is_independent_per_repo(pool, monkeypatc
 @pytest.mark.asyncio
 async def test_managed_audit_blocks_11th_new_repo_this_month(pool, monkeypatch):
     await upsert_installation(pool, 100, "octocat")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
     for i in range(10):
@@ -336,7 +336,7 @@ async def test_managed_audit_new_repo_limit_does_not_block_repeat_audit(pool, mo
     # month must not count against the cap again on a repeat run - only
     # genuinely new repos do.
     await upsert_installation(pool, 100, "octocat")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
     # Already at the cap with 10 *other* repos - if the already-counted
@@ -382,7 +382,7 @@ async def test_managed_audit_new_repo_limit_does_not_block_repeat_audit(pool, mo
 @pytest.mark.asyncio
 async def test_start_managed_audit_passes_repo_full_name_to_the_job(pool, monkeypatch):
     await upsert_installation(pool, 100, "octocat")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 100, token_hash, "laptop", "octocat")
     fake_queue = MagicMock()

--- a/github-app/tests/test_managed_audit_api.py
+++ b/github-app/tests/test_managed_audit_api.py
@@ -182,7 +182,12 @@ async def test_managed_audit_requires_repo_full_name(pool):
 @pytest.mark.asyncio
 async def test_managed_audit_rejects_malformed_air_before_reserving_quota(monkeypatch):
     async def fake_authenticate(_request):
-        return {"installation_id": 100, "plan": "indie"}, "token-hash"
+        # Must be an installation actually entitled to managed audits
+        # (AIR, now that the flash plan also exists and is explicitly
+        # excluded) - this test is about malformed-evidence ordering, not
+        # entitlement, so the plan value here just needs to clear that
+        # gate, not be arbitrary.
+        return {"installation_id": 100, "plan": "air"}, "token-hash"
 
     reserve_repo_slot = AsyncMock()
     reserve_audit = AsyncMock()

--- a/github-app/tests/test_runtime_events_api.py
+++ b/github-app/tests/test_runtime_events_api.py
@@ -57,7 +57,7 @@ async def test_report_runtime_event_rejects_free_plan(pool):
 @pytest.mark.asyncio
 async def test_report_runtime_event_rejects_unparseable_event(pool):
     await upsert_installation(pool, 201, "octocat")
-    await set_installation_plan(pool, 201, "indie")
+    await set_installation_plan(pool, 201, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 201, token_hash, "laptop", "octocat")
     app.state.db_pool = pool
@@ -74,7 +74,7 @@ async def test_report_runtime_event_rejects_unparseable_event(pool):
 @pytest.mark.asyncio
 async def test_report_runtime_event_enqueues_job_with_parsed_fields(pool, monkeypatch):
     await upsert_installation(pool, 202, "octocat")
-    await set_installation_plan(pool, 202, "indie")
+    await set_installation_plan(pool, 202, "air")
     token_hash = hashlib.sha256(b"real-token").hexdigest()
     await create_api_token(pool, 202, token_hash, "laptop", "octocat")
 


### PR DESCRIPTION
## Summary

Audits and fixes real entitlement gaps for the new $6/mo flash tier across `github-app/scan_worker/jobs.py` and `github-app/app_server/*.py`, and wires up the real, live Paddle product/price for it.

**The core bug this closes:** most existing gates checked `installation["plan"] == "free"` to exclude the free tier — which meant any *new* plan value (like `"flash"`) was silently treated as fully-paid. Two consequences, both real:

- Flash Review's dual-model verification (`verify_with_second_model=not is_free_tier`) would have run for flash installs, even though flash is explicitly solo-Luna-generation only.
- `base_cap_for_plan()` had the opposite problem — it defaults to `$0.00` for any plan not in `PLAN_MONTHLY_PRICE_USD`, which would have blocked every flash review before this PR (flash wasn't in that dict at all).

### Changes

- **`jobs.py`**: flash gets its own 800-review/mo cap, solo-Luna generation (`verify_with_second_model` now keys off `plan == "air"`, not `is_free_tier`), and every genuinely AIR-exclusive trigger (Slack alerts, AIRview full/incremental build, live docs, live wiki, runtime events) switched from `== "free"` to `!= "air"`. Deterministic Check-Run gates (secrets, vulnerability, regression-fence, regression-risk) are left untouched — already correctly inclusive of any paid tier, and flash should get these at zero LLM cost per the "any deterministic check should be included" rule.
- **`llm_cost.py`**: flash priced at `$6.00/mo` with its own `$4.00` spend-cap override (not the shared 50%-of-price formula, which would give $3).
- **`admin.py` / `dashboard.py`**: flash does **not** get the managed dashboard/admin surface — same as free tier, AIR-only via `!= "air"`.
- **`managed_audit_api.py` / `embeddings_api.py` / `runtime_events.py`**: real API-level 402 entitlement gates switched from `== "free"` to `!= "air"`.
- **`frontend.py`**: added `"flash"` to valid checkout plans; a real price-ID validation guard (flash has no annual price yet, so `flash`+`year` is now rejected before checkout instead of reaching Paddle with `price_id=None`); fixed the plan-display-name function to cover all 3 plans instead of a binary air/free split; fixed a real post-checkout redirect bug — flash customers were being sent to `/dashboard`, which now 402s them (redirects to the marketing site instead).
- **`paddle_pricing.py`**: real, live Paddle product (`pro_01m1754jf8nkvhrn3sbaj9rmyq`, "Aletheore Flash") and monthly price (`pri_01m1754jr5msg62grry49kjhw5`, $6.00/mo) created via the Paddle MCP, wired into the price-ID ↔ plan maps the webhook handler and checkout both use.

### Test plan

- [x] `test_jobs.py`: new test asserting flash gets `verify_with_second_model=False` and reserves against the 800/mo cap, not AIR's 500/mo cap
- [x] `test_llm_cost.py`: new test asserting `base_cap_for_plan("flash") == 4.00` (not the shared-formula $3)
- [x] `test_frontend_subscribe.py`: new tests for the 3-way plan display name (including unrecognized-plan fallback)
- [x] `test_managed_audit_api.py`: fixed a pre-existing test whose placeholder plan value (`"indie"`) used to slip past the old lenient check by coincidence — now correctly uses `"air"`, an actually-entitled plan, since the test is about malformed-evidence ordering, not entitlement
- [x] Full local run of every touched test file: `248 passed, 261 skipped` in `github-app/`
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
