### PR TITLE
fix: close a real SSRF/DNS-rebinding gap in customer webhook alerts + a Ruby scanner gap

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -6,6 +6,7 @@ import logging
 import re
 import secrets
 import time
+import urllib.error
 from datetime import datetime, timedelta, timezone
 
 import asyncpg
@@ -858,29 +859,25 @@ async def test_webhook_url_route(org: str, repo: str, request: Request):
     if not webhook_url:
         raise HTTPException(status_code=400, detail="no alert webhook is configured yet")
 
-    # validate_external_https_url only ran once, when the URL was saved
-    # (set_webhook_url_route) - re-checking here, immediately before the
-    # fetch, closes the DNS-rebinding window down to the gap between this
-    # call and the actual request instead of "until someone edits the URL
-    # again." Same reasoning and pattern as the health-check sweep (see
-    # scan_worker/jobs.py's re-validation right before _endpoint_results).
-    # An attacker who fully controls this webhook URL's domain could
-    # otherwise register one that resolves to a public IP at save time,
-    # pass validation, then repoint DNS at an internal service before
-    # clicking "test."
-    try:
-        validate_external_https_url(webhook_url)
-    except UnsafeURLError:
-        raise HTTPException(status_code=400, detail="this webhook URL no longer resolves to a safe address") from None
-
     from scan_worker.slack import send_health_alert
 
+    # send_health_alert itself now re-validates and pins the URL right
+    # before connecting (see its own docstring) - closing the DNS-
+    # rebinding window to zero rather than the narrower "re-check, then
+    # make a second, independent, unvalidated connection" this route used
+    # to do with a standalone validate_external_https_url pre-check. An
+    # attacker who fully controls this webhook URL's domain could
+    # otherwise register one that resolves to a public IP at save time
+    # (set_webhook_url_route), pass validation, then repoint DNS at an
+    # internal service before clicking "test."
     try:
         send_health_alert(
             webhook_url,
             {"text": f"*Aletheore*: test notification for `{org}/{repo}` - your alert webhook is configured correctly."},
         )
-    except httpx.HTTPError:
+    except UnsafeURLError:
+        raise HTTPException(status_code=400, detail="this webhook URL no longer resolves to a safe address") from None
+    except (urllib.error.URLError, TimeoutError, OSError):
         # Not the raw exception message - it's an SSRF oracle otherwise,
         # distinguishing "connection refused" from "timed out" from an
         # actual response body/status from whatever the URL resolved to.

--- a/github-app/app_server/webhooks/marketplace.py
+++ b/github-app/app_server/webhooks/marketplace.py
@@ -16,21 +16,31 @@ logger = logging.getLogger(__name__)
 def _normalize_marketplace_plan_name(raw_name: str) -> str:
     """Marketplace plan display names are configured on GitHub's own
     listing page, not by our code - `purchase["plan"]["name"]` could be
-    anything an admin typed there, and the only two slugs the rest of the
-    codebase understands are "free" and "air" (see paddle_pricing.py).
-    Writing the raw name straight into installations.plan meant any name
-    that wasn't exactly the lowercase string "free" granted full paid
-    access, including a plan literally named "Free" with a capital F.
+    anything an admin typed there, and the only slugs the rest of the
+    codebase understands are "free", "flash", and "air" (see
+    paddle_pricing.py). Writing the raw name straight into
+    installations.plan meant any name that wasn't exactly the lowercase
+    string "free" granted full paid access, including a plan literally
+    named "Free" with a capital F.
 
-    Recognizes anything naming the paid tier ("air", case-insensitive,
-    matching the product's own AIR branding) and defaults everything
-    else to "free" - fail-closed, not fail-open, for a name this doesn't
-    recognize. Whatever the listing's plans are actually named should be
-    confirmed against this function before the Marketplace listing goes
-    live (website copy still says it's pending GitHub's review as of this
-    writing).
+    Recognizes anything naming a paid tier ("flash" or "air", case-
+    insensitive, matching the product's own tier branding) and defaults
+    everything else to "free" - fail-closed, not fail-open, for a name
+    this doesn't recognize. Checked before "air": a listing plan named
+    "Aletheore Flash" would otherwise never match "air" and fall through
+    to "free" anyway, but this ordering also protects against a future
+    plan name that happens to contain both substrings. Real bug this
+    fixes: the flash tier didn't exist yet when this function was first
+    written (#169) and nobody swept it when the tier launched - a
+    Marketplace purchase of a Flash-named plan would have silently
+    granted "free" instead of what the customer paid for. Whatever the
+    listing's plans are actually named should be confirmed against this
+    function before the Marketplace listing goes live.
     """
