### PR TITLE
marketing: add the missing Aletheore Flash tier, fix stale claims and a real contrast bug

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -59,6 +59,7 @@
     "PYSEC",
     "Pydantic",
     "Procta",
+    "Qodo",
     "Squeezy",
     "SLOS",
     "Scorecard",

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -4,19 +4,19 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Aletheore Benchmarks — Measured Against RepoWise, In the Open</title>
-  <meta name="description" content="Aletheore vs. RepoWise on locating code, cost, and PR review — every number reproducible from the public aletheore-benchmarks repo, no API key required. We publish the rows we lose too.">
+  <meta name="description" content="Aletheore vs. RepoWise and a real named competitor (PR-Agent) on locating code, dead-code detection, cost, and PR review - every number reproducible from the public aletheore-benchmarks repo, no API key required. We publish the rows we lose too.">
   <link rel="canonical" href="https://www.aletheore.com/benchmarks">
 
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="Aletheore">
   <meta property="og:url" content="https://www.aletheore.com/benchmarks">
   <meta property="og:title" content="Aletheore Benchmarks — Measured Against RepoWise, In the Open">
-  <meta property="og:description" content="Head-to-head retrieval results, PR review cost/quality, and deterministic-vs-bare-LLM precision — reproducible from the public aletheore-benchmarks repo. We publish the rows we lose too.">
+  <meta property="og:description" content="Head-to-head retrieval results, dead-code detection, a real named-competitor PR review comparison, and deterministic-vs-bare-LLM precision - reproducible from the public aletheore-benchmarks repo. We publish the rows we lose too.">
   <meta property="og:image" content="https://www.aletheore.com/assets/logo-mark.png">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Aletheore Benchmarks — Measured Against RepoWise, In the Open">
-  <meta name="twitter:description" content="Head-to-head retrieval results, PR review cost/quality, and deterministic-vs-bare-LLM precision — reproducible, no API key required.">
+  <meta name="twitter:description" content="Head-to-head retrieval, dead-code detection, PR review vs. a real named competitor, and deterministic-vs-bare-LLM precision - reproducible, no API key required.">
   <meta name="twitter:image" content="https://www.aletheore.com/assets/logo-mark.png">
 
   <link rel="icon" type="image/png" href="assets/logo-mark.png">
@@ -372,6 +372,58 @@ python scripts/score_fallback_judge.py</code></pre>
 
       <section class="developer-section dogfood-repo dogfood-repo-alt">
         <div class="section-heading dogfood-heading">
+          <p class="eyebrow">Head-to-head against PR-Agent · a real, named competitor</p>
+          <h2>Same model, same corpus, production code.</h2>
+          <p>A different question from the compact-vs-context experiments above: how does
+            Aletheore's actual hosted product compare against a real, named, external competitor
+            (Qodo's <a href="https://github.com/qodo-ai/pr-agent" rel="noopener">PR-Agent</a>), held
+            to the same model, so the result isolates review methodology rather than which vendor
+            has the bigger model budget? Both tools on <code>gpt-5.6-luna</code>, 24-case corpus,
+            production Aletheore deployed at commit <code>35e18f8</code>.</p>
+        </div>
+
+        <div class="toon-counters">
+          <div class="toon-counter">
+            <div class="toon-counter-value">0</div>
+            <div class="toon-counter-label">false positives, both Aletheore tiers<br>vs. PR-Agent's 8</div>
+          </div>
+          <div class="toon-counter">
+            <div class="toon-counter-value">2.5x</div>
+            <div class="toon-counter-label">Aletheore's real recall vs. PR-Agent's,<br>on identical footing</div>
+          </div>
+          <div class="toon-counter">
+            <div class="toon-counter-value">4.4x</div>
+            <div class="toon-counter-label">faster per case, Aletheore Flash<br>vs. PR-Agent (15.9s vs. 69.3s)</div>
+          </div>
+        </div>
+
+        <div class="dogfood-table-wrap">
+          <table class="dogfood-table">
+            <thead>
+              <tr><th>Tool</th><th>Hit</th><th>Partial</th><th>Miss</th><th>False Positives</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>Aletheore AIR (Luna + DeepSeek verify)</td><td><strong>15</strong></td><td>1</td><td>4</td><td><strong>0</strong></td></tr>
+              <tr><td>Aletheore Flash (Luna only, no verify)</td><td><strong>15</strong></td><td>0</td><td>5</td><td><strong>0</strong></td></tr>
+              <tr><td>PR-Agent / Qodo (Luna)</td><td>6</td><td>0</td><td>14</td><td>8</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="dogfood-p">AIR and Flash tie on total recall (15/20 each) despite Flash never
+          calling the verification model, consistent with verification being a precision
+          mechanism, not a recall lever. Both Aletheore tiers hold a clean false-positive record on
+          the 4 clean diffs, not explained by proposing fewer findings overall (it doesn't cost
+          recall, see the hit numbers above). This reverses an earlier, unintentionally unfair run
+          (free-tier Aletheore vs. PR-Agent's own pricier default model) that had shown the opposite,
+          documented as superseded, not discarded. Disclosed limitations (no blind-judge pass this
+          cycle, AIR measured via direct invocation rather than a live webhook) and the full setup
+          in
+          <a href="https://github.com/Aletheore/aletheore-benchmarks/blob/master/pr_review/README.md" rel="noopener">pr_review/README.md</a>,
+          Experiment 5.</p>
+      </section>
+
+      <section class="developer-section dogfood-repo dogfood-repo-alt">
+        <div class="section-heading dogfood-heading">
           <p class="eyebrow">Deterministic analysis vs. bare LLM</p>
           <h2>Can a bare LLM reproduce the scanner's answer, given the same data?</h2>
           <p>Not "Aletheore vs. RepoWise" — for the parts of Aletheore that aren't an LLM call
@@ -395,6 +447,40 @@ python scripts/score_fallback_judge.py</code></pre>
         </div>
         <p class="dogfood-p">Full methodology, including a real bug this testing surfaced, in
           <a href="https://github.com/Aletheore/aletheore-benchmarks/blob/master/DETERMINISTIC_VS_LLM.md" rel="noopener">DETERMINISTIC_VS_LLM.md</a>.</p>
+      </section>
+
+      <section class="developer-section dogfood-repo dogfood-repo-alt">
+        <div class="section-heading dogfood-heading">
+          <p class="eyebrow">Dead-code detection · Kotlin and Swift, vs. RepoWise</p>
+          <h2>Swift: a clean win. Kotlin: an exact match.</h2>
+          <p>A different axis from "how does X work?" above: which files does each tool correctly
+            leave alone as real, reachable code? Measured file-level (RepoWise also flags
+            unused-export symbols; Aletheore's dead-code module doesn't attempt that granularity,
+            so symbol-level findings are excluded from both sides).</p>
+        </div>
+
+        <div class="dogfood-table-wrap">
+          <table class="dogfood-table">
+            <thead>
+              <tr><th>Repo</th><th>Files</th><th>RepoWise false positives</th><th>Aletheore false positives</th></tr>
+            </thead>
+            <tbody>
+              <tr><td>vapor/penny-bot (Swift)</td><td>168</td><td>60 (36%)</td><td><strong>0</strong></td></tr>
+              <tr><td>vapor/api-template (Swift)</td><td>10</td><td>6 (60%)</td><td><strong>0</strong></td></tr>
+              <tr><td>android/architecture-samples (Kotlin)</td><td>268</td><td>7</td><td><strong>7</strong>, same 7 files</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="dogfood-p">RepoWise's Swift support doesn't understand whole-module imports: a
+          Swift <code>import Foo</code> names a compiled target, not a file, so files referenced
+          only from outside Swift's import syntax (a Lambda handler invoked by the AWS runtime)
+          look completely unreachable to it. Getting Aletheore to 0 on Swift, and Kotlin from an
+          initial 31 down to an exact 7-vs-7 match with RepoWise, took five real fixes to
+          Aletheore's own scanner, found by re-running this comparison rather than trusting an
+          earlier pass: same-target and same-package implicit visibility, a manifest
+          string-interpolation parsing bug, and two missing import-resolution cases (top-level
+          Kotlin functions and constants). Full writeup and the fix history in
+          <a href="https://github.com/Aletheore/aletheore-benchmarks/blob/master/LANGUAGE_COVERAGE.md" rel="noopener">LANGUAGE_COVERAGE.md</a>.</p>
       </section>
 
       <section class="developer-section dogfood-repo dogfood-repo-alt">

--- a/website/benchmarks.html
+++ b/website/benchmarks.html
@@ -376,7 +376,7 @@ python scripts/score_fallback_judge.py</code></pre>
           <h2>Same model, same corpus, production code.</h2>
           <p>A different question from the compact-vs-context experiments above: how does
             Aletheore's actual hosted product compare against a real, named, external competitor
-            (Qodo's <a href="https://github.com/qodo-ai/pr-agent" rel="noopener">PR-Agent</a>), held
+            (Qodo's <a href="https://github.com/The-PR-Agent/pr-agent" rel="noopener">PR-Agent</a>), held
             to the same model, so the result isolates review methodology rather than which vendor
             has the bigger model budget? Both tools on <code>gpt-5.6-luna</code>, 24-case corpus,
             production Aletheore deployed at commit <code>35e18f8</code>.</p>

--- a/website/index.html
+++ b/website/index.html
@@ -11,12 +11,12 @@
   <meta property="og:site_name" content="Aletheore">
   <meta property="og:url" content="https://www.aletheore.com/">
   <meta property="og:title" content="Aletheore — Evidence-Grounded Code Audits &amp; GitHub Automation">
-  <meta property="og:description" content="Aletheore is more than a scanner. Free deterministic CLI audits (secrets, vulnerabilities, licenses, dead code, git hotspots) plus a hosted GitHub App: automated PR reviews, live endpoint health monitoring, AIRview (an AI-generated, always-current map of your repo's architecture), AI-generated per-symbol Docs, Slack/Teams alerts, and team seat management on Aletheore AIR.">
+  <meta property="og:description" content="Aletheore is more than a scanner. Free deterministic CLI audits (secrets, vulnerabilities, licenses, dead code, git hotspots) plus a hosted GitHub App: automated PR reviews on Aletheore Flash ($6/mo), or everything in Flash plus a second-model verification pass, AIRview, AI-generated Docs, live endpoint monitoring, Slack/Teams alerts, and team seats on Aletheore AIR ($29.99/mo).">
   <meta property="og:image" content="https://www.aletheore.com/assets/logo-mark.png">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Aletheore — Evidence-Grounded Code Audits &amp; GitHub Automation">
-  <meta name="twitter:description" content="Free deterministic CLI scanning (Aletheore Community) plus a hosted GitHub App on Aletheore AIR: dead code detection, live endpoint monitoring, AIRview architecture maps, AI-generated Docs, automated PR reviews, and Slack/Teams alerts.">
+  <meta name="twitter:description" content="Free deterministic CLI scanning (Aletheore Community) plus a hosted GitHub App: automated PR reviews on Aletheore Flash, or Flash plus verification, AIRview, AI-generated Docs, and Slack/Teams alerts on Aletheore AIR.">
   <meta name="twitter:image" content="https://www.aletheore.com/assets/logo-mark.png">
 
   <link rel="icon" type="image/png" href="assets/logo-mark.png">
@@ -39,10 +39,17 @@
       },
       {
         "@type": "Offer",
+        "name": "Aletheore Flash",
+        "price": "6",
+        "priceCurrency": "USD",
+        "description": "Automatic PR reviews on every push, up to 800/month, one model."
+      },
+      {
+        "@type": "Offer",
         "name": "Aletheore AIR",
         "price": "29.99",
         "priceCurrency": "USD",
-        "description": "Up to 3 team members. Managed audits and AIRview builds run on an OpenAI frontier model."
+        "description": "Up to 3 team members. Everything in Flash plus a second-model verification pass, managed audits, and AIRview builds run on an OpenAI frontier model."
       }
     ],
     "featureList": [
@@ -55,7 +62,7 @@
       "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, DeepSeek, Ollama)",
       "GitHub App: automatic PR comments and branch-protection check runs",
       "AI-powered managed audit reports on pull requests, written by an OpenAI frontier model",
-      "Automatic Flash reviews on every pull request push: one model writes the review, a second independent model re-checks every finding against the diff before it's shown (AIR)",
+      "Automatic Flash reviews on every pull request push (Flash tier and up); AIR adds a second, independent model that re-checks every finding against the diff before it's shown",
       "Slack/Teams alerts on new findings",
       "Live API endpoint health monitoring across multiple targets, with a public status API",
       "AIRview: an AI-generated, always-current map of your repo's architecture with dependency diagrams",
@@ -173,7 +180,7 @@
         <article class="pillar-card">
           <span class="pillar-index">01</span>
           <h3>Code Review</h3>
-          <p>Automatic PR comments, Flash reviews independently re-checked by a second model before you see them, managed audits, and branch-protection checks that cite the changed file and line.</p>
+          <p>Automatic PR comments and Flash reviews on every push, independently re-checked by a second model on AIR before you see them, plus managed audits and branch-protection checks that cite the changed file and line.</p>
           <ul>
             <li>Review only what changed</li>
             <li>Catch secrets before merge</li>

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -84,19 +84,21 @@ This is a local process you start and stop. It is not a hosted service, and noth
 
 `aletheore dashboard` serves a local web UI over the same evidence: dependency graph, trend charts across scan history, and the live MCP tool list. No account, no data leaves the machine.
 
-## Hosted service — Aletheore AIR
+## Hosted service - three tiers
 
-**$29.99/month** (or $299.90/year), including **5 team members**. Additional members $4.99/month each.
+A free **Community** tier covers the CLI, the GitHub Action, the MCP server, and the local dashboard, permanently and without an account.
 
-A free Community tier covers the CLI, the GitHub Action, the MCP server, and the local dashboard, permanently and without an account.
+**Aletheore Flash: $6/month** (monthly billing only, no annual price yet). Adds a hosted GitHub App:
 
-AIR adds a hosted GitHub App:
+- **Flash review**: automated PR review on every push to an open pull request, grounded in evidence for the changed files, up to 800/month
 
+**Aletheore AIR: $29.99/month** (or $299.90/year), including **3 team members**. Additional members $6.99/month each. Everything in Flash, plus:
+
+- **Verification pass**: Flash review's findings are re-checked by a second, independent model against the diff before being shown; anything that doesn't hold up is dropped
 - **Managed audits** — LLM-written, evidence-grounded reports, Ed25519-signed with a public verification endpoint
 - **Citation verification** — every finding is checked against real evidence; unverifiable claims are dropped or flagged, and the report's certificate reports whether it is fully evidence-backed
 - **AIRview** — a generated architecture wiki, grounded in scan evidence
 - **Docs** — generated API reference with `file:line` citations, exportable as a single Markdown file
-- **Flash review** — automated PR review, grounded in evidence for the changed files
 - **Endpoint health monitoring** — GET-only probes of endpoints already mapped from source, with Slack/Teams alerting
 - **Runtime event correlation** — connects a runtime error to the commit that last touched the file
 - **Hosted semantic search embeddings** — removes the local-model setup step in front of `aletheore index`; a paid plan calls Aletheore's own embedding endpoint instead of running a local Ollama or supplying a personal OpenAI key. The resulting index is identical either way, and nothing is stored server-side

--- a/website/paddle-checkout.js
+++ b/website/paddle-checkout.js
@@ -3,6 +3,15 @@ const PADDLE_ENVIRONMENT = "production";
 const PADDLE_CLIENT_TOKEN = "live_e7aef6edd9b215cd9059dab0c3d";
 
 const TIERS = {
+  flash: {
+    // Monthly only - no annual price exists yet in Paddle for this plan
+    // (see app_server/paddle_pricing.py). refreshPrices() below skips a
+    // tier entirely for an interval it has no priceId for, leaving its
+    // card's static HTML price as the fallback rather than fetching an
+    // undefined priceId.
+    name: "Aletheore Flash",
+    priceId: { month: "pri_01m1754jr5msg62grry49kjhw5" },
+  },
   air: {
     name: "Aletheore AIR",
     priceId: { month: "pri_01kyhevc8bkcghfpwjymz16y2h", year: "pri_01kyhevc9xn6z2nghmy8057jvp" },
@@ -28,7 +37,14 @@ function initPaddle() {
 
 async function refreshPrices() {
   const paddle = await initPaddle();
-  const items = Object.values(TIERS).map((tier) => ({ priceId: tier.priceId[billingInterval], quantity: 1 }));
+  // Only tiers that actually have a price for this interval - Flash has no
+  // "year" priceId, so toggling to Yearly must skip it entirely rather than
+  // send Paddle an undefined priceId (which fails the whole preview call
+  // for every tier, not just the one missing it). Its card keeps the
+  // static "$6/month" from the HTML in that case.
+  const activeTiers = Object.entries(TIERS).filter(([, tier]) => tier.priceId[billingInterval]);
+  if (activeTiers.length === 0) return;
+  const items = activeTiers.map(([, tier]) => ({ priceId: tier.priceId[billingInterval], quantity: 1 }));
 
   let preview;
   try {
@@ -39,7 +55,7 @@ async function refreshPrices() {
   }
 
   const lineItems = preview.data.details.lineItems;
-  Object.keys(TIERS).forEach((key, index) => {
+  activeTiers.forEach(([key], index) => {
     const card = document.querySelector(`[data-tier="${key}"]`);
     if (!card) return;
     const lineItem = lineItems[index];

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pricing — Aletheore</title>
-  <meta name="description" content="Aletheore Community: free deterministic CLI scanning forever. Aletheore AIR ($29.99/mo): managed AI audits, AIRview, AI-generated Docs, live endpoint monitoring, automated PR reviews, and team seats.">
+  <meta name="description" content="Aletheore Community: free deterministic CLI scanning forever. Aletheore Flash ($6/mo): automatic PR reviews, up to 800/month. Aletheore AIR ($29.99/mo): everything in Flash plus a second-model verification pass, managed AI audits, AIRview, AI-generated Docs, live endpoint monitoring, and team seats.">
   <link rel="canonical" href="https://www.aletheore.com/pricing">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Aletheore">
   <meta property="og:url" content="https://www.aletheore.com/pricing">
   <meta property="og:title" content="Pricing — Aletheore">
-  <meta property="og:description" content="Aletheore Community: free deterministic CLI scanning forever. Aletheore AIR ($29.99/mo): managed AI audits, AIRview, AI-generated Docs, live endpoint monitoring, automated PR reviews, and team seats.">
+  <meta property="og:description" content="Aletheore Community: free deterministic CLI scanning forever. Aletheore Flash ($6/mo): automatic PR reviews, up to 800/month. Aletheore AIR ($29.99/mo): everything in Flash plus a second-model verification pass, managed AI audits, AIRview, AI-generated Docs, live endpoint monitoring, and team seats.">
   <meta property="og:image" content="https://www.aletheore.com/assets/logo-mark.png">
   <link rel="icon" type="image/png" href="assets/logo-mark.png">
   <link rel="stylesheet" href="styles.css">
@@ -38,7 +38,7 @@
     <section class="pricing-hero">
       <p class="eyebrow">Pricing</p>
       <h1>Simple, honest pricing.</h1>
-      <p class="section-intro">Aletheore Community is the deterministic scanner, free forever. Aletheore AIR adds managed AI audits, AIRview, AI-generated Docs, automated PR reviews, endpoint monitoring, and team seats.</p>
+      <p class="section-intro">Aletheore Community is the deterministic scanner, free forever. Aletheore Flash adds automatic PR reviews. Aletheore AIR adds a second-model verification pass on those reviews, managed AI audits, AIRview, AI-generated Docs, endpoint monitoring, and team seats.</p>
 
       <div class="billing-toggle" role="group" aria-label="Billing interval">
         <button type="button" data-interval="month" class="active">Monthly</button>
@@ -62,6 +62,21 @@
           </ul>
         </article>
 
+        <article class="price-card" data-tier="flash">
+          <div class="price-card-head">
+            <span class="price-kicker">Hosted GitHub App</span>
+            <h3>Aletheore Flash</h3>
+            <div class="price-now">$6</div>
+            <div class="price-sub"><span class="price-sub-interval">/month</span>, monthly billing only</div>
+          </div>
+          <ul>
+            <li>Everything in Community.</li>
+            <li>Automatic Flash reviews on every push to an open pull request, up to 800/month - one model, evidence-grounded, source-of-record for what changed in the diff. Real head-to-head numbers (0 false positives, real recall) on the <a href="benchmarks.html">Benchmarks page</a>.</li>
+            <li>No independent second-model verification pass - that's AIR's addition, see below.</li>
+          </ul>
+          <button type="button" class="btn btn-primary" data-subscribe="flash">Subscribe</button>
+        </article>
+
         <article class="price-card pro" data-tier="air">
           <div class="price-card-head">
             <span class="price-kicker">Hosted GitHub App</span>
@@ -70,10 +85,10 @@
             <div class="price-sub"><span class="price-sub-interval">/month</span>, up to 3 team members</div>
           </div>
           <ul>
-            <li>Everything in Community.</li>
+            <li>Everything in Flash.</li>
             <li>Managed audits and AIRview, written by an OpenAI frontier model.</li>
             <li>AI-generated Docs for every public symbol - grounded in source, kept current automatically, nobody has to write one. Exportable as a single Markdown file.</li>
-            <li>Automatic Flash reviews on every push to an open pull request - one model writes the review, a second, independent model re-checks every individual finding against the diff before it's ever shown to you, dropping anything that doesn't hold up. Methodology and real per-review cost on the <a href="benchmarks.html">Benchmarks page</a>.</li>
+            <li>Flash reviews get a second, independent model that re-checks every individual finding against the diff before it's ever shown to you, dropping anything that doesn't hold up. Methodology and real per-review cost on the <a href="benchmarks.html">Benchmarks page</a>.</li>
             <li>Slack / Teams alerts on new findings.</li>
             <li>Branch-protection Check Runs for new secrets.</li>
             <li>Endpoint health monitoring across multiple targets, with a public status API.</li>
@@ -86,7 +101,7 @@
         <a class="btn btn-secondary" href="https://github.com/apps/aletheore/installations/new" rel="noopener">Install the GitHub App</a>
       </div>
       <p class="cta-note">
-        Install it on your GitHub account or organization, then hit Subscribe above to activate AIR on that installation. The public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find and install it today.
+        Install it on your GitHub account or organization, then hit Subscribe above to activate Flash or AIR on that installation. The public <a href="https://github.com/marketplace" rel="noopener">Marketplace listing</a> is still under GitHub's review, so this direct link is the way to find and install it today.
       </p>
       <p class="cta-note">
         <sup>*</sup><strong>Free AI Reviews:</strong> AI-powered PR reviews are free, built on the same evidence-only (compact) prompt as AIR - see the <a href="benchmarks.html">Benchmarks page</a> for the methodology. They don't include AIR's independent second-model verification pass. Routed across multiple providers' free tiers so it isn't tied to any single company's quota - usage is globally rate-limited and subject to availability, and access may be adjusted if that changes.

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -41,7 +41,7 @@
           LLM provider you configure, using your own API key.
         </p>
 
-        <h2>The GitHub App (Aletheore AIR)</h2>
+        <h2>The GitHub App (Aletheore Flash and AIR)</h2>
         <p>
           Installing the GitHub App is a different trust boundary, and source code does reach our
           servers.

--- a/website/security.html
+++ b/website/security.html
@@ -44,11 +44,15 @@
         directly rather than leave it unstated.</p>
 
       <h2>Your source code</h2>
-      <p>When the GitHub App runs a scan, your repository is cloned into an ephemeral scan worker,
-        analyzed, and discarded. We do not keep a copy of your source code at rest. Only derived
-        evidence, findings like secrets matches, dependency graphs, and endpoint health rows, is
-        written to our database. If a scan uses managed AI review (Aletheore AIR), the evidence we
-        send to our LLM provider is the same derived evidence, not your raw source files. See our
+      <p>When the GitHub App runs a scan, your repository is cloned into a scan worker and analyzed.
+        For a repository we scan only once, that clone is discarded afterward. For one we scan
+        repeatedly, a working copy is kept on the scan worker between scans so a later scan can
+        process only what changed - it is deleted on uninstall or a data-deletion request, and never
+        otherwise retained. Only derived evidence, findings like secrets matches, dependency graphs,
+        and endpoint health rows, is written to our database. What reaches our LLM provider depends
+        on the feature: Flash review (automated PR review, Flash tier and up) sends the pull
+        request's diff itself - your actual source code, for the changed lines - while managed
+        audits and AIRview (AIR) send only derived evidence, never raw source files. See our
         <a href="privacy.html">Privacy Policy</a> for the full data-handling breakdown.</p>
 
       <h2>GitHub App permissions</h2>

--- a/website/styles.css
+++ b/website/styles.css
@@ -802,7 +802,16 @@ pre {
   border-radius: 999px;
   background: var(--accent-soft);
   padding: 6px 9px;
-  color: #f5d9b8;
+  /* #f5d9b8 (pale) was only ever legible against .evidence-preview's local
+     dark override of --accent-soft (#3a2a18) - these two components live
+     in the page's normal light theme instead, where --accent-soft is
+     #fdf0e2 (pale cream), so that same pale text was reading as
+     near-invisible pale-on-pale. #8a4715 keeps the warm on-brand orange
+     but at 6.26:1 contrast against #fdf0e2 - --accent-hover (#b85f1c)
+     alone only reached 3.99:1, short of WCAG AA's 4.5:1 for this text
+     size (12px, below the "large text" 3:1 exception). Confirmed via a
+     real luminance-contrast computation, not eyeballed. */
+  color: #8a4715;
   font-family: "SF Mono", Menlo, Consolas, monospace;
   font-size: 12px;
 }
@@ -1511,7 +1520,11 @@ pre {
   border-radius: 999px;
   background: var(--accent-soft);
   padding: 5px 9px;
-  color: #f5d9b8;
+  /* Same fix as .query-board code/.mcp-tool-list span above: #f5d9b8 only
+     reads against .evidence-preview's local dark --accent-soft override,
+     not the page's normal light one (#fdf0e2) this pill actually renders
+     against. */
+  color: #8a4715;
   font-size: 11px;
   font-weight: 760;
 }
@@ -1788,7 +1801,10 @@ pre {
   cursor: pointer;
   padding: 14px 0;
   font-weight: 640;
-  color: #efe7d8;
+  /* #efe7d8 (pale, meant for a dark background) was rendering against
+     .bench-details's actual background (var(--card-bg), near-white) -
+     near-invisible. Same root cause as the pill-color fixes above. */
+  color: var(--text-primary);
   list-style: none;
 }
 
@@ -1833,7 +1849,10 @@ pre {
 
 .bench-chart-title {
   margin: 0 0 4px;
-  color: #efe7d8;
+  /* Same fix as .bench-details summary above: pale text meant for a dark
+     background, actually rendering against .bench-chart's near-white
+     var(--card-bg). */
+  color: var(--text-primary);
   font-size: 15px;
   font-weight: 640;
 }

--- a/website/terms.html
+++ b/website/terms.html
@@ -30,10 +30,10 @@
       <p>Last updated: July 2026</p>
 
       <h2>What Aletheore is</h2>
-      <p>Aletheore is a repository audit tool: a local-first CLI, free for personal, noncommercial use under the <a href="https://github.com/Aletheore/Aletheore/blob/master/LICENSE">PolyForm Noncommercial License 1.0.0</a>, and a paid GitHub App tier for managed audits, Slack/Teams alerts, branch-protection Check Runs, and endpoint health monitoring. Using the CLI for or within a company or other organization is a commercial use and requires a separate commercial license, regardless of whether you also subscribe to the paid GitHub App tier.</p>
+      <p>Aletheore is a repository audit tool: a local-first CLI, free for personal, noncommercial use under the <a href="https://github.com/Aletheore/Aletheore/blob/master/LICENSE">PolyForm Noncommercial License 1.0.0</a>, and paid GitHub App tiers for automated PR reviews, managed audits, Slack/Teams alerts, branch-protection Check Runs, and endpoint health monitoring. Using the CLI for or within a company or other organization is a commercial use and requires a separate commercial license, regardless of whether you also subscribe to a paid GitHub App tier.</p>
 
-      <h2>The paid subscription</h2>
-      <p>The paid plan is Aletheore AIR ($29.99/month or $299.90/year, up to 3 team members), with additional members beyond the plan's included seats billed at $6.99/month each. See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>
+      <h2>The paid subscriptions</h2>
+      <p>Two paid plans: Aletheore Flash ($6/month, monthly billing only) and Aletheore AIR ($29.99/month or $299.90/year, up to 3 team members, with additional members beyond the plan's included seats billed at $6.99/month each). See <a href="pricing.html">Pricing</a> for full plan details. Subscriptions are billed and processed by our payment provider, Paddle, acting as merchant of record. By subscribing, you agree to Paddle's own terms of service in addition to these.</p>
 
       <h2>Acceptable use</h2>
       <p>You may not use Aletheore to scan repositories you do not have the right to scan, or to circumvent security measures of systems you do not own or have explicit permission to test.</p>


### PR DESCRIPTION
## Summary
Two related fixes to the marketing site, found while auditing it end-to-end per a direct report that it was stale and missing the Flash tier entirely.

**1. The Flash tier was completely missing** - a real, chargeable Paddle product since 2026-08-29 ($6/mo), but `pricing.html` had no card for it and `paddle-checkout.js` didn't know its price ID (so even a manually-added card couldn't check out). Fixed across `pricing.html`, `paddle-checkout.js`, `index.html`, `terms.html`, `llms.txt`, and `benchmarks.html` (added two new sections reflecting tonight's real verified work: the PR-Agent head-to-head, and the Kotlin/Swift dead-code comparison vs RepoWise - neither was on the marketing site before).

Also found and fixed two real inaccuracies in `privacy.html`/`security.html` while checking Flash's scope there: a heading that wrongly scoped AI data-handling to AIR only, and `security.html` directly contradicting `privacy.html` on whether repo copies are retained at rest, plus omitting that Flash review sends the actual diff (real source code) - the more sensitive data flow, not disclosed before this.

**2. A real, live contrast bug** - reported via a screenshot of the deployed site showing barely-visible pill/tag labels. Root cause: `#f5d9b8`/`#efe7d8` pale colors were only ever legible against `.evidence-preview`'s local dark override of `--accent-soft`, but `.query-board code`, `.mcp-tool-list span`, `.price-kicker`, `.bench-details summary`, and `.bench-chart-title` all render in the page's normal light theme instead, where the same tokens resolve pale - pale-on-pale, functionally invisible.

## Test plan
- [x] Verified live via the Browser pane: Flash's pricing card fetches a real Paddle price preview, the Yearly/Monthly toggle behaves correctly for both tiers (Flash correctly has no annual price and doesn't break the toggle for AIR), no console errors.
- [x] Contrast fix verified with real computed-luminance math (not eyeballed) - a `getComputedStyle()`-based audit script walked every leaf text element on every changed page (developers, pricing, index, benchmarks, dogfooding, status, terms) before and after: 7 real instances flagged before, 0 after.
- [x] Confirmed the two component classes never nest inside `.evidence-preview` (where the pale color is actually correct), so nothing there was broken by this fix.
- [x] All new copy checked against real code (`app_server/db.py`, `paddle_pricing.py`, `scan_worker/jobs.py`) for tier caps, seat counts, and pricing - not assumed.