### PR TITLE
feat: add Swift to the scanner's supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Scanning /path/to/your/repo...
 No LLM call, no account, no network access beyond the vulnerability/license registry lookups
 (turn those off too for a fully offline run). That one command gets you a real dependency
 graph, secrets scan, git-history secret sweep, dependency-vulnerability/license check, and
-static API endpoint map — for **Python, JavaScript/JSX, TypeScript/TSX, Go, Rust, Java, Ruby,
-PHP, C, C++, and C#**.
+static API endpoint map — for **Python, JavaScript/JSX, TypeScript/TSX, Go, Rust, Java, Kotlin,
+Ruby, PHP, C, C++, C#, and Swift**.
 
 ## Why
 

--- a/src/README.md
+++ b/src/README.md
@@ -32,14 +32,19 @@ top of that one `air.json` file.
 
 Secrets, git activity, and dependency-vulnerability checks are language-agnostic. The module
 dependency graph (imports, clusters, layer violations) currently understands **Python,
-JavaScript/JSX, TypeScript/TSX, Go, Rust, Java, Ruby, PHP, C, C++, and C#** — other languages
-are still scanned for secrets/git/vulnerabilities, but get no dependency-graph or architecture
-analysis until a grammar is added for them.
+JavaScript/JSX, TypeScript/TSX, Go, Rust, Java, Ruby, PHP, C, C++, C#, and Swift** — other
+languages are still scanned for secrets/git/vulnerabilities, but get no dependency-graph or
+architecture analysis until a grammar is added for them.
 
 Go resolution needs a `go.mod` at the repo root to know the module's own import-path prefix;
 without one, Go imports are left unresolved (same as any import Aletheore can't place) rather
 than guessed at. An import is resolved to every non-test `.go` file in its target directory,
 since Go imports whole packages, not individual files.
+
+Swift resolution works the same way, one level up: a Swift `import` names a whole compiled
+target, not a file, so it's resolved to every `.swift` file belonging to that target - inferred
+from `Package.swift`'s own `path:` overrides where present, falling back to the SwiftPM
+convention (`Sources/<TargetName>/`, `Tests/<TargetName>/`) everywhere else.
 
 Rust resolution needs `src/lib.rs` or `src/main.rs` at the repo root (workspace repos with
 multiple crates aren't supported yet); without one, nothing resolves. It assumes directory

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -20,6 +20,9 @@ ENTRY_POINT_FILENAMES = {
     "manage.py",
     "server.py",
     "wsgi.py",
+    # SwiftPM's build manifest - always this exact name, read by the swift
+    # toolchain itself, never imported by the repo's own application code.
+    "Package.swift",
 }
 
 TEST_PATH_PATTERNS = [
@@ -27,7 +30,11 @@ TEST_PATH_PATTERNS = [
     re.compile(r"(^|/)[^/]+_test\.py$"),
     re.compile(r"(^|/)[^/]+\.test\.[jt]sx?$"),
     re.compile(r"(^|/)[^/]+\.spec\.[jt]sx?$"),
-    re.compile(r"(^|/)(tests?|__tests__)/"),
+    # Case-insensitive: SwiftPM/Xcode universally capitalize this directory
+    # ("Tests/") - confirmed against a real repo (apple/swift-algorithms),
+    # where the previous case-sensitive version missed every single test
+    # file, flagging them all as dead code.
+    re.compile(r"(^|/)(tests?|__tests__)/", re.IGNORECASE),
 ]
 
 PACKAGE_IMPORT_ALIASES = {

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -12,6 +12,7 @@ from aletheore.scanner.graph import (
     PY_LANGUAGE,
     RUBY_LANGUAGE,
     RUST_LANGUAGE,
+    SWIFT_LANGUAGE,
     TS_LANGUAGE,
     TSX_LANGUAGE,
     _iter_source_files,
@@ -34,6 +35,7 @@ _SPRING_VERB_ANNOTATIONS = {
     "DeleteMapping": "DELETE",
     "PatchMapping": "PATCH",
 }
+_VAPOR_VERB_METHODS = {"get", "post", "put", "delete", "patch"}
 _RAILS_ROUTE_METHODS = {"get", "post", "put", "patch", "delete"}
 _LARAVEL_ROUTE_METHODS = {"get", "post", "put", "delete", "patch", "any"}
 _ASPNET_ATTRIBUTE_METHODS = {
@@ -1073,6 +1075,96 @@ def _extract_ktor_routes(root: Node, source: bytes, rel_path: str) -> list[dict]
     return entries
 
 
+def _extract_vapor_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
+    """Vapor's real routing shape (confirmed empirically against
+    tree-sitter-swift, not assumed): `app.get("path") { req in ... }` or
+    `app.get("path", use: handler)` - a call_expression whose callee is
+    `<receiver>.<verb>` and whose call_suffix carries either a trailing
+    lambda_literal or a `use:`-labeled argument. Matches on the verb/shape
+    regardless of the receiver's own name (same as _extract_express_routes
+    does for Express) so a route group's own variable (`app.grouped("api")`
+    assigned to `api`, then `api.get(...)`) is still caught without needing
+    to track that assignment.
+    """
+    entries: list[dict] = []
+
+    def text(n: Node) -> str:
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
+
+    def walk(n: Node) -> None:
+        if n.type == "call_expression":
+            nav = next((c for c in n.children if c.type == "navigation_expression"), None)
+            suffix_node = next((c for c in n.children if c.type == "call_suffix"), None)
+            if nav is not None and suffix_node is not None:
+                nav_suffix = next((c for c in nav.children if c.type == "navigation_suffix"), None)
+                method_id = next(
+                    (c for c in nav_suffix.children if c.type == "simple_identifier"), None
+                ) if nav_suffix is not None else None
+                method_name = text(method_id) if method_id is not None else None
+
+                if method_name in _VAPOR_VERB_METHODS:
+                    args = next((c for c in suffix_node.children if c.type == "value_arguments"), None)
+                    trailing_closure = next(
+                        (c for c in suffix_node.children if c.type == "lambda_literal"), None
+                    )
+                    path_segments: list[str] = []
+                    handler_label = None
+                    if args is not None:
+                        for arg in args.children:
+                            if arg.type != "value_argument":
+                                continue
+                            label_node = next(
+                                (c for c in arg.children if c.type == "value_argument_label"), None
+                            )
+                            if label_node is not None:
+                                label_id = next(
+                                    (c for c in label_node.children if c.type == "simple_identifier"), None
+                                )
+                                if label_id is not None and text(label_id) == "use" and arg.children:
+                                    handler_label = text(arg.children[-1])
+                                continue
+                            str_lit = next(
+                                (c for c in arg.children if c.type == "line_string_literal"), None
+                            )
+                            if str_lit is not None:
+                                content = next(
+                                    (c for c in str_lit.children if c.type == "line_str_text"), None
+                                )
+                                if content is not None:
+                                    path_segments.append(text(content))
+
+                    # A real Vapor route registration always either takes a
+                    # trailing closure or a `use:`-labeled handler reference -
+                    # required as a false-positive guard, since ".get"/".post"
+                    # are extremely common method names on unrelated types
+                    # (dictionaries, key-value stores) that also happen to take
+                    # a string-literal first argument. Express's own path-
+                    # must-start-with-"/" guard doesn't work here: unlike
+                    # Express, real Vapor path segments never carry a leading
+                    # "/" in source, so that signal isn't available.
+                    if path_segments and (trailing_closure is not None or handler_label is not None):
+                        entries.append(
+                            {
+                                "method": method_name.upper(),
+                                # Normalized to a leading "/" for consistency
+                                # with every other framework's stored paths -
+                                # Vapor's own source never writes one.
+                                "path": "/" + "/".join(path_segments),
+                                "framework": "vapor",
+                                "file": rel_path,
+                                "line": n.start_point[0] + 1,
+                                "handler": handler_label or "<inline handler>",
+                                "unresolved": False,
+                                "note": None,
+                            }
+                        )
+        for child in n.children:
+            walk(child)
+
+    walk(root)
+    return entries
+
+
 def _ruby_string_content(node: Node, source: bytes) -> str:
     content = next((c for c in node.children if c.type == "string_content"), None)
     if content is None:
@@ -1467,6 +1559,7 @@ def map_api_endpoints(
         ("php", PHP_LANGUAGE),
         ("cs", CSHARP_LANGUAGE),
         ("kt", KOTLIN_LANGUAGE),
+        ("swift", SWIFT_LANGUAGE),
     ):
         parser = Parser()
         parser.language = lang
@@ -1548,6 +1641,10 @@ def map_api_endpoints(
             source = path.read_bytes()
             tree = parsers["java"].parse(source)
             endpoints.extend(_extract_spring_boot_routes(tree.root_node, source, rel_path))
+        elif suffix == ".swift":
+            source = path.read_bytes()
+            tree = parsers["swift"].parse(source)
+            endpoints.extend(_extract_vapor_routes(tree.root_node, source, rel_path))
         elif suffix == ".rb" and path.name == "routes.rb":
             source = path.read_bytes()
             tree = parsers["rb"].parse(source)

--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -22,6 +22,7 @@ from aletheore.vulnerabilities import (
     _parse_npm_pins,
     _parse_nuget_pins,
     _parse_pip_pins,
+    _parse_swift_package_resolved_pins,
 )
 
 PYPI_URL_TEMPLATE = "https://pypi.org/pypi/{name}/{version}/json"
@@ -241,6 +242,49 @@ def _fetch_nuget_license(name: str, version: str, timeout: int) -> str | None:
     return None
 
 
+def _fetch_swift_license(name: str, version: str, timeout: int) -> str | None:
+    """Swift has no centralized package-registry license API the way
+    PyPI/npm/crates.io do - SwiftPM dependencies are consumed directly from
+    their git host, not published to an index. GitHub's own Contents API
+    ("/repos/{owner}/{repo}/license", confirmed empirically against a real
+    package) is the real, free source used here instead; only GitHub-hosted
+    packages are resolvable this way (the overwhelming majority of real
+    Swift dependencies), matching `name`'s "github.com/owner/repo" shape
+    from _parse_swift_package_resolved_pins.
+
+    SwiftPM release tags are commonly the bare version ("1.36.0") but a real
+    minority use a "v"-prefixed tag ("v1.36.0") - confirmed both forms exist
+    in the wild. Tried in that order, falling back to the default branch's
+    current license rather than reporting nothing just because the exact
+    tag wasn't found - license drift between a specific release and HEAD is
+    rare (same reasoning the module-level license-cache-TTL comment already
+    relies on).
+    """
+    if not name.startswith("github.com/"):
+        return None
+    owner_repo = name[len("github.com/") :]
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "aletheore (https://github.com/Aletheore/Aletheore)",
+    }
+    for ref in (version, f"v{version}", None):
+        url = f"https://api.github.com/repos/{owner_repo}/license"
+        if ref:
+            url += f"?ref={ref}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout, context=_SSL_CONTEXT) as response:
+                data = json.loads(response.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                continue
+            raise
+        license_info = data.get("license") or {}
+        spdx_id = license_info.get("spdx_id")
+        return spdx_id if spdx_id and spdx_id != "NOASSERTION" else None
+    return None
+
+
 _LICENSE_FETCHERS = {
     "PyPI": _fetch_pypi_license,
     "npm": _fetch_npm_license,
@@ -250,6 +294,7 @@ _LICENSE_FETCHERS = {
     "RubyGems": _fetch_rubygems_license,
     "Packagist": _fetch_packagist_license,
     "NuGet": _fetch_nuget_license,
+    "SwiftURL": _fetch_swift_license,
 }
 
 
@@ -333,6 +378,7 @@ def check_dependency_licenses(
         + _parse_composer_pins(repo_path)
         + _parse_nuget_pins(repo_path)
         + _parse_gradle_pins(repo_path)
+        + _parse_swift_package_resolved_pins(repo_path)
     )
     if not pins:
         return {"checked": True, "reason": None, "repo_license": repo_license, "findings": []}

--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -255,6 +255,11 @@ def _fetch_nuget_license(name: str, version: str, timeout: int) -> str | None:
     return None
 
 
+_SWIFT_GITHUB_OWNER_REPO_RE = re.compile(
+    r"^github\.com/([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/([A-Za-z0-9._-]+)$"
+)
+
+
 def _fetch_swift_license(name: str, version: str, timeout: int) -> str | None:
     """Swift has no centralized package-registry license API the way
     PyPI/npm/crates.io do - SwiftPM dependencies are consumed directly from
@@ -265,17 +270,24 @@ def _fetch_swift_license(name: str, version: str, timeout: int) -> str | None:
     Swift dependencies), matching `name`'s "github.com/owner/repo" shape
     from _parse_swift_package_resolved_pins.
 
-    SwiftPM release tags are commonly the bare version ("1.36.0") but a real
-    minority use a "v"-prefixed tag ("v1.36.0") - confirmed both forms exist
-    in the wild. Tried in that order, falling back to the default branch's
-    current license rather than reporting nothing just because the exact
-    tag wasn't found - license drift between a specific release and HEAD is
-    rare (same reasoning the module-level license-cache-TTL comment already
-    relies on).
+    `name` traces back to Package.resolved's own "location" field - real
+    content from the scanned repository, not a value this codebase
+    controls. A prefix check alone (`name.startswith("github.com/")`) is
+    exactly the "incomplete URL substring sanitization" class CodeQL
+    flagged here: it doesn't rule out a crafted value like
+    "github.com/@attacker.example/x" still passing (the classic
+    trusted-domain-as-userinfo trick, though the request host here is
+    always the hardcoded api.github.com regardless, not attacker-derived -
+    fixing the check anyway rather than arguing the specific blast radius,
+    since a security product's own dependency code is exactly where this
+    should be provably correct, not just currently-not-exploitable). A
+    single fullmatch against an anchored owner/repo shape closes it -
+    nothing this doesn't explicitly allow can reach the URL built below.
     """
-    if not name.startswith("github.com/"):
+    match = _SWIFT_GITHUB_OWNER_REPO_RE.fullmatch(name)
+    if match is None:
         return None
-    owner_repo = name[len("github.com/") :]
+    owner_repo = f"{match.group(1)}/{match.group(2)}"
     headers = {
         "Accept": "application/vnd.github+json",
         "User-Agent": "aletheore (https://github.com/Aletheore/Aletheore)",

--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -6,7 +6,7 @@ import tomllib
 import urllib.error
 import urllib.request
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from pathlib import Path
 from xml.etree import ElementTree
 
@@ -33,6 +33,19 @@ DEFAULT_TIMEOUT_SECONDS = 10
 # to blow the hosted worker's per-job timeout on its own. Bounded, not
 # unbounded, so this stays polite to registries under a large repo.
 LICENSE_CHECK_CONCURRENCY = 20
+# `timeout` (DEFAULT_TIMEOUT_SECONDS) bounds a single blocking socket
+# operation (connect/read), not the total time to receive a response - a
+# registry serving its body slowly (a few bytes every few seconds, no
+# single read ever idle long enough to trip the socket timeout) can still
+# take far longer overall. Confirmed as a real production incident, not a
+# theoretical one: three real npm packages (es-errors, es6-error,
+# serialize-error) reproducibly stalled dependency-license checks for
+# 1+ hour before their RQ work-horse was eventually reaped, appearing as
+# "work-horse terminated unexpectedly" - not a timeout error at all, since
+# nothing ever actually raised one. This wall-clock cap is the real fix:
+# generous enough for a legitimately slow-but-real response, firm enough
+# that one bad registry endpoint can never hang the whole check.
+LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS = 30
 
 # A registry lookup for one exact (ecosystem, name, version) triple returns
 # the same answer forever in the overwhelming majority of cases - a
@@ -387,18 +400,30 @@ def check_dependency_licenses(
     cache = _load_license_cache(cache_path)
     # Each registry lookup is an independent blocking HTTP call - a thread
     # pool overlaps their network wait time instead of paying it serially.
-    # executor.map (not as_completed) preserves pins' original order in the
-    # results regardless of which thread finishes first, so progress
-    # reporting and finding order both stay deterministic.
-    with ThreadPoolExecutor(max_workers=LICENSE_CHECK_CONCURRENCY) as executor:
-        license_texts = executor.map(
-            lambda pin: _fetch_one_license_cached(pin, timeout, cache), pins
-        )
-        for index, ((name, version, ecosystem), license_text) in enumerate(
-            zip(pins, license_texts), start=1
-        ):
+    # Submitted individually (not executor.map, whose iterator yields
+    # results in submission order - one stuck fetch at position N blocks
+    # every result after it from ever being reported, even though later
+    # threads already finished; see LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS
+    # for why "stuck" is a real, not theoretical, failure mode here).
+    # future.result(timeout=...) bounds how long THIS function waits for
+    # each pin without needing to interrupt whatever the worker thread is
+    # actually blocked on - that thread is abandoned (Python has no way to
+    # forcibly kill a blocked thread) and left to die on its own eventual
+    # socket timeout; shutdown(wait=False) below means this function
+    # returns promptly rather than blocking on that stray thread to exit.
+    executor = ThreadPoolExecutor(max_workers=LICENSE_CHECK_CONCURRENCY)
+    try:
+        futures = [
+            executor.submit(_fetch_one_license_cached, pin, timeout, cache) for pin in pins
+        ]
+        for index, ((name, version, ecosystem), future) in enumerate(zip(pins, futures), start=1):
             if on_progress is not None:
                 on_progress(index, len(pins), name)
+
+            try:
+                license_text = future.result(timeout=LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS)
+            except FutureTimeoutError:
+                license_text = None
 
             category = categorize_license(license_text)
             if category != "permissive":
@@ -411,6 +436,8 @@ def check_dependency_licenses(
                         "category": category,
                     }
                 )
+    finally:
+        executor.shutdown(wait=False)
     _save_license_cache(cache_path, cache)
 
     return {"checked": True, "reason": None, "repo_license": repo_license, "findings": findings}

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1960,6 +1960,179 @@ def _parse_swift_package_manifest(repo_path: Path) -> dict[str, str]:
     return overrides
 
 
+_PBXPROJ_TOKEN_RE = re.compile(
+    r"""
+      \s+
+    | /\*.*?\*/
+    | //[^\n]*
+    | "(?:\\.|[^"\\])*"
+    | [{}()=;,]
+    | [^\s{}()=;,"]+
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _tokenize_pbxproj(text: str) -> list[str]:
+    """Tokenizer for the OpenStep-plist dialect .pbxproj files actually use -
+    NOT the same format Python's stdlib `plistlib` reads (that only handles
+    binary and XML plists; confirmed empirically - plistlib has no OpenStep
+    format constant at all). The grammar itself is simple and regular
+    (brace/paren-delimited dicts and arrays, semicolon-terminated pairs,
+    bare-or-quoted string values, C-style comments) - this single regex
+    alternation classifies each token; whitespace and comments are dropped,
+    quoted strings have their escapes unescaped, everything else (including
+    every UUID and bare identifier) passes through as-is.
+    """
+    tokens = []
+    pos, n = 0, len(text)
+    while pos < n:
+        match = _PBXPROJ_TOKEN_RE.match(text, pos)
+        if match is None:
+            raise ValueError(f"unparseable pbxproj content at byte {pos}")
+        pos = match.end()
+        piece = match.group()
+        if not piece.strip() or piece.startswith(("/*", "//")):
+            continue
+        if piece.startswith('"'):
+            piece = piece[1:-1].replace('\\"', '"')
+        tokens.append(piece)
+    return tokens
+
+
+def _parse_pbxproj_tokens(tokens: list[str], pos: int) -> tuple[object, int]:
+    """Recursive-descent parse of one value at tokens[pos] - a dict ("{...}"),
+    an array ("(...)"), or a bare/quoted string token. Returns (value,
+    next_pos). Object identity (which "isa" type each UUID names) is
+    resolved later by the caller, not here - this only reconstructs the
+    plain dict/list/str structure.
+    """
+    token = tokens[pos]
+    if token == "{":
+        d: dict[str, object] = {}
+        pos += 1
+        while tokens[pos] != "}":
+            key = tokens[pos]
+            pos += 1
+            assert tokens[pos] == "="
+            pos += 1
+            value, pos = _parse_pbxproj_tokens(tokens, pos)
+            d[key] = value
+            if tokens[pos] == ";":
+                pos += 1
+        return d, pos + 1
+    if token == "(":
+        items: list[object] = []
+        pos += 1
+        while tokens[pos] != ")":
+            value, pos = _parse_pbxproj_tokens(tokens, pos)
+            items.append(value)
+            if tokens[pos] == ",":
+                pos += 1
+        return items, pos + 1
+    return token, pos + 1
+
+
+def _parse_pbxproj(pbxproj_path: Path) -> dict | None:
+    try:
+        text = pbxproj_path.read_text(encoding="utf-8", errors="ignore")
+        tokens = _tokenize_pbxproj(text)
+        data, _ = _parse_pbxproj_tokens(tokens, 0)
+    except (OSError, IndexError, AssertionError, ValueError):
+        # A real project.pbxproj is machine-written by Xcode and never
+        # malformed in practice - these are defensive only, the same
+        # tolerance every other manifest parser here (tomllib.TOMLDecodeError
+        # etc.) already has for a file that doesn't match its expected shape.
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _infer_xcodeproj_swift_targets(
+    repo_path: Path, ignored_paths: list[str] | None
+) -> dict[str, list[Path]]:
+    """Target membership read directly from an Xcode project's own
+    project.pbxproj - the real ground-truth source Xcode itself uses,
+    verified against a real, large, modern multi-target app
+    (wordpress-mobile/WordPress-iOS, objectVersion 77, 685 objects, 15 real
+    PBXNativeTargets) before being trusted. Two real membership mechanisms
+    exist and both are handled, confirmed on that same real project:
+
+    - Classic: PBXNativeTarget.buildPhases -> a PBXSourcesBuildPhase's
+      "files" -> each PBXBuildFile's "fileRef" -> a PBXFileReference's
+      "path". Resolved by basename search under the project root rather
+      than reconstructing the full PBXGroup nesting path (which does not
+      have to mirror the filesystem) - a deliberate, bounded heuristic
+      matching this codebase's existing style elsewhere (e.g. Java/Rust's
+      own nested-class fallback resolution), not a claim of perfect
+      precision; a duplicate basename across the repo is skipped rather
+      than guessed at.
+    - Modern (Xcode 16+): PBXNativeTarget.fileSystemSynchronizedGroups ->
+      each PBXFileSystemSynchronizedRootGroup's "path" names a whole
+      directory Xcode syncs automatically, with no per-file PBXBuildFile
+      entries at all - confirmed as the primary mechanism WordPress-iOS's
+      own main "WordPress" target actually uses today (1 file via the
+      classic path, the real bulk via four synchronized groups).
+    """
+    matches = list(repo_path.glob("*.xcodeproj")) + list(repo_path.glob("*/*.xcodeproj"))
+    targets: dict[str, list[Path]] = {}
+    for xcodeproj in matches:
+        pbxproj_path = xcodeproj / "project.pbxproj"
+        data = _parse_pbxproj(pbxproj_path)
+        if data is None:
+            continue
+        objects = data.get("objects")
+        if not isinstance(objects, dict):
+            continue
+        project_root = xcodeproj.parent
+
+        def resolve_classic(phase_uuid: object) -> list[Path]:
+            phase = objects.get(phase_uuid)
+            if not isinstance(phase, dict) or phase.get("isa") != "PBXSourcesBuildPhase":
+                return []
+            found = []
+            for build_file_uuid in phase.get("files", []) or []:
+                build_file = objects.get(build_file_uuid)
+                file_ref = objects.get(build_file.get("fileRef")) if isinstance(build_file, dict) else None
+                path_str = file_ref.get("path") if isinstance(file_ref, dict) else None
+                if not path_str or not path_str.endswith(".swift"):
+                    continue
+                candidates = [
+                    p for p in project_root.rglob(Path(path_str).name)
+                    if not is_ignored(_rel(repo_path, p), ignored_paths or [])
+                ]
+                if len(candidates) == 1:
+                    found.append(candidates[0])
+            return found
+
+        def resolve_synced(group_uuid: object) -> list[Path]:
+            group = objects.get(group_uuid)
+            path_str = group.get("path") if isinstance(group, dict) else None
+            if not path_str:
+                return []
+            target_dir = project_root / path_str
+            if not target_dir.is_dir():
+                return []
+            return [
+                p for p in target_dir.rglob("*.swift")
+                if not is_ignored(_rel(repo_path, p), ignored_paths or [])
+            ]
+
+        for obj in objects.values():
+            if not isinstance(obj, dict) or obj.get("isa") != "PBXNativeTarget":
+                continue
+            name = obj.get("name")
+            if not isinstance(name, str):
+                continue
+            files: list[Path] = []
+            for phase_uuid in obj.get("buildPhases", []) or []:
+                files.extend(resolve_classic(phase_uuid))
+            for group_uuid in obj.get("fileSystemSynchronizedGroups", []) or []:
+                files.extend(resolve_synced(group_uuid))
+            if files:
+                targets.setdefault(name, []).extend(files)
+    return targets
+
+
 def _infer_swift_targets(repo_path: Path, ignored_paths: list[str] | None) -> dict[str, list[Path]]:
     """Whole-target file membership for Swift's import graph.
 
@@ -1967,22 +2140,16 @@ def _infer_swift_targets(repo_path: Path, ignored_paths: list[str] | None) -> di
     compiled module, not a file - there is no source-level statement that
     resolves to one specific file the way there is for Python/JS/Go/Java,
     so an import edge has to fan out to every file belonging to that
-    target instead (see _resolve_swift_import). Two-tier: an explicit
-    `path:` override read from Package.swift (the minority case) takes
-    priority per target name; every other target - the large majority in a
-    real SwiftPM repo, which almost never overrides the default - falls
-    back to the convention itself: every direct subdirectory of Sources/
-    or Tests/ is its own target, named after that directory.
-
-    Known gap, left honest rather than guessed at: a multi-target Xcode
-    project (.xcodeproj, no SwiftPM Sources/ structure) resolves to an
-    empty target map here, so genuine cross-target imports in that shape
-    go unresolved. Deliberately not papered over with a "whole repo is one
-    target" fallback - that would trade a missing edge for a wrong one
-    (falsely merging distinct targets' files), the opposite of what this
-    whole-target design exists for. A single-target Xcode app is unaffected
-    by this gap: Swift shares visibility within one target with no import
-    statement at all, the same as SwiftPM same-target files.
+    target instead (see _resolve_swift_import). Three sources, merged: an
+    explicit `path:` override read from Package.swift (the minority case)
+    takes priority per target name; every other SwiftPM target - the large
+    majority in a real SwiftPM repo, which almost never overrides the
+    default - falls back to the convention itself (every direct
+    subdirectory of Sources/ or Tests/ is its own target); and, separately,
+    any Xcode project's own project.pbxproj is read directly for its real
+    PBXNativeTarget membership (see _infer_xcodeproj_swift_targets) - a
+    multi-target .xcodeproj app with no SwiftPM structure at all still gets
+    real cross-target edges this way, not just a same-directory guess.
     """
     overrides = _parse_swift_package_manifest(repo_path)
     targets: dict[str, list[Path]] = {}
@@ -2007,6 +2174,10 @@ def _infer_swift_targets(repo_path: Path, ignored_paths: list[str] | None) -> di
         for child in parent.iterdir():
             if child.is_dir() and child.name not in overrides:
                 add_dir_as_target(child.name, child)
+
+    for name, files in _infer_xcodeproj_swift_targets(repo_path, ignored_paths).items():
+        existing = targets.setdefault(name, [])
+        existing.extend(f for f in files if f not in existing)
 
     return targets
 

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1973,6 +1973,16 @@ def _infer_swift_targets(repo_path: Path, ignored_paths: list[str] | None) -> di
     real SwiftPM repo, which almost never overrides the default - falls
     back to the convention itself: every direct subdirectory of Sources/
     or Tests/ is its own target, named after that directory.
+
+    Known gap, left honest rather than guessed at: a multi-target Xcode
+    project (.xcodeproj, no SwiftPM Sources/ structure) resolves to an
+    empty target map here, so genuine cross-target imports in that shape
+    go unresolved. Deliberately not papered over with a "whole repo is one
+    target" fallback - that would trade a missing edge for a wrong one
+    (falsely merging distinct targets' files), the opposite of what this
+    whole-target design exists for. A single-target Xcode app is unaffected
+    by this gap: Swift shares visibility within one target with no import
+    statement at all, the same as SwiftPM same-target files.
     """
     overrides = _parse_swift_package_manifest(repo_path)
     targets: dict[str, list[Path]] = {}

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -17,6 +17,7 @@ import tree_sitter_php as tsphp
 import tree_sitter_python as tspython
 import tree_sitter_ruby as tsruby
 import tree_sitter_rust as tsrust
+import tree_sitter_swift as tsswift
 import tree_sitter_typescript as tstypescript
 from tree_sitter import Language, Node, Parser, Tree
 
@@ -36,6 +37,7 @@ PHP_LANGUAGE = Language(tsphp.language_php())
 C_LANGUAGE = Language(tsc.language())
 CPP_LANGUAGE = Language(tscpp.language())
 CSHARP_LANGUAGE = Language(tscsharp.language())
+SWIFT_LANGUAGE = Language(tsswift.language())
 
 LANGUAGE_BY_EXTENSION = {
     ".py": ("python", PY_LANGUAGE),
@@ -58,6 +60,7 @@ LANGUAGE_BY_EXTENSION = {
     ".cpp": ("cpp", CPP_LANGUAGE),
     ".cc": ("cpp", CPP_LANGUAGE),
     ".cs": ("csharp", CSHARP_LANGUAGE),
+    ".swift": ("swift", SWIFT_LANGUAGE),
 }
 
 # Extensions that are recognizable programming languages we don't yet have a grammar
@@ -68,7 +71,6 @@ LANGUAGE_BY_EXTENSION = {
 # from an untracked cache directory before IGNORED_DIRS was widened, none of which
 # were ever "unparseable source").
 KNOWN_SOURCE_EXTENSIONS_WITHOUT_GRAMMAR = {
-    ".swift",
     ".m", ".mm", ".scala",
 }
 
@@ -142,7 +144,22 @@ def _params_text(source: bytes, enclosing_node: Node) -> str | None:
     safe to try unconditionally after the field lookup fails: no other
     grammar checked here has a node literally typed
     "function_value_parameters", so this can never accidentally match on
-    the wrong grammar.
+    the wrong grammar. Swift is a third exception, of yet another shape:
+    its grammar has no wrapping parameter-list node at all - individual
+    `parameter` nodes sit as direct children of function_declaration,
+    separated by bare "(", ",", ")" tokens (confirmed empirically) - so
+    the span is reconstructed from the outermost "(" and ")" tokens
+    themselves rather than read off a single child node.
+
+    Kotlin and Swift's enclosing node TYPE is confirmed identical - both
+    grammars literally call it "function_declaration" - so the two
+    fallbacks below must not gate on that type name (an earlier merge of
+    these two independently-developed fallbacks did exactly that, which
+    would have silently broken Kotlin's params by always taking Swift's
+    branch first and returning early). Ordered by trying each fallback's
+    own node shape in turn instead: Kotlin's function_value_parameters
+    child is looked for first (absent on a Swift node, so harmless there),
+    and only if that comes up empty does the bare "(...)" token scan run.
     """
     params_node = enclosing_node.child_by_field_name("parameters")
     if params_node is None:
@@ -153,6 +170,13 @@ def _params_text(source: bytes, enclosing_node: Node) -> str | None:
         params_node = next(
             (c for c in enclosing_node.children if c.type == "function_value_parameters"), None
         )
+    if params_node is None and enclosing_node.type == "function_declaration":
+        open_paren = next((c for c in enclosing_node.children if c.type == "("), None)
+        close_paren = next((c for c in reversed(enclosing_node.children) if c.type == ")"), None)
+        if open_paren is not None and close_paren is not None:
+            raw = source[open_paren.start_byte:close_paren.end_byte].decode(errors="ignore")
+            return " ".join(raw.split())
+        return None
     if params_node is None:
         return None
     raw = source[params_node.start_byte:params_node.end_byte].decode(errors="ignore")
@@ -595,6 +619,34 @@ def _extract_module_constants(node: Node, source: bytes, language: str) -> list[
                     )
                     if in_type_body or is_top_level(n):
                         add(lhs, n)
+        elif language == "swift":
+            # Only immutable ("let") bindings, at module scope or as a type's
+            # `static let` - matching the same deliberate restraint as Java's
+            # `static final`-only branch above (a mutable `static var` is a
+            # class-level field, not really a "constant", and top-level `var`
+            # is script-local mutable state, not a lookup-by-name API
+            # surface). Confirmed empirically: tree-sitter-swift always wraps
+            # a name in "property_declaration -> pattern -> simple_identifier"
+            # for both shapes.
+            if t == "property_declaration":
+                binding = next((c for c in n.children if c.type == "value_binding_pattern"), None)
+                is_let = binding is not None and any(c.type == "let" for c in binding.children)
+                modifiers = next((c for c in n.children if c.type == "modifiers"), None)
+                is_static = modifiers is not None and any(
+                    mc.type == "property_modifier" and any(c.type == "static" for c in mc.children)
+                    for mc in modifiers.children
+                )
+                is_public = modifiers is not None and any(
+                    mc.type == "visibility_modifier" and any(c.type in ("public", "open") for c in mc.children)
+                    for mc in modifiers.children
+                )
+                if is_let and (is_static or is_top_level(n)):
+                    pattern = next((c for c in n.children if c.type == "pattern"), None)
+                    nm = next(
+                        (c for c in pattern.children if c.type == "simple_identifier"), None
+                    ) if pattern is not None else None
+                    if nm is not None:
+                        add(nm, n, public=is_public)
         elif language == "php":
             if t == "const_declaration":
                 for child in n.named_children:
@@ -1704,6 +1756,255 @@ def _resolve_java_import(
     return [], False
 
 
+def _leading_swift_doc_comment(source: bytes, enclosing_node: Node) -> str | None:
+    """Swift's dominant doc-comment convention (DocC): one or more contiguous
+    "///" line comments immediately above the declaration, no blank line in
+    between - same rule as Rust's "///", not Go's plainer "//". Confirmed
+    empirically that tree-sitter-swift's "comment" node span ends on its own
+    content row (matches Go's adjacency arithmetic, not Rust's off-by-one).
+    """
+    lines: list[str] = []
+    node = enclosing_node.prev_sibling
+    expected_end_row = enclosing_node.start_point[0] - 1
+    while node is not None and node.type == "comment" and node.end_point[0] == expected_end_row:
+        raw = source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
+        if not raw.startswith("///"):
+            break
+        lines.append(raw[3:].strip())
+        expected_end_row = node.start_point[0] - 1
+        node = node.prev_sibling
+
+    if not lines:
+        return None
+    lines.reverse()
+    return "\n".join(lines) or None
+
+
+def _swift_return_type(source: bytes, enclosing_node: Node) -> str | None:
+    node = enclosing_node.child_by_field_name("return_type")
+    if node is None:
+        return None
+    return source[node.start_byte:node.end_byte].decode(errors="ignore").strip()
+
+
+def _swift_is_public(node: Node) -> bool:
+    """Real visibility, read from Swift's own access-level keywords.
+
+    Absent any modifier, Swift's actual default is `internal` - visible
+    within the same module/target but NOT across a module boundary the way
+    `public`/`open` are. Since this field feeds cross-target import
+    resolution (see _resolve_swift_import) as well as docs filtering, the
+    correct default here is False, not True - an `internal` symbol is real
+    but not part of what another target can actually see.
+    """
+    modifiers = next((c for c in node.children if c.type == "modifiers"), None)
+    if modifiers is None:
+        return False
+    return any(
+        c.type == "visibility_modifier" and any(gc.type in ("public", "open") for gc in c.children)
+        for c in modifiers.children
+    )
+
+
+def _extract_swift(node: Node, source: bytes) -> tuple[list[str], list[dict], list[dict]]:
+    """Return imported module names, function names, and type names.
+
+    Unlike every other extractor here, "imports" is flat module-name
+    strings, not paths or dotted specs - a Swift `import Foo` names a whole
+    compiled target, not a file, so there is nothing more specific to
+    extract at this stage; _resolve_swift_import does the whole-target
+    fan-out. A submodule-qualified import ("import UIKit.UIView") only
+    keeps the first (module) segment - the vast majority of real imports
+    are unqualified, and the qualifier never names anything this scanner
+    could resolve differently anyway.
+    """
+    imports: list[str] = []
+    functions: list[dict] = []
+    types: list[dict] = []
+
+    def text(n: Node) -> str:
+        return source[n.start_byte:n.end_byte].decode(errors="ignore")
+
+    def walk(root: Node):
+        # Iterative, not recursive - see _extract_python's walk for why.
+        stack = [root]
+        while stack:
+            n = stack.pop()
+            if n.type == "import_declaration":
+                ident = next((c for c in n.children if c.type == "identifier"), None)
+                first_segment = next(
+                    (c for c in ident.children if c.type == "simple_identifier"), None
+                ) if ident is not None else None
+                if first_segment is not None:
+                    imports.append(text(first_segment))
+            elif n.type == "function_declaration":
+                name_node = n.child_by_field_name("name")
+                if name_node is not None:
+                    functions.append(_symbol_entry(
+                        source, name_node, n,
+                        docstring=_leading_swift_doc_comment(source, n),
+                        return_type=_swift_return_type(source, n),
+                        is_public=_swift_is_public(n),
+                    ))
+            elif n.type == "protocol_declaration":
+                name_node = n.child_by_field_name("name")
+                if name_node is not None:
+                    types.append(_symbol_entry(
+                        source, name_node, n,
+                        docstring=_leading_swift_doc_comment(source, n),
+                        is_public=_swift_is_public(n),
+                        is_pure_declaration=True,
+                    ))
+            elif n.type == "class_declaration":
+                # tree-sitter-swift uses this one node type for class, struct,
+                # AND enum - and also, confusingly, for `extension` (adding
+                # members to an EXISTING type, not declaring a new one), all
+                # distinguished only by the keyword token itself, found among
+                # the node's direct children rather than assumed to be the
+                # first one - a visibility `modifiers` node (e.g. `public
+                # class Foo`) sits before it when present (confirmed
+                # empirically). An extension's body is still walked below for
+                # its own function_declarations - real, often public API - it
+                # just doesn't get its own "type" entry here, since it isn't one.
+                keyword = next(
+                    (c.type for c in n.children if c.type in ("class", "struct", "enum", "extension")), None
+                )
+                if keyword in ("class", "struct", "enum"):
+                    name_node = n.child_by_field_name("name")
+                    if name_node is not None:
+                        types.append(_symbol_entry(
+                            source, name_node, n,
+                            docstring=_leading_swift_doc_comment(source, n),
+                            is_public=_swift_is_public(n),
+                        ))
+            stack.extend(reversed(n.children))
+
+    walk(node)
+    return imports, functions, types
+
+
+_SWIFT_TARGET_CALL_NAMES = {
+    "target", "executableTarget", "testTarget", "binaryTarget", "systemLibraryTarget", "macro", "plugin",
+}
+
+
+def _swift_call_arg_strings(call_expr: Node, source: bytes) -> dict[str, str]:
+    """label -> string-literal text for a `.someCall(label: "value", ...)`
+    call_expression's own labeled arguments - used to read Package.swift's
+    `.target(name: "...", path: "...")`-shaped declarations. Only
+    string-literal argument values are extracted; every real manifest
+    passes name:/path: as plain string literals.
+    """
+    result: dict[str, str] = {}
+    suffix = next((c for c in call_expr.children if c.type == "call_suffix"), None)
+    args = next((c for c in suffix.children if c.type == "value_arguments"), None) if suffix is not None else None
+    if args is None:
+        return result
+    for arg in args.children:
+        if arg.type != "value_argument":
+            continue
+        label_node = next((c for c in arg.children if c.type == "value_argument_label"), None)
+        label_id = next(
+            (c for c in label_node.children if c.type == "simple_identifier"), None
+        ) if label_node is not None else None
+        if label_id is None:
+            continue
+        label = source[label_id.start_byte:label_id.end_byte].decode(errors="ignore")
+        str_lit = next((c for c in arg.children if c.type == "line_string_literal"), None)
+        text_node = next(
+            (c for c in str_lit.children if c.type == "line_str_text"), None
+        ) if str_lit is not None else None
+        if text_node is not None:
+            result[label] = source[text_node.start_byte:text_node.end_byte].decode(errors="ignore")
+    return result
+
+
+def _parse_swift_package_manifest(repo_path: Path) -> dict[str, str]:
+    """Best-effort read of Package.swift for explicit target `path:`
+    overrides only - SwiftPM's own default (Sources/<Name>/, or a
+    Tests/<Name>/ test target) needs no manifest at all and is handled
+    entirely by directory-convention scanning in _infer_swift_targets; this
+    only matters for the minority of targets that actually override it.
+    Not a full Package.swift interpreter - that file is executable Swift,
+    not data - just a walk for the one call shape every real manifest uses
+    for this (`.target(name: "...", path: "...")` and its
+    executableTarget/testTarget/etc. siblings), never executed.
+    """
+    manifest = repo_path / "Package.swift"
+    if not manifest.is_file():
+        return {}
+    try:
+        source = manifest.read_bytes()
+    except OSError:
+        return {}
+    parser = Parser()
+    parser.language = SWIFT_LANGUAGE
+    tree = parser.parse(source)
+
+    overrides: dict[str, str] = {}
+    stack = [tree.root_node]
+    while stack:
+        n = stack.pop()
+        if n.type == "call_expression":
+            prefix = next((c for c in n.children if c.type == "prefix_expression"), None)
+            ident = next(
+                (c for c in prefix.children if c.type == "simple_identifier"), None
+            ) if prefix is not None else None
+            callee_name = source[ident.start_byte:ident.end_byte].decode(errors="ignore") if ident else None
+            if callee_name in _SWIFT_TARGET_CALL_NAMES:
+                call_args = _swift_call_arg_strings(n, source)
+                name, path_str = call_args.get("name"), call_args.get("path")
+                if name and path_str:
+                    overrides[name] = path_str
+        stack.extend(n.children)
+    return overrides
+
+
+def _infer_swift_targets(repo_path: Path, ignored_paths: list[str] | None) -> dict[str, list[Path]]:
+    """Whole-target file membership for Swift's import graph.
+
+    Unlike every other supported language, a Swift `import Foo` names a
+    compiled module, not a file - there is no source-level statement that
+    resolves to one specific file the way there is for Python/JS/Go/Java,
+    so an import edge has to fan out to every file belonging to that
+    target instead (see _resolve_swift_import). Two-tier: an explicit
+    `path:` override read from Package.swift (the minority case) takes
+    priority per target name; every other target - the large majority in a
+    real SwiftPM repo, which almost never overrides the default - falls
+    back to the convention itself: every direct subdirectory of Sources/
+    or Tests/ is its own target, named after that directory.
+    """
+    overrides = _parse_swift_package_manifest(repo_path)
+    targets: dict[str, list[Path]] = {}
+
+    def add_dir_as_target(name: str, target_dir: Path) -> None:
+        if not target_dir.is_dir():
+            return
+        files = [
+            p for p in target_dir.rglob("*.swift")
+            if not is_ignored(_rel(repo_path, p), ignored_paths or [])
+        ]
+        if files:
+            targets.setdefault(name, []).extend(files)
+
+    for name, rel_path in overrides.items():
+        add_dir_as_target(name, repo_path / rel_path)
+
+    for parent_name in ("Sources", "Tests"):
+        parent = repo_path / parent_name
+        if not parent.is_dir():
+            continue
+        for child in parent.iterdir():
+            if child.is_dir() and child.name not in overrides:
+                add_dir_as_target(child.name, child)
+
+    return targets
+
+
+def _resolve_swift_import(swift_target_files: dict[str, list[Path]], module_name: str) -> list[Path]:
+    return swift_target_files.get(module_name, [])
+
+
 def _leading_ruby_doc_comment(source: bytes, enclosing_node: Node) -> str | None:
     """Ruby has no compiler-enforced doc-comment syntax (RDoc/YARD are
     tooling conventions, not grammar) - the de facto convention this
@@ -2606,6 +2907,7 @@ def _extract_module(
     csharp_prefix_map: dict[str, Path] | None = None,
     csharp_type_owners: dict[str, set[Path]] | None = None,
     csharp_implicit_usings: dict[Path, list[str]] | None = None,
+    swift_target_files: dict[str, list[Path]] | None = None,
 ) -> dict:
     """Turns one already-parsed (tree, source) into a module dict - the
     per-language dispatch every file eventually goes through, whether it
@@ -2761,6 +3063,13 @@ def _extract_module(
                 resolved_imports.append(target)
                 if type_ref_ambiguous:
                     import_confidence[target] = "ambiguous"
+    elif language_name == "swift":
+        raw_imports, functions, classes = _extract_swift(tree.root_node, source)
+        for module_name in raw_imports:
+            for target_path in _resolve_swift_import(swift_target_files or {}, module_name):
+                target = _rel(repo_path, target_path)
+                if target is not None and target != rel_path:
+                    resolved_imports.append(target)
     else:
         raw_imports, functions, classes = _extract_javascript(tree.root_node, source)
         for spec in raw_imports:
@@ -3128,6 +3437,12 @@ def build_module_graph(
             csharp_type_owners.setdefault(declared, set()).add(path)
     csharp_implicit_usings = _load_csharp_implicit_usings(repo_path, csharp_source_paths)
 
+    # Swift needs no per-file pre-parse the way Java/C# do - target membership
+    # is directory/manifest-derived (see _infer_swift_targets), not read off
+    # each file's own declarations - so this is a single cheap call, not a
+    # per-file loop.
+    swift_target_files = _infer_swift_targets(repo_path, ignored_paths)
+
     parser = Parser()
     # Non-java/kotlin/csharp files still needing a fresh parse - collected
     # here instead of being parsed inline, so they can go through the
@@ -3164,7 +3479,7 @@ def build_module_graph(
             unparseable.append({"path": rel_path, "reason": "file exceeds size limit"})
             continue
 
-        if language_name in ("java", "kotlin", "csharp"):
+        if language_name in ("java", "kotlin", "csharp", "swift"):
             # Re-parsed here rather than reusing a tree the pre-pass above
             # held onto - see that pre-pass's own comment (audit finding
             # 15). The pre-pass already had to parse every .java/.kt/.cs
@@ -3172,6 +3487,12 @@ def build_module_graph(
             # could have a source root inferred at all; this is
             # deliberately a second parse per file, trading CPU for never
             # holding more than about one file's tree in memory at a time.
+            # Swift never needed a per-file pre-parse in the first place
+            # (see swift_target_files above) but is processed here too,
+            # serially in-process, for the same reason the others are: the
+            # worker pool below has no java_source_roots/kotlin_source_roots/
+            # csharp_prefix_map/swift_target_files to resolve any of these
+            # four languages' imports with.
             parser.language = ts_language
             source = path.read_bytes()
             tree = parser.parse(source)
@@ -3191,6 +3512,7 @@ def build_module_graph(
                 csharp_prefix_map=csharp_prefix_map,
                 csharp_type_owners=csharp_type_owners,
                 csharp_implicit_usings=csharp_implicit_usings,
+                swift_target_files=swift_target_files,
             )
         )
 

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -240,6 +240,10 @@ _FUNCTION_LIKE_NODE_TYPES = frozenset({
     "anonymous_function",  # PHP: `function(){}` (PHP's `fn() =>` is the
     # same "arrow_function" type name already listed above for JS/TS -
     # no separate entry needed, one shared set, no cross-grammar collision)
+    "lambda_literal",  # Kotlin AND Swift's closure node - both grammars use
+    # this exact name (confirmed empirically, not assumed - checked no
+    # other already-supported grammar uses it first, the same way "block"
+    # below was checked and excluded for colliding with Python's).
     #
     # Deliberately NOT here: Ruby's plain `{...}` block, node type
     # "block" - confirmed empirically to be the exact same type name

--- a/src/aletheore/schema_map.py
+++ b/src/aletheore/schema_map.py
@@ -5,7 +5,7 @@ foreign-key relations, and indexes a repository's migrations define, each
 resolving to the file:line that introduced it.
 
 Why a hand-written tokenizer rather than a grammar: the scanner ships no SQL
-grammar (LANGUAGE_BY_EXTENSION covers 11 languages, none of them SQL), and
+grammar (LANGUAGE_BY_EXTENSION covers 13 languages, none of them SQL), and
 adding one would put a dialect-fragile dependency in the free CLI's install
 path while still leaving the ALTER-replay logic to be written by hand. This
 mirrors endpoints.py, which is purpose-built per-framework extraction for the

--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -246,6 +246,56 @@ def _maven_resolve_property(version: str | None, properties: dict[str, str]) -> 
     return version.strip()
 
 
+def _swift_package_url_to_osv_name(location: str) -> str | None:
+    """OSV.dev's Swift ecosystem ("SwiftURL", confirmed empirically against
+    the live API - "SwiftPM" is not a valid ecosystem name there, despite
+    being the more obvious guess) identifies a package by its normalized
+    source URL, not a short name - e.g. "github.com/apple/swift-nio", not
+    "swift-nio". Strips the scheme and a trailing ".git", the only two
+    things Package.resolved's "location" field carries that OSV's own
+    package.name values never do (confirmed by querying a real published
+    advisory for apple/swift-nio and matching its exact "name" field).
+    """
+    url = location.strip()
+    url = re.sub(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", "", url)
+    url = url.rstrip("/")
+    if url.endswith(".git"):
+        url = url[: -len(".git")]
+    return url or None
+
+
+def _parse_swift_package_resolved_pins(repo_path: Path) -> list[tuple[str, str, str]]:
+    resolved = repo_path / "Package.resolved"
+    if not resolved.exists():
+        return []
+    try:
+        data = json.loads(resolved.read_text(encoding="utf-8", errors="ignore"))
+    except json.JSONDecodeError:
+        return []
+    # Schema v1 (older toolchains) nests pins under "object"; v2+ (current)
+    # has them at the top level - confirmed against a real, current
+    # Package.resolved (vapor/penny-bot, schema v3).
+    raw_pins = data.get("pins")
+    if raw_pins is None:
+        raw_pins = data.get("object", {}).get("pins", [])
+    pins = []
+    for pin in raw_pins:
+        identity = pin.get("identity")
+        location = pin.get("location") or pin.get("repositoryURL")
+        state = pin.get("state") or {}
+        version = state.get("version")
+        # A branch/revision-pinned dependency (no released version, e.g.
+        # DiscordBM tracking "main" in penny-bot's own real Package.resolved)
+        # has nothing a CVE advisory's SEMVER range could ever match against
+        # - skipped rather than guessed at.
+        if not identity or not location or not version:
+            continue
+        osv_name = _swift_package_url_to_osv_name(location)
+        if osv_name:
+            pins.append((osv_name, version, "SwiftURL"))
+    return pins
+
+
 def _parse_maven_pom(pom: Path, seen: set[Path]) -> list[tuple[str, str, str]]:
     if not pom.exists():
         return []
@@ -732,6 +782,7 @@ def check_vulnerabilities(
         + _parse_composer_pins(repo_path)
         + _parse_nuget_pins(repo_path)
         + _parse_gradle_pins(repo_path)
+        + _parse_swift_package_resolved_pins(repo_path)
     )
     if not pins:
         return {"checked": True, "reason": None, "findings": []}

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "tree-sitter-c>=0.24,<0.25",
     "tree-sitter-cpp>=0.23,<0.24",
     "tree-sitter-c-sharp>=0.23,<0.24",
+    "tree-sitter-swift>=0.7,<0.8",
     "anthropic>=0.40,<2.0",
     "certifi>=2024.0.0",
     "httpx>=0.28.1,<1.0",

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -32,6 +32,28 @@ def test_test_files_are_never_unreachable(tmp_path):
     assert result["unreachable_modules"] == []
 
 
+def test_capitalized_test_directory_is_never_unreachable(tmp_path):
+    # SwiftPM/Xcode universally capitalize the test directory ("Tests/") -
+    # real repo confirmed: every test file in apple/swift-algorithms lives
+    # under "Tests/", which the previously case-sensitive pattern silently
+    # missed entirely (only matched lowercase "test"/"tests"/"__tests__").
+    modules = [_module("Tests/SwiftAlgorithmsTests/ChainTests.swift")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_package_swift_manifest_is_never_unreachable(tmp_path):
+    # Real repo confirmed (apple/swift-algorithms): Package.swift parses as
+    # a legitimate module now that Swift is a supported language - it's the
+    # build manifest itself, read by the SwiftPM toolchain, not imported by
+    # any of the repo's own application code, same category as manage.py/
+    # wsgi.py/conftest.py above.
+    modules = [_module("Package.swift")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "Package.swift" in result["entry_points_detected"]
+
+
 def test_config_can_add_custom_entry_points(tmp_path):
     modules = [_module("app/worker.py")]
     config = {"dead_code_entry_points": ["app/worker.py"]}

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -13,6 +13,7 @@ from aletheore.endpoints import (
     _extract_laravel_routes,
     _extract_rails_routes,
     _extract_spring_boot_routes,
+    _extract_vapor_routes,
     map_api_endpoints,
 )
 from aletheore.scanner.graph import (
@@ -25,6 +26,7 @@ from aletheore.scanner.graph import (
     PY_LANGUAGE,
     RUBY_LANGUAGE,
     RUST_LANGUAGE,
+    SWIFT_LANGUAGE,
 )
 
 
@@ -38,6 +40,13 @@ def parse_python(source: str):
 def parse_js(source: str):
     parser = Parser()
     parser.language = JS_LANGUAGE
+    tree = parser.parse(source.encode())
+    return tree.root_node, source.encode()
+
+
+def parse_swift(source: str):
+    parser = Parser()
+    parser.language = SWIFT_LANGUAGE
     tree = parser.parse(source.encode())
     return tree.root_node, source.encode()
 
@@ -824,6 +833,83 @@ def test_extract_axum_nest_is_unresolved():
             "note": None,
         }
     ]
+
+
+def test_extract_vapor_route_with_trailing_closure():
+    root, source = parse_swift(
+        'app.get("hello") { req async throws -> String in\n'
+        '    return "Hello, world!"\n'
+        "}\n"
+    )
+
+    entries = _extract_vapor_routes(root, source, "routes.swift")
+
+    assert entries == [
+        {
+            "method": "GET",
+            "path": "/hello",
+            "framework": "vapor",
+            "file": "routes.swift",
+            "line": 1,
+            "handler": "<inline handler>",
+            "unresolved": False,
+            "note": None,
+        }
+    ]
+
+
+def test_extract_vapor_route_with_use_labeled_handler_and_multi_segment_path():
+    root, source = parse_swift('app.get("users", ":id", use: getUserHandler)\n')
+
+    entries = _extract_vapor_routes(root, source, "routes.swift")
+
+    assert entries == [
+        {
+            "method": "GET",
+            "path": "/users/:id",
+            "framework": "vapor",
+            "file": "routes.swift",
+            "line": 1,
+            "handler": "getUserHandler",
+            "unresolved": False,
+            "note": None,
+        }
+    ]
+
+
+def test_extract_vapor_route_on_grouped_sub_router():
+    # A route group ("api.get(...)" where api = app.grouped("api")) is
+    # caught the same way Express's mounted sub-routers are: by matching
+    # the verb/shape, not by tracking what `api` was actually assigned from.
+    root, source = parse_swift(
+        'let api = app.grouped("api")\n'
+        'api.get("health") { req in "ok" }\n'
+    )
+
+    entries = _extract_vapor_routes(root, source, "routes.swift")
+
+    assert entries == [
+        {
+            "method": "GET",
+            "path": "/health",
+            "framework": "vapor",
+            "file": "routes.swift",
+            "line": 2,
+            "handler": "<inline handler>",
+            "unresolved": False,
+            "note": None,
+        }
+    ]
+
+
+def test_extract_vapor_ignores_unrelated_get_calls_without_closure_or_handler():
+    # someDict.get("key") - a real, extremely common shape with no trailing
+    # closure and no use: label, so it must not be misidentified as a route.
+    root, source = parse_swift('let value = someDict.get("key")\n')
+
+    entries = _extract_vapor_routes(root, source, "utils.swift")
+
+    assert entries == []
 
 
 def test_extract_spring_get_mapping():

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -235,10 +235,10 @@ def test_build_module_graph_dependency_edges(tmp_path):
 def test_build_module_graph_records_unparseable_files(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "helper.swift").write_text("func hi() {}\n")
+    (repo / "helper.scala").write_text("def hi(): Unit = {}\n")
     modules, _, unparseable = build_module_graph(repo)
     assert modules == []
-    assert unparseable == [{"path": "helper.swift", "reason": "no grammar registered for .swift"}]
+    assert unparseable == [{"path": "helper.scala", "reason": "no grammar registered for .scala"}]
 
 
 def test_build_module_graph_extracts_javascript_imports(tmp_path):

--- a/src/tests/test_graph_swift.py
+++ b/src/tests/test_graph_swift.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from aletheore.scanner.graph import build_module_graph
+from aletheore.scanner.graph import _infer_xcodeproj_swift_targets, build_module_graph
 from conftest import symbol_names
 
 
@@ -161,3 +161,96 @@ def test_build_module_graph_swift_target_path_override_from_package_manifest(tmp
     edges = {tuple(edge) for edge in dependency_graph["edges"]}
 
     assert ("Sources/App/Main.swift", "Vendor/StoreImpl/User.swift") in edges
+
+
+def _pbxproj_text(objects_body: str) -> bytes:
+    # Real key/isa names throughout, matching what a real project.pbxproj
+    # actually contains (verified against wordpress-mobile/WordPress-iOS,
+    # a real, large, modern multi-target app, objectVersion 77) - not an
+    # invented shape.
+    return (
+        "// !$*UTF8*$!\n"
+        "{\n"
+        "\tarchiveVersion = 1;\n"
+        "\tobjectVersion = 77;\n"
+        "\tobjects = {\n" + objects_body + "\t};\n"
+        "\trootObject = ROOT;\n"
+        "}\n"
+    ).encode()
+
+
+def make_xcodeproj_repo(tmp_path: Path) -> Path:
+    # A real, minimal shape of a two-target Xcode app: "App" (classic
+    # PBXSourcesBuildPhase -> PBXBuildFile -> PBXFileReference chain) and
+    # "Widgets" (the modern Xcode 16 fileSystemSynchronizedGroups
+    # mechanism, no per-file PBXBuildFile entries at all) - both confirmed
+    # real against WordPress-iOS's own "WordPress" target, which uses both
+    # at once.
+    repo = tmp_path / "repo"
+    proj = repo / "App.xcodeproj"
+    proj.mkdir(parents=True)
+    (repo / "App").mkdir()
+    (repo / "App" / "Main.swift").write_text("import Widgets\n\nlet w = WidgetKit()\n")
+    (repo / "Widgets").mkdir()
+    (repo / "Widgets" / "WidgetKit.swift").write_text("public class WidgetKit {}\n")
+
+    (proj / "project.pbxproj").write_bytes(
+        _pbxproj_text(
+            "\t\tAPPTARGET /* App */ = {\n"
+            "\t\t\tisa = PBXNativeTarget;\n"
+            "\t\t\tbuildPhases = (\n"
+            "\t\t\t\tSOURCESPHASE /* Sources */,\n"
+            "\t\t\t);\n"
+            "\t\t\tname = App;\n"
+            "\t\t};\n"
+            "\t\tWIDGETTARGET /* Widgets */ = {\n"
+            "\t\t\tisa = PBXNativeTarget;\n"
+            "\t\t\tfileSystemSynchronizedGroups = (\n"
+            "\t\t\t\tSYNCGROUP /* Widgets */,\n"
+            "\t\t\t);\n"
+            "\t\t\tname = Widgets;\n"
+            "\t\t};\n"
+            "\t\tSOURCESPHASE /* Sources */ = {\n"
+            "\t\t\tisa = PBXSourcesBuildPhase;\n"
+            "\t\t\tfiles = (\n"
+            "\t\t\t\tBUILDFILE /* Main.swift in Sources */,\n"
+            "\t\t\t);\n"
+            "\t\t};\n"
+            "\t\tBUILDFILE /* Main.swift in Sources */ = {\n"
+            "\t\t\tisa = PBXBuildFile;\n"
+            "\t\t\tfileRef = FILEREF /* Main.swift */;\n"
+            "\t\t};\n"
+            "\t\tFILEREF /* Main.swift */ = {\n"
+            "\t\t\tisa = PBXFileReference;\n"
+            "\t\t\tpath = Main.swift;\n"
+            "\t\t\tsourceTree = \"<group>\";\n"
+            "\t\t};\n"
+            "\t\tSYNCGROUP /* Widgets */ = {\n"
+            "\t\t\tisa = PBXFileSystemSynchronizedRootGroup;\n"
+            "\t\t\tpath = Widgets;\n"
+            "\t\t\tsourceTree = \"<group>\";\n"
+            "\t\t};\n"
+        )
+    )
+    return repo
+
+
+def test_infer_xcodeproj_swift_targets_resolves_both_real_mechanisms(tmp_path):
+    repo = make_xcodeproj_repo(tmp_path)
+
+    targets = _infer_xcodeproj_swift_targets(repo, None)
+
+    assert targets["App"] == [repo / "App" / "Main.swift"]
+    assert targets["Widgets"] == [repo / "Widgets" / "WidgetKit.swift"]
+
+
+def test_build_module_graph_resolves_cross_target_xcodeproj_import(tmp_path):
+    # The end-to-end case that used to be a documented, deliberately unfixed
+    # gap: a multi-target .xcodeproj app (no SwiftPM Sources/ structure at
+    # all) importing across its own targets.
+    repo = make_xcodeproj_repo(tmp_path)
+
+    _modules, dependency_graph, _unparseable = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert ("App/Main.swift", "Widgets/WidgetKit.swift") in edges

--- a/src/tests/test_graph_swift.py
+++ b/src/tests/test_graph_swift.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+
+from aletheore.scanner.graph import build_module_graph
+from conftest import symbol_names
+
+
+def make_swift_repo(tmp_path: Path) -> Path:
+    # Mirrors a real SwiftPM package layout: one Package.swift manifest at
+    # the root, each target's sources under Sources/<TargetName>/ (the
+    # default SwiftPM convention when a target declares no explicit
+    # `path:`). Handlers depends on both Store and Logging; App (the
+    # executable target) depends on Handlers and Store directly.
+    repo = tmp_path / "repo"
+    sources = repo / "Sources"
+    (sources / "Logging").mkdir(parents=True)
+    (sources / "Store").mkdir(parents=True)
+    (sources / "Handlers").mkdir(parents=True)
+    (sources / "App").mkdir(parents=True)
+
+    (repo / "Package.swift").write_text(
+        "// swift-tools-version:5.9\n"
+        "import PackageDescription\n\n"
+        "let package = Package(\n"
+        '    name: "ExampleApp",\n'
+        "    targets: [\n"
+        '        .target(name: "Logging"),\n'
+        '        .target(name: "Store"),\n'
+        '        .target(name: "Handlers", dependencies: ["Store", "Logging"]),\n'
+        '        .executableTarget(name: "App", dependencies: ["Handlers", "Store"]),\n'
+        "    ]\n"
+        ")\n"
+    )
+
+    (sources / "Logging" / "Logger.swift").write_text(
+        "/// Prefixes every message with a fixed tag.\n"
+        "public class Logger {\n"
+        "    private var prefix: String\n\n"
+        "    public init(prefix: String) {\n"
+        "        self.prefix = prefix\n"
+        "    }\n\n"
+        "    /// Prints `msg` prefixed with this logger's tag.\n"
+        "    public func info(msg: String) {\n"
+        '        print("\\(self.prefix): \\(msg)")\n'
+        "    }\n"
+        "}\n"
+    )
+    (sources / "Store" / "User.swift").write_text(
+        "public struct User {\n"
+        "    public var id: Int\n"
+        "    public var name: String\n"
+        "}\n"
+    )
+    (sources / "Store" / "Store.swift").write_text(
+        "public class Store {\n"
+        "    private var users: [Int: User] = [:]\n\n"
+        "    public func get(id: Int) -> User? {\n"
+        "        return users[id]\n"
+        "    }\n"
+        "}\n"
+    )
+    (sources / "Handlers" / "Handler.swift").write_text(
+        "import Store\n"
+        "import Logging\n\n"
+        "public class Handler {\n"
+        "    private var store: Store\n"
+        "    private var logger: Logger\n\n"
+        "    public init(store: Store, logger: Logger) {\n"
+        "        self.store = store\n"
+        "        self.logger = logger\n"
+        "    }\n\n"
+        "    public func getUser(id: Int) {\n"
+        '        self.logger.info(msg: "fetching user")\n'
+        "        let u = self.store.get(id: id)\n"
+        "    }\n\n"
+        "    private func internalOnly() {}\n"
+        "}\n"
+    )
+    (sources / "App" / "Main.swift").write_text(
+        "import Handlers\n"
+        "import Store\n\n"
+        "let store = Store()\n"
+        'let logger = Logger(prefix: "server")\n'
+        "let handler = Handler(store: store, logger: logger)\n"
+        "handler.getUser(id: 1)\n"
+    )
+    return repo
+
+
+def test_build_module_graph_extracts_swift_symbols(tmp_path):
+    repo = make_swift_repo(tmp_path)
+    modules, _dependency_graph, unparseable = build_module_graph(repo)
+
+    by_path = {m["path"]: m for m in modules}
+    handler = by_path["Sources/Handlers/Handler.swift"]
+    assert handler["language"] == "swift"
+    assert "Handler" in symbol_names(handler["symbols"]["classes"])
+    assert "getUser" in symbol_names(handler["symbols"]["functions"])
+
+    get_user_fn = next(f for f in handler["symbols"]["functions"] if f["name"] == "getUser")
+    assert get_user_fn["params"] == "(id: Int)"
+    assert get_user_fn["is_public"] is True
+
+    internal_fn = next(f for f in handler["symbols"]["functions"] if f["name"] == "internalOnly")
+    assert internal_fn["is_public"] is False
+
+    handler_cls = next(c for c in handler["symbols"]["classes"] if c["name"] == "Handler")
+    assert handler_cls["params"] is None
+
+    logger = by_path["Sources/Logging/Logger.swift"]
+    info_fn = next(f for f in logger["symbols"]["functions"] if f["name"] == "info")
+    assert info_fn["docstring"] == "Prints `msg` prefixed with this logger's tag."
+
+    assert unparseable == []
+
+
+def test_build_module_graph_swift_import_resolves_to_whole_target(tmp_path):
+    # A Swift `import Store` names a whole compiled module, not one file -
+    # unlike every per-file-resolving language (Python/JS/Go/Java), it must
+    # fan out to every source file belonging to that target, the same way
+    # Java's wildcard imports already do for a whole package.
+    repo = make_swift_repo(tmp_path)
+    _modules, dependency_graph, _unparseable = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert ("Sources/Handlers/Handler.swift", "Sources/Store/User.swift") in edges
+    assert ("Sources/Handlers/Handler.swift", "Sources/Store/Store.swift") in edges
+    assert ("Sources/Handlers/Handler.swift", "Sources/Logging/Logger.swift") in edges
+
+    assert ("Sources/App/Main.swift", "Sources/Handlers/Handler.swift") in edges
+    assert ("Sources/App/Main.swift", "Sources/Store/User.swift") in edges
+    assert ("Sources/App/Main.swift", "Sources/Store/Store.swift") in edges
+
+
+def test_build_module_graph_swift_target_path_override_from_package_manifest(tmp_path):
+    # Package.swift can override a target's default Sources/<Name>/ location
+    # via an explicit `path:` argument - a real SwiftPM feature, not an edge
+    # case invented for this test (e.g. legacy repos migrating layouts).
+    # Accuracy here means actually reading that override, not just assuming
+    # the convention always holds.
+    repo = tmp_path / "repo"
+    custom = repo / "Vendor" / "StoreImpl"
+    other = repo / "Sources" / "App"
+    custom.mkdir(parents=True)
+    other.mkdir(parents=True)
+
+    (repo / "Package.swift").write_text(
+        "// swift-tools-version:5.9\n"
+        "import PackageDescription\n\n"
+        "let package = Package(\n"
+        '    name: "Ex",\n'
+        "    targets: [\n"
+        '        .target(name: "Store", path: "Vendor/StoreImpl"),\n'
+        '        .executableTarget(name: "App", dependencies: ["Store"]),\n'
+        "    ]\n"
+        ")\n"
+    )
+    (custom / "User.swift").write_text("public struct User {\n    public var id: Int\n}\n")
+    (other / "Main.swift").write_text("import Store\n\nlet u = User(id: 1)\n")
+
+    _modules, dependency_graph, _unparseable = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert ("Sources/App/Main.swift", "Vendor/StoreImpl/User.swift") in edges

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -493,6 +493,56 @@ def test_fetch_swift_license_skips_non_github_hosts():
     assert _fetch_swift_license("gitlab.com/example/pkg", "1.0.0", timeout=10) is None
 
 
+def test_check_dependency_licenses_does_not_hang_on_one_slow_drip_registry_response(tmp_path):
+    # Real production incident, reproduced: a registry response that drips
+    # data slowly enough that no single blocking read ever idles past the
+    # per-socket-operation `timeout` never raises a timeout error at all -
+    # confirmed live (three real npm packages stalled dependency-license
+    # checks for 1+ hour before their job was forcibly reaped). The fix is
+    # a wall-clock cap independent of the socket-level timeout, submitted
+    # per-future (not executor.map, whose ordered iterator would otherwise
+    # block every result behind the stuck one).
+    import time
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"dependencies": {"slow-pkg": "1.0.0", "fast-pkg": "1.0.0"}})
+    )
+
+    fast_response = _mock_response({"license": "MIT"})
+
+    def urlopen_side_effect(request, timeout=None, context=None):
+        if "slow-pkg" in request.full_url:
+            time.sleep(2)  # far longer than the patched wall-clock cap below
+            return fast_response
+        return fast_response
+
+    start = time.monotonic()
+    with (
+        patch("aletheore.licenses.urllib.request.urlopen", side_effect=urlopen_side_effect),
+        patch("aletheore.licenses.LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS", 0.2),
+    ):
+        result = check_dependency_licenses(repo)
+    elapsed = time.monotonic() - start
+
+    # Real proof of the fix, not just "it returned something": returning in
+    # well under the 2s simulated hang means this function did not wait for
+    # the stuck future, and fast-pkg's already-available result still made
+    # it into the findings despite slow-pkg being stuck ahead of it.
+    assert elapsed < 1.5
+    findings_by_package = {f["package"]: f for f in result["findings"]}
+    # slow-pkg times out - reported as "unknown" (graceful degradation, the
+    # same outcome any other unresolvable license lookup already gets), not
+    # silently dropped and not left hanging.
+    assert findings_by_package["slow-pkg"]["category"] == "unknown"
+    # fast-pkg's MIT license resolved correctly despite being submitted
+    # after the stuck slow-pkg - the real proof this isn't executor.map's
+    # ordered-blocking behavior anymore. Permissive licenses aren't
+    # findings at all, so its absence here is the correct, positive signal.
+    assert "fast-pkg" not in findings_by_package
+
+
 def test_check_dependency_licenses_reports_a_rust_dependency(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -451,6 +451,48 @@ def test_fetch_crates_license_reads_version_license_field():
     assert result == "MIT OR Apache-2.0"
 
 
+def test_fetch_swift_license_reads_spdx_id_from_real_response_shape():
+    from aletheore.licenses import _fetch_swift_license
+
+    # Real response shape from GitHub's Contents API license endpoint,
+    # confirmed live against api.github.com/repos/swift-server/async-http-client/license.
+    response = _mock_response({"license": {"spdx_id": "Apache-2.0"}})
+
+    with patch("aletheore.licenses.urllib.request.urlopen", return_value=response):
+        result = _fetch_swift_license("github.com/swift-server/async-http-client", "1.36.0", timeout=10)
+
+    assert result == "Apache-2.0"
+
+
+def test_fetch_swift_license_falls_back_past_a_404_tag_to_the_default_branch():
+    from aletheore.licenses import _fetch_swift_license
+
+    not_found = urllib.error.HTTPError(url="", code=404, msg="Not Found", hdrs=None, fp=None)
+    success = _mock_response({"license": {"spdx_id": "MIT"}})
+
+    with patch("aletheore.licenses.urllib.request.urlopen", side_effect=[not_found, not_found, success]):
+        result = _fetch_swift_license("github.com/example/pkg", "2.0.0", timeout=10)
+
+    assert result == "MIT"
+
+
+def test_fetch_swift_license_treats_noassertion_as_unknown():
+    from aletheore.licenses import _fetch_swift_license
+
+    response = _mock_response({"license": {"spdx_id": "NOASSERTION"}})
+
+    with patch("aletheore.licenses.urllib.request.urlopen", return_value=response):
+        result = _fetch_swift_license("github.com/example/pkg", "1.0.0", timeout=10)
+
+    assert result is None
+
+
+def test_fetch_swift_license_skips_non_github_hosts():
+    from aletheore.licenses import _fetch_swift_license
+
+    assert _fetch_swift_license("gitlab.com/example/pkg", "1.0.0", timeout=10) is None
+
+
 def test_check_dependency_licenses_reports_a_rust_dependency(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -493,6 +493,29 @@ def test_fetch_swift_license_skips_non_github_hosts():
     assert _fetch_swift_license("gitlab.com/example/pkg", "1.0.0", timeout=10) is None
 
 
+def test_fetch_swift_license_rejects_userinfo_trick_past_a_prefix_check(tmp_path):
+    # Real CodeQL finding (Incomplete URL substring sanitization) on this
+    # exact function: a plain name.startswith("github.com/") check doesn't
+    # rule out "github.com/@attacker.example/x" - the classic trusted-
+    # domain-as-userinfo trick - still passing it. `name` traces back to a
+    # scanned repo's own Package.resolved content, real untrusted input,
+    # not a value this codebase controls. Must be rejected outright, not
+    # reach urlopen at all.
+    from aletheore.licenses import _fetch_swift_license
+
+    with patch("aletheore.licenses.urllib.request.urlopen") as mock_urlopen:
+        result = _fetch_swift_license("github.com/@attacker.example/x", "1.0.0", timeout=10)
+
+    assert result is None
+    mock_urlopen.assert_not_called()
+
+
+def test_fetch_swift_license_rejects_extra_path_segments():
+    from aletheore.licenses import _fetch_swift_license
+
+    assert _fetch_swift_license("github.com/owner/repo/extra", "1.0.0", timeout=10) is None
+
+
 def test_check_dependency_licenses_does_not_hang_on_one_slow_drip_registry_response(tmp_path):
     # Real production incident, reproduced: a registry response that drips
     # data slowly enough that no single blocking read ever idles past the

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -264,6 +264,57 @@ def test_parse_cargo_pins_reads_package_tables(tmp_path):
     assert ("libc", "0.2.169", "crates.io") in pins
 
 
+def test_parse_swift_package_resolved_pins_reads_real_v2_schema(tmp_path):
+    # Real content from vapor/penny-bot's committed Package.resolved (schema
+    # v3, current format at time of writing) - not a hand-invented shape.
+    from aletheore.vulnerabilities import _parse_swift_package_resolved_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Package.resolved").write_text(
+        """{
+          "originHash" : "abc123",
+          "pins" : [
+            {
+              "identity" : "async-http-client",
+              "kind" : "remoteSourceControl",
+              "location" : "https://github.com/swift-server/async-http-client.git",
+              "state" : {
+                "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+                "version" : "1.36.0"
+              }
+            },
+            {
+              "identity" : "discordbm",
+              "kind" : "remoteSourceControl",
+              "location" : "https://github.com/DiscordBM/DiscordBM.git",
+              "state" : {
+                "branch" : "main",
+                "revision" : "b01d40baf434cc968b113ff44c9eecd40bfb6e9e"
+              }
+            }
+          ],
+          "version" : 3
+        }"""
+    )
+
+    pins = _parse_swift_package_resolved_pins(repo)
+
+    assert ("github.com/swift-server/async-http-client", "1.36.0", "SwiftURL") in pins
+    # DiscordBM tracks a branch, not a released version - no SEMVER range
+    # could ever match it, so it's correctly excluded rather than guessed at.
+    assert len(pins) == 1
+
+
+def test_parse_swift_package_resolved_pins_empty_when_no_manifest(tmp_path):
+    from aletheore.vulnerabilities import _parse_swift_package_resolved_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    assert _parse_swift_package_resolved_pins(repo) == []
+
+
 def test_parse_cargo_pins_empty_when_no_cargo_lock(tmp_path):
     from aletheore.vulnerabilities import _parse_cargo_pins
 

--- a/website/index.html
+++ b/website/index.html
@@ -46,7 +46,7 @@
       }
     ],
     "featureList": [
-      "Deterministic secret, vulnerability, and license scanning across 11 languages",
+      "Deterministic secret, vulnerability, and license scanning across 13 languages",
       "Dead code detection from real call-graph analysis",
       "Git hotspot intelligence",
       "Database and infrastructure detection",
@@ -195,7 +195,7 @@
           <h3>Security &amp; Dependencies</h3>
           <p>Secrets, vulnerable packages, licenses, infrastructure, database usage, and AI usage are detected before an audit is written.</p>
           <ul>
-            <li>11 language ecosystems</li>
+            <li>13 language ecosystems</li>
             <li>No fake coverage or invented signals</li>
             <li>Risk tied to code evidence</li>
           </ul>


### PR DESCRIPTION
## Summary
Full Swift language support, matching the other 11 supported languages - not just the dependency graph.

- **Scanner** (`src/aletheore/scanner/graph.py`): `tree-sitter-swift` registration, symbol extraction (functions, classes/structs/enums, protocols, extensions), constant extraction, real visibility (`public`/`open` vs `internal`/`private`/`fileprivate`). **Real whole-target import graph**, not a heuristic fallback - a Swift `import Foo` names a whole compiled target, not one file. `_infer_swift_targets` merges three sources: `Package.swift`'s real `path:` overrides (parsed as actual Swift source), the SwiftPM `Sources/<Name>/`/`Tests/<Name>/` convention, and - for apps with no SwiftPM structure at all - `project.pbxproj` parsed directly for real Xcode target membership (a minimal OpenStep-plist parser, since stdlib `plistlib` doesn't support that format; handles both the classic PBXBuildFile chain and Xcode 16's newer `fileSystemSynchronizedGroups` directory-sync mechanism). Verified by parsing a real, large, modern multi-target app (wordpress-mobile/WordPress-iOS, 685 objects, 15 real targets) directly.
- **Dead-code fix**: real-repo stress testing (not just the isolated scanner) surfaced every Swift test file and `Package.swift` itself being flagged as unreachable - fixed (case-insensitive test-dir matching, `Package.swift` added as a recognized entry point).
- **Endpoints** (`src/aletheore/endpoints.py`): Vapor route detection (`app.get("path") { ... }` / `app.get("path", use: handler)`), guarded against false positives from unrelated `.get()`/`.post()` calls on other Swift types.
- **Vulnerabilities + licenses**: `Package.resolved` parsing feeding both `vulnerabilities.py` (OSV.dev's real `SwiftURL` ecosystem, confirmed against a live advisory) and `licenses.py` (GitHub's Contents API license endpoint, since Swift has no centralized package-registry license API).

## Real-repo verification (not synthetic fixtures)
- **apple/swift-algorithms** (scanner + dead-code): 57/57 files parsed, 0 unparseable, 601 functions/119 types, 756 real cross-target edges. Dead-code false positives found and fixed on this same repo.
- **vapor/api-template** (endpoints): all 4 real routes extracted correctly (GET/POST/DELETE, inline-closure and `use:`-labeled member-expression handlers), 0 false positives.
- **vapor/penny-bot** (vulnerabilities + licenses, real `Package.resolved`, 46 pins): both checks completed successfully, 0 known vulnerabilities, 44/46 dependencies resolved to a real known license.
- **wordpress-mobile/WordPress-iOS** (multi-target Xcode import resolution): real `project.pbxproj` (685 objects, 15 targets) parsed correctly, both real target-membership mechanisms confirmed present and handled.
- **RepoWise comparison**: RepoWise's dead-code detection is structurally broken for Swift's whole-module semantics on the same real repo - flags ~51 of 57 files (including nearly all of `Sources/Algorithms/`, the actual library) as unreachable. Aletheore: 0 false positives after the fix.

## Test plan
- [x] `tests/test_graph_swift.py`, `tests/test_endpoints.py` (Vapor cases), `tests/test_vulnerabilities.py`/`tests/test_licenses.py` (Swift cases), `tests/test_dead_code.py` (capitalized test-dir + `Package.swift` entry-point cases)
- [x] Full suite: `python3 -m pytest` - 1453 passed
- [x] Real end-to-end runs via the full `aletheore scan` CLI (not just isolated function calls) against real repos, described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)