-    if "air" in raw_name.strip().lower():
+    normalized = raw_name.strip().lower()
+    if "flash" in normalized:
+        return "flash"
+    if "air" in normalized:
         return "air"
     return "free"
 

--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -7,6 +7,7 @@ bge-m3 actually underperformed nomic. See jina_embed/server.py, which
 serves this model behind a plain /embed endpoint.
 """
 
+import functools
 import logging
 import os
 
@@ -34,7 +35,18 @@ CURRENT_EMBEDDER = "jina-embed:jina-embeddings-v2-base-code"
 logger = logging.getLogger(__name__)
 
 
+@functools.lru_cache(maxsize=None)
 def _client(base_url: str | None = None) -> httpx.Client:
+    # Process-wide pooled client, one per distinct base_url, reused across
+    # every embed_text call - matches app_server/http_client.py's identical
+    # @lru_cache pooling convention (see get_github_api_client's docstring
+    # there for the reasoning). Real gap this closes: this was a fresh
+    # httpx.Client() - and a fresh TCP handshake to the jina-embed sidecar
+    # - constructed and torn down on EVERY embed_text call, the exact
+    # anti-pattern #183 fixed for the GitHub API and Redis clients but
+    # never got swept into this file. embed_text is called once per cache-
+    # eligible packet from packet_cache.py/flash_review_cache.py -
+    # potentially dozens of times in a single AIRview build.
     return httpx.Client(base_url=base_url or os.environ.get("JINA_EMBED_BASE_URL", "http://jina-embed:80"))
 
 
@@ -47,14 +59,17 @@ def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 
     if len(text) > MAX_EMBEDDING_CHARS:
         text = text[:MAX_EMBEDDING_CHARS]
     try:
-        with _client(base_url) as client:
-            response = client.post(
-                "/embed",
-                json={"text": text},
-                timeout=timeout_seconds,
-            )
-            response.raise_for_status()
-            data = response.json()
+        # Not a `with` block: _client is now a pooled, cached-for-the-
+        # process-lifetime client (see its own docstring) - closing it
+        # after one call would break every subsequent call.
+        client = _client(base_url)
+        response = client.post(
+            "/embed",
+            json={"text": text},
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
     except (httpx.HTTPError, ValueError) as exc:
         logger.warning("embedding call failed (%s); treating cache as unavailable", type(exc).__name__)
         return None

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2252,7 +2252,20 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
     """
     webhook_url = installation.get("webhook_url")
     if webhook_url:
-        send_health_alert(webhook_url, message)
+        # This docstring's own "fires on every channel independently"
+        # promise wasn't actually true for any of the three channels below
+        # - an unguarded exception here (send_health_alert now also raises
+        # UnsafeURLError when a saved webhook URL no longer resolves to a
+        # safe address, see its own docstring, on top of the delivery
+        # failures it could already raise) would skip email/Pushover
+        # entirely instead of just skipping this one channel.
+        try:
+            send_health_alert(webhook_url, message)
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger("scan_worker.jobs").warning(
+                "Slack/Teams alert failed for installation=%s (%s)",
+                installation.get("installation_id"), exc,
+            )
 
     alert_email = installation.get("alert_email")
     if alert_email:
@@ -2271,7 +2284,13 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
     if pushover_user_key:
         settings = get_settings()
         if settings.pushover_api_token:
-            send_pushover_alert(settings.pushover_api_token, pushover_user_key, message)
+            try:
+                send_pushover_alert(settings.pushover_api_token, pushover_user_key, message)
+            except Exception as exc:  # noqa: BLE001
+                logging.getLogger("scan_worker.jobs").warning(
+                    "Pushover alert failed for installation=%s (%s)",
+                    installation.get("installation_id"), exc,
+                )
         else:
             # A saved user key with no server-side app token configured -
             # not an error in the installation's own config, so it

--- a/github-app/scan_worker/slack.py
+++ b/github-app/scan_worker/slack.py
@@ -1,8 +1,42 @@
+import json
 import re
+import urllib.request
 
-import httpx
+from aletheore.healthcheck import opener_for
+from app_server.url_validation import validate_and_pin_https_url
 
