### PR TITLE
fix: recognize JVM test files, Android manifest components, and Hilt/Dagger DI wiring in dead-code detection

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -35,6 +35,17 @@ TEST_PATH_PATTERNS = [
     # where the previous case-sensitive version missed every single test
     # file, flagging them all as dead code.
     re.compile(r"(^|/)(tests?|__tests__)/", re.IGNORECASE),
+    # JVM (Java/Kotlin) PascalCase suffix convention - e.g. TaskDaoTest.kt,
+    # StatisticsScreenTest.kt. Confirmed against a real repo
+    # (android/architecture-samples): without this, every androidTest file
+    # flagged as dead code purely because JUnit/instrumentation invokes them
+    # by reflection, never a plain import.
+    re.compile(r"(^|/)[^/]+Test\.(kt|kts|java)$"),
+    # Gradle's androidTest/test source-set convention - doesn't require the
+    # PascalCase suffix above (e.g. a test helper/fixture file), and
+    # "androidTest" isn't matched by the tests?/__tests__ pattern above
+    # since it's one fused word, not "test" as its own path segment.
+    re.compile(r"(^|/)(androidTest|test)/.+\.(kt|kts|java)$"),
 ]
 
 PACKAGE_IMPORT_ALIASES = {

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -1,4 +1,5 @@
 import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 from aletheore.repo_config import is_ignored
@@ -75,6 +76,26 @@ _MAIN_GUARD_PATTERN = re.compile(r"if\s+__name__\s*==\s*[\'\"]__main__[\'\"]\s*:
 # Python's __main__ guard above. Always at file scope, so a start-of-line
 # anchor (allowing leading whitespace) is enough without a full parse.
 _SWIFT_MAIN_ATTRIBUTE_PATTERN = re.compile(r"^\s*@main\b", re.MULTILINE)
+
+# Hilt/Dagger annotations that mark a Kotlin/Java class as wired into the DI
+# graph by an annotation processor rather than a plain import - confirmed on
+# a real repo (android/architecture-samples): @HiltAndroidApp's Application
+# subclass and @HiltViewModel's ViewModels are both instantiated by
+# generated Hilt code, never imported by name anywhere in the app's own
+# source. This is deliberately a narrow, scoped signal, not general DI-graph
+# resolution (which would require following @Binds/@Provides wiring across
+# arbitrarily many files) - the same bounded-heuristic category as the
+# __main__ guard and @main checks above, not a claim of full DI awareness.
+# @Module alone is too weak on its own (a project's own unrelated "Module"
+# concept could reuse the bare name) - real Hilt/Dagger modules always pair
+# it with @InstallIn (or, for a test-only module that replaces a production
+# one, @TestInstallIn - confirmed against a real repo, where every @Module
+# in the shared-test source set uses @TestInstallIn instead), confirmed
+# against every @Module in this same repo.
+_HILT_ANDROID_APP_PATTERN = re.compile(r"^\s*@HiltAndroidApp\b", re.MULTILINE)
+_HILT_VIEWMODEL_PATTERN = re.compile(r"^\s*@HiltViewModel\b", re.MULTILINE)
+_DAGGER_MODULE_PATTERN = re.compile(r"^\s*@Module\b", re.MULTILINE)
+_DAGGER_INSTALL_IN_PATTERN = re.compile(r"^\s*@(?:InstallIn|TestInstallIn)\b", re.MULTILINE)
 
 _HTML_SCRIPT_SRC_PATTERN = re.compile(r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE)
 
@@ -188,6 +209,81 @@ def _has_swift_main_attribute(repo_path: Path, path: str) -> bool:
     return bool(_SWIFT_MAIN_ATTRIBUTE_PATTERN.search(content))
 
 
+def _has_hilt_dagger_annotation(repo_path: Path, path: str) -> bool:
+    if not path.endswith((".kt", ".kts", ".java")):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    if _HILT_ANDROID_APP_PATTERN.search(content) or _HILT_VIEWMODEL_PATTERN.search(content):
+        return True
+    return bool(_DAGGER_MODULE_PATTERN.search(content) and _DAGGER_INSTALL_IN_PATTERN.search(content))
+
+
+_ANDROID_NAME_ATTR = "{http://schemas.android.com/apk/res/android}name"
+# Only components an app declares by class name for the OS to instantiate
+# via reflection - deliberately excludes <action>/<category> (also carry
+# android:name, but name Intent actions like "android.intent.action.MAIN",
+# never a class) and <activity-alias> (its own android:name is the alias's
+# component name, not a real class - the aliased class is either its
+# separate android:targetActivity, out of this bounded heuristic's scope,
+# or already covered by its own <activity> declaration elsewhere).
+_ANDROID_MANIFEST_ENTRY_TAGS = {"application", "activity", "service", "receiver", "provider"}
+
+
+def _android_manifest_entry_points(repo_path: Path, ignored_paths: list[str] | None = None) -> set[str]:
+    """Component classes named in AndroidManifest.xml - instantiated by the
+    Android OS via reflection from this XML, never a plain Kotlin/Java
+    import. Confirmed on a real repo (android/architecture-samples):
+    TodoApplication.kt (referenced only by
+    <application android:name=".TodoApplication">) and TodoActivity.kt (the
+    launcher activity, referenced only by
+    <activity android:name="...TodoActivity"> with a MAIN/LAUNCHER
+    intent-filter) both looked completely unreachable without this.
+
+    Resolved the same way _infer_xcodeproj_swift_targets resolves an Xcode
+    target's file membership: basename search under the repo root, keeping
+    only an unambiguous single match. A manifest entry names a class, not a
+    file path (and android:name's shorthand form, ".TodoApplication", isn't
+    even a full class name) - reconstructing a path from it would have to
+    guess which of app/src/main/java/, .../kotlin/, or a build-flavor
+    source set actually holds the file, so this takes just the simple class
+    name (the segment after the last '.') and lets the basename search
+    handle the rest, same as the Xcode case.
+    """
+    entry_points: set[str] = set()
+    patterns = ignored_paths or []
+    for manifest_path in repo_path.rglob("AndroidManifest.xml"):
+        rel_manifest = manifest_path.relative_to(repo_path).as_posix()
+        if is_ignored(rel_manifest, patterns):
+            continue
+        try:
+            root = ET.parse(manifest_path).getroot()
+        except (ET.ParseError, OSError):
+            continue
+        for element in root.iter():
+            tag = element.tag.rsplit("}", 1)[-1]
+            if tag not in _ANDROID_MANIFEST_ENTRY_TAGS:
+                continue
+            qualified_name = element.attrib.get(_ANDROID_NAME_ATTR)
+            if not qualified_name:
+                continue
+            simple_name = qualified_name.rsplit(".", 1)[-1]
+            if not simple_name:
+                continue
+            candidates = [
+                p for p in repo_path.rglob(f"{simple_name}.kt")
+                if not is_ignored(p.relative_to(repo_path).as_posix(), patterns)
+            ] or [
+                p for p in repo_path.rglob(f"{simple_name}.java")
+                if not is_ignored(p.relative_to(repo_path).as_posix(), patterns)
+            ]
+            if len(candidates) == 1:
+                entry_points.add(candidates[0].relative_to(repo_path).as_posix())
+    return entry_points
+
+
 def _swift_target_reachable_files(
     repo_path: Path,
     modules: list[dict],
@@ -288,6 +384,7 @@ def find_dead_code(
             custom_entry_points = {path for path in raw_entry_points if isinstance(path, str)}
 
     html_script_entry_points = _html_script_entry_points(repo_path, ignored_paths)
+    android_manifest_entry_points = _android_manifest_entry_points(repo_path, ignored_paths)
     swift_reachable_files = _swift_target_reachable_files(repo_path, modules, ignored_paths)
 
     unreachable_modules = []
@@ -302,7 +399,12 @@ def find_dead_code(
         if path in swift_reachable_files:
             continue
         if not module.get("imported_by", []):
-            if path in html_script_entry_points or _has_main_guard(repo_path, path):
+            if (
+                path in html_script_entry_points
+                or path in android_manifest_entry_points
+                or _has_main_guard(repo_path, path)
+                or _has_hilt_dagger_annotation(repo_path, path)
+            ):
                 entry_points_detected.append(path)
                 continue
             unreachable_modules.append(

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -54,6 +54,27 @@ def test_package_swift_manifest_is_never_unreachable(tmp_path):
     assert "Package.swift" in result["entry_points_detected"]
 
 
+def test_jvm_test_files_are_never_unreachable(tmp_path):
+    # Real repo confirmed (android/architecture-samples): androidTest files
+    # are invoked by instrumentation/JUnit reflection, never a plain import,
+    # so they always look unreachable to the import graph. The PascalCase
+    # "*Test.kt" suffix is the JVM convention (unlike Python's "test_*.py"),
+    # and "androidTest" is one fused word - not matched by the tests?/
+    # __tests__ directory pattern, which requires "test" as its own segment.
+    modules = [
+        _module(
+            "app/src/androidTest/java/com/example/todoapp/tasks/TasksScreenTest.kt"
+        ),
+        _module("app/src/androidTest/java/com/example/todoapp/data/TaskDaoTest.kt"),
+        _module("app/src/test/java/com/example/todoapp/data/TaskRepositoryTest.java"),
+        # A test-directory file with no "*Test" suffix (a fixture/helper) -
+        # only the directory-convention pattern catches this one.
+        _module("app/src/androidTest/java/com/example/todoapp/util/TestUtils.kt"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
 def test_config_can_add_custom_entry_points(tmp_path):
     modules = [_module("app/worker.py")]
     config = {"dead_code_entry_points": ["app/worker.py"]}

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -75,6 +75,188 @@ def test_jvm_test_files_are_never_unreachable(tmp_path):
     assert result["unreachable_modules"] == []
 
 
+def test_android_manifest_application_shorthand_name_is_never_unreachable(tmp_path):
+    # Real repo confirmed (android/architecture-samples): TodoApplication.kt
+    # carries @HiltAndroidApp and is referenced only by AndroidManifest.xml's
+    # <application android:name=".TodoApplication"> - the Android OS
+    # instantiates it via reflection from that XML, never a plain Kotlin
+    # import. ".TodoApplication" is the manifest shorthand form (relative to
+    # the app's package), not a file path or a full class name.
+    manifest_dir = tmp_path / "app" / "src" / "main"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "AndroidManifest.xml").write_text(
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">\n'
+        '    <application android:name=".TodoApplication" />\n'
+        "</manifest>\n"
+    )
+    app_dir = tmp_path / "app" / "src" / "main" / "java" / "com" / "example" / "todoapp"
+    app_dir.mkdir(parents=True)
+    (app_dir / "TodoApplication.kt").write_text(
+        "@HiltAndroidApp\nclass TodoApplication : Application()\n"
+    )
+    modules = [_module("app/src/main/java/com/example/todoapp/TodoApplication.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "app/src/main/java/com/example/todoapp/TodoApplication.kt" in result["entry_points_detected"]
+
+
+def test_android_manifest_activity_fully_qualified_name_is_never_unreachable(tmp_path):
+    # Real repo confirmed (android/architecture-samples): TodoActivity.kt,
+    # the app's launcher activity, is referenced only by AndroidManifest.xml's
+    # <activity android:name="com.example...TodoActivity"> with a
+    # MAIN/LAUNCHER intent-filter - the fully-qualified form, unlike
+    # TodoApplication's shorthand above.
+    manifest_dir = tmp_path / "app" / "src" / "main"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "AndroidManifest.xml").write_text(
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">\n'
+        "    <application>\n"
+        '        <activity android:name="com.example.todoapp.TodoActivity" />\n'
+        "    </application>\n"
+        "</manifest>\n"
+    )
+    app_dir = tmp_path / "app" / "src" / "main" / "java" / "com" / "example" / "todoapp"
+    app_dir.mkdir(parents=True)
+    (app_dir / "TodoActivity.kt").write_text("class TodoActivity : AppCompatActivity()\n")
+    modules = [_module("app/src/main/java/com/example/todoapp/TodoActivity.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "app/src/main/java/com/example/todoapp/TodoActivity.kt" in result["entry_points_detected"]
+
+
+def test_android_manifest_ignores_action_and_category_name_attributes(tmp_path):
+    # <action>/<category> tags also carry android:name (e.g.
+    # "android.intent.action.MAIN"), but those name Intent actions, never a
+    # class - only <application>/<activity>/<service>/<receiver>/<provider>
+    # are treated as entry-point-bearing tags.
+    manifest_dir = tmp_path / "app" / "src" / "main"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "AndroidManifest.xml").write_text(
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">\n'
+        "    <application>\n"
+        '        <activity android:name="com.example.todoapp.TodoActivity">\n'
+        "            <intent-filter>\n"
+        '                <action android:name="android.intent.action.MAIN" />\n'
+        '                <category android:name="android.intent.category.LAUNCHER" />\n'
+        "            </intent-filter>\n"
+        "        </activity>\n"
+        "    </application>\n"
+        "</manifest>\n"
+    )
+    app_dir = tmp_path / "app" / "src" / "main" / "java" / "com" / "example" / "todoapp"
+    app_dir.mkdir(parents=True)
+    (app_dir / "MAIN.kt").write_text("class MAIN\n")
+    (app_dir / "TodoActivity.kt").write_text("class TodoActivity : AppCompatActivity()\n")
+    modules = [
+        _module("app/src/main/java/com/example/todoapp/MAIN.kt"),
+        _module("app/src/main/java/com/example/todoapp/TodoActivity.kt"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [m["path"] for m in result["unreachable_modules"]]
+    assert "app/src/main/java/com/example/todoapp/MAIN.kt" in paths
+    assert "app/src/main/java/com/example/todoapp/TodoActivity.kt" not in paths
+
+
+def test_android_manifest_entry_point_skips_an_ambiguous_basename_match(tmp_path):
+    # A manifest entry names a class, not a file path - resolved the same
+    # way _infer_xcodeproj_swift_targets resolves Xcode target membership:
+    # basename search under the repo root, kept only when unambiguous. Two
+    # files sharing "Foo.kt" as their basename means the manifest's "Foo"
+    # can't be resolved to either one specifically, so neither is treated
+    # as an entry point (matches the Xcode resolver's own tie-breaking).
+    manifest_dir = tmp_path / "app" / "src" / "main"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "AndroidManifest.xml").write_text(
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android">\n'
+        '    <application android:name=".Foo" />\n'
+        "</manifest>\n"
+    )
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "Foo.kt").write_text("class Foo\n")
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "Foo.kt").write_text("class Foo\n")
+    modules = [_module("a/Foo.kt"), _module("b/Foo.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [m["path"] for m in result["unreachable_modules"]]
+    assert "a/Foo.kt" in paths
+    assert "b/Foo.kt" in paths
+
+
+def test_hilt_android_app_annotation_is_never_unreachable(tmp_path):
+    (tmp_path / "TodoApplication.kt").write_text(
+        "@HiltAndroidApp\nclass TodoApplication : Application()\n"
+    )
+    modules = [_module("TodoApplication.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "TodoApplication.kt" in result["entry_points_detected"]
+
+
+def test_hilt_viewmodel_annotation_is_never_unreachable(tmp_path):
+    # Real repo confirmed (android/architecture-samples): TasksViewModel.kt
+    # and its sibling ViewModels carry @HiltViewModel + @Inject constructor -
+    # instantiated via Hilt's generated factory, never a plain import.
+    (tmp_path / "TasksViewModel.kt").write_text(
+        "@HiltViewModel\nclass TasksViewModel @Inject constructor() : ViewModel()\n"
+    )
+    modules = [_module("TasksViewModel.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "TasksViewModel.kt" in result["entry_points_detected"]
+
+
+def test_dagger_module_with_install_in_is_never_unreachable(tmp_path):
+    # Real repo confirmed (android/architecture-samples): DataModules.kt's
+    # @Module classes are wired into Hilt's DI graph via @InstallIn, never
+    # imported by name anywhere in the app's own source.
+    (tmp_path / "DataModules.kt").write_text(
+        "@Module\n@InstallIn(SingletonComponent::class)\nobject RepositoryModule\n"
+    )
+    modules = [_module("DataModules.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "DataModules.kt" in result["entry_points_detected"]
+
+
+def test_dagger_module_with_test_install_in_is_never_unreachable(tmp_path):
+    # Real repo confirmed (android/architecture-samples): DatabaseTestModule.kt
+    # and RepositoryTestModule.kt (shared-test source set) use @TestInstallIn
+    # rather than @InstallIn - Hilt's variant for a test module that replaces
+    # a production one - same DI-wiring mechanism, just for test builds.
+    (tmp_path / "DatabaseTestModule.kt").write_text(
+        "@Module\n"
+        "@TestInstallIn(components = [SingletonComponent::class], replaces = [DatabaseModule::class])\n"
+        "object DatabaseTestModule\n"
+    )
+    modules = [_module("DatabaseTestModule.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "DatabaseTestModule.kt" in result["entry_points_detected"]
+
+
+def test_dagger_module_without_install_in_stays_unreachable(tmp_path):
+    # A bare @Module with no @InstallIn/@TestInstallIn isn't enough on its
+    # own - real Hilt/Dagger modules always pair @Module with one of those,
+    # and requiring the pair avoids matching an unrelated project's own
+    # "Module" concept that happens to reuse the annotation name.
+    (tmp_path / "NotActuallyDagger.kt").write_text("@Module\nclass NotActuallyDagger\n")
+    modules = [_module("NotActuallyDagger.kt")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [m["path"] for m in result["unreachable_modules"]]
+    assert "NotActuallyDagger.kt" in paths
+
+
+def test_hilt_dagger_annotation_ignored_outside_jvm_files(tmp_path):
+    # The annotation text alone isn't the signal - only a real .kt/.kts/
+    # .java file gets this heuristic, the same file-extension gate every
+    # other language-specific check here (main guard, @main) already uses.
+    (tmp_path / "not_kotlin.py").write_text("# @HiltViewModel\nclass NotKotlin: pass\n")
+    modules = [_module("not_kotlin.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [m["path"] for m in result["unreachable_modules"]]
+    assert "not_kotlin.py" in paths
+
+
 def test_main_swift_is_never_unreachable(tmp_path):
     # Real repo confirmed (vapor/api-template): Sources/Run/main.swift is
     # Swift's classic top-level-code entry point (predates @main, still


### PR DESCRIPTION
## Summary
Found while preparing a Kotlin RepoWise comparison write-up: on a real repo (android/architecture-samples), Aletheore over-reported dead code relative to RepoWise (7 files flagged, all build.gradle.kts/config files, no real .kt files). Two commits close this gap in full.

**Commit 1 - JVM test files:**
- `TEST_PATH_PATTERNS` had entries for Python, JS/TS, and Swift's `Tests/` directory, but nothing for Java/Kotlin.
- Adds the JVM PascalCase `*Test.kt`/`*Test.java` suffix convention, plus the `androidTest`/`test` source-set directory convention for files without that suffix. `androidTest` isn't caught by the existing `tests?`/`__tests__` pattern since it's one fused word, not `test` as its own path segment.
- Confirmed on the real repo: unreachable-module count drops from 31 to 24, all 7 removed being exactly the androidTest files.

**Commit 2 - Android manifest components + Hilt/Dagger DI wiring:**
- `_android_manifest_entry_points` parses every `AndroidManifest.xml` (`<application>`/`<activity>`/`<service>`/`<receiver>`/`<provider>` - deliberately excludes `<action>`/`<category>`, which also carry `android:name` but for Intent actions, never a class), resolving each named class by basename search under the repo root - same approach `_infer_xcodeproj_swift_targets` already uses for Xcode target membership, keeping only an unambiguous single match. Handles both the manifest's shorthand (`.ClassName`) and fully-qualified forms.
- `_has_hilt_dagger_annotation` recognizes `@HiltAndroidApp`, `@HiltViewModel`, and `@Module` paired with `@InstallIn` or its test variant `@TestInstallIn` - classes wired into the DI graph by an annotation processor, never imported by name. Deliberately narrow: not general DI-graph resolution (open-ended - would mean following `@Binds`/`@Provides` wiring across arbitrarily many files), just the same "instantiated by a framework, not a plain import" shape the `__main__` guard and Swift `@main` checks already use elsewhere in this file.
- Verified against the real repo: 24 → 15 unreachable files. All 8 real app classes originally found (TodoApplication, TodoActivity, 4 ViewModels, DataModules, DatabaseTestModule, RepositoryTestModule) are now correctly detected, plus one more real catch not in the original list (`HiltTestActivity.kt`, debug-flavor manifest).
- **One remaining real `.kt` false positive is knowingly not fixed here:** `CustomTestRunner.kt` is referenced only by `build.gradle.kts`'s `testInstrumentationRunner = "..."` string config - a third, distinct reference mechanism (Gradle build-script config, not a manifest or a DI annotation) outside this fix's scope.

## Test plan
- [x] `pytest tests/test_dead_code.py` - 31 passed (10 new tests for the manifest/Hilt/Dagger heuristics, covering both name forms, ambiguous-basename skip, the `@Module`-without-`@InstallIn` non-match, and the JVM-file-extension gate)
- [x] Full suite: 1493 passed
- [x] Re-scanned the real repo (android/architecture-samples) before/after each commit via `aletheore scan . --no-check-vulnerabilities --no-check-licenses` + `aletheore query dead-code`, confirmed the exact counts and file lists above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr