### PR TITLE
fix: sort changed files by diff size, replace flat file-count evidence caps with a byte budget

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -200,12 +200,49 @@ def fetch_review_file_context(
     return file_context, file_contents
 
 
+def order_changed_files_by_diff_size(
+    changed_files: list[str], diff_patches: tuple[tuple[str, str], ...] | None
+) -> list[str]:
+    """changed_files, most-surgical-change-first.
+
+    GitHub's changed-files listing carries no relevance ordering of its
+    own, so every downstream context builder that caps how many files it
+    covers (a flat MAX_CONTEXT_FILES slice, or a byte budget) was
+    effectively covering an arbitrary N files in GitHub's own order, not
+    the ones most likely to matter. A small, targeted diff is a better
+    signal of "this is probably where the bug is" than list position -
+    a real miss traced to exactly this: a one-function fix inside a huge
+    bundled file never reached context because larger, less relevant
+    files happened to sort earlier in GitHub's listing.
+
+    Files with no patch data (renamed with no content change, or
+    genuinely omitted by GitHub - see fetch_pr_diff) sort last, after
+    every file real size evidence exists for, rather than being treated
+    as high-priority by default. Stable sort, so files within each group
+    keep their original relative order.
+    """
+    patch_sizes = {filename: len(patch) for filename, patch in (diff_patches or ())}
+    return sorted(changed_files, key=lambda path: (path not in patch_sizes, patch_sizes.get(path, 0)))
+
+
+# Budget for build_code_evidence_context/build_dependency_impact_context -
+# each entry is a compact one-line summary (symbol/dependency/risk facts),
+# not raw source, so this is far smaller than MAX_REFERENCED_SYMBOL_BYTES
+# below (which holds real source text). A real byte budget accumulated
+# over the diff-size-sorted file list, same pattern as
+# build_referenced_symbol_context, replaces the flat changed_files[:30]
+# slice both functions used to apply regardless of how small each line is
+# or how many files would otherwise fit.
+MAX_CODE_EVIDENCE_BYTES = 20_000
+
+
 def build_code_evidence_context(evidence: dict | None, changed_files: list[str]) -> str:
     if not evidence:
         return ""
     modules = evidence.get("repository", {}).get("modules", [])
     lines = []
-    for file_path in changed_files[:MAX_CONTEXT_FILES]:
+    total_bytes = 0
+    for file_path in changed_files:
         module = next((entry for entry in modules if entry.get("path") == file_path), None)
         if not module:
             continue
@@ -242,7 +279,12 @@ def build_code_evidence_context(evidence: dict | None, changed_files: list[str])
         ]
         if risk_summaries:
             parts.append(f"risk={'; '.join(risk_summaries[:3])}")
-        lines.append(" ".join(parts))
+        line = " ".join(parts)
+        encoded_len = len(line.encode("utf-8"))
+        if total_bytes + encoded_len > MAX_CODE_EVIDENCE_BYTES:
+            break
+        lines.append(line)
+        total_bytes += encoded_len
     if not lines:
         return ""
     return "--- deterministic code evidence for changed files ---\n" + "\n".join(lines)