-from app_server.http_client import get_generic_http_client
+WEBHOOK_POST_TIMEOUT_SECONDS = 10
+
+
+def _post_to_webhook(webhook_url: str, payload: dict) -> None:
+    """POST payload as JSON to a customer-configured Slack/Teams webhook
+    URL, pinned to the exact address validate_and_pin_https_url resolved
+    and approved.
+
+    Real gap this closes: both callers of this used to hand a plain URL
+    string straight to an httpx client, which re-resolves DNS itself at
+    request time - independently of, and later than, any validation a
+    caller happened to do first. A webhook URL that resolves to a public
+    IP when saved (passing validation) can have its DNS repointed at an
+    internal address before the next alert fires; the old code would then
+    happily connect there. Resolving once here and pinning the real
+    request to that exact IP (see aletheore.healthcheck.opener_for, the
+    same mechanism already proven for the health-check sweep) closes the
+    window to zero instead of merely narrowing it. Raises UnsafeURLError
+    if the URL no longer resolves to a safe address, or
+    urllib.error.URLError/HTTPError/OSError on a real delivery failure -
+    both already expected and handled by every caller.
+    """
+    url, pinned_ip = validate_and_pin_https_url(webhook_url)
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    # HTTPError (raised for any non-2xx status) is itself a URLError
+    # subclass - the same "raises on any non-2xx" contract
+    # response.raise_for_status() gave callers before this.
+    with opener_for(pinned_ip).open(request, timeout=WEBHOOK_POST_TIMEOUT_SECONDS):
+        pass
 
 
 def _detect_platform(webhook_url: str) -> str:
@@ -132,14 +166,11 @@ def send_slack_alert(
     diff: dict,
     repo_full_name: str,
     pr_number: int,
-    http_client: httpx.Client | None = None,
 ) -> None:
     if not _has_new_findings(diff):
         return
-    client = http_client or get_generic_http_client()
     payload = _render_payload(webhook_url, format_slack_message(diff, repo_full_name, pr_number))
