### PR TITLE
fix: resolve top-level Kotlin val/var imports

### DIFF
--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1634,8 +1634,17 @@ def _kotlin_class_file(root: Path, segments: list[str]) -> Path | None:
     # optional `\S+\.` handles an extension function's receiver type
     # (`fun LocalTask.toExternal()`), which sits between `fun` and the
     # name this import actually names.
+    #
+    # A top-level `val`/`var` is the same shape one level simpler - a
+    # module-level constant or computed property with no parameter list
+    # at all (confirmed against the same real repo:
+    # CoroutinesUtils.kt's `val WhileUiSubscribed: SharingStarted = ...`,
+    # imported by name, same failure as the function case above before
+    # this).
     needle = re.compile(
-        rf"\b(?:class|interface|object)\s+{escaped}\b|\bfun\s+(?:\S+\.)?{escaped}\s*\("
+        rf"\b(?:class|interface|object)\s+{escaped}\b"
+        rf"|\bfun\s+(?:\S+\.)?{escaped}\s*\("
+        rf"|\b(?:val|var)\s+{escaped}\b"
     )
     for candidate in sorted(directory.glob("*.kt")) + sorted(directory.glob("*.kts")):
         try:

--- a/src/tests/test_graph_kotlin.py
+++ b/src/tests/test_graph_kotlin.py
@@ -180,6 +180,34 @@ def test_build_module_graph_kotlin_extension_function_import_resolves(tmp_path):
     ) in edges
 
 
+def test_build_module_graph_kotlin_top_level_val_import_resolves(tmp_path):
+    # Real repo confirmed (android/architecture-samples): CoroutinesUtils.kt's
+    # `val WhileUiSubscribed: SharingStarted = ...` - a module-level
+    # constant/computed property, imported by name from another file, had
+    # zero incoming edges before this (needle only matched class/interface/
+    # object/fun, never val/var).
+    repo = tmp_path / "repo"
+    src = repo / "src" / "main" / "kotlin" / "com" / "example"
+    (src / "util").mkdir(parents=True)
+    (src / "util" / "CoroutinesUtils.kt").write_text(
+        "package com.example.util\n\n"
+        "val WhileUiSubscribed: Long = 5000L\n"
+    )
+    (src / "Main.kt").write_text(
+        "package com.example\n\n"
+        "import com.example.util.WhileUiSubscribed\n\n"
+        "fun main() { println(WhileUiSubscribed) }\n"
+    )
+
+    _, dependency_graph, _ = build_module_graph(repo)
+    edges = {tuple(edge) for edge in dependency_graph["edges"]}
+
+    assert (
+        "src/main/kotlin/com/example/Main.kt",
+        "src/main/kotlin/com/example/util/CoroutinesUtils.kt",
+    ) in edges
+
+
 def test_build_module_graph_kotlin_wildcard_import_resolves_every_file_in_package(tmp_path):
     repo = tmp_path / "repo"
     src = repo / "src" / "main" / "kotlin" / "com" / "example"


### PR DESCRIPTION
## Summary
Small follow-up to #487, found during final verification of that same fix. `_kotlin_class_file`'s needle matched `class`/`interface`/`object` and (as of #487) `fun`, but never a top-level `val`/`var` - a module-level constant or computed property, one declaration kind simpler than a function.

Confirmed on the same real repo (android/architecture-samples): `CoroutinesUtils.kt`'s `val WhileUiSubscribed: SharingStarted = ...`, imported by name from `TasksViewModel.kt`, had zero incoming edges before this.

Re-scanned end-to-end: dead-code false positives on this repo drop from 12 to 11.

## Test plan
- [x] New unit test.
- [x] Full suite: 1496 passed.
- [x] Re-scanned the real repo before/after.