### PR TITLE
feat: Kotlin endpoint detection (Ktor) + Gradle manifest parsing

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -7,6 +7,7 @@ from aletheore.scanner.graph import (
     GO_LANGUAGE,
     JAVA_LANGUAGE,
     JS_LANGUAGE,
+    KOTLIN_LANGUAGE,
     PHP_LANGUAGE,
     PY_LANGUAGE,
     RUBY_LANGUAGE,
@@ -959,6 +960,119 @@ def _extract_spring_boot_routes(root: Node, source: bytes, rel_path: str) -> lis
     return entries
 
 
+_KTOR_VERB_METHODS = {"get", "post", "put", "delete", "patch", "head", "options"}
+
+# Ktor route-definition calls (route(...), routing { }, verb calls) are the
+# one Kotlin call_expression shape tests directly against real parsed
+# output (see _ktor_call_shape) - Gradle dependency calls in
+# vulnerabilities.py's _parse_gradle_kts_pins independently discovered the
+# same real fact about this grammar: call_expression has no "function"/
+# "arguments" field names at all, purely positional children. Confirmed
+# again here rather than assumed carried over.
+def _ktor_call_shape(node: Node, source: bytes) -> tuple[str, str | None, Node] | None:
+    """Recognizes `name { ... }` and `name("path") { ... }` - the two real
+    shapes every Ktor DSL call takes (routing { }, route("/x") { },
+    get { }, get("/x") { }, authenticate { }, and any other receiver-
+    lambda call, since Ktor's own routing DSL is just ordinary Kotlin
+    trailing-lambda syntax, not special grammar). Returns
+    (identifier_name, path_or_None, annotated_lambda_node), or None if
+    node isn't a call_expression shaped this way at all (e.g. a plain
+    function call with no trailing lambda, or an assignment).
+    """
+    if node.type != "call_expression":
+        return None
+    children = node.children
+    if len(children) != 2 or children[1].type != "annotated_lambda":
+        return None
+    head, lambda_node = children
+    if head.type == "identifier":
+        return source[head.start_byte:head.end_byte].decode(errors="ignore"), None, lambda_node
+    if head.type == "call_expression":
+        inner = head.children
+        if len(inner) == 2 and inner[0].type == "identifier" and inner[1].type == "value_arguments":
+            name = source[inner[0].start_byte:inner[0].end_byte].decode(errors="ignore")
+            path = None
+            named = inner[1].named_children
+            if named and named[0].type == "value_argument" and named[0].named_children:
+                value = named[0].named_children[0]
+                if value.type == "string_literal":
+                    content = next((c for c in value.children if c.type == "string_content"), None)
+                    if content is not None:
+                        path = source[content.start_byte:content.end_byte].decode(errors="ignore")
+            return name, path, lambda_node
+    return None
+
+
+def _ktor_join_path(prefix_stack: list[str], leaf: str | None) -> str:
+    segments = [seg.strip("/") for seg in (*prefix_stack, leaf) if seg]
+    return "/" + "/".join(segments) if segments else "/"
+
+
+def _extract_ktor_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
+    """Ktor's routing DSL has no special grammar of its own - `routing { }`,
+    `route("/x") { }`, and `get("/x") { }` are ordinary Kotlin calls with a
+    trailing lambda (see _ktor_call_shape), which is what makes this
+    different from every other framework already handled here: Spring's
+    shape is annotations (a fixed, closed vocabulary), Axum's is chained
+    combinators (a flat call chain) - Ktor's is arbitrary nesting depth of
+    the *same* call-with-lambda shape, where only real domain knowledge
+    (which identifiers are HTTP verbs vs. the path-prefixing `route` vs.
+    an unrelated pass-through wrapper like `authenticate { }`) distinguishes
+    a route definition from routing-adjacent scaffolding. Confirmed
+    against real, hand-verified Ktor code (parsed directly with
+    tree_sitter_kotlin, not assumed from documentation) - no real Ktor
+    server code was found in this project's own verification repo
+    (android/architecture-samples, a client app), so this specific
+    extractor's correctness rests on that direct grammar inspection plus
+    its own test fixtures, not a real third-party server repo.
+    """
+    entries: list[dict] = []
+
+    def walk(node: Node, prefix_stack: list[str]) -> None:
+        shape = _ktor_call_shape(node, source)
+        if shape is not None:
+            name, path, lambda_node = shape
+            lambda_literal = next((c for c in lambda_node.children if c.type == "lambda_literal"), None)
+            body = next((c for c in lambda_literal.children if c.type != "{" and c.type != "}"), lambda_literal) if lambda_literal else None
+            if name in _KTOR_VERB_METHODS:
+                entries.append(
+                    {
+                        "method": name.upper(),
+                        "path": _ktor_join_path(prefix_stack, path),
+                        "framework": "ktor",
+                        "file": rel_path,
+                        "line": node.start_point[0] + 1,
+                        "handler": "<lambda>",
+                        "unresolved": False,
+                        "note": None,
+                    }
+                )
+                if lambda_literal is not None:
+                    walk(lambda_literal, prefix_stack)
+                return
+            if name == "route":
+                new_stack = [*prefix_stack, path] if path else prefix_stack
+                if lambda_literal is not None:
+                    walk(lambda_literal, new_stack)
+                return
+            # Any other call-with-trailing-lambda (routing, authenticate,
+            # install, intercept, static, ...) is real routing-adjacent
+            # scaffolding, not a route itself and not a path prefix -
+            # recurse into its body with the prefix stack unchanged rather
+            # than either skipping it (would miss every route nested
+            # inside authenticate { }, a real, common pattern) or treating
+            # its own name as a path segment (wrong - authenticate isn't
+            # part of the URL).
+            if lambda_literal is not None:
+                walk(lambda_literal, prefix_stack)
+            return
+        for child in node.children:
+            walk(child, prefix_stack)
+
+    walk(root, [])
+    return entries
+
+
 def _ruby_string_content(node: Node, source: bytes) -> str:
     content = next((c for c in node.children if c.type == "string_content"), None)
     if content is None:
@@ -1352,6 +1466,7 @@ def map_api_endpoints(
         ("rb", RUBY_LANGUAGE),
         ("php", PHP_LANGUAGE),
         ("cs", CSHARP_LANGUAGE),
+        ("kt", KOTLIN_LANGUAGE),
     ):
         parser = Parser()
         parser.language = lang
@@ -1446,5 +1561,9 @@ def map_api_endpoints(
             tree = parsers["cs"].parse(source)
             endpoints.extend(_extract_aspnet_attribute_routes(tree.root_node, source, rel_path))
             endpoints.extend(_extract_aspnet_minimal_routes(tree.root_node, source, rel_path))
+        elif suffix == ".kt":
+            source = path.read_bytes()
+            tree = parsers["kt"].parse(source)
+            endpoints.extend(_extract_ktor_routes(tree.root_node, source, rel_path))
 
     return {"checked": True, "endpoints": endpoints}

--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -17,6 +17,7 @@ from aletheore.vulnerabilities import (
     _parse_composer_pins,
     _parse_gemfile_lock_pins,
     _parse_go_pins,
+    _parse_gradle_pins,
     _parse_maven_pins,
     _parse_npm_pins,
     _parse_nuget_pins,
@@ -331,6 +332,7 @@ def check_dependency_licenses(
         + _parse_gemfile_lock_pins(repo_path)
         + _parse_composer_pins(repo_path)
         + _parse_nuget_pins(repo_path)
+        + _parse_gradle_pins(repo_path)
     )
     if not pins:
         return {"checked": True, "reason": None, "repo_license": repo_license, "findings": []}

--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from xml.etree import ElementTree
 
 import certifi
+from tree_sitter import Node
 
 OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
 OSV_VULN_URL_TEMPLATE = "https://api.osv.dev/v1/vulns/{vuln_id}"
@@ -439,6 +440,235 @@ def _parse_nuget_pins(repo_path: Path) -> list[tuple[str, str, str]]:
     return pins
 
 
+_GRADLE_DEPENDENCY_CONFIGURATIONS = {
+    "implementation", "api", "compileOnly", "runtimeOnly",
+    "testImplementation", "testApi", "testCompileOnly", "testRuntimeOnly",
+    "androidTestImplementation", "kapt", "ksp",
+}
+
+# Coordinates resolve through the same Maven Central repository Java's
+# pom.xml already targets - Gradle just has two different Kotlin/Groovy
+# syntaxes for declaring the same "group:artifact:version" triple. "Maven"
+# here is deliberate, not a typo for a Gradle-specific ecosystem string:
+# confirmed against OSV.dev's own ecosystem list, which has no separate
+# "Gradle" entry - Gradle dependencies ARE Maven coordinates.
+_GRADLE_ECOSYSTEM = "Maven"
+
+
+def _kotlin_navigation_segments(node: Node, source: bytes) -> list[str] | None:
+    """Flattens a (possibly nested) navigation_expression like
+    `libs.androidx.annotation` into ["libs", "androidx", "annotation"].
+    Returns None for anything that isn't a plain dotted-identifier chain
+    (a method call in the middle, an indexing expression, etc.) rather
+    than guessing - an unresolvable catalog reference should be skipped,
+    not silently mis-resolved.
+    """
+    if node.type == "identifier":
+        return [source[node.start_byte:node.end_byte].decode(errors="ignore")]
+    if node.type != "navigation_expression":
+        return None
+    children = [c for c in node.children if c.type != "."]
+    if len(children) != 2:
+        return None
+    left, right = children
+    left_segments = _kotlin_navigation_segments(left, source)
+    if left_segments is None or right.type != "identifier":
+        return None
+    return left_segments + [source[right.start_byte:right.end_byte].decode(errors="ignore")]
+
+
+def _parse_gradle_version_catalog(repo_path: Path) -> dict[str, tuple[str, str, str | None]]:
+    """Parses gradle/libs.versions.toml's [libraries] table into
+    {dotted-accessor-key: (group, artifact, version-or-None)}, matching
+    the real accessor Kotlin/Groovy code actually calls (e.g. TOML key
+    "androidx-annotation" -> code accessor libs.androidx.annotation) -
+    confirmed empirically against a real catalog (android/architecture-
+    samples), not assumed from the Gradle docs. Every [libraries] entry
+    key is hyphen-separated; the generated accessor dot-separates the
+    same segments, so the accessor's segments after "libs" rejoin with
+    "-" to become the lookup key back into this dict.
+    version is None when the entry gives a plain "version" field pointing
+    at something other than version.ref, or omits it (a BOM-managed
+    dependency) - such an entry is real but not usable as an OSV.dev pin
+    without a resolvable version, so callers must skip it rather than
+    invent one.
+    """
+    catalog_path = repo_path / "gradle" / "libs.versions.toml"
+    if not catalog_path.exists():
+        return {}
+    try:
+        data = tomllib.loads(catalog_path.read_text(encoding="utf-8", errors="ignore"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError):
+        return {}
+    versions = data.get("versions", {}) or {}
+    libraries = data.get("libraries", {}) or {}
+    catalog: dict[str, tuple[str, str, str | None]] = {}
+    for key, entry in libraries.items():
+        if not isinstance(entry, dict):
+            continue
+        group = entry.get("group")
+        artifact = entry.get("name")
+        if not group or not artifact:
+            # The other real libs.versions.toml shape: a bare "module"
+            # string ("androidx.core:core-ktx") instead of split
+            # group/name fields - both are real, seen in the wild.
+            module = entry.get("module")
+            if isinstance(module, str) and ":" in module:
+                group, artifact = module.split(":", 1)
+            else:
+                continue
+        version_ref = entry.get("version")
+        if isinstance(version_ref, dict):
+            version = versions.get(version_ref.get("ref"))
+        elif isinstance(version_ref, str):
+            version = version_ref
+        else:
+            version = None
+        catalog[key.replace(".", "-")] = (group, artifact, version)
+    return catalog
+
+
+def _parse_gradle_kts_pins(
+    build_file: Path, catalog: dict[str, tuple[str, str, str | None]]
+) -> list[tuple[str, str, str]]:
+    """build.gradle.kts, parsed as real Kotlin source via tree_sitter_kotlin
+    (the same grammar graph.py uses) - AST-based, matching this codebase's
+    standard, not a regex over Kotlin source. Two real dependency-
+    declaration shapes exist and both are handled: a direct string literal
+    ("group:artifact:version"), and a version-catalog accessor
+    (libs.androidx.annotation) resolved against catalog. Confirmed via a
+    real repo (android/architecture-samples) that the catalog form is the
+    dominant one in modern Gradle projects, not a rare corner case - a
+    parser that only handled string literals would resolve close to zero
+    real dependencies there.
+    """
+    try:
+        from aletheore.scanner.graph import KOTLIN_LANGUAGE
+        from tree_sitter import Parser as _TSParser
+    except ImportError:
+        return []
+    try:
+        source = build_file.read_bytes()
+    except OSError:
+        return []
+    parser = _TSParser(KOTLIN_LANGUAGE)
+    tree = parser.parse(source)
+
+    pins: list[tuple[str, str, str]] = []
+
+    def walk(node: Node) -> None:
+        if node.type == "call_expression":
+            # No field names on this grammar's call_expression at all
+            # (confirmed empirically: child_by_field_name("function") and
+            # ("arguments") both return None) - children are purely
+            # positional: identifier, then value_arguments (when the call
+            # has parenthesized args at all - a trailing-lambda-only call
+            # like `get { ... }` has no value_arguments child, correctly
+            # excluded here since dependency declarations always use
+            # parens).
+            func = node.children[0] if node.children and node.children[0].type == "identifier" else None
+            if func is not None:
+                name = source[func.start_byte:func.end_byte].decode(errors="ignore")
+                if name in _GRADLE_DEPENDENCY_CONFIGURATIONS:
+                    args = next((c for c in node.children if c.type == "value_arguments"), None)
+                    if args is not None:
+                        for arg in args.named_children:
+                            value = arg.named_children[0] if arg.type == "value_argument" and arg.named_children else arg
+                            if value.type == "string_literal":
+                                content = next((c for c in value.children if c.type == "string_content"), None)
+                                if content is not None:
+                                    text = source[content.start_byte:content.end_byte].decode(errors="ignore")
+                                    parts = text.split(":")
+                                    if len(parts) == 3:
+                                        pins.append((f"{parts[0]}:{parts[1]}", parts[2], _GRADLE_ECOSYSTEM))
+                            else:
+                                segments = _kotlin_navigation_segments(value, source)
+                                if segments and segments[0] == "libs" and len(segments) > 1:
+                                    key = "-".join(segments[1:])
+                                    resolved = catalog.get(key)
+                                    if resolved and resolved[2]:
+                                        group, artifact, version = resolved
+                                        pins.append((f"{group}:{artifact}", version, _GRADLE_ECOSYSTEM))
+        for child in node.children:
+            walk(child)
+
+    walk(tree.root_node)
+    return pins
+
+
+_GRADLE_GROOVY_STRING_DEP_RE = re.compile(
+    r"""\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testApi|
+    androidTestImplementation|kapt|ksp)\s*[( ]\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]""",
+    re.VERBOSE,
+)
+
+
+def _parse_gradle_groovy_pins(build_file: Path) -> list[tuple[str, str, str]]:
+    """build.gradle (Groovy DSL) - deliberately regex-based, not a real
+    parse. There is no tree-sitter-groovy grammar among this project's
+    dependencies, and adding one would mean building full Groovy language
+    support (a much bigger task than parsing Gradle manifests) just to
+    read dependency declarations. This only catches the direct string-
+    literal coordinate shape, not version-catalog accessors (Groovy's
+    `libs.androidx.annotation` needs real parsing to distinguish from
+    surrounding code the way the .kts AST walk above does safely) - a
+    narrower, explicitly acknowledged heuristic, not full coverage.
+    """
+    try:
+        text = build_file.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+    pins = []
+    for match in _GRADLE_GROOVY_STRING_DEP_RE.finditer(text):
+        group, artifact, version = match.groups()
+        pins.append((f"{group}:{artifact}", version, _GRADLE_ECOSYSTEM))
+    return pins
+
+
+def _gradle_included_subprojects(repo_path: Path) -> list[str]:
+    """Real subproject paths from settings.gradle(.kts)'s include(...)
+    calls, e.g. include(":app") -> "app", include(":core:data") ->
+    "core/data" - a plain regex over the settings file text is enough
+    here (unlike dependency declarations, an include(...) argument is
+    always a simple string literal in practice, never a catalog
+    reference), confirmed against a real multi-module repo (android/
+    architecture-samples, which includes :app and :shared-test).
+    """
+    subprojects = []
+    for name in ("settings.gradle.kts", "settings.gradle"):
+        settings_file = repo_path / name
+        if not settings_file.exists():
+            continue
+        text = settings_file.read_text(encoding="utf-8", errors="ignore")
+        for match in re.finditer(r"""include\s*\(\s*['"]([^'"]+)['"]""", text):
+            path = match.group(1).lstrip(":").replace(":", "/")
+            if path:
+                subprojects.append(path)
+    return subprojects
+
+
+def _parse_gradle_pins(repo_path: Path) -> list[tuple[str, str, str]]:
+    catalog = _parse_gradle_version_catalog(repo_path)
+    build_dirs = [repo_path] + [repo_path / sub for sub in _gradle_included_subprojects(repo_path)]
+    pins: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for build_dir in build_dirs:
+        for filename, is_kts in (("build.gradle.kts", True), ("build.gradle", False)):
+            build_file = build_dir / filename
+            if not build_file.exists():
+                continue
+            found = (
+                _parse_gradle_kts_pins(build_file, catalog)
+                if is_kts
+                else _parse_gradle_groovy_pins(build_file)
+            )
+            for pin in found:
+                if pin not in seen:
+                    seen.add(pin)
+                    pins.append(pin)
+    return pins
+
+
 def _query_batch(pins: list[tuple[str, str, str]], timeout: int) -> list[dict]:
     queries = [
         {
@@ -501,6 +731,7 @@ def check_vulnerabilities(
         + _parse_gemfile_lock_pins(repo_path)
         + _parse_composer_pins(repo_path)
         + _parse_nuget_pins(repo_path)
+        + _parse_gradle_pins(repo_path)
     )
     if not pins:
         return {"checked": True, "reason": None, "findings": []}

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -9,6 +9,7 @@ from aletheore.endpoints import (
     _extract_flask_fastapi_routes,
     _extract_gin_routes,
     _extract_go_net_http_routes,
+    _extract_ktor_routes,
     _extract_laravel_routes,
     _extract_rails_routes,
     _extract_spring_boot_routes,
@@ -19,6 +20,7 @@ from aletheore.scanner.graph import (
     GO_LANGUAGE,
     JAVA_LANGUAGE,
     JS_LANGUAGE,
+    KOTLIN_LANGUAGE,
     PHP_LANGUAGE,
     PY_LANGUAGE,
     RUBY_LANGUAGE,
@@ -57,6 +59,13 @@ def parse_rust(source: str):
 def parse_java(source: str):
     parser = Parser()
     parser.language = JAVA_LANGUAGE
+    tree = parser.parse(source.encode())
+    return tree.root_node, source.encode()
+
+
+def parse_kotlin(source: str):
+    parser = Parser()
+    parser.language = KOTLIN_LANGUAGE
     tree = parser.parse(source.encode())
     return tree.root_node, source.encode()
 
@@ -1159,3 +1168,91 @@ def test_map_api_endpoints_covers_all_new_languages(tmp_path):
 
     paths = {e["path"] for e in result["endpoints"]}
     assert paths == {"/health", "/ping", "/x", "y", "/z", "/w"}
+
+
+def test_extract_ktor_top_level_route_with_path():
+    root, source = parse_kotlin(
+        'fun main() { routing { get("/health") { call.respondText("ok") } } }\n'
+    )
+
+    entries = _extract_ktor_routes(root, source, "Routes.kt")
+
+    assert entries == [
+        {
+            "method": "GET",
+            "path": "/health",
+            "framework": "ktor",
+            "file": "Routes.kt",
+            "line": 1,
+            "handler": "<lambda>",
+            "unresolved": False,
+            "note": None,
+        }
+    ]
+
+
+def test_extract_ktor_bare_verb_inherits_route_prefix():
+    # get { } with no path argument at all - real, idiomatic Ktor for "the
+    # base path of the enclosing route(...) block" - a shape that has no
+    # equivalent in Spring's annotation vocabulary or Axum's combinator
+    # chain, so nothing existing already covers this.
+    root, source = parse_kotlin(
+        'fun r() { routing { route("/users/{id}") { get { respond() } } } }\n'
+    )
+
+    entries = _extract_ktor_routes(root, source, "Routes.kt")
+
+    assert len(entries) == 1
+    assert entries[0]["method"] == "GET"
+    assert entries[0]["path"] == "/users/{id}"
+
+
+def test_extract_ktor_route_prefix_composes_with_sub_path():
+    root, source = parse_kotlin(
+        'fun r() { routing { route("/users") { post("/create") { respond() } } } }\n'
+    )
+
+    entries = _extract_ktor_routes(root, source, "Routes.kt")
+
+    assert entries[0]["method"] == "POST"
+    assert entries[0]["path"] == "/users/create"
+
+
+def test_extract_ktor_pass_through_wrapper_does_not_become_a_path_segment():
+    # authenticate { } (and install/intercept/etc.) are real, common Ktor
+    # wrappers with a trailing lambda but no path meaning at all -
+    # confirmed by direct AST inspection this shape is indistinguishable
+    # from route(...) at the grammar level (both are call-with-lambda);
+    # only the identifier name tells them apart. Getting this wrong either
+    # way is a real bug: skipping authenticate{} entirely would silently
+    # lose every route nested inside auth, and treating "authenticate" as
+    # a literal path segment would corrupt every path under it.
+    root, source = parse_kotlin(
+        'fun r() { routing { authenticate { route("/admin") { delete("/purge") { respond() } } } } }\n'
+    )
+
+    entries = _extract_ktor_routes(root, source, "Routes.kt")
+
+    assert len(entries) == 1
+    assert entries[0]["method"] == "DELETE"
+    assert entries[0]["path"] == "/admin/purge"
+    assert "authenticate" not in entries[0]["path"]
+
+
+def test_extract_ktor_ignores_calls_with_no_trailing_lambda():
+    root, source = parse_kotlin('fun r() { val x = someHelper("/not/a/route") }\n')
+
+    entries = _extract_ktor_routes(root, source, "Routes.kt")
+
+    assert entries == []
+
+
+def test_map_api_endpoints_extracts_kotlin_ktor_routes(tmp_path):
+    (tmp_path / "Routes.kt").write_text(
+        'fun r() { routing { get("/kt") { respond() } } }\n'
+    )
+
+    result = map_api_endpoints(tmp_path)
+
+    paths = {e["path"] for e in result["endpoints"]}
+    assert "/kt" in paths

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -624,3 +624,36 @@ def test_check_dependency_licenses_reports_a_nuget_dependency(tmp_path):
     assert len(result["findings"]) == 1
     assert result["findings"][0]["ecosystem"] == "NuGet"
     assert result["findings"][0]["category"] == "copyleft-strong"
+
+
+def test_check_dependency_licenses_reports_a_gradle_dependency(tmp_path):
+    # Gradle coordinates resolve through the same Maven Central repository
+    # (and the same _fetch_maven_license fetcher) Java's pom.xml pins
+    # already use - this only proves _parse_gradle_pins is correctly wired
+    # into check_dependency_licenses's pin list, not new fetch logic.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "build.gradle.kts").write_text(
+        'dependencies {\n    implementation("com.example:some-gpl-thing:1.0.0")\n}\n'
+    )
+
+    pom_xml = (
+        b'<?xml version="1.0" encoding="UTF-8"?>\n'
+        b'<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        b"  <licenses>\n"
+        b"    <license>\n"
+        b"      <name>GPL-3.0</name>\n"
+        b"    </license>\n"
+        b"  </licenses>\n"
+        b"</project>\n"
+    )
+
+    with patch(
+        "aletheore.licenses.urllib.request.urlopen", return_value=_mock_bytes_response(pom_xml)
+    ):
+        result = check_dependency_licenses(repo)
+
+    assert len(result["findings"]) == 1
+    assert result["findings"][0]["ecosystem"] == "Maven"
+    assert result["findings"][0]["package"] == "com.example:some-gpl-thing"
+    assert result["findings"][0]["category"] == "copyleft-strong"

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -831,3 +831,159 @@ def test_filter_by_severity_always_keeps_findings_with_no_derivable_severity():
     unknown = {"advisory_id": "no-cvss-data", "severity": []}
     result = filter_by_severity([unknown], "critical")
     assert result == [unknown]
+
+
+def test_parse_gradle_kts_pins_reads_direct_string_coordinate(tmp_path):
+    from aletheore.vulnerabilities import _parse_gradle_kts_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    build_file = repo / "build.gradle.kts"
+    build_file.write_text(
+        'dependencies {\n    implementation("com.squareup.retrofit2:retrofit:2.9.0")\n}\n'
+    )
+
+    pins = _parse_gradle_kts_pins(build_file, {})
+
+    assert pins == [("com.squareup.retrofit2:retrofit", "2.9.0", "Maven")]
+
+
+def test_parse_gradle_kts_pins_resolves_version_catalog_accessor(tmp_path):
+    from aletheore.vulnerabilities import _parse_gradle_kts_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    build_file = repo / "build.gradle.kts"
+    build_file.write_text(
+        "dependencies {\n    implementation(libs.androidx.annotation)\n}\n"
+    )
+    catalog = {"androidx-annotation": ("androidx.annotation", "annotation", "1.9.1")}
+
+    pins = _parse_gradle_kts_pins(build_file, catalog)
+
+    assert pins == [("androidx.annotation:annotation", "1.9.1", "Maven")]
+
+
+def test_parse_gradle_kts_pins_skips_catalog_entry_with_no_resolvable_version(tmp_path):
+    # A real libs.versions.toml shape: a BOM-managed entry with no version
+    # field of its own - not a bug to invent a version for, a real
+    # "cannot resolve without more context" case that must be skipped
+    # rather than silently producing a wrong pin.
+    from aletheore.vulnerabilities import _parse_gradle_kts_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    build_file = repo / "build.gradle.kts"
+    build_file.write_text("dependencies {\n    implementation(libs.compose.bom)\n}\n")
+    catalog = {"compose-bom": ("androidx.compose", "compose-bom", None)}
+
+    pins = _parse_gradle_kts_pins(build_file, catalog)
+
+    assert pins == []
+
+
+def test_parse_gradle_version_catalog_reads_libraries_and_resolves_version_ref(tmp_path):
+    from aletheore.vulnerabilities import _parse_gradle_version_catalog
+
+    repo = tmp_path / "repo"
+    (repo / "gradle").mkdir(parents=True)
+    (repo / "gradle" / "libs.versions.toml").write_text(
+        '[versions]\nannotation = "1.9.1"\n\n'
+        "[libraries]\n"
+        'androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "annotation" }\n'
+    )
+
+    catalog = _parse_gradle_version_catalog(repo)
+
+    assert catalog["androidx-annotation"] == ("androidx.annotation", "annotation", "1.9.1")
+
+
+def test_parse_gradle_version_catalog_handles_bare_module_shape(tmp_path):
+    # The other real libs.versions.toml entry shape: a single "module"
+    # string ("group:artifact") instead of split group/name fields - both
+    # are real and seen in the wild, not a hypothetical.
+    from aletheore.vulnerabilities import _parse_gradle_version_catalog
+
+    repo = tmp_path / "repo"
+    (repo / "gradle").mkdir(parents=True)
+    (repo / "gradle" / "libs.versions.toml").write_text(
+        '[versions]\ncoreKtx = "1.15.0"\n\n'
+        "[libraries]\n"
+        'androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }\n'
+    )
+
+    catalog = _parse_gradle_version_catalog(repo)
+
+    assert catalog["androidx-core-ktx"] == ("androidx.core", "core-ktx", "1.15.0")
+
+
+def test_parse_gradle_groovy_pins_reads_direct_string_coordinate(tmp_path):
+    from aletheore.vulnerabilities import _parse_gradle_groovy_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    build_file = repo / "build.gradle"
+    build_file.write_text(
+        "dependencies {\n    implementation 'com.squareup.okhttp3:okhttp:4.12.0'\n}\n"
+    )
+
+    pins = _parse_gradle_groovy_pins(build_file)
+
+    assert pins == [("com.squareup.okhttp3:okhttp", "4.12.0", "Maven")]
+
+
+def test_parse_gradle_pins_covers_root_and_included_subprojects(tmp_path):
+    from aletheore.vulnerabilities import _parse_gradle_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "settings.gradle.kts").write_text('include(":app")\ninclude(":core:data")\n')
+    (repo / "build.gradle.kts").write_text(
+        'dependencies {\n    implementation("com.example:root-dep:1.0.0")\n}\n'
+    )
+    app_dir = repo / "app"
+    app_dir.mkdir()
+    (app_dir / "build.gradle.kts").write_text(
+        'dependencies {\n    implementation("com.example:app-dep:2.0.0")\n}\n'
+    )
+    nested_dir = repo / "core" / "data"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "build.gradle.kts").write_text(
+        'dependencies {\n    implementation("com.example:data-dep:3.0.0")\n}\n'
+    )
+
+    pins = _parse_gradle_pins(repo)
+
+    names = {p[0] for p in pins}
+    assert names == {"com.example:root-dep", "com.example:app-dep", "com.example:data-dep"}
+
+
+def test_parse_gradle_pins_empty_when_no_gradle_files(tmp_path):
+    from aletheore.vulnerabilities import _parse_gradle_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    assert _parse_gradle_pins(repo) == []
+
+
+def test_check_vulnerabilities_includes_gradle_pins(tmp_path, monkeypatch):
+    from aletheore import vulnerabilities
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "build.gradle.kts").write_text(
+        'dependencies {\n    implementation("com.example:foo:1.0.0")\n}\n'
+    )
+
+    captured = {}
+
+    def fake_query_batch(pins, timeout):
+        captured["pins"] = pins
+        return [{"vulns": []} for _ in pins]
+
+    monkeypatch.setattr(vulnerabilities, "_query_batch", fake_query_batch)
+
+    vulnerabilities.check_vulnerabilities(repo, cache_path=tmp_path / "cache.json")
+
+    assert ("com.example:foo", "1.0.0", "Maven") in captured["pins"]


### PR DESCRIPTION
## Summary
Extends Kotlin support (#479, this PR's base) to match the other 11 languages fully - `endpoints.py`, `vulnerabilities.py`, and `licenses.py` were the three real gaps a peer audit found.

- **Ktor endpoint detection**: real AST-based extraction (empirically verified against `tree_sitter_kotlin` directly, not assumed), correctly handles nested `route()` prefixing and pass-through wrappers (`authenticate { }` etc.) without corrupting paths. No real Ktor server code exists in the verification repo (a client app) - correctness rests on direct grammar inspection + hand-verified fixtures, disclosed honestly rather than hidden.
- **Gradle manifest parsing**: `build.gradle.kts` via real Kotlin AST (handles both direct string coordinates and the Gradle Version Catalog pattern - confirmed the catalog form is dominant in modern repos: a string-literal-only parser resolves 0/30 real deps in the verification repo). `build.gradle` (Groovy) uses an explicitly-documented regex fallback (no tree-sitter-groovy grammar in this project, adding one is out of scope). Multi-module support via `settings.gradle(.kts)`.
- **Real stress test** against `android/architecture-samples`: `aletheore scan` completes in ~5.3s, 55 Kotlin modules, 30 real dependencies resolved, 0 known vulnerabilities (real, not a bug). Found and documented a real pre-existing gap: 22/30 license lookups return "unknown" because `_fetch_maven_license` only checks Maven Central, and AndroidX artifacts publish to Google's Maven repo instead (confirmed: 200 vs 404 for the identical coordinate). Not introduced by this change, but surfaced at real scale here - left as a flagged follow-up, out of scope for this PR.
- **RepoWise comparison: blocked.** `repowise init` needs a real LLM provider key not available/authorized in this environment; no lower-level static-only path exists in its CLI. Reported honestly rather than faked.

## Test plan
- [x] 6 new Ktor tests (`test_endpoints.py`) - top-level route, bare-verb prefix inheritance, path composition, pass-through-wrapper correctness, no-trailing-lambda rejection, full-pipeline integration.
- [x] 9 new Gradle tests (`test_vulnerabilities.py`) - direct coordinates, version-catalog resolution (both `group`/`name` and bare `module` shapes), unresolvable-version skip, Groovy fallback, multi-module coverage, empty-repo case, full wiring.
- [x] 1 new license wiring test (`test_licenses.py`).
- [x] Full suite: 1458 passed, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr