### PR TITLE
fix: Swift dead-code false positives from same-target reachability + manifest interpolation

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from aletheore.repo_config import is_ignored
 from aletheore.scanner.detect import IGNORED_DIRS
+from aletheore.scanner.graph import _infer_swift_targets
 from aletheore.vulnerabilities import _parse_npm_direct_pins, _parse_pip_pins
 
 ENTRY_POINT_FILENAMES = {
@@ -23,6 +24,12 @@ ENTRY_POINT_FILENAMES = {
     # SwiftPM's build manifest - always this exact name, read by the swift
     # toolchain itself, never imported by the repo's own application code.
     "Package.swift",
+    # Swift's classic top-level-code entry point (predates the @main
+    # attribute, still standard in Vapor's own project template): the one
+    # file in a target the compiler allows top-level executable statements
+    # in, by both language rule and universal convention its entry point.
+    # Confirmed on a real repo (vapor/api-template): Sources/Run/main.swift.
+    "main.swift",
 }
 
 TEST_PATH_PATTERNS = [
@@ -51,6 +58,12 @@ PACKAGE_IMPORT_ALIASES = {
 # Confirmed on this repo: RQ worker processes and standalone scripts/*.py
 # CLI tools all follow this convention regardless of filename.
 _MAIN_GUARD_PATTERN = re.compile(r"if\s+__name__\s*==\s*[\'\"]__main__[\'\"]\s*:")
+
+# A Swift @main type (an AWS Lambda handler, a CLI's entry struct, ...) is
+# invoked by the runtime, never imported by another file - same category as
+# Python's __main__ guard above. Always at file scope, so a start-of-line
+# anchor (allowing leading whitespace) is enough without a full parse.
+_SWIFT_MAIN_ATTRIBUTE_PATTERN = re.compile(r"^\s*@main\b", re.MULTILINE)
 
 _HTML_SCRIPT_SRC_PATTERN = re.compile(r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE)
 
@@ -154,6 +167,53 @@ def _has_main_guard(repo_path: Path, path: str) -> bool:
     return bool(_MAIN_GUARD_PATTERN.search(content))
 
 
+def _has_swift_main_attribute(repo_path: Path, path: str) -> bool:
+    if not path.endswith(".swift"):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(_SWIFT_MAIN_ATTRIBUTE_PATTERN.search(content))
+
+
+def _swift_target_reachable_files(
+    repo_path: Path,
+    modules: list[dict],
+    ignored_paths: list[str] | None,
+) -> set[str]:
+    """Every Swift file belonging to a target that's reachable some other
+    way (imported from another target, or containing a @main entry point).
+
+    Swift files within one target see each other with no import statement
+    at all - that's how Swift's compilation model works, unlike every other
+    language here - so the per-file import graph can never show intra-
+    target edges no matter how well cross-target import resolution works.
+    Confirmed on a real repo (vapor/penny-bot): a target's @main handler
+    file imported by nothing outside it, alongside sibling files (a
+    repository/service layer) the handler itself references with no
+    import, both looked equally unreachable before this.
+    """
+    swift_targets = _infer_swift_targets(repo_path, ignored_paths)
+    if not swift_targets:
+        return set()
+
+    modules_by_path = {module["path"]: module for module in modules}
+    reachable_files: set[str] = set()
+    for name, files in swift_targets.items():
+        rel_paths = [
+            file_path.relative_to(repo_path).as_posix() if file_path.is_absolute() else file_path.as_posix()
+            for file_path in files
+        ]
+        target_is_reachable = any(
+            modules_by_path.get(rel, {}).get("imported_by") or _has_swift_main_attribute(repo_path, rel)
+            for rel in rel_paths
+        )
+        if target_is_reachable:
+            reachable_files.update(rel_paths)
+    return reachable_files
+
+
 def _html_script_entry_points(repo_path: Path, ignored_paths: list[str] | None = None) -> set[str]:
     # Plain <script src="..."> tags (no bundler, no ES module imports) are
     # invisible to the JS import graph - confirmed on this repo's website/:
@@ -217,6 +277,7 @@ def find_dead_code(
             custom_entry_points = {path for path in raw_entry_points if isinstance(path, str)}
 
     html_script_entry_points = _html_script_entry_points(repo_path, ignored_paths)
+    swift_reachable_files = _swift_target_reachable_files(repo_path, modules, ignored_paths)
 
     unreachable_modules = []
     entry_points_detected = []
@@ -226,6 +287,8 @@ def find_dead_code(
             entry_points_detected.append(path)
             continue
         if is_test_file(path):
+            continue
+        if path in swift_reachable_files:
             continue
         if not module.get("imported_by", []):
             if path in html_script_entry_points or _has_main_guard(repo_path, path):

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1915,9 +1915,24 @@ def _swift_call_arg_strings(call_expr: Node, source: bytes) -> dict[str, str]:
             continue
         label = source[label_id.start_byte:label_id.end_byte].decode(errors="ignore")
         str_lit = next((c for c in arg.children if c.type == "line_string_literal"), None)
-        text_node = next(
-            (c for c in str_lit.children if c.type == "line_str_text"), None
-        ) if str_lit is not None else None
+        if str_lit is None:
+            continue
+        # A string with interpolation (e.g. "./Lambdas/\(name)", the shape a
+        # programmatic manifest's factory function uses to build several
+        # targets from one call site) isn't a pure literal - `name` is a
+        # runtime value, never resolvable from source alone. Skipping it
+        # here is deliberate: picking the first line_str_text child instead
+        # (the old behavior) silently returned a truncated fragment of the
+        # real value ("./Lambdas/", missing the interpolated suffix) as if
+        # it were the whole thing - confirmed on a real repo (vapor/
+        # penny-bot), where this merged eight distinct Lambda targets into
+        # one fictitious "Lambda" target spanning the entire Lambdas/
+        # directory. An unresolvable value should fall through to
+        # _infer_swift_targets's own directory-convention scan instead of
+        # being reported as this.
+        if any(c.type == "interpolated_expression" for c in str_lit.children):
+            continue
+        text_node = next((c for c in str_lit.children if c.type == "line_str_text"), None)
         if text_node is not None:
             result[label] = source[text_node.start_byte:text_node.end_byte].decode(errors="ignore")
     return result

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -54,6 +54,57 @@ def test_package_swift_manifest_is_never_unreachable(tmp_path):
     assert "Package.swift" in result["entry_points_detected"]
 
 
+def test_main_swift_is_never_unreachable(tmp_path):
+    # Real repo confirmed (vapor/api-template): Sources/Run/main.swift is
+    # Swift's classic top-level-code entry point (predates @main, still
+    # what Vapor's own project template uses) - same category as
+    # Package.swift above, not this repo's own application code importing
+    # it.
+    modules = [_module("Sources/Run/main.swift")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "Sources/Run/main.swift" in result["entry_points_detected"]
+
+
+def test_swift_target_siblings_of_a_main_entry_point_are_never_unreachable(tmp_path):
+    # Real repo confirmed (vapor/penny-bot): a target's @main handler file
+    # is imported by nothing outside the target (nothing in Swift *can*
+    # import a leaf executable target), and its sibling files within the
+    # same target (a repository/service layer) are referenced by the
+    # handler with no import statement at all - Swift files within one
+    # target see each other implicitly. Both looked equally unreachable
+    # before this: the per-file import graph can never show intra-target
+    # edges, no matter how well cross-target import resolution works.
+    target_dir = tmp_path / "Sources" / "AutoFaqsLambda"
+    target_dir.mkdir(parents=True)
+    (target_dir / "AutoFaqsHandler.swift").write_text(
+        "import AWSLambdaRuntime\n\n@main\nstruct AutoFaqsHandler: LambdaHandler {}\n"
+    )
+    (target_dir / "S3AutoFaqsRepository.swift").write_text(
+        "struct S3AutoFaqsRepository {}\n"
+    )
+    modules = [
+        _module("Sources/AutoFaqsLambda/AutoFaqsHandler.swift"),
+        _module("Sources/AutoFaqsLambda/S3AutoFaqsRepository.swift"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, ignored_paths=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_swift_target_with_no_reachable_member_stays_unreachable(tmp_path):
+    # An entirely orphaned target (no @main, nothing imports it) should
+    # still be flagged - the fix only propagates reachability from a
+    # target that's actually reachable some other way, it doesn't make
+    # every Swift file immune to dead-code detection.
+    target_dir = tmp_path / "Sources" / "Orphan"
+    target_dir.mkdir(parents=True)
+    (target_dir / "OrphanThing.swift").write_text("struct OrphanThing {}\n")
+    modules = [_module("Sources/Orphan/OrphanThing.swift")]
+    result = find_dead_code(tmp_path, modules, config=None, ignored_paths=None)
+    paths = [m["path"] for m in result["unreachable_modules"]]
+    assert "Sources/Orphan/OrphanThing.swift" in paths
+
+
 def test_config_can_add_custom_entry_points(tmp_path):
     modules = [_module("app/worker.py")]
     config = {"dead_code_entry_points": ["app/worker.py"]}

--- a/src/tests/test_graph_swift.py
+++ b/src/tests/test_graph_swift.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from aletheore.scanner.graph import _infer_xcodeproj_swift_targets, build_module_graph
+from aletheore.scanner.graph import _infer_swift_targets, _infer_xcodeproj_swift_targets, build_module_graph
 from conftest import symbol_names
 
 
@@ -161,6 +161,53 @@ def test_build_module_graph_swift_target_path_override_from_package_manifest(tmp
     edges = {tuple(edge) for edge in dependency_graph["edges"]}
 
     assert ("Sources/App/Main.swift", "Vendor/StoreImpl/User.swift") in edges
+
+
+def test_interpolated_manifest_target_path_is_never_mistaken_for_a_literal(tmp_path):
+    # Real repo confirmed (vapor/penny-bot): a factory function shape - a
+    # static func building several similar targets from one call site, each
+    # passing a literal name but building name:/path: with string
+    # interpolation ("\(name)Lambda", "./Lambdas/\(name)") - isn't a
+    # resolvable literal at all; `name` is a runtime parameter. The old
+    # behavior extracted the interpolated string's first literal text
+    # fragment instead of recognizing it wasn't a plain literal, silently
+    # producing a wrong, truncated path ("./Lambdas/", the parent of every
+    # such target) under a wrong, truncated name ("Lambda") - merging eight
+    # distinct real targets into one fictitious one spanning their entire
+    # shared parent directory. Skipping the value entirely (falling through
+    # to _infer_swift_targets's own directory-convention scan, which
+    # correctly can't resolve a directory this manifest never names
+    # literally either) is the honest outcome - not a wrong merge.
+    repo = tmp_path / "repo"
+    (repo / "Lambdas" / "AutoFaqs").mkdir(parents=True)
+    (repo / "Lambdas" / "AutoPings").mkdir(parents=True)
+    (repo / "Lambdas" / "AutoFaqs" / "Handler.swift").write_text("@main\nstruct Handler {}\n")
+    (repo / "Lambdas" / "AutoPings" / "Handler.swift").write_text("@main\nstruct Handler {}\n")
+
+    (repo / "Package.swift").write_text(
+        "// swift-tools-version:5.9\n"
+        "import PackageDescription\n\n"
+        "extension PackageDescription.Target {\n"
+        "    static func lambdaTarget(name: String) -> PackageDescription.Target {\n"
+        '        .executableTarget(name: "\\(name)Lambda", path: "./Lambdas/\\(name)")\n'
+        "    }\n"
+        "}\n\n"
+        "let package = Package(\n"
+        '    name: "Ex",\n'
+        "    targets: [\n"
+        '        .lambdaTarget(name: "AutoFaqs"),\n'
+        '        .lambdaTarget(name: "AutoPings"),\n'
+        "    ]\n"
+        ")\n"
+    )
+
+    targets = _infer_swift_targets(repo, None)
+    assert "Lambda" not in targets
+    all_files = {path.name for files in targets.values() for path in files}
+    # Neither Handler.swift shows up under any wrong merged grouping -
+    # both are genuinely unresolvable here, same as any target this
+    # manifest never names literally.
+    assert not all_files
 
 
 def _pbxproj_text(objects_body: str) -> bytes:


### PR DESCRIPTION
## Summary
Found while re-verifying the RepoWise comparison write-up. Two compounding issues on real repos (apple/swift-algorithms, vapor/api-template, vapor/penny-bot):

1. **Same-target reachability**: Swift files within one target see each other with no import statement at all - unlike every other supported language here - so the per-file import graph can never show intra-target edges. A target's `@main` entry point (or `main.swift`, Swift's classic top-level-code convention) looked unreachable itself, and so did every sibling file it referenced with no import. Fixed by treating a target as one reachability unit: if any file in it is reachable (imported from another target, or an entry point), every file in it is.

2. **Manifest string interpolation**: `Package.swift` can be genuinely executable Swift - a factory function building several targets from one call site, with `name:`/`path:` built via string interpolation (`"\(name)Lambda"`, `"./Lambdas/\(name)"`). `_swift_call_arg_strings` was silently extracting the first literal text fragment of an interpolated string as if it were the whole value - confirmed on a real repo (vapor/penny-bot), where this merged eight distinct Lambda targets into one fictitious `"Lambda"` target spanning their entire shared parent directory. Now skipped entirely when interpolation is present, falling through to the honest "unresolvable" state instead of a wrong merge.

## Test plan
- [x] New unit tests for both fixes, plus a false-negative guard rail (an orphaned target with no reachable member still gets flagged).
- [x] Full suite: 1482 passed.
- [x] Re-scanned real repos before/after:
  - vapor/api-template: 1 → 0 false positives (`main.swift` fix)
  - vapor/penny-bot: unaffected (168 files; its Lambda targets are genuinely unresolvable via static parsing either way - a separate, harder problem, not attempted here)
  - apple/swift-algorithms: unaffected (0 before, 0 after)