@@ -263,7 +305,8 @@ def build_dependency_impact_context(evidence: dict | None, changed_files: list[s
         if module.get("path")
     }
     lines: list[str] = []
-    for path in changed_files[:MAX_CONTEXT_FILES]:
+    total_bytes = 0
+    for path in changed_files:
         module = modules.get(path)
         if not module:
             continue
@@ -275,7 +318,12 @@ def build_dependency_impact_context(evidence: dict | None, changed_files: list[s
         if imported_by:
             facts.append("imported_by=" + ",".join(imported_by[:8]))
         if len(facts) > 1:
-            lines.append(" ".join(facts))
+            line = " ".join(facts)
+            encoded_len = len(line.encode("utf-8"))
+            if total_bytes + encoded_len > MAX_CODE_EVIDENCE_BYTES:
+                break
+            lines.append(line)
+            total_bytes += encoded_len
     if not lines:
         return ""
     return "--- deterministic dependency impact context (raw graph facts, not conclusions) ---\n" + "\n".join(lines)

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -124,6 +124,7 @@ from scan_worker.flash_review import (
     fetch_review_file_context,
     files_missing_from_review_context,
     is_non_substantive_diff,
+    order_changed_files_by_diff_size,
     review_diff,
 )
 from scan_worker.flash_review_cache import (
@@ -1836,6 +1837,12 @@ def _run_flash_review(
             ", ".join(diff_omitted_files[:10]),
         )
     changed_files = fetch_pr_changed_files(client, token, repo_full_name, diff_base, head_sha)
+    # GitHub's changed-files listing carries no relevance ordering - sorted
+    # once here so every downstream context builder (evidence, dependency
+    # impact, referenced symbols, file content) sees the most surgical
+    # changes first instead of covering an arbitrary prefix of GitHub's own
+    # order. See order_changed_files_by_diff_size's docstring.
+    changed_files = order_changed_files_by_diff_size(changed_files, diff_patches)
     try:
         pr_context = fetch_pr_context(client, token, repo_full_name, pr_number)
     except Exception:  # noqa: BLE001

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -20,8 +20,10 @@ from scan_worker.flash_review import (
     build_referenced_symbol_context,
     find_semantic_regressions,
     is_non_substantive_diff,
+    order_changed_files_by_diff_size,
     review_diff,
 )
+from scan_worker.flash_review import MAX_CODE_EVIDENCE_BYTES
 
 
 def test_diff_valid_lines_maps_added_and_context_lines_by_file():
@@ -861,6 +863,93 @@ def test_build_dependency_impact_context_includes_raw_graph_facts():
 
     assert "imports=b.py" in context
     assert "imported_by=app.py,worker.py" in context
+
+
+def test_order_changed_files_by_diff_size_puts_smallest_patch_first():
+    # A small, targeted diff is a better signal of "the bug is probably
+    # here" than GitHub's arbitrary listing order.
+    diff_patches = (
+        ("huge.py", "x" * 5000),
+        ("tiny.py", "x" * 10),
+        ("medium.py", "x" * 500),
+    )
+
+    ordered = order_changed_files_by_diff_size(["huge.py", "tiny.py", "medium.py"], diff_patches)
+
+    assert ordered == ["tiny.py", "medium.py", "huge.py"]
+
+
+def test_order_changed_files_by_diff_size_puts_files_with_no_patch_data_last():
+    # A file GitHub omitted a patch for (or that has none, e.g. a pure
+    # rename) has no real size signal - it should not jump ahead of files
+    # we actually know are small, just because an unknown defaults to 0.
+    diff_patches = (("small.py", "x" * 10),)
+
+    ordered = order_changed_files_by_diff_size(
+        ["no_patch_a.py", "small.py", "no_patch_b.py"], diff_patches
+    )
+
+    assert ordered == ["small.py", "no_patch_a.py", "no_patch_b.py"]
+
+
+def test_order_changed_files_by_diff_size_is_a_noop_without_patch_data():
+    ordered = order_changed_files_by_diff_size(["b.py", "a.py"], None)
+
+    assert ordered == ["b.py", "a.py"]
+
+
+def test_build_code_evidence_context_demotes_files_past_the_byte_budget():
+    modules = [
+        {
+            "path": f"file_{i}.py",
+            "imports": ["dep.py"],
+            "symbols": {
+                "functions": [{"name": f"a_fairly_long_function_name_{i}", "start_line": 1, "end_line": 2}],
+                "classes": [],
+            },
+        }
+        for i in range(50)
+    ]
+    evidence = {
+        "repository": {"modules": modules, "api_endpoints": {"endpoints": []}},
+        "security": {
+            "secrets": {"findings": []},
+            "dependency_vulnerabilities": {"findings": []},
+            "dependency_licenses": {"findings": []},
+        },
+        "architecture": {"layer_violations": {"violations": []}},
+    }
+    changed_files = [f"file_{i}.py" for i in range(50)]
+
+    # A tight budget makes the cutoff reachable within a handful of files,
+    # proving the byte budget - not just MAX_CONTEXT_FILES's old count - is
+    # what stops it.
+    with patch("scan_worker.flash_review.MAX_CODE_EVIDENCE_BYTES", 500):
+        context = build_code_evidence_context(evidence, changed_files)
+
+    assert len(context.encode("utf-8")) <= 700  # header + one line's slack
+    assert "file_0.py" in context
+    assert "file_49.py" not in context  # past the budget, correctly demoted
+
+
+def test_build_dependency_impact_context_demotes_files_past_the_byte_budget():
+    modules = [
+        {
+            "path": f"file_{i}.py",
+            "imports": [f"dep_{j}.py" for j in range(8)],
+            "imported_by": [f"caller_{j}.py" for j in range(8)],
+        }
+        for i in range(80)
+    ]
+    evidence = {"repository": {"modules": modules}}
+    changed_files = [f"file_{i}.py" for i in range(80)]
+
+    with patch("scan_worker.flash_review.MAX_CODE_EVIDENCE_BYTES", 500):
+        context = build_dependency_impact_context(evidence, changed_files)
+
+    assert len(context.encode("utf-8")) <= 700
+    assert "file_0.py" in context
+    assert "file_79.py" not in context
 
 
 @patch("scan_worker.flash_review.writing_adapter_for")


### PR DESCRIPTION
## Summary
- `changed_files[:MAX_CONTEXT_FILES]` truncated at position 30 in GitHub's own arbitrary listing order, in three places: `fetch_review_file_context`, `build_code_evidence_context`, and `build_dependency_impact_context`. A small, targeted fix sitting past that boundary was invisible to the model regardless of relevance - confirmed as a real contributor to case 007's miss (lodash's real one-function fix never reached evidence).
- `order_changed_files_by_diff_size` sorts `changed_files` by ascending real diff-patch size once, in `jobs.py`, right after `diff_patches` is computed - files with no patch data (renamed with no content change, or genuinely omitted by GitHub) sort last rather than defaulting to high priority. Every downstream context builder now sees the most surgical changes first instead of an arbitrary GitHub-ordered prefix.
- `build_code_evidence_context` and `build_dependency_impact_context` also swap their flat file-count slice for a real byte budget (`MAX_CODE_EVIDENCE_BYTES`, same greedy-accumulate-until-exceeded pattern `build_referenced_symbol_context` already used) - each evidence line is small, so this can now cover more than 30 files when lines are short, never fewer.

## Test plan
- [x] 180/180 tests pass on top of #471 and #472 combined
- [x] Verified live against real `gpt-5.6-luna` on case 007 (lodash unintended-mutation bug), combined with #472's reasoning-room change: now correctly flags line 5690 (ground truth: 5689) with the exact right root cause - removing `isArray(value)` breaks the deferred-clone-to-cloneDeep behavior for arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)