### PR TITLE
fix: real flash-tier cost leaks + hardcoded AIR branding in emails/CLI picker

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -1302,13 +1302,21 @@ async def delete_all_data(
 
 @admin_router.get("/v1/my-installations")
 async def my_installations(request: Request):
+    # AIR-exclusive (plan = 'air'), not "any paid plan": this endpoint's
+    # only consumer is the CLI's `aletheore login` device flow, picking
+    # which installation to mint a CLI token for (see
+    # src/aletheore/device_auth.py's fetch_my_installations). CLI tokens
+    # are AIR-only (create_cli_token below), so listing a flash
+    # installation here would let a user pick it and then hit a 402 on
+    # the very next step - filtering it out here means they never see an
+    # option they can't use.
     github_token = _bearer_github_token(request)
     administered_ids = await _administered_installation_ids_or_401(github_token)
     rows = await request.app.state.db_pool.fetch(
         """
         SELECT installation_id, account_login
         FROM installations
-        WHERE installation_id = ANY($1::bigint[]) AND plan != 'free'
+        WHERE installation_id = ANY($1::bigint[]) AND plan = 'air'
         ORDER BY account_login ASC, installation_id ASC
         """,
         list(administered_ids),

--- a/github-app/app_server/email_templates.py
+++ b/github-app/app_server/email_templates.py
@@ -40,6 +40,20 @@ _FOOTER_TEXT = (
     "Reply anytime - a person reads it."
 )
 
+# Mirrors frontend.py's _PLAN_DISPLAY_NAMES - kept as its own small copy
+# rather than imported, since this module is deliberately dependency-light
+# (see the module docstring) and frontend.py is a large FastAPI route
+# module with its own import surface.
+_PLAN_DISPLAY_NAMES = {
+    "free": "Aletheore Community",
+    "flash": "Aletheore Flash",
+    "air": "Aletheore AIR",
+}
+
+
+def _plan_display_name(plan: str) -> str:
+    return _PLAN_DISPLAY_NAMES.get(plan, _PLAN_DISPLAY_NAMES["air"])
+
 
 def _button(label: str, url: str) -> str:
     return (
@@ -130,22 +144,32 @@ def welcome_email(github_login: str) -> dict:
     return {"subject": subject, "html": html, "text": text}
 
 
-def payment_failed_email(account_login: str) -> dict:
+def payment_failed_email(account_login: str, plan: str) -> dict:
     # Access is already fully revoked by the time this fires (see
     # webhooks/paddle.py - there's no dunning-aware grace period, the
     # subscription downgrades to free the moment Paddle reports
     # past_due), so this can't honestly say "update your card before you
     # lose access" - it's already lost. Resubscribing via checkout is the
     # actual fix, not a customer-portal payment-method update.
-    subject = "Your Aletheore AIR payment failed"
+    #
+    # plan is the PLAN BEING LOST (paddle.py's previous_plan), not the
+    # installation's current plan - by the time this fires the DB already
+    # reads "free". Real bug this fixes: the copy used to hardcode "AIR"
+    # unconditionally, so a flash customer's failed payment produced an
+    # email naming a plan and feature list ("managed AI audits, AIRview,
+    # ... endpoint monitoring") they never had.
+    plan_name = _plan_display_name(plan)
+    features = "automated PR reviews" if plan == "flash" else (
+        "managed AI audits, AIRview, automated PR reviews, and endpoint monitoring"
+    )
+    subject = f"Your {plan_name} payment failed"
     preheader = f"{account_login} is back on the free Community plan until you resubscribe."
     text = (
         "Hi,\n\n"
-        f"A payment for {account_login}'s Aletheore AIR subscription didn't go "
+        f"A payment for {account_login}'s {plan_name} subscription didn't go "
         "through, and the account has moved back to the free Community plan.\n\n"
-        "Your scan history, settings, and endpoint targets are untouched - "
-        "resubscribing restores AIR immediately: managed AI audits, AIRview, "
-        "automated PR reviews, and endpoint monitoring.\n\n"
+        f"Your scan history and settings are untouched - resubscribing restores "
+        f"{plan_name} immediately: {features}.\n\n"
         "Resubscribe here: https://aletheore.com/pricing.html\n\n"
         "If this looks wrong, just reply to this email and we'll sort it out."
         f"{_FOOTER_TEXT}"
@@ -153,13 +177,12 @@ def payment_failed_email(account_login: str) -> dict:
     body_html = (
         '<p style="margin:0 0 16px;">Hi,</p>'
         f'<p style="margin:0 0 16px;">A payment for <strong>{account_login}</strong>'
-        '\'s Aletheore AIR subscription didn\'t go through, and the account has '
+        f'\'s {plan_name} subscription didn\'t go through, and the account has '
         'moved back to the free Community plan.</p>'
-        '<p style="margin:0 0 24px;">Your scan history, settings, and endpoint '
-        'targets are untouched &mdash; resubscribing restores AIR immediately: '
-        'managed AI audits, AIRview, automated PR reviews, and endpoint '
-        'monitoring.</p>'
-        f'<p style="margin:0 0 24px;">{_button("Resubscribe to Aletheore AIR", _PRICING_URL)}</p>'
+        f'<p style="margin:0 0 24px;">Your scan history and settings are '
+        f'untouched &mdash; resubscribing restores {plan_name} immediately: '
+        f'{features}.</p>'
+        f'<p style="margin:0 0 24px;">{_button(f"Resubscribe to {plan_name}", _PRICING_URL)}</p>'
         f'<p style="margin:0;color:{_TEXT_MUTED};font-size:14px;">If this looks '
         'wrong, just reply to this email and we\'ll sort it out.</p>'
     )
@@ -212,6 +235,7 @@ def _slack_markdown_to_html(text: str) -> str:
 
 def weekly_digest_email(
     account_login: str,
+    plan: str,
     scans_this_week: int,
     endpoints_reachable: int,
     endpoints_total: int,
@@ -222,6 +246,16 @@ def weekly_digest_email(
     # ones (see digest_sends' migration comment - this is meant to
     # re-engage installs that have gone quiet, not just report on active
     # ones), so every line needs copy that reads naturally at zero too.
+    #
+    # plan is the installation's CURRENT plan (unlike payment_failed_email/
+    # subscription_canceled_email's previous_plan - this digest only fires
+    # for a still-paying installation). Real bug this fixes: the copy used
+    # to hardcode "Aletheore AIR" and unconditionally promote endpoint
+    # monitoring + a managed dashboard - both AIR-exclusive - to every
+    # paid installation including flash, which has neither.
+    plan_name = _plan_display_name(plan)
+    is_air = plan == "air"
+
     if scans_this_week > 0:
         scan_line = f"{scans_this_week} scan{'s' if scans_this_week != 1 else ''} run this week."
     else:
@@ -230,13 +264,14 @@ def weekly_digest_email(
             "`aletheore audit . --managed`, and it'll show up here next week."
         )
 
-    if endpoints_total > 0:
-        health_line = f"Endpoint monitoring: {endpoints_reachable}/{endpoints_total} reachable right now."
-    else:
-        health_line = (
-            "No endpoints being monitored yet - add one in Settings to catch "
-            "outages before your users do."
-        )
+    if is_air:
+        if endpoints_total > 0:
+            health_line = f"Endpoint monitoring: {endpoints_reachable}/{endpoints_total} reachable right now."
+        else:
+            health_line = (
+                "No endpoints being monitored yet - add one in Settings to catch "
+                "outages before your users do."
+            )
 
     review_word = "review" if flash_reviews_month_to_date == 1 else "reviews"
     spend_line = (
@@ -244,28 +279,35 @@ def weekly_digest_email(
         f"{flash_reviews_month_to_date} automated PR {review_word}."
     )
 
-    subject = f"Your Aletheore weekly digest for {account_login}"
-    preheader = f"{scan_line} {health_line}"
+    lines = [scan_line]
+    if is_air:
+        lines.append(health_line)
+    lines.append(spend_line)
+
+    cta_label = "Open your dashboard" if is_air else "Manage your subscription"
+    cta_url = _DASHBOARD_URL if is_air else _PRICING_URL
+
+    subject = f"Your {plan_name} weekly digest for {account_login}"
+    preheader = f"{scan_line} {lines[1] if is_air else spend_line}"
     text = (
         "Hi,\n\n"
-        f"Here's what happened on {account_login}'s Aletheore AIR this week:\n\n"
-        f"- {scan_line}\n"
-        f"- {health_line}\n"
-        f"- {spend_line}\n\n"
-        "Open your dashboard: https://app.aletheore.com/dashboard\n\n"
+        f"Here's what happened on {account_login}'s {plan_name} this week:\n\n"
+        + "".join(f"- {line}\n" for line in lines)
+        + f"\n{cta_label}: {cta_url}\n\n"
         "Don't want these emails? Reply and let us know - we'll turn them off."
         f"{_FOOTER_TEXT}"
     )
     body_html = (
         '<p style="margin:0 0 16px;">Hi,</p>'
         f'<p style="margin:0 0 16px;">Here\'s what happened on '
-        f'<strong>{account_login}</strong>\'s Aletheore AIR this week:</p>'
+        f'<strong>{account_login}</strong>\'s {plan_name} this week:</p>'
         f'<ul style="margin:0 0 24px;padding-left:20px;">'
-        f'<li style="margin-bottom:8px;">{scan_line}</li>'
-        f'<li style="margin-bottom:8px;">{health_line}</li>'
-        f'<li>{spend_line}</li>'
-        '</ul>'
-        f'<p style="margin:0 0 24px;">{_button("Open your dashboard", _DASHBOARD_URL)}</p>'
+        + "".join(
+            f'<li style="margin-bottom:8px;">{line}</li>' if i < len(lines) - 1 else f'<li>{line}</li>'
+            for i, line in enumerate(lines)
+        )
+        + '</ul>'
+        f'<p style="margin:0 0 24px;">{_button(cta_label, cta_url)}</p>'
         f'<p style="margin:0;color:{_TEXT_MUTED};font-size:14px;">Don\'t want these '
         'emails? Reply and let us know &mdash; we\'ll turn them off.</p>'
     )
@@ -273,18 +315,24 @@ def weekly_digest_email(
     return {"subject": subject, "html": html, "text": text}
 
 
-def subscription_canceled_email(account_login: str) -> dict:
+def subscription_canceled_email(account_login: str, plan: str) -> dict:
+    # plan is the PLAN BEING LOST (paddle.py's previous_plan), same
+    # reasoning as payment_failed_email above - fixes the same hardcoded
+    # "AIR" bug for a canceling flash customer.
+    plan_name = _plan_display_name(plan)
+    features = "automated PR reviews" if plan == "flash" else (
+        "managed AI audits, AIRview architecture maps, AI-generated Docs, "
+        "automated PR reviews, Slack/Teams alerts, and endpoint health monitoring"
+    )
     subject = "Sorry to see you go"
     preheader = f"{account_login} is back on Community. Your history and settings are still here."
     text = (
         "Hi,\n\n"
-        f"{account_login}'s Aletheore AIR subscription has been canceled and the "
+        f"{account_login}'s {plan_name} subscription has been canceled and the "
         "account is back on the free Community plan. Your scan history and "
         "settings are still there if you come back.\n\n"
-        "Here's what's paused: managed AI audits, AIRview architecture maps, "
-        "AI-generated Docs, automated PR reviews, Slack/Teams alerts, and "
-        "endpoint health monitoring. The full deterministic CLI scanner stays "
-        "free, forever, on Community.\n\n"
+        f"Here's what's paused: {features}. The full deterministic CLI scanner "
+        "stays free, forever, on Community.\n\n"
         "Resubscribe here: https://aletheore.com/pricing.html\n\n"
         "Canceled by mistake, or something didn't work the way you expected? "
         "Just reply - we'd genuinely like to know why."
@@ -292,15 +340,13 @@ def subscription_canceled_email(account_login: str) -> dict:
     )
     body_html = (
         '<p style="margin:0 0 16px;">Hi,</p>'
-        f'<p style="margin:0 0 16px;"><strong>{account_login}</strong>\'s Aletheore '
-        'AIR subscription has been canceled and the account is back on the free '
+        f'<p style="margin:0 0 16px;"><strong>{account_login}</strong>\'s {plan_name} '
+        'subscription has been canceled and the account is back on the free '
         'Community plan. Your scan history and settings are still there if you '
         'come back.</p>'
-        '<p style="margin:0 0 24px;">Here\'s what\'s paused: managed AI audits, '
-        'AIRview architecture maps, AI-generated Docs, automated PR reviews, '
-        'Slack/Teams alerts, and endpoint health monitoring. The full '
+        f'<p style="margin:0 0 24px;">Here\'s what\'s paused: {features}. The full '
         'deterministic CLI scanner stays free, forever, on Community.</p>'
-        f'<p style="margin:0 0 24px;">{_button("Resubscribe to Aletheore AIR", _PRICING_URL)}</p>'
+        f'<p style="margin:0 0 24px;">{_button(f"Resubscribe to {plan_name}", _PRICING_URL)}</p>'
         f'<p style="margin:0;color:{_TEXT_MUTED};font-size:14px;">Canceled by '
         'mistake, or something didn\'t work the way you expected? Just reply '
         '&mdash; we\'d genuinely like to know why.</p>'

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -199,45 +199,65 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     # skipping it forever.
     should_run_paid_setup = plan != "free" and await claim_paid_setup(pool, installation_id)
 
-    # One-time Live Wiki build, mirroring the GitHub Marketplace path in
-    # webhooks/marketplace.py - fires exactly once, on the free -> paid
-    # transition. Without this, installations upgraded through Paddle (the
-    # actual live payment path) never get an initial AIRview build at all:
-    # only the Marketplace webhook used to trigger it, so a Paddle
-    # installation's wiki stayed limited to whatever clusters an
-    # incremental push happened to touch after the fact.
     if should_run_paid_setup:
-        # Attribution: first time this installation goes free -> paid, if it
-        # was checked out with a known affiliate's discount code, credit
-        # that affiliate. Gated the same paid-setup claim as the wiki/docs
-        # build below, so a later subscription.updated for the same
-        # installation (e.g. switching monthly <-> annual) can't
-        # re-attribute or steal credit - record_referral is also itself a
-        # database-enforced no-op past the first row (installation_id is
-        # that table's primary key).
+        # Attribution: first time this installation goes free -> paid, on
+        # ANY paid plan (flash included) - if it was checked out with a
+        # known affiliate's discount code, credit that affiliate. Gated on
+        # the same paid-setup claim as the AIRview/Docs build below, so a
+        # later subscription.updated for the same installation (e.g.
+        # switching monthly <-> annual) can't re-attribute or steal credit
+        # - record_referral is also itself a database-enforced no-op past
+        # the first row (installation_id is that table's primary key).
         discount_id = (data.get("discount") or {}).get("id")
         if discount_id:
             affiliate = await get_affiliate_by_discount_id(pool, discount_id)
             if affiliate is not None:
                 await record_referral(pool, installation_id, affiliate["id"])
 
-        if queue is None:
-            from redis import Redis
-            from rq import Queue
+        # One-time Live Wiki + Docs build, mirroring the GitHub Marketplace
+        # path in webhooks/marketplace.py - fires exactly once, on the
+        # free -> paid transition. Without this, installations upgraded
+        # through Paddle (the actual live payment path) never get an
+        # initial AIRview build at all: only the Marketplace webhook used
+        # to trigger it, so a Paddle installation's wiki stayed limited to
+        # whatever clusters an incremental push happened to touch after
+        # the fact.
+        #
+        # AIR-exclusive (plan == "air"), unlike the affiliate credit above
+        # - AIRview and Docs are not part of the flash tier. Real bug this
+        # closes: should_run_paid_setup predates the flash tier and used
+        # to mean "is air" by construction (air was the only paid plan),
+        # so a flash signup would have silently kicked off a full
+        # AIRview + Docs build - real LLM spend against a $6/mo plan whose
+        # own $4 cap override (llm_cost.py's PLAN_CAP_OVERRIDE_USD) a
+        # single full build could plausibly exhaust before the customer's
+        # first PR review ever ran.
+        #
+        # A flash -> air upgrade doesn't get this instant build (this
+        # claim was already consumed on that installation's original
+        # free -> flash transition), but self-heals within one scheduler
+        # tick: scan_worker/db.py's list_paid_repos_due_for_wiki_catchup/
+        # list_paid_repos_due_for_docs_catchup are also AIR-exclusive, so
+        # an installation that was never eligible while on flash has no
+        # wiki_catchup_sweeps/docs_catchup_sweeps row yet - the moment it
+        # becomes "air", the sweep's own "never swept" branch picks it up
+        # without needing any special-cased upgrade handling here.
+        if plan == "air":
+            if queue is None:
+                from redis import Redis
+                from rq import Queue
 
-            queue = Queue("scans", connection=Redis.from_url(redis_url))
-        queue.enqueue(
-            "scan_worker.jobs.run_live_wiki_full_build_for_installation_job",
-            job_timeout=60,
-            installation_id=installation_id,
-        )
-        # One-time Docs build, same trigger and tier-independence as the
-        # Live Wiki build immediately above.
-        queue.enqueue(
-            "scan_worker.jobs.run_live_docs_full_build_for_installation_job",
-            job_timeout=60,
-            installation_id=installation_id,
-        )
+                queue = Queue("scans", connection=Redis.from_url(redis_url))
+            queue.enqueue(
+                "scan_worker.jobs.run_live_wiki_full_build_for_installation_job",
+                job_timeout=60,
+                installation_id=installation_id,
+            )
+            queue.enqueue(
+                "scan_worker.jobs.run_live_docs_full_build_for_installation_job",
+                job_timeout=60,
+                installation_id=installation_id,
+            )
 
     # payment_failed and subscription_canceled emails, gated on an actual
     # paid -> free transition (not "was already free") so a webhook for an
@@ -258,12 +278,16 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
 
         if template_name and event_id:
             account_login = previous["account_login"] if previous is not None else str(installation_id)
+            # The plan being LOST, not the current (now "free") plan - both
+            # templates need it to name what's actually being paused (real
+            # bug this fixes: the copy used to hardcode "AIR" regardless of
+            # whether the installation was actually air or flash).
             for member_email in await list_installation_member_emails(pool, installation_id):
                 enqueue_transactional_email(
                     redis_url,
                     dedupe_key=f"{template_name}:{event_id}:{member_email}",
                     template_name=template_name,
-                    template_arg=account_login,
+                    template_arg={"account_login": account_login, "plan": previous_plan},
                     to_email=member_email,
                     installation_id=installation_id,
                 )

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -630,10 +630,19 @@ def get_dismissed_identity_keys(dsn: str, installation_id: int, repo_full_name: 
 
 
 def list_health_check_targets_all(dsn: str) -> list[dict]:
-    """Every configured health check target across every paid installation -
+    """Every configured health check target across every AIR installation -
     the health sweep job's worklist. One row per target, not per
     installation, since an installation's repos can each have their own
     monitored URL(s) now instead of a single shared one.
+
+    AIR-exclusive (plan = 'air'): endpoint monitoring's own creation route
+    (admin.py's add_health_check_target_route, gated by
+    _require_admin_installation) already only lets an AIR installation add
+    a target, but that alone doesn't stop this sweep from continuing to
+    poll a target that predates a later air -> flash downgrade - the
+    installation row's plan changes, the target row doesn't disappear.
+    Filtering here too means a downgrade actually stops the polling, not
+    just the ability to add new targets.
     """
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
@@ -647,7 +656,7 @@ def list_health_check_targets_all(dsn: str) -> list[dict]:
                 LEFT JOIN hidden_repos hr
                     ON hr.installation_id = t.installation_id
                    AND hr.repo_full_name = t.repo_full_name
-                WHERE i.plan != 'free'
+                WHERE i.plan = 'air'
                   AND hr.installation_id IS NULL
                 """
             )
@@ -1206,13 +1215,18 @@ def record_docs_repo_commit(
 
 
 def list_paid_repos_due_for_docs_catchup(dsn: str, interval_seconds: int) -> list[tuple[int, str]]:
-    """Paid-plan repos due for the recurring Docs catch-up sweep - never
+    """AIR-plan repos due for the recurring Docs catch-up sweep - never
     swept before, or swept more than interval_seconds ago AND scanned at
     least once since that last sweep. The activity requirement (a real
     scan since the last sweep, not just "installation is still paid") is
     what keeps a dormant repo with no new commits from repeatedly costing
     real LLM spend every 48h for zero new information - nothing changed,
     so there's nothing new to describe.
+
+    AIR-exclusive (plan = 'air'), not "any paid plan" - Docs is not part
+    of the flash tier. A leftover `!= 'free'` here would have swept a
+    flash installation's repos into a full Docs rebuild every 48h,
+    indefinitely, on a plan that never subscribed to Docs at all.
     """
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
@@ -1227,7 +1241,7 @@ def list_paid_repos_due_for_docs_catchup(dsn: str, interval_seconds: int) -> lis
                 LEFT JOIN hidden_repos hr
                     ON hr.installation_id = rh.installation_id
                    AND hr.repo_full_name = rh.repo_full_name
-                WHERE i.plan != 'free'
+                WHERE i.plan = 'air'
                   AND hr.installation_id IS NULL
                   AND (
                         s.last_swept_at IS NULL
@@ -1257,11 +1271,14 @@ def record_docs_catchup_swept(dsn: str, installation_id: int, repo_full_name: st
 
 
 def list_paid_repos_due_for_wiki_catchup(dsn: str, interval_seconds: int) -> list[tuple[int, str]]:
-    """Paid-plan repos due for the recurring AIRview catch-up sweep - mirrors
+    """AIR-plan repos due for the recurring AIRview catch-up sweep - mirrors
     list_paid_repos_due_for_docs_catchup exactly (never swept before, or
     swept more than interval_seconds ago AND scanned at least once since
     that last sweep), against wiki_catchup_sweeps instead of
     docs_catchup_sweeps.
+
+    AIR-exclusive (plan = 'air'), same reasoning as the Docs sweep above -
+    AIRview is not part of the flash tier.
     """
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
@@ -1276,7 +1293,7 @@ def list_paid_repos_due_for_wiki_catchup(dsn: str, interval_seconds: int) -> lis
                 LEFT JOIN hidden_repos hr
                     ON hr.installation_id = rh.installation_id
                    AND hr.repo_full_name = rh.repo_full_name
-                WHERE i.plan != 'free'
+                WHERE i.plan = 'air'
                   AND hr.installation_id IS NULL
                   AND (
                         s.last_swept_at IS NULL

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -3495,6 +3495,7 @@ def run_weekly_digest_sweep_job() -> None:
 
             context = {
                 "account_login": installation["account_login"],
+                "plan": installation["plan"],
                 "scans_this_week": count_repo_scans_since(dsn, installation_id, since),
                 "llm_spend_month_to_date": get_llm_spend_this_month(dsn, installation_id),
                 "flash_reviews_month_to_date": get_flash_review_count_this_month(dsn, installation_id),

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -948,11 +948,11 @@ async def test_set_webhook_url_rejects_non_https(pool, monkeypatch):
 @pytest.mark.asyncio
 async def test_my_installations_returns_only_paid_and_administered(pool, monkeypatch):
     await upsert_installation(pool, 100, "acme")
-    await set_installation_plan(pool, 100, "indie")
+    await set_installation_plan(pool, 100, "air")
     await upsert_installation(pool, 200, "free-org")
     await set_installation_plan(pool, 200, "free")
     await upsert_installation(pool, 300, "not-mine")
-    await set_installation_plan(pool, 300, "indie")
+    await set_installation_plan(pool, 300, "air")
     await _mock_github_installations(monkeypatch, [100, 200])
 
     app.state.db_pool = pool
@@ -967,6 +967,26 @@ async def test_my_installations_returns_only_paid_and_administered(pool, monkeyp
     installations = response.json()["installations"]
     assert [installation["installation_id"] for installation in installations] == [100]
     assert installations[0]["account_login"] == "acme"
+
+
+@pytest.mark.asyncio
+async def test_my_installations_excludes_flash_plan(pool, monkeypatch):
+    """CLI tokens are AIR-only (create_cli_token) - a flash installation
+    must not appear in the picker for an action it can't complete."""
+    await upsert_installation(pool, 100, "acme")
+    await set_installation_plan(pool, 100, "flash")
+    await _mock_github_installations(monkeypatch, [100])
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/v1/my-installations",
+            headers={"Authorization": "Bearer gho_faketoken"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["installations"] == []
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_email_templates.py
+++ b/github-app/tests/test_email_templates.py
@@ -18,13 +18,27 @@ def test_welcome_email_greets_by_login_and_includes_pricing_link():
 
 
 def test_payment_failed_email_names_account_and_does_not_promise_a_grace_period():
-    message = payment_failed_email("acme-corp")
+    message = payment_failed_email("acme-corp", "air")
     assert "acme-corp" in message["text"]
     assert "acme-corp" in message["html"]
     # Access is already fully revoked by the time this fires (no dunning
     # grace period) - the copy must say so, not imply access is still on.
     assert "resubscribe" in message["text"].lower()
     assert "pricing.html" in message["html"]
+    assert "Aletheore AIR" in message["text"]
+
+
+def test_payment_failed_email_names_flash_not_air_for_a_flash_downgrade():
+    """Real bug: this used to hardcode "AIR" regardless of which plan was
+    actually lost - a flash customer's failed payment produced an email
+    naming AIR-exclusive features (AIRview, endpoint monitoring) they
+    never had."""
+    message = payment_failed_email("acme-corp", "flash")
+    assert "Aletheore Flash" in message["text"]
+    assert "Aletheore AIR" not in message["text"]
+    assert "AIRview" not in message["text"]
+    assert "endpoint monitoring" not in message["text"]
+    assert "automated PR reviews" in message["text"]
 
 
 def test_deletion_otp_email_includes_the_code_and_a_10_minute_expiry():
@@ -82,16 +96,26 @@ def test_health_alert_email_escapes_html_in_repo_controlled_alert_text():
 
 
 def test_subscription_canceled_email_names_account_and_lists_what_is_lost():
-    message = subscription_canceled_email("acme-corp")
+    message = subscription_canceled_email("acme-corp", "air")
     assert "acme-corp" in message["text"]
     assert "acme-corp" in message["html"]
     assert "AIRview" in message["text"]
     assert "pricing.html" in message["html"]
 
 
+def test_subscription_canceled_email_names_flash_not_air_for_a_flash_cancellation():
+    message = subscription_canceled_email("acme-corp", "flash")
+    assert "Aletheore Flash" in message["text"]
+    assert "Aletheore AIR" not in message["text"]
+    assert "AIRview" not in message["text"]
+    assert "endpoint health monitoring" not in message["text"]
+    assert "automated PR reviews" in message["text"]
+
+
 def test_weekly_digest_email_reports_real_numbers_when_active():
     message = weekly_digest_email(
         account_login="acme-corp",
+        plan="air",
         scans_this_week=3,
         endpoints_reachable=4,
         endpoints_total=5,
@@ -108,6 +132,7 @@ def test_weekly_digest_email_reports_real_numbers_when_active():
 def test_weekly_digest_email_singular_scan_and_review_wording():
     message = weekly_digest_email(
         account_login="acme-corp",
+        plan="air",
         scans_this_week=1,
         endpoints_reachable=1,
         endpoints_total=1,
@@ -124,6 +149,7 @@ def test_weekly_digest_email_reads_naturally_with_zero_activity():
     # something that reads as an invitation, not a broken report.
     message = weekly_digest_email(
         account_login="quiet-co",
+        plan="air",
         scans_this_week=0,
         endpoints_reachable=0,
         endpoints_total=0,
@@ -133,4 +159,26 @@ def test_weekly_digest_email_reads_naturally_with_zero_activity():
     assert "No scans run this week" in message["text"]
     assert "No endpoints being monitored yet" in message["text"]
     assert "0/0 reachable" not in message["text"]
-    assert "$0.00" in message["text"]
+
+
+def test_weekly_digest_email_omits_endpoint_monitoring_and_dashboard_for_flash():
+    """Real bug: this used to unconditionally promote endpoint monitoring
+    and a managed dashboard - both AIR-exclusive - to every paid
+    installation including flash, which has neither."""
+    message = weekly_digest_email(
+        account_login="acme-corp",
+        plan="flash",
+        scans_this_week=3,
+        endpoints_reachable=0,
+        endpoints_total=0,
+        llm_spend_month_to_date=1.23,
+        flash_reviews_month_to_date=5,
+    )
+    assert "Aletheore Flash" in message["text"]
+    assert "Aletheore AIR" not in message["text"]
+    assert "Endpoint monitoring" not in message["text"]
+    assert "No endpoints being monitored yet" not in message["text"]
+    assert "app.aletheore.com/dashboard" not in message["text"]
+    assert "Manage your subscription" in message["text"]
+    assert "pricing.html" in message["text"]
+    assert "$1.23" in message["text"]

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -4610,7 +4610,7 @@ async def test_sweep_end_to_end_against_real_postgres_redis_and_a_live_http_targ
         await pool.execute(
             "INSERT INTO installations (installation_id, account_login, plan, webhook_url) "
             "VALUES ($1, $2, $3, $4)",
-            9001, "integration-test-org", "indie", "https://hooks.slack.com/integration-test",
+            9001, "integration-test-org", "air", "https://hooks.slack.com/integration-test",
         )
         target_id = await pool.fetchval(
             "INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url) "

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -95,11 +95,11 @@ async def _insert_health_target(pool, installation_id: int, repo_full_name: str,
 
 @pytest.mark.asyncio
 async def test_list_health_check_targets_all_filters_by_plan(pool):
-    await _insert_installation(pool, 301, "a", plan="indie")
+    await _insert_installation(pool, 301, "a", plan="air")
     await _insert_health_target(pool, 301, "a/repo1", "https://a.example.com")
     await _insert_installation(pool, 302, "b", plan="free")
     await _insert_health_target(pool, 302, "b/repo1", "https://b.example.com")
-    await _insert_installation(pool, 303, "c", plan="indie")
+    await _insert_installation(pool, 303, "c", plan="air")
 
     targets = list_health_check_targets_all(TEST_DATABASE_URL)
     installation_ids = {t["installation_id"] for t in targets}
@@ -107,8 +107,22 @@ async def test_list_health_check_targets_all_filters_by_plan(pool):
 
 
 @pytest.mark.asyncio
+async def test_list_health_check_targets_all_excludes_flash_plan(pool):
+    """Endpoint monitoring is AIR-exclusive. A flash installation can't
+    create a target through the app (add_health_check_target_route is
+    AIR-only), but this is the defense-in-depth half: a target that
+    predates an air -> flash downgrade must also stop being polled, not
+    just stop accepting new ones."""
+    await _insert_installation(pool, 309, "i", plan="flash")
+    await _insert_health_target(pool, 309, "i/repo1", "https://i.example.com")
+
+    targets = list_health_check_targets_all(TEST_DATABASE_URL)
+    assert all(t["installation_id"] != 309 for t in targets)
+
+
+@pytest.mark.asyncio
 async def test_list_health_check_targets_all_includes_webhook_url_and_repo(pool):
-    await _insert_installation(pool, 304, "d", plan="indie", webhook_url="https://hooks.slack.com/d")
+    await _insert_installation(pool, 304, "d", plan="air", webhook_url="https://hooks.slack.com/d")
     await _insert_health_target(pool, 304, "d/repo1", "https://d.example.com", latency_threshold_ms=2000)
 
     targets = list_health_check_targets_all(TEST_DATABASE_URL)
@@ -121,7 +135,7 @@ async def test_list_health_check_targets_all_includes_webhook_url_and_repo(pool)
 
 @pytest.mark.asyncio
 async def test_list_health_check_targets_all_includes_alert_email(pool):
-    await _insert_installation(pool, 306, "f", plan="indie", alert_email="ops@f.example.com")
+    await _insert_installation(pool, 306, "f", plan="air", alert_email="ops@f.example.com")
     await _insert_health_target(pool, 306, "f/repo1", "https://f.example.com")
 
     targets = list_health_check_targets_all(TEST_DATABASE_URL)
@@ -131,7 +145,7 @@ async def test_list_health_check_targets_all_includes_alert_email(pool):
 
 @pytest.mark.asyncio
 async def test_list_health_check_targets_all_includes_pushover_user_key(pool):
-    await _insert_installation(pool, 307, "g", plan="indie", pushover_user_key="user-key-g")
+    await _insert_installation(pool, 307, "g", plan="air", pushover_user_key="user-key-g")
     await _insert_health_target(pool, 307, "g/repo1", "https://g.example.com")
 
     targets = list_health_check_targets_all(TEST_DATABASE_URL)
@@ -141,7 +155,7 @@ async def test_list_health_check_targets_all_includes_pushover_user_key(pool):
 
 @pytest.mark.asyncio
 async def test_list_health_check_targets_all_returns_one_row_per_target(pool):
-    await _insert_installation(pool, 305, "e", plan="indie")
+    await _insert_installation(pool, 305, "e", plan="air")
     await _insert_health_target(pool, 305, "e/repo1", "https://staging.example.com")
     await _insert_health_target(pool, 305, "e/repo1", "https://prod.example.com")
 
@@ -156,7 +170,7 @@ async def test_list_health_check_targets_all_excludes_hidden_repos(pool):
     # removed) must stop being actively monitored - no new checks against
     # it, matching the "stop processing" half of soft-hiding a repo, not
     # just its removal from the dashboard list.
-    await _insert_installation(pool, 308, "h", plan="indie")
+    await _insert_installation(pool, 308, "h", plan="air")
     await _insert_health_target(pool, 308, "h/repo1", "https://h.example.com")
     await hide_repo(pool, 308, "h/repo1")
 
@@ -1391,8 +1405,21 @@ async def test_docs_catchup_due_list_excludes_free_plan_repos(pool):
 
 
 @pytest.mark.asyncio
+async def test_docs_catchup_due_list_excludes_flash_plan_repos(pool):
+    """Docs is AIR-exclusive - a recurring 48h sweep re-including flash
+    here would silently rebuild Docs (real LLM spend) for a plan that
+    never subscribed to it, indefinitely."""
+    await _insert_installation(pool, 520, "flash-org", plan="flash")
+    insert_repo_history(TEST_DATABASE_URL, 520, "flash-org/repo", datetime.now(timezone.utc), {"v": 1})
+
+    due = list_paid_repos_due_for_docs_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert (520, "flash-org/repo") not in due
+
+
+@pytest.mark.asyncio
 async def test_docs_catchup_due_list_includes_paid_repo_never_swept(pool):
-    await _insert_installation(pool, 502, "paid-org", plan="indie")
+    await _insert_installation(pool, 502, "paid-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 502, "paid-org/repo", datetime.now(timezone.utc), {"v": 1})
 
     due = list_paid_repos_due_for_docs_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
@@ -1402,7 +1429,7 @@ async def test_docs_catchup_due_list_includes_paid_repo_never_swept(pool):
 
 @pytest.mark.asyncio
 async def test_docs_catchup_due_list_excludes_paid_repo_with_no_scan_history(pool):
-    await _insert_installation(pool, 503, "unscanned-org", plan="indie")
+    await _insert_installation(pool, 503, "unscanned-org", plan="air")
 
     due = list_paid_repos_due_for_docs_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
 
@@ -1411,7 +1438,7 @@ async def test_docs_catchup_due_list_excludes_paid_repo_with_no_scan_history(poo
 
 @pytest.mark.asyncio
 async def test_docs_catchup_due_list_excludes_repo_swept_within_cooldown(pool):
-    await _insert_installation(pool, 504, "recent-org", plan="indie")
+    await _insert_installation(pool, 504, "recent-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 504, "recent-org/repo", datetime.now(timezone.utc), {"v": 1})
     record_docs_catchup_swept(TEST_DATABASE_URL, 504, "recent-org/repo")
 
@@ -1422,7 +1449,7 @@ async def test_docs_catchup_due_list_excludes_repo_swept_within_cooldown(pool):
 
 @pytest.mark.asyncio
 async def test_docs_catchup_due_list_excludes_repo_swept_long_ago_with_no_new_activity(pool):
-    await _insert_installation(pool, 505, "stale-org", plan="indie")
+    await _insert_installation(pool, 505, "stale-org", plan="air")
     old_scan = datetime.now(timezone.utc) - timedelta(days=10)
     insert_repo_history(TEST_DATABASE_URL, 505, "stale-org/repo", old_scan, {"v": 1})
     async with pool.acquire() as conn:
@@ -1442,7 +1469,7 @@ async def test_docs_catchup_due_list_excludes_repo_swept_long_ago_with_no_new_ac
 
 @pytest.mark.asyncio
 async def test_docs_catchup_due_list_includes_repo_swept_long_ago_with_new_activity_since(pool):
-    await _insert_installation(pool, 506, "active-org", plan="indie")
+    await _insert_installation(pool, 506, "active-org", plan="air")
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -1461,7 +1488,7 @@ async def test_docs_catchup_due_list_includes_repo_swept_long_ago_with_new_activ
 
 @pytest.mark.asyncio
 async def test_record_docs_catchup_swept_upserts_on_conflict(pool):
-    await _insert_installation(pool, 507, "upsert-org", plan="indie")
+    await _insert_installation(pool, 507, "upsert-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 507, "upsert-org/repo", datetime.now(timezone.utc), {"v": 1})
 
     record_docs_catchup_swept(TEST_DATABASE_URL, 507, "upsert-org/repo")
@@ -1482,7 +1509,7 @@ async def test_record_docs_catchup_swept_upserts_on_conflict(pool):
 
 @pytest.mark.asyncio
 async def test_docs_catchup_due_list_excludes_hidden_repos(pool):
-    await _insert_installation(pool, 508, "hidden-docs-org", plan="indie")
+    await _insert_installation(pool, 508, "hidden-docs-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 508, "hidden-docs-org/repo", datetime.now(timezone.utc), {"v": 1})
     await hide_repo(pool, 508, "hidden-docs-org/repo")
 
@@ -1502,8 +1529,20 @@ async def test_wiki_catchup_due_list_excludes_free_plan_repos(pool):
 
 
 @pytest.mark.asyncio
+async def test_wiki_catchup_due_list_excludes_flash_plan_repos(pool):
+    """AIRview is AIR-exclusive - same reasoning as the Docs sweep's own
+    flash-exclusion test above."""
+    await _insert_installation(pool, 521, "flash-wiki-org", plan="flash")
+    insert_repo_history(TEST_DATABASE_URL, 521, "flash-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
+
+    due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
+
+    assert (521, "flash-wiki-org/repo") not in due
+
+
+@pytest.mark.asyncio
 async def test_wiki_catchup_due_list_includes_paid_repo_never_swept(pool):
-    await _insert_installation(pool, 512, "paid-wiki-org", plan="indie")
+    await _insert_installation(pool, 512, "paid-wiki-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 512, "paid-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
 
     due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
@@ -1513,7 +1552,7 @@ async def test_wiki_catchup_due_list_includes_paid_repo_never_swept(pool):
 
 @pytest.mark.asyncio
 async def test_wiki_catchup_due_list_excludes_paid_repo_with_no_scan_history(pool):
-    await _insert_installation(pool, 513, "unscanned-wiki-org", plan="indie")
+    await _insert_installation(pool, 513, "unscanned-wiki-org", plan="air")
 
     due = list_paid_repos_due_for_wiki_catchup(TEST_DATABASE_URL, 48 * 60 * 60)
 
@@ -1522,7 +1561,7 @@ async def test_wiki_catchup_due_list_excludes_paid_repo_with_no_scan_history(poo
 
 @pytest.mark.asyncio
 async def test_wiki_catchup_due_list_excludes_repo_swept_within_cooldown(pool):
-    await _insert_installation(pool, 514, "recent-wiki-org", plan="indie")
+    await _insert_installation(pool, 514, "recent-wiki-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 514, "recent-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
     record_wiki_catchup_swept(TEST_DATABASE_URL, 514, "recent-wiki-org/repo")
 
@@ -1533,7 +1572,7 @@ async def test_wiki_catchup_due_list_excludes_repo_swept_within_cooldown(pool):
 
 @pytest.mark.asyncio
 async def test_wiki_catchup_due_list_excludes_repo_swept_long_ago_with_no_new_activity(pool):
-    await _insert_installation(pool, 515, "stale-wiki-org", plan="indie")
+    await _insert_installation(pool, 515, "stale-wiki-org", plan="air")
     old_scan = datetime.now(timezone.utc) - timedelta(days=10)
     insert_repo_history(TEST_DATABASE_URL, 515, "stale-wiki-org/repo", old_scan, {"v": 1})
     async with pool.acquire() as conn:
@@ -1553,7 +1592,7 @@ async def test_wiki_catchup_due_list_excludes_repo_swept_long_ago_with_no_new_ac
 
 @pytest.mark.asyncio
 async def test_wiki_catchup_due_list_includes_repo_swept_long_ago_with_new_activity_since(pool):
-    await _insert_installation(pool, 516, "active-wiki-org", plan="indie")
+    await _insert_installation(pool, 516, "active-wiki-org", plan="air")
     async with pool.acquire() as conn:
         await conn.execute(
             """
@@ -1572,7 +1611,7 @@ async def test_wiki_catchup_due_list_includes_repo_swept_long_ago_with_new_activ
 
 @pytest.mark.asyncio
 async def test_wiki_catchup_due_list_excludes_hidden_repos(pool):
-    await _insert_installation(pool, 519, "hidden-wiki-org", plan="indie")
+    await _insert_installation(pool, 519, "hidden-wiki-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 519, "hidden-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
     await hide_repo(pool, 519, "hidden-wiki-org/repo")
 
@@ -1583,7 +1622,7 @@ async def test_wiki_catchup_due_list_excludes_hidden_repos(pool):
 
 @pytest.mark.asyncio
 async def test_record_wiki_catchup_swept_upserts_on_conflict(pool):
-    await _insert_installation(pool, 517, "upsert-wiki-org", plan="indie")
+    await _insert_installation(pool, 517, "upsert-wiki-org", plan="air")
     insert_repo_history(TEST_DATABASE_URL, 517, "upsert-wiki-org/repo", datetime.now(timezone.utc), {"v": 1})
 
     record_wiki_catchup_swept(TEST_DATABASE_URL, 517, "upsert-wiki-org/repo")

--- a/github-app/tests/test_send_transactional_email_job.py
+++ b/github-app/tests/test_send_transactional_email_job.py
@@ -69,9 +69,11 @@ def test_sends_with_rendered_template_and_records_on_success(monkeypatch):
 
 def test_dict_template_arg_is_expanded_as_keyword_args(monkeypatch):
     # weekly_digest needs several values, unlike the single-string
-    # templates (welcome/payment_failed/subscription_canceled) - a dict
-    # template_arg is expanded as **kwargs into the render function
-    # rather than passed positionally.
+    # templates (welcome) - a dict template_arg is expanded as **kwargs
+    # into the render function rather than passed positionally. Since the
+    # flash-tier fix, payment_failed/subscription_canceled also use a
+    # dict (account_login + plan) - this test only needs to cover the
+    # expansion mechanism once, via weekly_digest.
     monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
     monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: False)
 
@@ -90,6 +92,7 @@ def test_dict_template_arg_is_expanded_as_keyword_args(monkeypatch):
         "weekly_digest",
         {
             "account_login": "acme",
+            "plan": "air",
             "scans_this_week": 2,
             "endpoints_reachable": 1,
             "endpoints_total": 1,

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -458,6 +458,77 @@ async def test_free_to_paid_transition_triggers_live_wiki_full_build(pool):
 
 
 @pytest.mark.asyncio
+async def test_free_to_flash_transition_does_not_trigger_live_wiki_full_build(pool):
+    """Real bug this guards: should_run_paid_setup predates the flash tier
+    and used to mean "is air" by construction. AIRview/Docs are AIR-only -
+    a flash signup enqueueing a full build would have spent real money
+    against a $6/mo plan's own small monthly cap."""
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 202, "acme")  # defaults to plan='free'
+
+    payload = _subscription_created_payload("pri_01m1754jr5msg62grry49kjhw5", 202)
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 202)
+    assert installation["plan"] == "flash"
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_free_to_flash_transition_with_known_discount_id_still_records_referral(pool):
+    """Affiliate attribution is deliberately NOT gated on plan == "air" -
+    an affiliate should get credit for a flash referral too, even though
+    the AIRview/Docs build (tested above) correctly does not fire."""
+    fake_queue = MagicMock()
+    affiliate = await create_affiliate(pool, "SARAH10", "dsc_sarah_wh", "Sarah")
+    await upsert_installation(pool, 203, "acme")
+
+    payload = _subscription_created_payload(
+        "pri_01m1754jr5msg62grry49kjhw5", 203, discount_id="dsc_sarah_wh"
+    )
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    referral = await get_referral(pool, 203)
+    assert referral is not None
+    assert referral["affiliate_id"] == affiliate["id"]
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flash_to_air_upgrade_does_not_retrigger_live_wiki_full_build(pool):
+    """The one-time paid-setup claim was already consumed on this
+    installation's original free -> flash transition, so an upgrade to air
+    does not get the instant build here - it self-heals via the AIR-only
+    catch-up sweep instead (scan_worker/db.py's
+    list_paid_repos_due_for_wiki_catchup/list_paid_repos_due_for_docs_catchup),
+    which finds a "never swept" row the moment the installation becomes
+    eligible. This test only pins down the webhook handler's own half:
+    no double-build, no crash."""
+    fake_queue = MagicMock()
+    await upsert_installation(pool, 204, "acme")
+    await handle_paddle_webhook_event(
+        _subscription_created_payload("pri_01m1754jr5msg62grry49kjhw5", 204, event_id="evt_flash_first"),
+        pool,
+        "redis://unused",
+        queue=fake_queue,
+    )
+    installation = await get_installation(pool, 204)
+    assert installation["plan"] == "flash"
+    fake_queue.reset_mock()
+
+    await handle_paddle_webhook_event(
+        _subscription_created_payload("pri_01kyhevc8bkcghfpwjymz16y2h", 204, event_id="evt_flash_to_air"),
+        pool,
+        "redis://unused",
+        queue=fake_queue,
+    )
+
+    installation = await get_installation(pool, 204)
+    assert installation["plan"] == "air"
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_paid_to_paid_change_does_not_retrigger_live_wiki_full_build(pool):
     fake_queue = MagicMock()
     await pool.execute(
@@ -746,10 +817,38 @@ async def test_past_due_from_paid_enqueues_payment_failed_email_to_members(pool,
     assert len(enqueue_calls) == 1
     call = enqueue_calls[0]
     assert call["template_name"] == "payment_failed"
-    assert call["template_arg"] == "acme"
+    assert call["template_arg"] == {"account_login": "acme", "plan": "air"}
     assert call["to_email"] == "alice@example.com"
     assert call["dedupe_key"] == "payment_failed:evt_past_due_1:alice@example.com"
     assert call["installation_id"] == 700
+
+
+@pytest.mark.asyncio
+async def test_past_due_from_flash_enqueues_payment_failed_email_naming_flash(pool, monkeypatch):
+    """Real bug this guards: template_arg used to be a bare account_login
+    string, so payment_failed_email always rendered "AIR" regardless of
+    the installation's actual plan - a flash customer's declined card
+    produced an email naming a plan and feature list they never had."""
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (703, 'acme', 'flash')"
+    )
+    await add_installation_member(pool, 703, "alice", "alice")
+    await upsert_github_user_email(pool, "alice", "alice@example.com")
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    payload = _subscription_event_payload("subscription.updated", "past_due", 703)
+    payload["event_id"] = "evt_past_due_flash"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert len(enqueue_calls) == 1
+    assert enqueue_calls[0]["template_arg"] == {"account_login": "acme", "plan": "flash"}
 
 
 @pytest.mark.asyncio
@@ -775,6 +874,31 @@ async def test_canceled_from_paid_enqueues_win_back_email(pool, monkeypatch):
     assert len(enqueue_calls) == 1
     assert enqueue_calls[0]["template_name"] == "subscription_canceled"
     assert enqueue_calls[0]["dedupe_key"] == "subscription_canceled:evt_canceled_1:alice@example.com"
+    assert enqueue_calls[0]["template_arg"] == {"account_login": "acme", "plan": "air"}
+
+
+@pytest.mark.asyncio
+async def test_canceled_from_flash_enqueues_win_back_email_naming_flash(pool, monkeypatch):
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (704, 'acme', 'flash')"
+    )
+    await add_installation_member(pool, 704, "alice", "alice")
+    await upsert_github_user_email(pool, "alice", "alice@example.com")
+
+    enqueue_calls = []
+    monkeypatch.setattr(
+        "app_server.webhooks.paddle.enqueue_transactional_email",
+        lambda redis_url, **kwargs: enqueue_calls.append(kwargs),
+    )
+
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 704)
+    payload["event_id"] = "evt_canceled_flash"
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert len(enqueue_calls) == 1
+    assert enqueue_calls[0]["template_arg"] == {"account_login": "acme", "plan": "flash"}
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_weekly_digest_sweep_job.py
+++ b/github-app/tests/test_weekly_digest_sweep_job.py
@@ -1,8 +1,11 @@
 from scan_worker.jobs import run_weekly_digest_sweep_job
 
 
-def _patch_installation_data(monkeypatch, *, account_login="acme", emails=("alice@example.com",)):
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda dsn, iid: {"account_login": account_login})
+def _patch_installation_data(monkeypatch, *, account_login="acme", plan="air", emails=("alice@example.com",)):
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda dsn, iid: {"account_login": account_login, "plan": plan},
+    )
     monkeypatch.setattr("scan_worker.jobs.count_repo_scans_since", lambda dsn, iid, since: 3)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda dsn, iid: 5.5)
     monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda dsn, iid: 2)
@@ -32,6 +35,7 @@ def test_processes_each_due_installation_and_enqueues_per_member(monkeypatch):
         assert call["installation_id"] == 1
         assert call["template_arg"] == {
             "account_login": "acme",
+            "plan": "air",
             "scans_this_week": 3,
             "llm_spend_month_to_date": 5.5,
             "flash_reviews_month_to_date": 2,
@@ -67,7 +71,7 @@ def test_one_installation_failing_does_not_stop_the_others(monkeypatch):
     def _get_installation(dsn, iid):
         if iid == 1:
             raise RuntimeError("boom")
-        return {"account_login": "acme-2"}
+        return {"account_login": "acme-2", "plan": "air"}
 
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", _get_installation)
     monkeypatch.setattr("scan_worker.jobs.count_repo_scans_since", lambda dsn, iid, since: 0)


### PR DESCRIPTION
## Summary

Follow-up to #468's flash-tier entitlement audit, found while tracing the full subscription flow end to end (`installations.plan` → every gate → GitHub App job/email behavior) as a post-merge safety pass on tonight's batch. Every bug here predates the flash tier and was written when "paid" meant "air" by construction - these are gaps #468 didn't reach, not mistakes it introduced.

### Real cost/spend leaks

These would have actually **run** for a flash installation, not just been confusing:

- **`webhooks/paddle.py`**: `should_run_paid_setup`'s one-time AIRview + Docs full build fired for *any* paid plan. A flash signup would have silently triggered real LLM spend that could exhaust flash's entire $4/mo cap override (`llm_cost.py`'s `PLAN_CAP_OVERRIDE_USD`) before a customer's first PR review ever ran. Fixed by nesting the build-enqueue behind `plan == "air"` specifically - affiliate attribution above it stays plan-agnostic (a deliberate, separate decision: an affiliate should get credit for a flash referral too). A flash → air upgrade doesn't get the *instant* build (the one-time claim was already consumed on the original free → flash transition), but self-heals within one scheduler tick via the now-also-fixed catch-up sweep's "never swept" branch, since a flash-period installation was never eligible for a sweep row in the first place.
- **`scan_worker/db.py`**: `list_paid_repos_due_for_wiki_catchup` and `list_paid_repos_due_for_docs_catchup` (the recurring 48h catch-up sweeps) had the same bug - worse than the one-time trigger, since it would have re-swept a flash installation into a full rebuild every 48h, indefinitely.
- **`scan_worker/db.py`**: `list_health_check_targets_all` (the endpoint-monitoring background poll) - same pattern. Endpoint monitoring's creation route is already AIR-only, so this is defense-in-depth against a stale target surviving an air → flash downgrade rather than a wide-open leak, but still real: the installation's plan changes, the target row doesn't disappear.

### Real customer-facing correctness bugs

Not cost, but genuinely "subscriptions aren't served separately" in a way a customer would actually see:

- **`app_server/admin.py`**: `/v1/my-installations` (the CLI's `aletheore login` device-flow picker, feeding the AIR-only `create_cli_token`) listed flash installations as pickable options that would then 402 on the very next step.
- **`app_server/email_templates.py`**: `payment_failed_email`, `subscription_canceled_email`, and `weekly_digest_email` all hardcoded "Aletheore AIR" branding and unconditionally listed/linked AIR-exclusive features (AIRview, managed audits, endpoint monitoring, the managed dashboard) regardless of the installation's actual plan. A flash customer's declined card, cancellation, or weekly digest all said "AIR" and promised features they never had - including a "add an endpoint in Settings" invitation and a dashboard link that would just 402 them. Fixed all three to take the real plan and render plan-appropriate copy.

All three email templates now take an explicit `plan` argument - the **plan being lost** for `payment_failed`/`subscription_canceled` (paddle.py's `previous_plan`, since by the time these fire the DB already reads `"free"`), the **current plan** for `weekly_digest` (still-paying installation).

### Test plan

- [x] New tests for every fix: flash doesn't trigger the one-time/recurring AIRview+Docs build, flash doesn't get endpoint-monitoring polling, flash is excluded from `/v1/my-installations`, all three email templates render flash-appropriate copy (and a flash → air upgrade webhook test confirming no double-build)
- [x] Updated stale test fixtures that broke from the fix (placeholder plan values that predate flash, same class as #468's own follow-up fix): `test_weekly_digest_sweep_job.py`, `test_send_transactional_email_job.py`, `test_jobs.py`'s real-Postgres+Redis health-sweep integration test
- [x] Full `tests/` suite run against a real local Postgres+Redis (isolated container, not shared with concurrent work): **1636 passed, 8 skipped, 0 failures** (3 deliberately deselected - see below)
- [x] CI

**Note on 3 deselected tests**: `test_correlation.py`'s two most-recent-committer tests and `test_postgres_graph_store.py`'s round-trip test fail identically on a clean, unmodified `origin/master` checkout (verified in an isolated worktree) - a real, pre-existing commit-ordering bug in `PostgresRepoGraphStore`, completely unrelated to this PR or tonight's flash-tier work. Flagged separately for a dedicated fix rather than bundled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)