-    response = client.post(webhook_url, json=payload)
-    response.raise_for_status()
+    _post_to_webhook(webhook_url, payload)
 
 
 def format_reachability_alert(
@@ -258,12 +289,6 @@ def format_runtime_error_alert(
     return {"text": text}
 
 
-def send_health_alert(
-    webhook_url: str,
-    message: dict,
-    http_client: httpx.Client | None = None,
-) -> None:
-    client = http_client or get_generic_http_client()
+def send_health_alert(webhook_url: str, message: dict) -> None:
     payload = _render_payload(webhook_url, message)
-    response = client.post(webhook_url, json=payload)
-    response.raise_for_status()
+    _post_to_webhook(webhook_url, payload)

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -2,6 +2,7 @@ import asyncio
 import socket
 import threading
 import time
+import urllib.error
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -709,7 +710,7 @@ async def test_send_test_notification_posts_to_saved_webhook(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
     sent = []
 
-    def fake_send_health_alert(webhook_url, message, http_client=None):
+    def fake_send_health_alert(webhook_url, message):
         sent.append((webhook_url, message))
 
     monkeypatch.setattr("scan_worker.slack.send_health_alert", fake_send_health_alert)
@@ -731,12 +732,8 @@ async def test_send_test_notification_posts_to_saved_webhook(pool, monkeypatch):
 async def test_send_test_notification_reports_delivery_failure(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
 
-    def fake_send_health_alert(webhook_url, message, http_client=None):
-        raise httpx.HTTPStatusError(
-            "internal secret detail that must never reach the caller",
-            request=None,
-            response=httpx.Response(502),
-        )
+    def fake_send_health_alert(webhook_url, message):
+        raise urllib.error.URLError("internal secret detail that must never reach the caller")
 
     monkeypatch.setattr("scan_worker.slack.send_health_alert", fake_send_health_alert)
     async with client:
@@ -756,23 +753,26 @@ async def test_send_test_notification_reports_delivery_failure(pool, monkeypatch
 @pytest.mark.asyncio
 async def test_send_test_notification_revalidates_the_url_right_before_fetching(pool, monkeypatch):
     # Same DNS-rebinding defense as the health-check sweep: a URL that
-    # validated fine when saved could resolve somewhere unsafe by the
-    # time "test" is clicked. This must be caught here too, not just at
-    # save time.
+    # validated fine when saved could resolve somewhere unsafe by the time
+    # "test" is clicked. This route no longer runs its own separate
+    # validate_external_https_url pre-check (a real, confirmed gap: that
+    # pattern validated the URL, then made a SECOND, independent,
+    # unvalidated connection for the real request - a DNS-rebinding window
+    # scan_worker.slack.send_health_alert itself now closes to zero by
+    # validating, pinning, and connecting to that exact pinned address in
+    # one step, see its own docstring) - this test simulates that
+    # revalidation failing inside send_health_alert and asserts this route
+    # still translates it into a clean 400.
     client = await _logged_in_client(pool, monkeypatch)
 
-    def fake_send_health_alert(webhook_url, message, http_client=None):
-        raise AssertionError("must not fetch a webhook URL that just failed revalidation")
+    def fake_send_health_alert(webhook_url, message):
+        raise UnsafeURLError("now resolves internally")
 
     monkeypatch.setattr("scan_worker.slack.send_health_alert", fake_send_health_alert)
     async with client:
         await client.put(
             "/admin/octocat/hello-world/webhook-url",
             json={"webhook_url": "https://hooks.slack.com/services/x"},
-        )
-        monkeypatch.setattr(
-            "app_server.admin.validate_external_https_url",
-            MagicMock(side_effect=UnsafeURLError("now resolves internally")),
         )
         response = await client.post("/admin/octocat/hello-world/webhook-url/test")
 

--- a/github-app/tests/test_embedding_client.py
+++ b/github-app/tests/test_embedding_client.py
@@ -2,7 +2,7 @@ import json
 
 import httpx
 
-from scan_worker.embedding_client import MAX_EMBEDDING_CHARS, embed_text
+from scan_worker.embedding_client import MAX_EMBEDDING_CHARS, _client, embed_text
 
 
 def test_embed_text_returns_vector_on_success(monkeypatch):
@@ -109,3 +109,23 @@ def test_embed_text_returns_none_on_malformed_response(monkeypatch):
     )
 
     assert embed_text("some evidence text") is None
+
+
+def test_client_is_pooled_not_reconstructed_per_call():
+    # Real bug this guards: _client used to build a brand-new httpx.Client
+    # (and pay a fresh TCP handshake to the jina-embed sidecar) on every
+    # single embed_text call - the exact anti-pattern #183 fixed for the
+    # GitHub API and Redis clients but never got swept into this file.
+    # embed_text runs once per cache-eligible packet, potentially dozens
+    # of times in one AIRview build.
+    _client.cache_clear()
+    try:
+        first = _client("http://jina-embed:80")
+        second = _client("http://jina-embed:80")
+        assert first is second
+        # A distinct base_url still gets its own pooled client, not a
+        # shared one that would send requests to the wrong host.
+        other = _client("http://custom-jina-embed:9999")
+        assert other is not first
+    finally:
+        _client.cache_clear()

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3691,6 +3691,51 @@ def test_send_alerts_if_configured_sends_both_channels_when_both_set(monkeypatch
     assert len(email_sent) == 1
 
 
+def test_send_alerts_if_configured_isolates_a_slack_failure_from_other_channels(monkeypatch):
+    # Real bug this closes: this function's own docstring promises every
+    # channel "fires independently," but the Slack/Teams call was
+    # unguarded - any exception from it (send_health_alert now also
+    # raises UnsafeURLError when a saved webhook URL no longer resolves to
+    # a safe address, on top of the delivery failures it could already
+    # raise) skipped email/Pushover entirely instead of just skipping
+    # this one channel.
+    from app_server.config import get_settings
+    from app_server.url_validation import UnsafeURLError
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setenv("PUSHOVER_API_TOKEN", "server-app-token")
+    get_settings.cache_clear()
+
+    def failing_send_health_alert(url, msg, **k):
+        raise UnsafeURLError("'internal.example.com' resolves to a disallowed address")
+
+    monkeypatch.setattr("scan_worker.jobs.send_health_alert", failing_send_health_alert)
+    email_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **k: email_sent.append(k),
+    )
+    pushover_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_pushover_alert", lambda *a, **k: pushover_sent.append(a)
+    )
+
+    _send_alerts_if_configured(
+        {
+            "installation_id": 1,
+            "target_id": 900,
+            "webhook_url": "https://internal.example.com/webhook",
+            "alert_email": "ops@example.com",
+            "pushover_user_key": "u" * 30,
+        },
+        {"text": "down"},
+    )
+
+    assert len(email_sent) == 1
+    assert len(pushover_sent) == 1
+
+
 def test_send_alerts_if_configured_email_dedupe_key_collapses_within_the_same_second(monkeypatch):
     # Regression: the docstring says the dedupe_key includes wall-clock
     # time "down to the second" specifically so a genuine retry of the

--- a/github-app/tests/test_marketplace_webhook.py
+++ b/github-app/tests/test_marketplace_webhook.py
@@ -44,6 +44,16 @@ def test_normalize_marketplace_plan_name_recognizes_air_case_insensitively():
     assert _normalize_marketplace_plan_name("  AIR  ") == "air"
 
 
+def test_normalize_marketplace_plan_name_recognizes_flash_case_insensitively():
+    # Real bug this guards: the flash tier didn't exist yet when this
+    # function was first written, and nobody swept it when the tier
+    # launched - a Marketplace purchase of a Flash-named plan silently
+    # granted "free" instead of what the customer paid for.
+    assert _normalize_marketplace_plan_name("Aletheore Flash") == "flash"
+    assert _normalize_marketplace_plan_name("flash") == "flash"
+    assert _normalize_marketplace_plan_name("  FLASH  ") == "flash"
+
+
 def test_normalize_marketplace_plan_name_defaults_unrecognized_names_to_free():
     # Fail-closed: an unrecognized name must not grant paid access, unlike
     # the original bug where anything other than the exact lowercase

--- a/github-app/tests/test_slack.py
+++ b/github-app/tests/test_slack.py
@@ -1,7 +1,10 @@
 import json
+import socket
+from unittest.mock import MagicMock, patch
 
-import httpx
+import pytest
 
+from app_server.url_validation import UnsafeURLError
 from scan_worker.slack import (
     _detect_platform,
     _slack_markdown_to_adaptive_card_markdown,
@@ -14,6 +17,24 @@ from scan_worker.slack import (
     send_health_alert,
     send_slack_alert,
 )
+
+
+def _mock_opener(calls: list):
+    # Every webhook send is now pinned to a resolved IP (see slack.py's
+    # own docstring on _post_to_webhook) - real tests mock at that
+    # boundary (validate_and_pin_https_url + opener_for) instead of an
+    # httpx transport, so they exercise the real pin-then-POST wiring
+    # without doing real DNS/network I/O.
+    def fake_open(request, timeout=None):
+        calls.append(request)
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        return response
+
+    opener = MagicMock()
+    opener.open.side_effect = fake_open
+    return opener
 
 
 def _diff_with_new_secret():
@@ -34,21 +55,38 @@ def test_format_slack_message_mentions_repo_and_pr():
 
 def test_send_slack_alert_posts_to_webhook_url():
     calls = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        calls.append(request)
-        return httpx.Response(200)
-
-    client = httpx.Client(transport=httpx.MockTransport(handler))
-    send_slack_alert(
-        "https://hooks.slack.com/services/x",
-        _diff_with_new_secret(),
-        "octocat/hello-world",
-        42,
-        http_client=client,
-    )
+    with patch(
+        "scan_worker.slack.validate_and_pin_https_url",
+        return_value=("https://hooks.slack.com/services/x", "93.184.216.34"),
+    ) as mock_pin, patch("scan_worker.slack.opener_for", return_value=_mock_opener(calls)) as mock_opener_for:
+        send_slack_alert(
+            "https://hooks.slack.com/services/x",
+            _diff_with_new_secret(),
+            "octocat/hello-world",
+            42,
+        )
+    mock_pin.assert_called_once_with("https://hooks.slack.com/services/x")
+    mock_opener_for.assert_called_once_with("93.184.216.34")
     assert len(calls) == 1
-    assert str(calls[0].url) == "https://hooks.slack.com/services/x"
+    assert calls[0].full_url == "https://hooks.slack.com/services/x"
+
+
+def test_send_slack_alert_raises_when_the_webhook_url_no_longer_resolves_safely():
+    # Real regression this guards: a webhook URL that resolved to a public
+    # IP when saved can have its DNS repointed at an internal address
+    # before the next alert fires - the SSRF/DNS-rebinding gap #204 closed
+    # for the health-check sweep but this call path never got until now.
+    with patch(
+        "scan_worker.slack.validate_and_pin_https_url",
+        side_effect=UnsafeURLError("'internal.example.com' resolves to a disallowed address"),
+    ):
+        with pytest.raises(UnsafeURLError):
+            send_slack_alert(
+                "https://internal.example.com/webhook",
+                _diff_with_new_secret(),
+                "octocat/hello-world",
+                42,
+            )
 
 
 def test_format_reachability_alert_down():
@@ -176,14 +214,42 @@ def test_format_shape_change_alert_includes_evidence_context():
 
 def test_send_health_alert_posts_message():
     calls = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        calls.append(request)
-        return httpx.Response(200)
-
-    client = httpx.Client(transport=httpx.MockTransport(handler))
-    send_health_alert("https://hooks.slack.com/x", {"text": "test"}, http_client=client)
+    with patch(
+        "scan_worker.slack.validate_and_pin_https_url",
+        return_value=("https://hooks.slack.com/x", "93.184.216.34"),
+    ), patch("scan_worker.slack.opener_for", return_value=_mock_opener(calls)):
+        send_health_alert("https://hooks.slack.com/x", {"text": "test"})
     assert len(calls) == 1
+
+
+def test_send_health_alert_raises_when_the_webhook_url_no_longer_resolves_safely():
+    # Same regression coverage as send_slack_alert's own test above, for
+    # this call path - the production alert dispatcher's own gap (worse
+    # than the admin "test" button's, since it had zero validation at all
+    # before this fix).
+    with patch(
+        "scan_worker.slack.validate_and_pin_https_url",
+        side_effect=UnsafeURLError("'internal.example.com' resolves to a disallowed address"),
+    ):
+        with pytest.raises(UnsafeURLError):
+            send_health_alert("https://internal.example.com/webhook", {"text": "test"})
+
+
+def test_send_health_alert_end_to_end_refuses_a_webhook_that_resolves_internally():
+    # Same shape as app_server/tests/test_url_validation.py's own DNS-
+    # rebinding tests, but exercised through the real call path this
+    # session's audit found had zero protection at all - only DNS
+    # resolution and the actual network connection are mocked (real
+    # socket.getaddrinfo and a real urllib opener.open would otherwise
+    # both need live network I/O), everything else (validate_and_pin_
+    # https_url, opener_for) runs for real, proving the actual wiring
+    # refuses the connection rather than just that a mock says it does.
+    def fake_addrinfo(*args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))]
+
+    with patch("app_server.url_validation.socket.getaddrinfo", fake_addrinfo):
+        with pytest.raises(UnsafeURLError, match="disallowed"):
+            send_health_alert("https://webhook.example.com/x", {"text": "test"})
 
 
 def test_format_runtime_error_alert_includes_exception_and_location():
@@ -261,56 +327,39 @@ def test_to_teams_payload_wraps_text_in_adaptive_card():
 
 def test_send_slack_alert_sends_adaptive_card_to_teams_webhook():
     calls = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        calls.append(json.loads(request.content))
-        return httpx.Response(200)
-
-    client = httpx.Client(transport=httpx.MockTransport(handler))
-    send_slack_alert(
-        "https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual",
-        _diff_with_new_secret(),
-        "octocat/hello-world",
-        42,
-        http_client=client,
-    )
+    teams_url = "https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual"
+    with patch(
+        "scan_worker.slack.validate_and_pin_https_url", return_value=(teams_url, "93.184.216.34")
+    ), patch("scan_worker.slack.opener_for", return_value=_mock_opener(calls)):
+        send_slack_alert(teams_url, _diff_with_new_secret(), "octocat/hello-world", 42)
     assert len(calls) == 1
-    assert calls[0]["type"] == "message"
-    assert calls[0]["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
+    body = json.loads(calls[0].data)
+    assert body["type"] == "message"
+    assert body["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
 
 
 def test_send_slack_alert_sends_plain_text_to_slack_webhook():
     calls = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        calls.append(json.loads(request.content))
-        return httpx.Response(200)
-
-    client = httpx.Client(transport=httpx.MockTransport(handler))
-    send_slack_alert(
-        "https://hooks.slack.com/services/x",
-        _diff_with_new_secret(),
-        "octocat/hello-world",
-        42,
-        http_client=client,
-    )
+    with patch(
+        "scan_worker.slack.validate_and_pin_https_url",
+        return_value=("https://hooks.slack.com/services/x", "93.184.216.34"),
+    ), patch("scan_worker.slack.opener_for", return_value=_mock_opener(calls)):
+        send_slack_alert(
+            "https://hooks.slack.com/services/x", _diff_with_new_secret(), "octocat/hello-world", 42
+        )
     assert len(calls) == 1
-    assert "text" in calls[0]
-    assert "attachments" not in calls[0]
+    body = json.loads(calls[0].data)
+    assert "text" in body
+    assert "attachments" not in body
 
 
 def test_send_health_alert_sends_adaptive_card_to_teams_webhook():
     calls = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        calls.append(json.loads(request.content))
-        return httpx.Response(200)
-
-    client = httpx.Client(transport=httpx.MockTransport(handler))
-    send_health_alert(
-        "https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual",
-        {"text": "*Aletheore*: endpoint down"},
-        http_client=client,
-    )
+    teams_url = "https://prod-12.westus.logic.azure.com:443/workflows/abc/triggers/manual"
+    with patch(
+        "scan_worker.slack.validate_and_pin_https_url", return_value=(teams_url, "93.184.216.34")
+    ), patch("scan_worker.slack.opener_for", return_value=_mock_opener(calls)):
+        send_health_alert(teams_url, {"text": "*Aletheore*: endpoint down"})
     assert len(calls) == 1
-    assert calls[0]["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
+    body = json.loads(calls[0].data)
+    assert body["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"

--- a/src/aletheore/healthcheck.py
+++ b/src/aletheore/healthcheck.py
@@ -90,7 +90,16 @@ def _pinned_connection_class(base_class: type, pinned_ip: str) -> type:
     return _Pinned
 
 
-def _opener_for(pinned_ip: str | None) -> urllib.request.OpenerDirector:
+def opener_for(pinned_ip: str | None) -> urllib.request.OpenerDirector:
+    """A urllib opener that, when pinned_ip is given, connects every
+    request to that literal IP instead of letting the connection re-
+    resolve the URL's hostname itself - see _pinned_connection_class's
+    docstring for why that closes a real DNS-rebinding window rather than
+    just narrowing it. Public (not health-check-specific): any caller that
+    already validated-and-pinned a URL via app_server.url_validation.
+    validate_and_pin_https_url needs the exact same guarantee for its own
+    request, not just run_healthcheck's (see scan_worker.slack.
+    send_health_alert, which reuses this directly)."""
     if pinned_ip is None:
         return _NO_REDIRECT_OPENER
     pinned_https = _pinned_connection_class(http.client.HTTPSConnection, pinned_ip)
@@ -219,7 +228,7 @@ def run_healthcheck(
     address that was validated, not a fresh, unvalidated resolution. Plain
     CLI/MCP callers pass nothing and keep today's normal DNS behavior."""
     _require_http_scheme(base_url)
-    opener = _opener_for(pinned_ip)
+    opener = opener_for(pinned_ip)
     results: list[dict]
     if not endpoints:
         results = []

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -615,11 +615,35 @@ def _extract_module_constants(node: Node, source: bytes, language: str) -> list[
             if t == "assignment":
                 lhs = n.child_by_field_name("left")
                 if lhs is not None and lhs.type == "constant":
+                    # Walk up through Ruby's conditional/exception-handling
+                    # wrapper nodes (if/then/elsif/else/unless/case/when/
+                    # begin/rescue/ensure) to find whether this assignment
+                    # ultimately sits in a class/module's own body_statement,
+                    # not just checking one level up. Real bug this fixes: a
+                    # constant gated on a RUBY_VERSION/platform check, or
+                    # wrapped in begin/rescue for a defensive fallback, is
+                    # exactly as idiomatic a class-body constant as the flat
+                    # case above - confirmed live against tree-sitter-ruby's
+                    # actual parse tree - but its immediate parent is "then"
+                    # or "begin"/"rescue", never "body_statement" directly,
+                    # so it was silently invisible. A constant nested the
+                    # same way inside a def's body still correctly stays
+                    # excluded: the walk stops at the first body_statement
+                    # it reaches (a method's own, not a skippable wrapper),
+                    # and that one's parent is "method", not class/module.
+                    parent = n.parent
+                    hops = 0
+                    while parent is not None and hops < 6 and parent.type in (
+                        "then", "else", "elsif", "unless", "if", "case", "when",
+                        "begin", "rescue", "ensure", "rescue_modifier",
+                    ):
+                        parent = parent.parent
+                        hops += 1
                     in_type_body = (
-                        n.parent is not None
-                        and n.parent.type == "body_statement"
-                        and n.parent.parent is not None
-                        and n.parent.parent.type in ("class", "module")
+                        parent is not None
+                        and parent.type == "body_statement"
+                        and parent.parent is not None
+                        and parent.parent.type in ("class", "module")
                     )
                     if in_type_body or is_top_level(n):
                         add(lhs, n)

--- a/src/tests/test_graph.py
+++ b/src/tests/test_graph.py
@@ -951,6 +951,39 @@ def test_build_module_graph_ruby_extracts_constants_declared_inside_class_or_mod
     assert symbol_names(modules[0]["symbols"]["constants"]) == ["DROP_BODY"]
 
 
+def test_build_module_graph_ruby_extracts_constants_nested_inside_conditional_and_exception_blocks(tmp_path):
+    """Real bug: a constant gated on a RUBY_VERSION/platform check, or
+    wrapped in begin/rescue for a defensive fallback, is exactly as
+    idiomatic a class-body constant as the flat case above - but its
+    immediate parent is "then"/"begin"/"rescue", never "body_statement"
+    directly, so the flat in-body check alone left it silently invisible.
+    A constant nested the same way inside a def's body must still stay
+    excluded."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "base.rb").write_text(
+        "module Sinatra\n"
+        "  class Base\n"
+        "    if RUBY_VERSION >= \"3.0\"\n"
+        "      BAR = 1\n"
+        "    end\n"
+        "    begin\n"
+        "      BAZ = 2\n"
+        "    rescue\n"
+        "      QUX = 3\n"
+        "    end\n"
+        "    def method_local\n"
+        "      if true\n"
+        "        LOCAL = 4\n"
+        "      end\n"
+        "    end\n"
+        "  end\n"
+        "end\n"
+    )
+    modules, _graph, _unparseable = build_module_graph(repo)
+    assert sorted(symbol_names(modules[0]["symbols"]["constants"])) == ["BAR", "BAZ", "QUX"]
+
+
 def test_build_module_graph_ruby_does_not_extract_a_constant_assigned_inside_a_method(tmp_path):
     """A capitalised assignment inside a def body is a method-local, not
     part of the type's public API - must stay excluded even though it sits


### PR DESCRIPTION
## Summary

Continuing the backward gap-audit pass (see #499, merged). This branch started as the tail end of #499's work — it landed on the branch *after* #499 was already squash-merged, so it never made it into master. Recovering and continuing it here as its own PR.

**Batch 1 — HIGH severity, a real, unpatched SSRF/DNS-rebinding gap in the production alert-webhook path:**

- `scan_worker/slack.py`: `send_health_alert` and `send_slack_alert` both took a customer-configured Slack/Teams webhook URL and handed it straight to an `httpx` client, which re-resolves DNS itself at request time. A webhook URL that resolves to a public IP when saved can have its DNS repointed at an internal address before the next real alert fires.
  - The **production alert dispatcher** had **zero validation at all** on this path.
  - The admin **"test" button**'s own pre-check only narrowed the window rather than closing it.
  - Both now resolve, validate, and pin to that exact address in one step, reusing `aletheore.healthcheck`'s already-proven pinned-connection opener (now public as `opener_for`).
  - Also isolates a Slack/Teams alert failure from email/Pushover in `_send_alerts_if_configured`, honoring that function's own "fires on every channel independently" docstring promise.
- `graph.py`: Ruby constant extraction only checked one level up for "declared inside a class/module body," missing a constant gated on a `RUBY_VERSION`/platform check or wrapped in `begin`/`rescue`. Confirmed live against tree-sitter-ruby's actual parse tree.

**Batch 2 — Marketplace billing gap + a performance regression:**

- `webhooks/marketplace.py`: `_normalize_marketplace_plan_name` only recognized the "air" plan — the "flash" tier didn't exist yet when this function was written and nobody swept it when the tier launched. A Marketplace purchase of a Flash-named plan would silently grant "free" instead of what the customer paid for.
- `embedding_client.py`: `_client` built a brand-new `httpx.Client` (and paid a fresh TCP handshake to the jina-embed sidecar) on *every single* `embed_text` call — the exact anti-pattern a previous PR (#183) fixed for the GitHub API and Redis clients, but this sibling client was added independently and never got the same pooling convention. Now pooled via `@lru_cache`, matching `app_server/http_client.py`'s convention.

## Test plan
- [x] Verified with real Postgres/Redis test infra (`docker-compose.test.yml`)
- [x] `src/tests/` — 1515 passed
- [x] `github-app/tests/` — 1683 passed, 8 skipped, 0 failed
- [x] New regression tests for every fix, including a real DNS-rebinding refusal test and a client-pooling identity test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr