### PR TITLE
fix: Flash Review never consulted .aletheore.json's ignored_paths

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -5,6 +5,7 @@ import re
 import httpx
 
 from aletheore.pr_comment import COMMENT_MARKER
+from aletheore.repo_config import is_ignored
 
 MAX_CONTEXT_FILES = 30
 MAX_CONTEXT_FILE_BYTES = 80_000
@@ -357,6 +358,7 @@ def fetch_pr_diff(
     repo_full_name: str,
     base_ref: str,
     head_ref: str,
+    ignored_paths: list[str] = (),
 ) -> PRDiff:
     headers = {
         "Authorization": f"token {token}",
@@ -370,6 +372,21 @@ def fetch_pr_diff(
     all_patches: list[tuple[str, str]] = []
     omitted_files = []
     for file in response.json().get("files", []):
+        # A file matching .aletheore.json's own ignored_paths must never
+        # reach Flash Review at all - the deterministic `aletheore scan`
+        # path already excludes ignored paths at the source (see
+        # evidence.py's identical use of ignored_paths before any file is
+        # even parsed), but Flash Review's PR-comment pipeline is a
+        # separate, GitHub-API-only code path (no local checkout to read
+        # .aletheore.json from - see _run_flash_review) that never
+        # consulted this config at all: a customer who configured an
+        # ignored path still got Flash Review PR comments about exactly
+        # that path. Skipped before the patch/reconstruction logic below,
+        # not just omitted afterward - this is a deliberate exclusion per
+        # the repo's own config, not a genuinely missing/unreviewable
+        # file, so it belongs in neither patches nor omitted_files.
+        if ignored_paths and is_ignored(file["filename"], ignored_paths):
+            continue
         patch = file.get("patch")
         if not patch:
             # GitHub omits `patch` both for binary files and for text files

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -34,6 +34,7 @@ from aletheore.evidence_resolution import (
 from aletheore.history import compute_diff
 from aletheore.pr_comment import COMMENT_MARKER, format_diff_comment
 from aletheore.healthcheck import run_healthcheck
+from aletheore.repo_config import parse_repo_config
 from aletheore.signature_diff import find_regression_fence_violations
 from app_server.config import get_settings
 from app_server.db import MAX_SCANNED_REPOS_PER_MONTH
@@ -1851,7 +1852,24 @@ def _run_flash_review(
         settings.database_url, installation_id, repo_full_name, pr_number
     )
     diff_base = last_reviewed_sha or base_sha
-    diff_result = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha)
+    # Flash Review has no local checkout to read .aletheore.json from the
+    # way the deterministic `aletheore scan` path does (see evidence.py's
+    # identical use of ignored_paths, applied before any file is even
+    # parsed) - fetched here instead, straight from the PR head, so a
+    # customer's configured ignored_paths excludes a file from Flash
+    # Review's diff the same way it already excludes it from a real scan.
+    # Real gap this closes: without this, Flash Review posted PR comments
+    # about paths a customer had explicitly configured to be ignored.
+    # Best-effort: a fetch failure degrades to "no config" (review
+    # everything), matching every other config-read in this codebase's
+    # fail-open-on-infra-error discipline - a missing config must never
+    # block the review that's this job's actual deliverable.
+    try:
+        repo_config_text = fetch_file_content(client, token, repo_full_name, ".aletheore.json", ref=head_sha)
+    except Exception:  # noqa: BLE001
+        repo_config_text = None
+    ignored_paths = parse_repo_config(repo_config_text)["ignored_paths"]
+    diff_result = fetch_pr_diff(client, token, repo_full_name, diff_base, head_sha, ignored_paths=ignored_paths)
     diff_text = str(diff_result)
     diff_patches = getattr(diff_result, "patches", None)
     diff_omitted_files = getattr(diff_result, "omitted_files", ())

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -166,6 +166,49 @@ def test_fetch_pr_diff_returns_empty_string_when_no_files_changed():
     assert diff_text == ""
 
 
+def test_fetch_pr_diff_excludes_files_matching_ignored_paths():
+    # Real gap this closes: Flash Review's PR-comment pipeline has no
+    # local checkout to pick up .aletheore.json's ignored_paths the way
+    # the deterministic `aletheore scan` path does (see evidence.py) - a
+    # customer who configured an ignored path still got Flash Review PR
+    # comments about exactly that path. An ignored file must be excluded
+    # entirely (not appear in patches, and not appear in omitted_files
+    # either - it's a deliberate exclusion per config, not a genuinely
+    # missing/unreviewable file).
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "files": [
+                    {"filename": "vendor/lib.js", "patch": "@@ -1 +1 @@\n-old\n+new"},
+                    {"filename": "src/app.py", "patch": "@@ -1 +1 @@\n-old\n+new"},
+                ]
+            },
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    diff_text = fetch_pr_diff(
+        client, "fake-token", "octocat/hello-world", "aaa", "bbb", ignored_paths=["vendor/**"]
+    )
+
+    assert "vendor/lib.js" not in diff_text
+    assert "src/app.py" in diff_text
+    assert diff_text.omitted_files == ()
+    assert [f for f, _ in diff_text.patches] == ["src/app.py"]
+
+
+def test_fetch_pr_diff_with_no_ignored_paths_includes_every_file():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"files": [{"filename": "vendor/lib.js", "patch": "@@ -1 +1 @@\n-old\n+new"}]}
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    diff_text = fetch_pr_diff(client, "fake-token", "octocat/hello-world", "aaa", "bbb")
+
+    assert "vendor/lib.js" in diff_text
+
+
 def test_fetch_pr_diff_reconstructs_a_patch_github_omitted_for_a_large_text_file():
     # Real gap, confirmed live against benchmarks/pr-review-benchmark's own
     # case 007: GitHub's compare API returns patch=None for a large changed

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2392,6 +2392,64 @@ def test_flash_review_job_posts_findings_and_updates_state(monkeypatch):
     assert recorded_spend == [-FLASH_REVIEW_SPEND_RESERVE_USD]
 
 
