### PR TITLE
fix: /aletheore audit ChatOps trigger was flash-tier entitled

### DIFF
--- a/github-app/app_server/webhooks/issue_comment.py
+++ b/github-app/app_server/webhooks/issue_comment.py
@@ -39,20 +39,26 @@ async def handle_issue_comment_event(payload: dict, pool, redis_url: str, queue=
     repo_full_name = payload["repository"]["full_name"]
     commenter = payload["comment"]["user"]["login"]
 
-    # Managed audits are a paid feature (see managed_audit_api.py's own
-    # 402 for the HTTP trigger) - this ChatOps trigger had no equivalent
-    # gate at all, letting any repo with write/admin access (trivially
-    # granted by installing the free app on your own repo) run unlimited
-    # clone+scan cycles on the shared scans queue. Silent, matching the
+    # Managed audits are AIR-exclusive (see managed_audit_api.py's own 402
+    # for the HTTP trigger, "!= air" not "== free") - the flash tier does
+    # not include managed audits at all, same as it doesn't include
+    # AIRview/Docs/the managed dashboard. This ChatOps trigger used to
+    # check "== free" (matching managed_audit_api.py's own pre-flash-tier
+    # check), which meant a flash installation - a real, live gap found
+    # during a full-session final audit - passed straight through: any
+    # commenter with write access on a $6/mo flash repo could type
+    # "/aletheore audit" and get a full, real managed-audit run, a
+    # meaningfully more expensive LLM workload than the PR reviews the
+    # tier is actually priced for. Silent on rejection, matching the
     # permission-denied case right below: this fires from any commenter
     # with write access, not just the installer, so it's not obviously a
     # billing question they're asking - same reasoning as staying quiet
     # on a permission check failure rather than narrating access details
     # to whoever happens to comment.
     installation = await get_installation(pool, installation_id)
-    if installation is None or installation["plan"] == "free":
+    if installation is None or installation["plan"] != "air":
         logger.info(
-            "ignoring '%s' on %s: managed audits require a paid plan",
+            "ignoring '%s' on %s: managed audits require the AIR plan",
             AUDIT_COMMAND,
             repo_full_name,
         )

--- a/github-app/tests/test_issue_comment_webhook.py
+++ b/github-app/tests/test_issue_comment_webhook.py
@@ -163,6 +163,23 @@ async def test_audit_command_on_a_free_plan_installation_does_not_enqueue(pool, 
 
 
 @pytest.mark.asyncio
+async def test_audit_command_on_a_flash_plan_installation_does_not_enqueue(pool, monkeypatch):
+    # Real, live gap found during a full-session final audit: this gate
+    # used to check "== free", which the $6/mo flash plan (a real value
+    # once #468 shipped) passed straight through - flash does not include
+    # managed audits, same exclusion as AIRview/Docs/the managed
+    # dashboard, but any write-access commenter on a flash repo could
+    # still trigger a full, real, meaningfully-more-expensive-than-a-PR-
+    # review managed-audit run via this ChatOps command.
+    await upsert_installation(pool, 111, "octocat")
+    await set_installation_plan(pool, 111, "flash")
+    _mock_permission_check(monkeypatch, "write")
+    fake_queue = MagicMock()
+    await handle_issue_comment_event(_payload("/aletheore audit"), pool, "redis://unused", queue=fake_queue)
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_audit_command_with_no_installation_row_does_not_enqueue(pool, monkeypatch):
     _mock_permission_check(monkeypatch, "write")
     fake_queue = MagicMock()


### PR DESCRIPTION
## Summary
Real, live gap found during a full-session final audit of the flash tier's entitlement boundaries: `issue_comment.py`'s `/aletheore audit` ChatOps trigger still checked `installation["plan"] == "free"` (excluding only free), predating the flash plan (#468). Managed audits are AIR-exclusive - same exclusion as AIRview/Docs/the managed dashboard - but any commenter with write access on a $6/mo flash repo could type `/aletheore audit` in a PR and trigger a full, real managed-audit run, a meaningfully more expensive LLM workload than the PR reviews the tier is actually priced for.

The direct HTTP trigger (`managed_audit_api.py`'s `start_managed_audit`) was already correctly fixed to `!= air` in #468 - this ChatOps trigger is a separate, parallel entry point into the same feature that the same audit missed.

Found and fixed independently alongside a parallel session doing the same full-repo audit overnight, which caught several sibling instances of this exact bug class (the Paddle webhook's one-time paid-setup trigger, the AIRview/Docs recurring catch-up sweeps, the health-check-targets sweep, and the CLI token picker) - shipping this one separately to avoid a merge collision with that larger, already-in-progress fix.

## Test plan
- [x] New test (`test_audit_command_on_a_flash_plan_installation_does_not_enqueue`) confirms a flash-plan installation's `/aletheore audit` command does not enqueue anything.
- [x] Full `test_issue_comment_webhook.py` suite: 14 passed, run against real local Postgres (not just collected/skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr