### PR TITLE
fix: skip PR scan jobs cleanly when the PR is already closed

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -453,6 +453,31 @@ def fetch_pr_context(
     return "\n".join(parts) if len(parts) > 1 else ""
 
 
+def fetch_pr_is_open(
+    client: httpx.Client,
+    token: str,
+    repo_full_name: str,
+    pr_number: int,
+) -> bool:
+    """Whether a PR is still open right now, per GitHub's own record.
+
+    A PR's head_sha can stop being fetchable at all once its source branch
+    is deleted (a squash-merge-and-delete-branch is a completely normal,
+    fast workflow) - `git checkout` on that sha then fails with "unable to
+    read tree", not because anything is broken, but because there is
+    nothing left to check out. Confirmed as a real production failure:
+    a scan job queued against a PR's head_sha lost the race against that
+    same PR being merged and its branch deleted before the job ran.
+    """
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    response = client.get(f"/repos/{repo_full_name}/pulls/{pr_number}", headers=headers)
+    response.raise_for_status()
+    return response.json().get("state") == "open"
+
+
 def fetch_default_branch_head_sha(
     client: httpx.Client,
     token: str,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -143,6 +143,7 @@ from scan_worker.github_api import (
     fetch_pr_changed_files,
     fetch_pr_context,
     fetch_pr_diff,
+    fetch_pr_is_open,
     upsert_pr_comment,
 )
 from app_server.email_templates import (
@@ -936,6 +937,18 @@ def run_pr_scan_job(
     try:
         app_jwt = generate_app_jwt(settings.github_app_id, settings.github_app_private_key)
         token = _token_sync(installation_id, app_jwt)
+
+        # A fast merge-and-delete-branch (a completely normal workflow)
+        # between this job being queued and actually running leaves
+        # head_sha unfetchable - not a scan failure, there's simply
+        # nothing left to check out, and the PR is already done. Checked
+        # here rather than only catching the eventual git error so this
+        # doesn't post a failure comment or count against the ops
+        # failed-jobs alert for what is, from the user's perspective, a
+        # PR that already finished successfully.
+        client = get_github_api_client()
+        if not fetch_pr_is_open(client, token, repo_full_name, pr_number):
+            return
 
         clone_url = _clone_url(repo_full_name, token)
         base_dir = job_dir / "base"

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -16,6 +16,7 @@ from scan_worker.github_api import (
     fetch_file_content,
     fetch_pr_changed_files,
     fetch_pr_diff,
+    fetch_pr_is_open,
     fetch_recent_commits_for_path,
     find_open_pull_request,
     upsert_pr_comment,
@@ -639,6 +640,34 @@ def test_fetch_default_branch_head_sha_returns_none_for_empty_repo_409():
 
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
     assert fetch_default_branch_head_sha(client, "token", "octocat/hello-world") is None
+
+
+def test_fetch_pr_is_open_true_for_open_pr():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"state": "open"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    assert fetch_pr_is_open(client, "token", "octocat/hello-world", 42) is True
+
+
+def test_fetch_pr_is_open_false_for_merged_pr():
+    # Real production failure this exists to prevent: a PR merged (and its
+    # branch deleted) between a scan job being queued and actually running
+    # left head_sha permanently unfetchable - "unable to read tree", not a
+    # real scan failure.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"state": "closed", "merged": True})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    assert fetch_pr_is_open(client, "token", "octocat/hello-world", 42) is False
+
+
+def test_fetch_pr_is_open_false_for_closed_unmerged_pr():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"state": "closed", "merged": False})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    assert fetch_pr_is_open(client, "token", "octocat/hello-world", 42) is False
 
 
 def test_ensure_branch_at_creates_ref_when_missing():

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -37,6 +37,17 @@ def _noop_repo_checkout_lock(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.repo_checkout_lock", _noop_spend_lock)
 
 
+@pytest.fixture(autouse=True)
+def _pr_is_open_by_default(monkeypatch):
+    # run_pr_scan_job now checks the PR is still open before attempting a
+    # checkout that's doomed once its branch is gone (see
+    # fetch_pr_is_open's docstring for the real production failure this
+    # closes) - a real network call none of the 30+ existing tests here
+    # expect. Default to "still open" so none of them need touching; the
+    # skip-when-closed path gets its own dedicated test overriding this.
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_is_open", lambda *a, **k: True)
+
+
 def _patch_no_spend_cap(monkeypatch) -> None:
     """AIRview/Docs build jobs now gate on the same installation monthly
     LLM spend cap managed audits and flash review already used - real
@@ -5564,6 +5575,38 @@ def test_run_pr_scan_job_skips_paid_repo_past_monthly_scan_cap(bare_repo_with_tw
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: cloned.append(True))
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    posted = []
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: posted.append(True))
+
+    run_pr_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        pr_number=7,
+        base_sha=base_sha,
+        head_sha=head_sha,
+    )
+
+    assert cloned == []
+    assert posted == []
+
+
+def test_run_pr_scan_job_skips_cleanly_when_pr_already_closed(bare_repo_with_two_commits, monkeypatch):
+    # Real production failure this closes: a PR merged (squash-merge-and-
+    # delete-branch, a completely normal fast workflow) between this job
+    # being queued and actually running left head_sha unfetchable by any
+    # git checkout - "unable to read tree", not a real scan failure, and
+    # not something a retry could ever fix. Checking PR state up front
+    # means this is a clean no-op instead of a failed job (a bot comment
+    # on an already-merged PR, and an ops "failed_jobs" alert for a PR
+    # that already finished successfully).
+    bare_path, base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_is_open", lambda *a, **k: False)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    cloned = []
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: cloned.append(True))
     posted = []
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: posted.append(True))
 

--- a/github-app/tests/test_pr_scan_e2e.py
+++ b/github-app/tests/test_pr_scan_e2e.py
@@ -44,6 +44,12 @@ def test_pull_request_webhook_to_pr_comment_end_to_end(
         lambda *a, **k: {"secret": set(), "vulnerability": set()},
     )
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", fake_upsert)
+    # This test deliberately makes no other GitHub API mock - real
+    # enqueue-through-perform, per its own docstring. fetch_pr_is_open is
+    # the one real network call run_pr_scan_job now makes before cloning
+    # anything; "fake-token" below isn't a real GitHub token, so an
+    # unmocked call here would 401, same as any other real call would.
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_is_open", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")


### PR DESCRIPTION
## Summary
Real production failure, root-caused live via SSH into scan-worker logs: `run_pr_scan_job` was queued against aletheore-benchmarks#10's head_sha, but by the time the job actually ran, the PR had already been squash-merged and its source branch deleted - a completely normal, fast workflow. That left `head_sha` unfetchable by any git checkout (`fatal: unable to read tree`), both via the persistent checkout and a fresh clone-and-checkout fallback, since no advertised ref points to it anymore once the branch is gone.

This wasn't a scan failure in any real sense - the PR had already finished successfully - but it still posted a scary "Aletheore couldn't complete this scan" bot comment on an already-merged PR and counted against the ops `failed_jobs` alert, the exact false-alarm shape investigated and fixed for a different root cause last night (#482).

Fixed by checking the PR's real current state via the GitHub API before attempting the doomed checkout - if it's no longer open, this is a clean no-op (no clone, no comment, no exception), not a failure.

Confirmed on production: exactly one incident (both checkout attempts for the same job, same sha) since the last deploy, not a storm - isolated to tonight's fast squash-merge-and-delete-branch pattern.

## Test plan
- [x] New unit tests: `fetch_pr_is_open` (open/merged/closed-unmerged), `run_pr_scan_job` skips cleanly when closed (no clone, no comment).
- [x] Added an autouse fixture defaulting the new check to "open" so none of the 30+ existing `run_pr_scan_job` tests needed touching (same pattern as the existing `_noop_repo_checkout_lock` fixture).
- [x] Ran the full `test_github_api.py` (42 passed) and every `*pr_scan_job*` test in `test_jobs.py` (9 passed) locally. Could not run the full `test_jobs.py`/`test_github_api.py` suite end-to-end (194 tests, needs a local Postgres/Redis via `docker-compose.test.yml`, Docker daemon unavailable in this environment) - CI will cover that.