+def test_flash_review_job_excludes_aletheore_json_ignored_paths_from_the_diff(monkeypatch):
+    # Real gap this closes: Flash Review's PR-comment pipeline has no
+    # local checkout to read .aletheore.json from the way the
+    # deterministic `aletheore scan` path does - a customer who
+    # configured ignored_paths still got Flash Review PR comments about
+    # exactly that path. .aletheore.json is now fetched straight from the
+    # PR head and threaded into fetch_pr_diff as ignored_paths.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.fetch_file_content",
+        lambda client, token, repo, path, ref=None: (
+            json.dumps({"ignored_paths": ["vendor/**"]}) if path == ".aletheore.json" else None
+        ),
+    )
+    diff_calls = []
+
+    def fake_fetch_pr_diff(client, token, repo, base, head, ignored_paths=()):
+        diff_calls.append(list(ignored_paths))
+        return "--- app.py ---\n+bug"
+
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", fake_fetch_pr_diff)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+    monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", **kwargs: [])
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr("scan_worker.jobs.create_pr_review_comment", lambda *a, **k: {"id": 1})
+    monkeypatch.setattr("scan_worker.jobs.insert_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.touch_flash_review_finding_comment", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False)
+
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert diff_calls == [["vendor/**"]]
+
+
 def test_flash_review_comment_body_prefixes_the_symbol_when_present():
     from scan_worker.jobs import _flash_review_comment_body
 

--- a/src/aletheore/repo_config.py
+++ b/src/aletheore/repo_config.py
@@ -28,7 +28,28 @@ def load_repo_config(repo_path: Path) -> dict:
         return result
 
     try:
-        data = json.loads(config_file.read_text(encoding="utf-8", errors="ignore"))
+        text = config_file.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return result
+    return parse_repo_config(text)
+
+
+def parse_repo_config(raw_text: str | None) -> dict:
+    """Same parsing/validation as load_repo_config, for a caller that
+    already has the config file's text some other way than a local
+    filesystem path - e.g. fetched from GitHub's Contents API for a repo
+    that was never cloned (see scan_worker.jobs._run_flash_review, which
+    reviews a PR diff purely via the GitHub API with no local checkout to
+    read a Path from). raw_text is None for "no .aletheore.json at this
+    ref" (GitHub's Contents API 404), same as load_repo_config's missing-
+    file case.
+    """
+    result = dict(DEFAULT_CONFIG)
+    if raw_text is None:
+        return result
+
+    try:
+        data = json.loads(raw_text)
     except json.JSONDecodeError:
         return result
     if not isinstance(data, dict):

--- a/src/tests/test_repo_config.py
+++ b/src/tests/test_repo_config.py
@@ -1,11 +1,27 @@
 import json
 from pathlib import Path
 
-from aletheore.repo_config import DEFAULT_CONFIG, is_ignored, load_repo_config
+from aletheore.repo_config import DEFAULT_CONFIG, is_ignored, load_repo_config, parse_repo_config
 
 
 def test_load_repo_config_returns_defaults_when_no_file(tmp_path: Path):
     assert load_repo_config(tmp_path) == DEFAULT_CONFIG
+
+
+def test_parse_repo_config_returns_defaults_for_none():
+    # None is parse_repo_config's "no .aletheore.json at this ref" case -
+    # a caller with no local checkout to read a Path from (see
+    # scan_worker.jobs._run_flash_review) fetches the file via GitHub's
+    # Contents API instead, which reports a missing file as a 404 rather
+    # than an OSError load_repo_config's Path-based check catches.
+    assert parse_repo_config(None) == DEFAULT_CONFIG
+
+
+def test_parse_repo_config_matches_load_repo_config_for_the_same_content(tmp_path: Path):
+    raw_text = json.dumps({"ignored_paths": ["vendor/**"], "severity_threshold": "high"})
+    (tmp_path / ".aletheore.json").write_text(raw_text)
+
+    assert parse_repo_config(raw_text) == load_repo_config(tmp_path)
 
 
 def test_load_repo_config_returns_defaults_on_malformed_json(tmp_path: Path):


### PR DESCRIPTION
## Summary

Continuing the backward gap-audit pass (see #499 and #503, both merged). This is the next batch, #128-#154.

**The bug:** `.aletheore.json`'s `ignored_paths` config was documented as excluding files from review, and the deterministic `aletheore scan` path (run as a subprocess against a real local checkout) picks it up automatically. But **Flash Review's PR-comment pipeline is a separate, GitHub-API-only code path with no local checkout to read `.aletheore.json` from at all** — it never consulted this config in any way.

A customer who configured an ignored path (`vendor/`, generated code, test fixtures) still got Flash Review PR comments about exactly that path, directly contradicting the config's stated purpose — and likely the most visible way a customer would ever notice this gap, since it's an unwanted PR comment rather than a merely-missing dashboard finding.

**The fix:**
- `repo_config.py`: split `load_repo_config`'s JSON-parsing/validation logic out into a new `parse_repo_config(raw_text)` that works from already-fetched text instead of a filesystem `Path`.
- `github_api.py`: `fetch_pr_diff` takes an optional `ignored_paths` list and excludes any matching file entirely — not into `patches`, and not into `omitted_files` either, since it's a deliberate exclusion per config, not a genuinely missing/unreviewable file.
- `jobs.py`: `_run_flash_review` fetches `.aletheore.json` straight from the PR head via the Contents API (best-effort — a fetch failure degrades to "no config," matching this codebase's fail-open-on-infra-error discipline) and threads its `ignored_paths` into `fetch_pr_diff`, so both the LLM review and the deterministic semantic checks (which consume the same filtered diff) respect it.

## Test plan
- [x] `src/tests/` — 1517 passed
- [x] `test_github_api.py` — 46 passed
- [x] `test_repo_config.py` — 18 passed
- [x] Full `flash_review_job` test cluster — 29 passed
- [ ] Full `github-app/tests/` suite against real Postgres/Redis — started before this PR was opened, still running; will confirm in a follow-up comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr