### PR TITLE
fix: reconstruct GitHub-omitted diff patches instead of silently dropping them

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -111,9 +111,19 @@ def _trim_patch_context(patch: str, context_lines: int = DIFF_PROMPT_CONTEXT_LIN
 class PRDiff(str):
     """Flattened diff text plus structured patches from GitHub."""
 
-    def __new__(cls, text: str, patches: tuple[tuple[str, str], ...]):
+    def __new__(
+        cls,
+        text: str,
+        patches: tuple[tuple[str, str], ...],
+        omitted_files: tuple[str, ...] = (),
+    ):
         value = str.__new__(cls, text)
         value.patches = patches
+        # Changed files GitHub's own compare API gave no patch for, and whose
+        # content couldn't be reconstructed either (binary, too large, or a
+        # fetch failure) - see fetch_pr_diff. These are genuinely invisible
+        # to review, not merely trimmed.
+        value.omitted_files = omitted_files
         return value
 
 
@@ -253,6 +263,53 @@ def create_check_run(
     response.raise_for_status()
 
 
+# A file this large wasn't going to fit the review budget even if it could
+# be diffed - not worth two extra fetches (base + head content) to find
+# that out. Real gap this guards against staying invisible, not a
+# performance concern: without this fallback, GitHub omitting `patch` for
+# a large changed file (a vendored/minified bundle is exactly this shape -
+# confirmed live against benchmarks/pr-review-benchmark's own case 007,
+# where GitHub's compare API returned has_patch=false for lodash.js)
+# silently dropped that file from the diff the model ever sees, with no
+# signal anywhere that anything was lost.
+MAX_RECONSTRUCTED_DIFF_FILE_BYTES = 2_000_000
+
+
+def _reconstruct_missing_patch(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    path: str,
+    base_ref: str,
+    head_ref: str,
+) -> str | None:
+    """Best-effort local diff for a file GitHub's compare API gave no patch
+    for. Returns None (never raises) for anything that isn't a clean win -
+    a deleted/unreadable/binary/too-large file, or a file whose base and
+    head content are byte-identical (GitHub's own omission wasn't hiding a
+    real change) - so the caller can fall back to just recording the file
+    as genuinely omitted rather than surfacing a wrong or noisy diff.
+    """
+    head_content = fetch_file_content(client, token, repo_full_name, path, head_ref)
+    if head_content is None or len(head_content.encode("utf-8")) > MAX_RECONSTRUCTED_DIFF_FILE_BYTES:
+        return None
+    base_content = fetch_file_content(client, token, repo_full_name, path, base_ref)
+    if base_content is not None and len(base_content.encode("utf-8")) > MAX_RECONSTRUCTED_DIFF_FILE_BYTES:
+        return None
+    if base_content == head_content:
+        return None
+    base_lines = (base_content or "").splitlines(keepends=True)
+    head_lines = head_content.splitlines(keepends=True)
+    diff_lines = [
+        line
+        for line in difflib.unified_diff(base_lines, head_lines, lineterm="")
+        if not (line.startswith("--- ") or line.startswith("+++ "))
+    ]
+    if not diff_lines:
+        return None
+    return "\n".join(line.rstrip("\n") for line in diff_lines)
+
+
 def fetch_pr_diff(
     client: httpx.Client,
     token: str,
@@ -271,14 +328,27 @@ def fetch_pr_diff(
     response.raise_for_status()
     parts = []
     patches = []
+    omitted_files = []
     for file in response.json().get("files", []):
         patch = file.get("patch")
+        if not patch:
+            # GitHub omits `patch` both for binary files and for text files
+            # it considers too large/complex to diff - reconstructing from
+            # the two full file versions recovers the second case (and
+            # naturally still fails, cleanly, for the first: a binary
+            # file's content fails fetch_file_content's utf-8 decode and
+            # comes back None).
+            patch = _reconstruct_missing_patch(
+                client, token, repo_full_name, file["filename"], base_ref, head_ref
+            )
         if patch:
             # Grounding always validates against the real, untrimmed patch
             # (patches, below) - only the text handed to the model shrinks.
             patches.append((file["filename"], patch))
             parts.append(f"--- {file['filename']} ---\n{_trim_patch_context(patch)}")
-    return PRDiff("\n\n".join(parts), tuple(patches))
+        else:
+            omitted_files.append(file["filename"])
+    return PRDiff("\n\n".join(parts), tuple(patches), tuple(omitted_files))
 
 
 def fetch_pr_changed_files(

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1824,6 +1824,17 @@ def _run_flash_review(
     diff_result = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha)
     diff_text = str(diff_result)
     diff_patches = getattr(diff_result, "patches", None)
+    diff_omitted_files = getattr(diff_result, "omitted_files", ())
+    if diff_omitted_files:
+        logging.getLogger("scan_worker.jobs").info(
+            "flash review diff incomplete for %s#%s: %d changed file(s) had no reviewable "
+            "diff at all - GitHub gave no patch and local reconstruction also failed "
+            "(binary, too large, or fetch error) (%s)",
+            repo_full_name,
+            pr_number,
+            len(diff_omitted_files),
+            ", ".join(diff_omitted_files[:10]),
+        )
     changed_files = fetch_pr_changed_files(client, token, repo_full_name, diff_base, head_sha)
     try:
         pr_context = fetch_pr_context(client, token, repo_full_name, pr_number)

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -126,7 +126,13 @@ def test_create_check_run_uses_custom_name_when_given():
 
 def test_fetch_pr_diff_concatenates_real_patches():
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/repos/octocat/hello-world/compare/aaa...bbb"
+        if request.url.path != "/repos/octocat/hello-world/compare/aaa...bbb":
+            # image.png's omitted patch: the reconstruction fallback fetches
+            # its content to try rebuilding a diff, and a real binary file's
+            # response correctly has no usable content - see
+            # test_fetch_pr_diff_records_omitted_files_when_reconstruction_also_fails
+            # for this behavior tested directly.
+            return httpx.Response(200, json={"content": "", "encoding": "none", "size": 1})
         return httpx.Response(
             200,
             json={
@@ -157,6 +163,97 @@ def test_fetch_pr_diff_returns_empty_string_when_no_files_changed():
     diff_text = fetch_pr_diff(client, "fake-token", "octocat/hello-world", "aaa", "bbb")
 
     assert diff_text == ""
+
+
+def test_fetch_pr_diff_reconstructs_a_patch_github_omitted_for_a_large_text_file():
+    # Real gap, confirmed live against benchmarks/pr-review-benchmark's own
+    # case 007: GitHub's compare API returns patch=None for a large changed
+    # text file (a minified/vendored bundle is exactly this shape), and
+    # without this fallback the file - and whatever real bug it contains -
+    # was silently invisible to Flash Review with no signal anything was
+    # lost.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/octocat/hello-world/compare/aaa...bbb":
+            return httpx.Response(
+                200, json={"files": [{"filename": "lib/bundle.js", "patch": None}]}
+            )
+        assert request.url.path == "/repos/octocat/hello-world/contents/lib/bundle.js"
+        ref = request.url.params["ref"]
+        content = b"function f() {\n  return isPlainObject(v) || isArray(v);\n}\n"
+        if ref == "bbb":
+            content = b"function f() {\n  return isPlainObject(v);\n}\n"
+        return httpx.Response(
+            200,
+            json={"content": base64.b64encode(content).decode(), "encoding": "base64", "size": len(content)},
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    diff_text = fetch_pr_diff(client, "fake-token", "octocat/hello-world", "aaa", "bbb")
+
+    assert "lib/bundle.js" in diff_text
+    assert "isPlainObject(v);" in diff_text
+    assert diff_text.omitted_files == ()
+    assert len(diff_text.patches) == 1
+    assert diff_text.patches[0][0] == "lib/bundle.js"
+
+
+def test_fetch_pr_diff_records_omitted_files_when_reconstruction_also_fails():
+    # A genuinely binary file: GitHub omits the patch, and the contents
+    # fetch's own base64/encoding check correctly refuses to treat it as
+    # text - reconstruction must fail closed here, not fabricate a diff.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/octocat/hello-world/compare/aaa...bbb":
+            return httpx.Response(200, json={"files": [{"filename": "image.png", "patch": None}]})
+        return httpx.Response(200, json={"content": "", "encoding": "none", "size": 12345})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    diff_text = fetch_pr_diff(client, "fake-token", "octocat/hello-world", "aaa", "bbb")
+
+    assert diff_text == ""
+    assert diff_text.patches == ()
+    assert diff_text.omitted_files == ("image.png",)
+
+
+def test_fetch_pr_diff_does_not_reconstruct_when_base_and_head_content_are_identical():
+    # GitHub's own patch omission isn't always hiding a real change (e.g. a
+    # pure mode/permission change with no content diff) - reconstructing an
+    # empty diff would be pure noise in the prompt, so this must still land
+    # in omitted_files rather than fabricate a no-op patch.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/octocat/hello-world/compare/aaa...bbb":
+            return httpx.Response(200, json={"files": [{"filename": "script.sh", "patch": None}]})
+        content = base64.b64encode(b"#!/bin/sh\necho hi\n").decode()
+        return httpx.Response(200, json={"content": content, "encoding": "base64", "size": 18})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    diff_text = fetch_pr_diff(client, "fake-token", "octocat/hello-world", "aaa", "bbb")
+
+    assert diff_text == ""
+    assert diff_text.omitted_files == ("script.sh",)
+
+
+def test_fetch_pr_diff_reconstructs_a_newly_added_file_github_omitted_a_patch_for():
+    # base_ref genuinely has no such file (a brand-new large file) -
+    # fetch_file_content correctly returns None for the base fetch (404),
+    # and the whole head content is the real diff, not a reason to give up.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/repos/octocat/hello-world/compare/aaa...bbb":
+            return httpx.Response(200, json={"files": [{"filename": "new_big.py", "patch": None}]})
+        ref = request.url.params["ref"]
+        if ref == "aaa":
+            return httpx.Response(404, json={"message": "Not Found"})
+        content = b"def f():\n    return 1\n"
+        return httpx.Response(
+            200,
+            json={"content": base64.b64encode(content).decode(), "encoding": "base64", "size": len(content)},
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    diff_text = fetch_pr_diff(client, "fake-token", "octocat/hello-world", "aaa", "bbb")
+
+    assert "new_big.py" in diff_text
+    assert "def f():" in diff_text
+    assert diff_text.omitted_files == ()
 
 
 def test_trim_patch_context_shrinks_wide_context_to_one_line():


### PR DESCRIPTION
## Summary
- GitHub's compare API omits `patch` for changed files it considers too large/complex to diff (confirmed live against a real PR in the pr-review-benchmark corpus: `has_patch: false` for a large changed file). `fetch_pr_diff` silently dropped those files from the diff with zero signal anything was lost, meaning a real bug could sit entirely outside what Flash Review ever reviews.
- Adds a fallback: when GitHub omits a patch, fetch the file's content at both base and head SHAs and reconstruct a real unified diff locally via `difflib`, reusing the same hunk format `_trim_patch_context` already parses elsewhere in this file.
- Files that still can't be diffed (binary, too large, identical content, or a fetch failure) are now tracked in `PRDiff.omitted_files` and logged in `jobs.py`, instead of vanishing without a trace.

## Test plan
- [x] 4 new tests in `test_github_api.py` covering: successful reconstruction of a large-file diff, a binary file failing closed into `omitted_files`, identical base/head content correctly staying omitted (no fabricated no-op diff), and a newly-added large file (no base version) reconstructing correctly.
- [x] Fixed one pre-existing test whose mock handler needed updating for the new fallback's extra HTTP calls (`test_fetch_pr_diff_concatenates_real_patches`).
- [x] Full `github_api.py` + `jobs.py` suite: 230/230 passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr