### PR TITLE
fix: cap dependency-license fetches to a real wall-clock timeout

### DIFF
--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -6,7 +6,7 @@ import tomllib
 import urllib.error
 import urllib.request
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from pathlib import Path
 from xml.etree import ElementTree
 
@@ -32,6 +32,19 @@ DEFAULT_TIMEOUT_SECONDS = 10
 # to blow the hosted worker's per-job timeout on its own. Bounded, not
 # unbounded, so this stays polite to registries under a large repo.
 LICENSE_CHECK_CONCURRENCY = 20
+# `timeout` (DEFAULT_TIMEOUT_SECONDS) bounds a single blocking socket
+# operation (connect/read), not the total time to receive a response - a
+# registry serving its body slowly (a few bytes every few seconds, no
+# single read ever idle long enough to trip the socket timeout) can still
+# take far longer overall. Confirmed as a real production incident, not a
+# theoretical one: three real npm packages (es-errors, es6-error,
+# serialize-error) reproducibly stalled dependency-license checks for
+# 1+ hour before their RQ work-horse was eventually reaped, appearing as
+# "work-horse terminated unexpectedly" - not a timeout error at all, since
+# nothing ever actually raised one. This wall-clock cap is the real fix:
+# generous enough for a legitimately slow-but-real response, firm enough
+# that one bad registry endpoint can never hang the whole check.
+LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS = 30
 
 # A registry lookup for one exact (ecosystem, name, version) triple returns
 # the same answer forever in the overwhelming majority of cases - a
@@ -341,18 +354,30 @@ def check_dependency_licenses(
     cache = _load_license_cache(cache_path)
     # Each registry lookup is an independent blocking HTTP call - a thread
     # pool overlaps their network wait time instead of paying it serially.
-    # executor.map (not as_completed) preserves pins' original order in the
-    # results regardless of which thread finishes first, so progress
-    # reporting and finding order both stay deterministic.
-    with ThreadPoolExecutor(max_workers=LICENSE_CHECK_CONCURRENCY) as executor:
-        license_texts = executor.map(
-            lambda pin: _fetch_one_license_cached(pin, timeout, cache), pins
-        )
-        for index, ((name, version, ecosystem), license_text) in enumerate(
-            zip(pins, license_texts), start=1
-        ):
+    # Submitted individually (not executor.map, whose iterator yields
+    # results in submission order - one stuck fetch at position N blocks
+    # every result after it from ever being reported, even though later
+    # threads already finished; see LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS
+    # for why "stuck" is a real, not theoretical, failure mode here).
+    # future.result(timeout=...) bounds how long THIS function waits for
+    # each pin without needing to interrupt whatever the worker thread is
+    # actually blocked on - that thread is abandoned (Python has no way to
+    # forcibly kill a blocked thread) and left to die on its own eventual
+    # socket timeout; shutdown(wait=False) below means this function
+    # returns promptly rather than blocking on that stray thread to exit.
+    executor = ThreadPoolExecutor(max_workers=LICENSE_CHECK_CONCURRENCY)
+    try:
+        futures = [
+            executor.submit(_fetch_one_license_cached, pin, timeout, cache) for pin in pins
+        ]
+        for index, ((name, version, ecosystem), future) in enumerate(zip(pins, futures), start=1):
             if on_progress is not None:
                 on_progress(index, len(pins), name)
+
+            try:
+                license_text = future.result(timeout=LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS)
+            except FutureTimeoutError:
+                license_text = None
 
             category = categorize_license(license_text)
             if category != "permissive":
@@ -365,6 +390,8 @@ def check_dependency_licenses(
                         "category": category,
                     }
                 )
+    finally:
+        executor.shutdown(wait=False)
     _save_license_cache(cache_path, cache)
 
     return {"checked": True, "reason": None, "repo_license": repo_license, "findings": findings}

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -451,6 +451,56 @@ def test_fetch_crates_license_reads_version_license_field():
     assert result == "MIT OR Apache-2.0"
 
 
+def test_check_dependency_licenses_does_not_hang_on_one_slow_drip_registry_response(tmp_path):
+    # Real production incident, reproduced: a registry response that drips
+    # data slowly enough that no single blocking read ever idles past the
+    # per-socket-operation `timeout` never raises a timeout error at all -
+    # confirmed live (three real npm packages stalled dependency-license
+    # checks for 1+ hour before their job was forcibly reaped). The fix is
+    # a wall-clock cap independent of the socket-level timeout, submitted
+    # per-future (not executor.map, whose ordered iterator would otherwise
+    # block every result behind the stuck one).
+    import time
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text(
+        json.dumps({"dependencies": {"slow-pkg": "1.0.0", "fast-pkg": "1.0.0"}})
+    )
+
+    fast_response = _mock_response({"license": "MIT"})
+
+    def urlopen_side_effect(request, timeout=None, context=None):
+        if "slow-pkg" in request.full_url:
+            time.sleep(2)  # far longer than the patched wall-clock cap below
+            return fast_response
+        return fast_response
+
+    start = time.monotonic()
+    with (
+        patch("aletheore.licenses.urllib.request.urlopen", side_effect=urlopen_side_effect),
+        patch("aletheore.licenses.LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS", 0.2),
+    ):
+        result = check_dependency_licenses(repo)
+    elapsed = time.monotonic() - start
+
+    # Real proof of the fix, not just "it returned something": returning in
+    # well under the 2s simulated hang means this function did not wait for
+    # the stuck future, and fast-pkg's already-available result still made
+    # it into the findings despite slow-pkg being stuck ahead of it.
+    assert elapsed < 1.5
+    findings_by_package = {f["package"]: f for f in result["findings"]}
+    # slow-pkg times out - reported as "unknown" (graceful degradation, the
+    # same outcome any other unresolvable license lookup already gets), not
+    # silently dropped and not left hanging.
+    assert findings_by_package["slow-pkg"]["category"] == "unknown"
+    # fast-pkg's MIT license resolved correctly despite being submitted
+    # after the stuck slow-pkg - the real proof this isn't executor.map's
+    # ordered-blocking behavior anymore. Permissive licenses aren't
+    # findings at all, so its absence here is the correct, positive signal.
+    assert "fast-pkg" not in findings_by_package
+
+
 def test_check_dependency_licenses_reports_a_rust_dependency(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
Real production incident, root-caused from a batch of live `[Aletheore alert] ops_monitor.failed_jobs.scans: OpsMonitorError` / `run_pr_scan_job: CalledProcessError` emails - not a synthetic finding.

Investigated on the live host (`root@187.127.169.89`): 14 jobs sitting in the `scans` queue's `FailedJobRegistry`. 10 of them (`run_live_wiki_incremental_update_job` / `run_live_docs_incremental_update_job`) failed with "Work-horse terminated unexpectedly" after running for **over an hour** - never a timeout error, because none ever fired. Traced to `check_dependency_licenses`'s npm fetches: `urlopen(timeout=10)` only bounds a single blocking socket operation (connect/read), not the total time to receive a response. A registry response that drips data slowly enough that no individual read ever idles past that bound can still take arbitrarily long overall - confirmed live against three real npm packages (`es-errors`, `es6-error`, `serialize-error`) that reproducibly stalled at the exact same points across multiple separate job runs.

Compounded by a second real bug: the fetch loop used `executor.map()`, whose iterator yields results in submission order - one stuck fetch blocks every result after it from ever being reported, even from worker threads that already finished their own work.

## Fix
- Submit futures individually instead of `executor.map()`.
- Bound each with a real wall-clock cap via `future.result(timeout=LICENSE_FETCH_WALL_CLOCK_TIMEOUT_SECONDS)` (30s), independent of the per-socket `timeout`.
- `executor.shutdown(wait=False)` so the function returns promptly rather than blocking on a thread still stuck waiting on its own eventual socket-level timeout (Python can't forcibly kill a blocked thread - it's abandoned, not fixed, and dies on its own later).
- A timed-out fetch degrades to the same "unknown" outcome any other unresolvable license lookup already gets - not a crash, not a silent drop.

## Test plan
- [x] New test simulates the real incident: a mocked slow-drip response held open for 2s (patched wall-clock cap: 0.2s) alongside a normal fast response. Asserts the whole check returns in under 1.5s (proving no hang) and that the fast package's result is still correct despite being submitted after the stuck one (proving the ordering bug is also fixed, not just papered over).
- [x] Full suite: `python3 -m pytest` - 1459 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)