### PR TITLE
fix: pack the diff-text budget smallest-first, matching evidence-context's convention

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -324,12 +324,22 @@ def _reconstruct_missing_patch(
 # jobs.py), which makes diff_text the one part of the prompt that's never
 # reduced - so this was the real, uncapped surface the whole time, just
 # never exercised by anything caught in review (a normal PR's total diff
-# rarely gets big enough to matter). PR-Agent's own equivalent
-# (pr_processing.py's pr_generate_compressed_diff) counts real tokens,
-# packs files largest-first, and demotes whatever doesn't fit to a
-# filename-only list instead of leaving the budget uncapped - same shape
-# adopted here, byte-counted rather than token-counted for consistency
-# with this file's other budgets.
+# rarely gets big enough to matter).
+#
+# Packs smallest patches first, matching order_changed_files_by_diff_size's
+# rationale in flash_review.py (see #473) rather than the largest-first
+# convention this originally shipped with (see #474; borrowed from
+# PR-Agent's own pr_generate_compressed_diff, which sorts descending). That
+# first choice was never validated against anything actually observed to
+# fail this way - reversed for two reasons: consistency (having the diff-
+# text budget and the evidence-context budget prioritize opposite things
+# for adjacent "what gets shown when it doesn't all fit" problems was an
+# unreconciled contradiction, caught in review, not by a failing case), and
+# because largest-first has a real, concrete failure mode #473's approach
+# doesn't: a single huge low-value file (a generated lockfile, a compiled
+# bundle) can consume the whole budget and starve several genuinely
+# important small files around it - the same shape of miss #473 fixed for
+# evidence context, case 007's small surgical fix losing out to size alone.
 MAX_DIFF_TOTAL_BYTES = 400_000
 
 
@@ -368,15 +378,14 @@ def fetch_pr_diff(
         else:
             omitted_files.append(file["filename"])
 
-    # Pack largest patches first (PR-Agent's own convention: a big,
-    # substantive change is more likely to matter than fitting many small
-    # ones around it) up to the total budget; anything that doesn't fit is
-    # tracked, not silently dropped.
-    by_size_desc = sorted(all_patches, key=lambda item: len(item[1]), reverse=True)
+    # Pack smallest patches first (see MAX_DIFF_TOTAL_BYTES above) up to the
+    # total budget; anything that doesn't fit is tracked, not silently
+    # dropped.
+    by_size_asc = sorted(all_patches, key=lambda item: len(item[1]))
     included_filenames: set[str] = set()
     total_bytes = 0
     budget_omitted_files = []
-    for filename, patch in by_size_desc:
+    for filename, patch in by_size_asc:
         patch_bytes = len(patch.encode("utf-8"))
         if total_bytes + patch_bytes > MAX_DIFF_TOTAL_BYTES:
             budget_omitted_files.append(filename)
@@ -385,7 +394,7 @@ def fetch_pr_diff(
         total_bytes += patch_bytes
 
     # Re-walk in GitHub's own original file order for the files that made
-    # the cut - the size-desc pass only decided which files fit, not what
+    # the cut - the size-asc pass only decided which files fit, not what
     # order they're shown in; a diff that jumps around out of order is
     # harder to review than one that doesn't.
     patches = [(f, p) for f, p in all_patches if f in included_filenames]

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -373,11 +373,15 @@ def test_trim_patch_context_handles_pure_removal():
     assert trimmed == patch
 
 
-def test_fetch_pr_diff_packs_largest_patches_first_under_a_total_byte_budget():
+def test_fetch_pr_diff_packs_smallest_patches_first_under_a_total_byte_budget():
     # Real gap: fetch_pr_diff had no total size cap at all before this -
-    # every file's patch got concatenated unconditionally. Mirrors
-    # PR-Agent's own pr_generate_compressed_diff: pack largest patches
-    # first, demote whatever doesn't fit instead of leaving it uncapped.
+    # every file's patch got concatenated unconditionally. Packs smallest
+    # patches first (matching order_changed_files_by_diff_size's rationale
+    # in flash_review.py, see #473): a single huge low-value file
+    # shouldn't be able to consume the whole budget and starve several
+    # genuinely important small files around it - the same shape of miss
+    # #473 fixed for evidence context. Demotes whatever doesn't fit
+    # instead of leaving the budget uncapped.
     import scan_worker.github_api as github_api_module
 
     original_budget = github_api_module.MAX_DIFF_TOTAL_BYTES
@@ -388,8 +392,8 @@ def test_fetch_pr_diff_packs_largest_patches_first_under_a_total_byte_budget():
                 200,
                 json={
                     "files": [
-                        {"filename": "small.py", "patch": "@@ -1,1 +1,1 @@\n-a\n+b"},
                         {"filename": "big.py", "patch": "@@ -1,1 +1,1 @@\n-" + "x" * 90 + "\n+" + "y" * 90},
+                        {"filename": "small.py", "patch": "@@ -1,1 +1,1 @@\n-a\n+b"},
                         {"filename": "medium.py", "patch": "@@ -1,1 +1,1 @@\n-" + "z" * 40 + "\n+" + "w" * 40},
                     ]
                 },
@@ -398,12 +402,13 @@ def test_fetch_pr_diff_packs_largest_patches_first_under_a_total_byte_budget():
         client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
         diff_text = fetch_pr_diff(client, "fake-token", "octocat/hello-world", "aaa", "bbb")
 
-        # big.py alone (~183 bytes) already exceeds the 100-byte budget, so
-        # only whichever single file fits under it should be included -
-        # the largest that fits, not just the first in GitHub's own order.
-        assert diff_text.budget_omitted_files != ()
+        # big.py (~183 bytes) alone exceeds the 100-byte budget, so it must
+        # lose out to the two smaller files even though it's listed first
+        # in GitHub's own order - proves the sort is smallest-first, not
+        # just "whatever fits" in arbitrary order.
         included_names = {name for name, _ in diff_text.patches}
-        assert included_names.isdisjoint(set(diff_text.budget_omitted_files))
+        assert "small.py" in included_names
+        assert "big.py" in diff_text.budget_omitted_files
     finally:
         github_api_module.MAX_DIFF_TOTAL_BYTES = original_budget
 


### PR DESCRIPTION
## Summary
- Resolves a real design inconsistency flagged in review by a peer session: #474 packed the diff-text total-size budget largest-first (borrowed from PR-Agent's `pr_generate_compressed_diff`, unvalidated against anything in our own corpus), while #473 (same day) packs evidence-context files smallest-first for a real, case-backed reason (case 007: a small surgical fix losing out to larger, less relevant files).
- Reversed #474's sort to smallest-first, matching #473: consistency between two adjacent "what gets shown when it doesn't all fit" mechanisms, and because largest-first has a concrete, more damaging failure mode for real-world PRs — a single generated/vendored/bundled file can consume the whole diff-text budget and starve several genuinely important small changes around it.
- Updated the one test that specifically asserted largest-first behavior to prove smallest-first instead (previously it only asserted "something got included/excluded," which happened to not distinguish the two orderings).

## Test plan
- [x] `test_fetch_pr_diff_packs_smallest_patches_first_under_a_total_byte_budget` (renamed/rewritten): proves `big.py` loses out to `small.py` even though `big.py` is listed first in GitHub's own order.
- [x] Full `test_github_api.py`: 39/39 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr