### PR TITLE
fix: Kotlin local functions incorrectly marked public

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import asyncpg
 
+from aletheore.evidence import is_evidence_version_compatible
 from app_server.evidence_limits import check_evidence_size
 from app_server.llm_cost import WARN_FRACTION_OF_CAP, crossed_spend_warning_threshold
 
@@ -1063,6 +1064,40 @@ async def count_health_check_targets(pool: asyncpg.Pool, installation_id: int, r
     return row["n"]
 
 
+def _version_gated_evidence(
+    installation_id: int, repo_full_name: str, raw: object
+) -> dict | None:
+    """Shared by get_recent_history and get_latest_evidence - the async,
+    hosted-dashboard counterpart of scan_worker.db's identically-named
+    sync helper (same reasoning, duplicated here rather than shared
+    because the two live in separate packages with no existing import
+    boundary between them).
+
+    repo_history rows outlive the schema that wrote them. The CLI, MCP
+    server, and scan_worker.db's own get_latest_evidence all version-
+    check evidence before reading it - real bug this closes: this async
+    path (the one the hosted dashboard actually calls, see dashboard.py)
+    did not, so after an EVIDENCE_VERSION bump the dashboard would keep
+    reading an old-shaped row as if current and crash rendering it (a raw
+    unhandled exception, not the clean "awaiting re-scan" this repo's
+    other read paths already give), or silently show stale/wrong data
+    for whatever keys happened to still be present in the old shape.
+    """
+    evidence = json.loads(raw) if isinstance(raw, str) else raw
+    if not is_evidence_version_compatible(
+        evidence.get("aletheore_version") if isinstance(evidence, dict) else None
+    ):
+        logging.getLogger("app_server.db").info(
+            "ignoring stored evidence for installation=%s repo=%s - written by "
+            "aletheore_version=%r, incompatible with this build; awaiting re-scan",
+            installation_id,
+            repo_full_name,
+            evidence.get("aletheore_version") if isinstance(evidence, dict) else None,
+        )
+        return None
+    return evidence
+
+
 async def get_recent_history(
     pool: asyncpg.Pool,
     installation_id: int,
@@ -1083,13 +1118,15 @@ async def get_recent_history(
     )
     history = []
     for row in rows:
-        evidence = row["evidence"]
-        history.append(
-            {
-                "scanned_at": row["scanned_at"],
-                "evidence": json.loads(evidence) if isinstance(evidence, str) else evidence,
-            }
-        )
+        # A version-incompatible row is dropped from the list entirely,
+        # not included with evidence=None - a history timeline entry
+        # whose evidence dict is missing keys the frontend expects to
+        # render would fail there instead of here, on a row the very
+        # next scan will overwrite anyway.
+        evidence = _version_gated_evidence(installation_id, repo_full_name, row["evidence"])
+        if evidence is None:
+            continue
+        history.append({"scanned_at": row["scanned_at"], "evidence": evidence})
     return history
 
 
@@ -1109,8 +1146,7 @@ async def get_latest_evidence(
     )
     if row is None:
         return None
-    evidence = row["evidence"]
-    return json.loads(evidence) if isinstance(evidence, str) else evidence
+    return _version_gated_evidence(installation_id, repo_full_name, row["evidence"])
 
 
 async def get_recent_endpoint_health(

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -29,6 +29,8 @@ logger = logging.getLogger(__name__)
 # (docs/audits/Claude_Audit.md finding 30, confirmed live: a held checkout
 # lock made a concurrent seat-admission call block for its full
 # lock_timeout and then fail), fixed by moving SEAT_LOCK_NAMESPACE to 6.
+# 7 is claimed below for the wiki-write lock - keep this registry comment
+# in sync with any new namespace either file adds.
 SCAN_SLOT_LOCK_NAMESPACE = 1
 SPEND_LOCK_NAMESPACE = 2
 # Namespace 3 is reserved for the per-repo checkout lock (see
@@ -36,6 +38,13 @@ SPEND_LOCK_NAMESPACE = 2
 # rather than a bare int, since the resource being protected is a
 # composite (installation, repo) pair, not a single id.
 REPO_CHECKOUT_LOCK_NAMESPACE = 3
+# Namespace 7 is reserved for the per-repo Live Wiki write lock (see
+# wiki_write_lock) - same composite-key shape as REPO_CHECKOUT_LOCK_NAMESPACE
+# above, deliberately a distinct namespace rather than reusing 3: a slow
+# AI-writing job blocking on an unrelated in-progress checkout (or vice
+# versa) would be needless coupling between two genuinely independent
+# resources for the same repo.
+WIKI_WRITE_LOCK_NAMESPACE = 7
 ADVISORY_LOCK_TIMEOUT = "5s"
 INSTALLATION_SPEND_LOCK_MAX_ATTEMPTS = 4
 INSTALLATION_SPEND_LOCK_RETRY_DELAY_SECONDS = 3
@@ -522,6 +531,51 @@ def repo_checkout_lock(dsn: str, installation_id: int, repo_full_name: str):
             cur.execute(
                 "SELECT pg_advisory_unlock(%s, hashtext(%s))",
                 (REPO_CHECKOUT_LOCK_NAMESPACE, key),
+            )
+        conn.close()
+
+
+@contextmanager
+def wiki_write_lock(dsn: str, installation_id: int, repo_full_name: str):
+    """Serializes one repo's Live Wiki writes (scan_worker.jobs.
+    _store_wiki_generation - the upsert/prune/overview-regenerate sequence,
+    not the slower LLM generation that runs before it) across whichever
+    job reaches it: a full build, an incremental push-triggered update, and
+    an incremental PR-triggered update can all be enqueued for the same
+    repo close together, on different scan-worker replicas, and none of
+    that concurrency is bounded by repo_checkout_lock - that lock's scope
+    ends (checkout releases) before the wiki job is even enqueued.
+
+    Real bug this closes: _store_wiki_generation prunes wiki_subsystems
+    rows using ITS OWN evidence snapshot's current cluster list
+    (delete_wiki_subsystems_not_in) - if an older-evidence job's write
+    lands after a newer-evidence job's (e.g. two pushes close together,
+    finishing out of order), the older job's prune step has no way to
+    know about a cluster the newer evidence already added, and deletes
+    that just-written, still-current subsystem row out from under it.
+
+    Deliberately blocking, same reasoning as repo_checkout_lock: a second
+    wiki write for the same repo should wait its turn and still run, not
+    fail fast and silently drop a real update. A distinct namespace from
+    repo_checkout_lock (see WIKI_WRITE_LOCK_NAMESPACE) - these are two
+    independent resources for the same repo, and coupling them would make
+    a slow AI-writing job needlessly block an unrelated checkout, or vice
+    versa.
+    """
+    key = f"{installation_id}:{repo_full_name}"
+    conn = psycopg.connect(dsn, autocommit=True)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_advisory_lock(%s, hashtext(%s))",
+                (WIKI_WRITE_LOCK_NAMESPACE, key),
+            )
+        yield
+    finally:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_advisory_unlock(%s, hashtext(%s))",
+                (WIKI_WRITE_LOCK_NAMESPACE, key),
             )
         conn.close()
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -113,6 +113,7 @@ from scan_worker.db import (
     upsert_docs_symbol,
     upsert_wiki_overview,
     upsert_wiki_subsystem,
+    wiki_write_lock,
 )
 from scan_worker.docs_repo_commit import sync_docs_to_repo
 from scan_worker.flash_review import (
@@ -3790,35 +3791,48 @@ def _store_wiki_generation(
     regenerates the overview from the full current set (fresh records
     merged with whatever was already stored for subsystems untouched by
     this run).
+
+    Wrapped in wiki_write_lock (see its own docstring for the real race
+    this closes): a full build and a push/PR-triggered incremental update
+    for the same repo can land here from two different scan-worker
+    replicas close together, and the prune step below trusts ITS OWN
+    evidence snapshot's cluster list - an older-evidence job finishing
+    after a newer one otherwise deletes a subsystem the newer job just
+    correctly wrote. Scoped around the whole write sequence, including
+    the overview regeneration below (itself an LLM call, not just a DB
+    write): the overview read (list_wiki_subsystems) happens after the
+    prune, so a concurrent writer landing in that gap would make the
+    overview reflect an inconsistent, half-pruned subsystem set too.
     """
-    for record in fresh_records:
-        upsert_wiki_subsystem(
-            dsn,
-            installation_id,
-            repo_full_name,
-            record["subsystem_id"],
-            record["name"],
-            record["description"],
-            record["files"],
-            record["diagram_mermaid"],
-            source_commit,
+    with wiki_write_lock(dsn, installation_id, repo_full_name):
+        for record in fresh_records:
+            upsert_wiki_subsystem(
+                dsn,
+                installation_id,
+                repo_full_name,
+                record["subsystem_id"],
+                record["name"],
+                record["description"],
+                record["files"],
+                record["diagram_mermaid"],
+                source_commit,
+            )
+
+        current_cluster_ids = [str(c["id"]) for c in evidence.get("architecture", {}).get("clusters", [])]
+        delete_wiki_subsystems_not_in(dsn, installation_id, repo_full_name, current_cluster_ids)
+
+        all_records = {r["subsystem_id"]: r for r in list_wiki_subsystems(dsn, installation_id, repo_full_name)}
+        for record in fresh_records:
+            all_records[record["subsystem_id"]] = record
+        if not all_records:
+            return
+
+        overview = live_wiki.generate_overview(
+            evidence, list(all_records.values()), writing_adapter, fetch_line_count=fetch_line_count
         )
-
-    current_cluster_ids = [str(c["id"]) for c in evidence.get("architecture", {}).get("clusters", [])]
-    delete_wiki_subsystems_not_in(dsn, installation_id, repo_full_name, current_cluster_ids)
-
-    all_records = {r["subsystem_id"]: r for r in list_wiki_subsystems(dsn, installation_id, repo_full_name)}
-    for record in fresh_records:
-        all_records[record["subsystem_id"]] = record
-    if not all_records:
-        return
-
-    overview = live_wiki.generate_overview(
-        evidence, list(all_records.values()), writing_adapter, fetch_line_count=fetch_line_count
-    )
-    upsert_wiki_overview(
-        dsn, installation_id, repo_full_name, overview["description"], overview["diagram_mermaid"], source_commit
-    )
+        upsert_wiki_overview(
+            dsn, installation_id, repo_full_name, overview["description"], overview["diagram_mermaid"], source_commit
+        )
 
 
 # Every cluster gets an LLM call in a full build (naming + subsystem

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -467,7 +467,7 @@ def _build_unchanged_scan_cache(
         return None
     diff_result = subprocess.run(
         ["git", "diff", "--name-only", previous_sha, current_sha],
-        cwd=checkout_dir, capture_output=True, text=True,
+        cwd=checkout_dir, capture_output=True, text=True, errors="ignore",
     )
     if diff_result.returncode != 0:
         return None
@@ -1150,12 +1150,25 @@ def run_initial_scan_job(installation_id: int, repo_full_name: str) -> None:
             return
         clone_url = _clone_url(repo_full_name, token)
         repo_dir = job_dir / "repo"
-        _clone_ref(clone_url, head_sha, repo_dir)
 
-        evidence_path = _run_scan(repo_dir)
-        evidence = json.loads(evidence_path.read_text())
-        evidence = _sync_persistent_git_graph(installation_id, repo_full_name, repo_dir, evidence)
-        _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
+        # Locked for the whole checkout-through-graph-sync span - see
+        # run_pr_scan_job's identical lock for why. Previously unlocked
+        # entirely: connecting a repo and then pushing to it in quick
+        # succession (this job and run_push_scan_job racing on different
+        # scan-worker replicas) could interleave their _sync_code_graph
+        # writes and leave code_graph_sync_state.last_synced_sha pointing at
+        # the OLDER of the two scans while the file/symbol/edge rows ended
+        # up a clobbered mix of both - corrupting the very state
+        # _build_unchanged_scan_cache trusts as ground truth for skipping
+        # re-parsing of "unchanged" files on the next PR scan, silently
+        # feeding stale parsed data into a real PR review.
+        with repo_checkout_lock(settings.database_url, installation_id, repo_full_name):
+            _clone_ref(clone_url, head_sha, repo_dir)
+
+            evidence_path = _run_scan(repo_dir)
+            evidence = json.loads(evidence_path.read_text())
+            evidence = _sync_persistent_git_graph(installation_id, repo_full_name, repo_dir, evidence)
+            _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
         _insert_history(installation_id, repo_full_name, evidence)
 
         # A repo added to an already-AIR installation should get its
@@ -1219,6 +1232,11 @@ def run_push_scan_job(
 
         # See run_pr_scan_job's identical lock for why this spans checkout
         # through git-graph-sync rather than just the checkout call.
+        # _sync_code_graph was previously dedented out here, running
+        # unlocked - the exact same cross-replica race run_initial_scan_job's
+        # lock docstring above describes, just reached from this job's side
+        # of it (a push landing while run_initial_scan_job is still mid-sync
+        # for the same repo, or two pushes racing each other).
         with repo_checkout_lock(settings.database_url, installation_id, repo_full_name):
             repo_dir = _prepare_head_checkout(
                 clone_url, head_sha, installation_id, repo_full_name, job_dir / "repo"
@@ -1227,7 +1245,7 @@ def run_push_scan_job(
             evidence_path = _run_scan(repo_dir)
             evidence = json.loads(evidence_path.read_text())
             evidence = _sync_persistent_git_graph(installation_id, repo_full_name, repo_dir, evidence)
-        _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
+            _sync_code_graph(installation_id, repo_full_name, head_sha, evidence)
         history_id = _insert_history(installation_id, repo_full_name, evidence)
 
         # AIR-exclusive - see the identical note on run_initial_scan_job's

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -11,6 +11,8 @@ import pytest
 from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
+from aletheore.evidence import EVIDENCE_VERSION
+
 from app_server.admin import (
     _fetch_administered_installation_ids,
     _administered_installation_ids_for_session_or_401,
@@ -47,7 +49,7 @@ async def _logged_in_client(pool, monkeypatch, installation_id=100, plan="air"):
         installation_id,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"scanned_at": "x"},
+        {"aletheore_version": EVIDENCE_VERSION, "scanned_at": "x"},
     )
     await create_session(
         pool,

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from aletheore.evidence import EVIDENCE_VERSION
 from app_server.auth import encrypt_access_token, sign_session_id
 from app_server.db import (
     create_session,
@@ -125,6 +126,7 @@ async def _seed_docs_build_status(pool, installation_id, repo_full_name, status,
 
 def _evidence_with_module(module_path: str, function_name: str, docstring: str | None) -> dict:
     return {
+        "aletheore_version": EVIDENCE_VERSION,
         "repository": {
             "modules": [
                 {
@@ -202,15 +204,15 @@ async def test_list_my_repos_returns_repos_across_administered_installations(poo
     await upsert_installation(pool, 702, "another-org")
     await set_installation_plan(pool, 702, "air")
     await insert_repo_history(
-        pool, 701, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 701, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     await insert_repo_history(
-        pool, 702, "another-org/service-b", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 702, "another-org/service-b", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     # A third installation the caller does NOT administer - must not leak in.
     await upsert_installation(pool, 703, "someone-else")
     await insert_repo_history(
-        pool, 703, "someone-else/private-repo", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 703, "someone-else/private-repo", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
 
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[701, 702])
@@ -236,7 +238,7 @@ async def test_list_my_repos_excludes_free_plan_installations(pool, monkeypatch)
     # managed dashboard for free, without anyone paying for it.
     await upsert_installation(pool, 704, "octocat")  # defaults to plan='free'
     await insert_repo_history(
-        pool, 704, "octocat/free-repo", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 704, "octocat/free-repo", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
 
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[704])
@@ -256,10 +258,10 @@ async def test_list_my_repos_excludes_a_hidden_repo(pool, monkeypatch):
     await upsert_installation(pool, 705, "octocat")
     await set_installation_plan(pool, 705, "air")
     await insert_repo_history(
-        pool, 705, "octocat/kept", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 705, "octocat/kept", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     await insert_repo_history(
-        pool, 705, "octocat/hidden", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 705, "octocat/hidden", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     await hide_repo(pool, 705, "octocat/hidden")
 
@@ -401,7 +403,7 @@ async def test_list_my_repos_does_not_duplicate_already_scanned_repos(pool, monk
     await upsert_installation(pool, 802, "some-user")
     await set_installation_plan(pool, 802, "air")
     await insert_repo_history(
-        pool, 802, "some-user/already-scanned", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 802, "some-user/already-scanned", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
 
     monkeypatch.setattr("app_server.dashboard.generate_app_jwt", lambda *a, **k: "fake-jwt")
@@ -573,7 +575,7 @@ async def test_dashboard_rejects_unadministered_installation_with_the_same_404_a
         1,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     # The caller is logged in, but their GitHub account administers a
     # different installation (999), not the one that owns this repo (1) -
@@ -597,7 +599,7 @@ async def test_dashboard_requires_paid_plan(pool, monkeypatch):
     # into a full managed dashboard for free.
     await upsert_installation(pool, 511, "octocat")  # defaults to plan='free'
     await insert_repo_history(
-        pool, 511, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 511, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[511])
     async with client:
@@ -609,7 +611,7 @@ async def test_dashboard_requires_paid_plan(pool, monkeypatch):
 async def test_dashboard_health_requires_paid_plan(pool, monkeypatch):
     await upsert_installation(pool, 512, "octocat")  # defaults to plan='free'
     await insert_repo_history(
-        pool, 512, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 512, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[512])
     async with client:
@@ -626,7 +628,7 @@ async def test_dashboard_returns_data_for_known_repo(pool, monkeypatch):
         1,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
     async with client:
@@ -642,7 +644,7 @@ async def test_dashboard_returns_empty_dismissed_finding_keys_by_default(pool, m
     await upsert_installation(pool, 1, "octocat")
     await set_installation_plan(pool, 1, "air")
     await insert_repo_history(
-        pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
     async with client:
@@ -694,7 +696,7 @@ async def test_dismiss_finding_route_then_get_dashboard_reflects_it(pool, monkey
     await upsert_installation(pool, 1, "octocat")
     await set_installation_plan(pool, 1, "air")
     await insert_repo_history(
-        pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 1, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[1])
     finding = {"path": "config.py", "pattern": "aws_access_key_id", "match_preview": "AKIA****...MNOP"}
@@ -1083,7 +1085,7 @@ async def test_dashboard_health_keeps_results_separate_per_target(pool, monkeypa
     await upsert_installation(pool, 503, "octocat")
     await set_installation_plan(pool, 503, "air")
     await insert_repo_history(
-        pool, 503, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 503, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     async with pool.acquire() as conn:
         staging_id = await conn.fetchval(
@@ -1138,7 +1140,7 @@ async def test_dashboard_health_history_returns_checks_newest_first(pool, monkey
     await upsert_installation(pool, 504, "octocat")
     await set_installation_plan(pool, 504, "air")
     await insert_repo_history(
-        pool, 504, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 504, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     async with pool.acquire() as conn:
         target_id = await conn.fetchval(
@@ -1184,7 +1186,7 @@ async def test_dashboard_health_history_respects_limit(pool, monkeypatch):
     await upsert_installation(pool, 505, "octocat")
     await set_installation_plan(pool, 505, "air")
     await insert_repo_history(
-        pool, 505, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 505, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     async with pool.acquire() as conn:
         for i in range(5):
@@ -1214,7 +1216,7 @@ async def test_dashboard_health_history_rejects_unadministered_installation(pool
     # with_the_same_404_as_a_nonexistent_repo for why (finding 34).
     await upsert_installation(pool, 506, "octocat")
     await insert_repo_history(
-        pool, 506, "octocat/hello-world", datetime.now(timezone.utc), {"repository": {"modules": []}}
+        pool, 506, "octocat/hello-world", datetime.now(timezone.utc), {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}}
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[])
     async with client:
@@ -1234,7 +1236,7 @@ async def test_dashboard_health_rejects_unadministered_installation(pool, monkey
         501,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     async with pool.acquire() as conn:
         await conn.execute(
@@ -1260,6 +1262,7 @@ async def test_dashboard_health_includes_evidence_resolution(pool, monkeypatch):
         "octocat/hello-world",
         datetime.now(timezone.utc),
         {
+            "aletheore_version": EVIDENCE_VERSION,
             "repository": {
                 "api_endpoints": {
                     "endpoints": [
@@ -1307,6 +1310,7 @@ async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
         "octocat/hello-world",
         datetime.now(timezone.utc),
         {
+            "aletheore_version": EVIDENCE_VERSION,
             "repository": {
                 "api_endpoints": {
                     "endpoints": [
@@ -1411,7 +1415,7 @@ async def test_dashboard_wiki_requires_paid_plan(pool, monkeypatch):
         601,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[601])
     async with client:
@@ -1428,7 +1432,7 @@ async def test_dashboard_wiki_returns_overview_and_subsystems(pool, monkeypatch)
         602,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     await _seed_wiki_overview(pool, 602, "octocat/hello-world")
     await _seed_wiki_subsystem(pool, 602, "octocat/hello-world", "auth")
@@ -1456,7 +1460,7 @@ async def test_dashboard_wiki_returns_null_overview_when_not_yet_generated(pool,
         603,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[603])
     async with client:
@@ -1482,7 +1486,7 @@ async def test_dashboard_wiki_surfaces_failed_build_status(pool, monkeypatch):
         605,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     await _seed_wiki_build_status(pool, 605, "octocat/hello-world", "failed", "model provider unavailable")
 
@@ -1510,7 +1514,7 @@ async def test_dashboard_wiki_surfaces_failed_status_alongside_existing_overview
         606,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     await _seed_wiki_overview(pool, 606, "octocat/hello-world")
     await _seed_wiki_build_status(pool, 606, "octocat/hello-world", "failed", "LLM API unavailable")
@@ -1544,7 +1548,7 @@ async def test_dashboard_wiki_subsystem_returns_detail(pool, monkeypatch):
         604,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     await _seed_wiki_subsystem(pool, 604, "octocat/hello-world", "auth")
 
@@ -1571,6 +1575,7 @@ async def test_dashboard_wiki_file_returns_structural_fallback_for_unpaged_modul
         "octocat/hello-world",
         datetime.now(timezone.utc),
         {
+            "aletheore_version": EVIDENCE_VERSION,
             "repository": {
                 "modules": [
                     {
@@ -1617,7 +1622,7 @@ async def test_dashboard_wiki_file_fetches_unindexed_file_without_llm(pool, monk
         608,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     monkeypatch.setattr(
         "app_server.dashboard._fetch_wiki_file_content_sync",
@@ -1643,7 +1648,7 @@ async def test_dashboard_wiki_subsystem_404s_for_unknown_id(pool, monkeypatch):
         605,
         "octocat/hello-world",
         datetime.now(timezone.utc),
-        {"repository": {"modules": []}},
+        {"aletheore_version": EVIDENCE_VERSION, "repository": {"modules": []}},
     )
     client = await _logged_in_client(pool, monkeypatch, administered_ids=[605])
     async with client:

--- a/github-app/tests/test_data_export.py
+++ b/github-app/tests/test_data_export.py
@@ -2,6 +2,7 @@ import hashlib
 
 import pytest
 
+from aletheore.evidence import EVIDENCE_VERSION
 from app_server.db import list_admin_actions
 from test_admin import _logged_in_client
 
@@ -53,7 +54,10 @@ async def test_export_contains_expected_shape_and_findings(pool, monkeypatch):
     assert body["account_login"] == "octocat"
     assert body["plan"] == "air"
     assert "octocat/hello-world" in body["connected_repos"]
-    assert body["latest_findings_by_repo"]["octocat/hello-world"] == {"scanned_at": "x"}
+    assert body["latest_findings_by_repo"]["octocat/hello-world"] == {
+        "aletheore_version": EVIDENCE_VERSION,
+        "scanned_at": "x",
+    }
     assert "exported_at" in body
     for key in ("members", "api_tokens", "health_check_targets"):
         assert key in body

--- a/github-app/tests/test_db.py
+++ b/github-app/tests/test_db.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from aletheore.evidence import EVIDENCE_VERSION
 from app_server.evidence_limits import EvidenceTooLargeError, MAX_EVIDENCE_BYTES
 from app_server.db import (
     add_installation_member_within_seat_limit,
@@ -21,6 +22,7 @@ from app_server.db import (
     get_extra_seats,
     get_installation_by_token_hash,
     get_installation,
+    get_latest_evidence,
     get_llm_spend_this_month,
     get_recent_history,
     get_max_tokens,
@@ -96,12 +98,61 @@ async def test_repo_history_rotation_keeps_only_20(pool):
     await upsert_installation(pool, 123, "octocat")
     start = datetime(2026, 1, 1, tzinfo=timezone.utc)
     for i in range(21):
-        await insert_repo_history(pool, 123, "octocat/repo", start + timedelta(minutes=i), {"n": i})
+        await insert_repo_history(
+            pool, 123, "octocat/repo", start + timedelta(minutes=i),
+            {"aletheore_version": EVIDENCE_VERSION, "n": i},
+        )
 
     history = await get_recent_history(pool, 123, "octocat/repo", limit=100)
     assert len(history) == 20
     assert history[0]["evidence"]["n"] == 20
     assert history[-1]["evidence"]["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_latest_evidence_returns_none_for_an_incompatible_version(pool):
+    # Real bug this guards: the hosted dashboard's own evidence-read path
+    # (this async get_latest_evidence, distinct from scan_worker.db's
+    # already-guarded sync version) never checked aletheore_version at
+    # all - a repo_history row written by an older, schema-incompatible
+    # build would surface as a raw, unhandled exception deep in dashboard
+    # rendering instead of a clean "awaiting re-scan".
+    await upsert_installation(pool, 123, "octocat")
+    await insert_repo_history(
+        pool, 123, "octocat/repo", datetime.now(timezone.utc), {"aletheore_version": "0.1.0", "n": 1}
+    )
+    assert await get_latest_evidence(pool, 123, "octocat/repo") is None
+
+
+@pytest.mark.asyncio
+async def test_get_latest_evidence_returns_the_evidence_for_a_compatible_version(pool):
+    await upsert_installation(pool, 123, "octocat")
+    await insert_repo_history(
+        pool, 123, "octocat/repo", datetime.now(timezone.utc),
+        {"aletheore_version": EVIDENCE_VERSION, "n": 1},
+    )
+    evidence = await get_latest_evidence(pool, 123, "octocat/repo")
+    assert evidence["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_recent_history_drops_rows_with_an_incompatible_version(pool):
+    # A version-incompatible row is dropped from the list entirely, not
+    # included with evidence=None - a history entry whose evidence dict
+    # is missing keys the frontend expects to render would fail there
+    # instead of here, on a row the next scan will overwrite anyway.
+    await upsert_installation(pool, 123, "octocat")
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    await insert_repo_history(
+        pool, 123, "octocat/repo", start, {"aletheore_version": "0.1.0", "n": "old-shape"}
+    )
+    await insert_repo_history(
+        pool, 123, "octocat/repo", start + timedelta(minutes=1),
+        {"aletheore_version": EVIDENCE_VERSION, "n": "current-shape"},
+    )
+    history = await get_recent_history(pool, 123, "octocat/repo", limit=100)
+    assert len(history) == 1
+    assert history[0]["evidence"]["n"] == "current-shape"
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -5631,6 +5631,104 @@ def test_run_push_scan_job_skips_paid_repo_past_monthly_scan_cap(bare_repo_with_
     assert cloned == []
 
 
+def test_run_initial_scan_job_syncs_code_graph_while_still_holding_repo_checkout_lock(
+    bare_repo_with_two_commits, monkeypatch
+):
+    # run_initial_scan_job previously called _sync_persistent_git_graph and
+    # _sync_code_graph with no locking at all - a repo connected and then
+    # pushed to in quick succession (this job racing run_push_scan_job on a
+    # different scan-worker replica) could interleave their writes and leave
+    # code_graph_sync_state.last_synced_sha pointing at the older of the two
+    # scans while the file/symbol/edge rows ended up a clobbered mix of
+    # both - corrupting the state _build_unchanged_scan_cache trusts as
+    # ground truth for skipping re-parsing of "unchanged" files on the next
+    # PR scan. Verifies the fix by overriding the autoused no-op lock with
+    # one that records enter/exit, and asserting both sync calls run
+    # strictly between them.
+    from scan_worker.jobs import run_initial_scan_job
+
+    bare_path, _base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.get_github_api_client", lambda *a, **k: object())
+    monkeypatch.setattr("scan_worker.jobs.fetch_default_branch_head_sha", lambda *a, **k: head_sha)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+
+    call_order: list[str] = []
+
+    @contextmanager
+    def _recording_lock(*args, **kwargs):
+        call_order.append("lock_enter")
+        yield
+        call_order.append("lock_exit")
+
+    monkeypatch.setattr("scan_worker.jobs.repo_checkout_lock", _recording_lock)
+    monkeypatch.setattr(
+        "scan_worker.jobs._sync_persistent_git_graph",
+        lambda *a, **k: call_order.append("sync_git") or (a[3] if len(a) > 3 else k.get("evidence")),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._sync_code_graph",
+        lambda *a, **k: call_order.append("sync_code"),
+    )
+
+    run_initial_scan_job(1, "octocat/hello-world")
+
+    assert call_order == ["lock_enter", "sync_git", "sync_code", "lock_exit"]
+
+
+def test_run_push_scan_job_syncs_code_graph_while_still_holding_repo_checkout_lock(
+    bare_repo_with_two_commits, monkeypatch
+):
+    # Direct sibling of the run_initial_scan_job fix above: _sync_code_graph
+    # here used to be dedented out of the `with repo_checkout_lock` block
+    # entirely, running unlocked after the lock had already released - the
+    # same class of race, just reached from this job's side of it (a push
+    # landing while run_initial_scan_job is still mid-sync for the same
+    # repo, or two pushes racing each other). Verifies the fix the same way:
+    # overrides the autoused no-op lock to record enter/exit and asserts
+    # _sync_code_graph runs strictly between them, not after lock_exit.
+    from scan_worker.jobs import run_push_scan_job
+
+    bare_path, _base_sha, head_sha = bare_repo_with_two_commits
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "free"})
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: bare_path)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs._insert_history", lambda *a, **k: None)
+
+    call_order: list[str] = []
+
+    @contextmanager
+    def _recording_lock(*args, **kwargs):
+        call_order.append("lock_enter")
+        yield
+        call_order.append("lock_exit")
+
+    monkeypatch.setattr("scan_worker.jobs.repo_checkout_lock", _recording_lock)
+    monkeypatch.setattr(
+        "scan_worker.jobs._sync_persistent_git_graph",
+        lambda *a, **k: call_order.append("sync_git") or (a[3] if len(a) > 3 else k.get("evidence")),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs._sync_code_graph",
+        lambda *a, **k: call_order.append("sync_code"),
+    )
+
+    run_push_scan_job(
+        installation_id=1,
+        repo_full_name="octocat/hello-world",
+        head_sha=head_sha,
+        changed_files=["app.py"],
+    )
+
+    assert call_order == ["lock_enter", "sync_git", "sync_code", "lock_exit"]
+
+
 def test_run_initial_scan_job_logs_and_reraises_on_inner_failure(monkeypatch, caplog):
     from scan_worker.jobs import run_initial_scan_job
 

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -64,6 +64,8 @@ from scan_worker.db import (
     upsert_docs_symbol,
     upsert_wiki_overview,
     upsert_wiki_subsystem,
+    wiki_write_lock,
+    WIKI_WRITE_LOCK_NAMESPACE,
 )
 
 TEST_DATABASE_URL = os.environ.get(
@@ -1177,6 +1179,78 @@ async def test_repo_checkout_lock_does_not_collide_with_spend_lock(pool):
 
 
 @pytest.mark.asyncio
+async def test_wiki_write_lock_blocks_concurrent_acquisition_for_same_repo(pool):
+    # Real bug this guards: _store_wiki_generation's prune step trusts its
+    # own evidence snapshot's cluster list - two wiki-write jobs for the
+    # same repo (a full build and a push-triggered incremental update, say)
+    # landing close together on different scan-worker replicas, finishing
+    # out of order, let the older-evidence one delete a subsystem the
+    # newer one just correctly wrote. This lock serializes them.
+    import psycopg
+
+    with wiki_write_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+        with psycopg.connect(TEST_DATABASE_URL, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_try_advisory_lock(%s, hashtext(%s))",
+                    (WIKI_WRITE_LOCK_NAMESPACE, "301:a/repo1"),
+                )
+                acquired = cur.fetchone()[0]
+        assert acquired is False
+
+
+@pytest.mark.asyncio
+async def test_wiki_write_lock_releases_after_context_exits(pool):
+    import psycopg
+
+    with wiki_write_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+        pass
+
+    with psycopg.connect(TEST_DATABASE_URL, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_try_advisory_lock(%s, hashtext(%s))",
+                (WIKI_WRITE_LOCK_NAMESPACE, "301:a/repo1"),
+            )
+            acquired = cur.fetchone()[0]
+            cur.execute(
+                "SELECT pg_advisory_unlock(%s, hashtext(%s))",
+                (WIKI_WRITE_LOCK_NAMESPACE, "301:a/repo1"),
+            )
+    assert acquired is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_write_lock_does_not_block_a_different_repo(pool):
+    import psycopg
+
+    with wiki_write_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+        with psycopg.connect(TEST_DATABASE_URL, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT pg_try_advisory_lock(%s, hashtext(%s))",
+                    (WIKI_WRITE_LOCK_NAMESPACE, "301:a/repo2"),
+                )
+                acquired = cur.fetchone()[0]
+                cur.execute(
+                    "SELECT pg_advisory_unlock(%s, hashtext(%s))",
+                    (WIKI_WRITE_LOCK_NAMESPACE, "301:a/repo2"),
+                )
+    assert acquired is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_write_lock_does_not_collide_with_repo_checkout_lock(pool):
+    # Deliberately a distinct namespace from repo_checkout_lock (see
+    # wiki_write_lock's own docstring) - a slow AI-writing job must not
+    # block an unrelated in-progress checkout for the same repo, or vice
+    # versa.
+    with repo_checkout_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+        with wiki_write_lock(TEST_DATABASE_URL, 301, "a/repo1"):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_scan_slot_lock_does_not_collide_with_spend_lock(pool):
     await _insert_installation(pool, 307, "a")
     with installation_spend_lock(TEST_DATABASE_URL, 307):
@@ -1214,9 +1288,13 @@ def test_every_advisory_lock_namespace_is_disjoint_across_both_files():
     )
 
     app_server_only = {API_TOKEN_LOCK_NAMESPACE, HEALTH_CHECK_TARGET_LOCK_NAMESPACE, SEAT_LOCK_NAMESPACE}
-    scan_worker_only = {SPEND_LOCK_NAMESPACE, REPO_CHECKOUT_LOCK_NAMESPACE}
+    scan_worker_only = {SPEND_LOCK_NAMESPACE, REPO_CHECKOUT_LOCK_NAMESPACE, WIKI_WRITE_LOCK_NAMESPACE}
 
     assert app_server_only.isdisjoint(scan_worker_only)
+    # Internally disjoint too - isdisjoint above only checks across files;
+    # a namespace value repeated within this one file would collide just
+    # as badly and slip past that check entirely.
+    assert len(scan_worker_only) == 3
 
 
 @pytest.mark.asyncio

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -240,7 +240,20 @@ def _extract_flask_fastapi_routes(
         if defining_file == rel_path
     }
 
-    def collect_static_prefixes(n: Node) -> None:
+    def collect_static_prefixes(root: Node) -> None:
+        # Iterative, not recursive - see graph.py's walk() for why. Prunes
+        # rather than descending unconditionally (skips function/class
+        # bodies below, per the module-scope note further down), so it
+        # can't reuse the plain _walk_tree() generator the unconditional
+        # walks in this file were converted to.
+        stack = [root]
+        while stack:
+            n = stack.pop()
+            collect_static_prefixes_body(n)
+            if n.type not in ("function_definition", "class_definition"):
+                stack.extend(reversed(n.children))
+
+    def collect_static_prefixes_body(n: Node) -> None:
         # include_router(...) prefixes are deliberately NOT collected here even
         # when the call happens to live in this same file - map_api_endpoints's
         # cross-file pre-pass (_collect_fastapi_include_prefixes) already scans
@@ -263,8 +276,8 @@ def _extract_flask_fastapi_routes(
         # actually binds to is always resolved from module scope (a
         # decorator can only reference a name already in scope at that
         # point), so nothing below module level is ever a real match here.
-        if n.type in ("function_definition", "class_definition"):
-            return
+        # (function_definition/class_definition bodies are pruned by the
+        # caller below, before it ever reaches this function.)
         if n.type == "call":
             function = n.child_by_field_name("function")
             args = n.child_by_field_name("arguments")
@@ -283,12 +296,10 @@ def _extract_flask_fastapi_routes(
                             prefix = literal(prefix_arg.child_by_field_name("value")) if prefix_arg else None
                             if prefix is not None:
                                 router_prefixes[source[left.start_byte:left.end_byte].decode()] = prefix
-        for child in n.children:
-            collect_static_prefixes(child)
 
     collect_static_prefixes(root)
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "decorated_definition":
             definition = n.child_by_field_name("definition")
             handler = "unknown"
@@ -393,17 +404,13 @@ def _extract_flask_fastapi_routes(
                                 "note": None,
                             }
                         )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
 def _extract_django_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         # "urlpatterns += [...]" (splitting the list across an initial
         # assignment plus one or more extensions - an ordinary, documented
         # Django organizing pattern) parses to augmented_assignment, a
@@ -426,10 +433,6 @@ def _extract_django_routes(root: Node, source: bytes, rel_path: str) -> list[dic
                     entry = _django_call_to_entry(item, source, rel_path)
                     if entry is not None:
                         entries.append(entry)
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -509,7 +512,7 @@ def _looks_like_express_path(path: str) -> bool:
 def _extract_express_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "call_expression":
             func = n.child_by_field_name("function")
             if func is not None and func.type == "member_expression":
@@ -554,10 +557,6 @@ def _extract_express_routes(root: Node, source: bytes, rel_path: str) -> list[di
                                         "note": None,
                                     }
                                 )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -600,7 +599,7 @@ def _go_handler_name(args_named: list[Node], source: bytes) -> str:
 def _extract_go_net_http_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "call_expression":
             func = n.child_by_field_name("function")
             if func is not None and func.type == "selector_expression":
@@ -710,17 +709,13 @@ def _extract_go_net_http_routes(root: Node, source: bytes, rel_path: str) -> lis
                                             "note": None,
                                         }
                                     )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
 def _extract_gin_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "call_expression":
             func = n.child_by_field_name("function")
             if func is not None and func.type == "selector_expression":
@@ -747,10 +742,6 @@ def _extract_gin_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
                                         "note": None,
                                     }
                                 )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -805,7 +796,7 @@ def _collect_axum_combinators(node: Node, source: bytes) -> list[tuple[str, str]
 def _extract_axum_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "call_expression":
             func = n.child_by_field_name("function")
             if func is not None and func.type == "field_expression":
@@ -852,10 +843,6 @@ def _extract_axum_routes(root: Node, source: bytes, rel_path: str) -> list[dict]
                                         "note": None,
                                     }
                                 )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -918,7 +905,7 @@ def _spring_class_prefix_note(method_node: Node, source: bytes) -> str | None:
 def _extract_spring_boot_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "method_declaration":
             name_node = n.child_by_field_name("name")
             handler = "unknown"
@@ -955,10 +942,6 @@ def _extract_spring_boot_routes(root: Node, source: bytes, rel_path: str) -> lis
                                     "note": _spring_class_prefix_note(n, source),
                                 }
                             )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -1030,12 +1013,22 @@ def _extract_ktor_routes(root: Node, source: bytes, rel_path: str) -> list[dict]
     """
     entries: list[dict] = []
 
-    def walk(node: Node, prefix_stack: list[str]) -> None:
+    # Iterative, not recursive - see graph.py's walk() for why (deeply-nested
+    # real-world ASTs can exceed Python's recursion limit and crash the whole
+    # scan). This walk prunes rather than descending unconditionally (a
+    # matched call recurses only into its own lambda body, carrying a
+    # threaded prefix_stack), so it can't reuse the plain _walk_tree()
+    # generator the other extractors below were converted to - the stack
+    # here carries (node, prefix_stack) pairs instead of bare nodes, and
+    # reversed(node.children) before pushing preserves the same left-to-right
+    # visiting order the original recursive calls produced.
+    stack: list[tuple[Node, list[str]]] = [(root, [])]
+    while stack:
+        node, prefix_stack = stack.pop()
         shape = _ktor_call_shape(node, source)
         if shape is not None:
             name, path, lambda_node = shape
             lambda_literal = next((c for c in lambda_node.children if c.type == "lambda_literal"), None)
-            body = next((c for c in lambda_literal.children if c.type != "{" and c.type != "}"), lambda_literal) if lambda_literal else None
             if name in _KTOR_VERB_METHODS:
                 entries.append(
                     {
@@ -1050,13 +1043,13 @@ def _extract_ktor_routes(root: Node, source: bytes, rel_path: str) -> list[dict]
                     }
                 )
                 if lambda_literal is not None:
-                    walk(lambda_literal, prefix_stack)
-                return
+                    stack.append((lambda_literal, prefix_stack))
+                continue
             if name == "route":
                 new_stack = [*prefix_stack, path] if path else prefix_stack
                 if lambda_literal is not None:
-                    walk(lambda_literal, new_stack)
-                return
+                    stack.append((lambda_literal, new_stack))
+                continue
             # Any other call-with-trailing-lambda (routing, authenticate,
             # install, intercept, static, ...) is real routing-adjacent
             # scaffolding, not a route itself and not a path prefix -
@@ -1066,12 +1059,10 @@ def _extract_ktor_routes(root: Node, source: bytes, rel_path: str) -> list[dict]
             # its own name as a path segment (wrong - authenticate isn't
             # part of the URL).
             if lambda_literal is not None:
-                walk(lambda_literal, prefix_stack)
-            return
-        for child in node.children:
-            walk(child, prefix_stack)
+                stack.append((lambda_literal, prefix_stack))
+            continue
+        stack.extend((child, prefix_stack) for child in reversed(node.children))
 
-    walk(root, [])
     return entries
 
 
@@ -1091,7 +1082,7 @@ def _extract_vapor_routes(root: Node, source: bytes, rel_path: str) -> list[dict
     def text(n: Node) -> str:
         return source[n.start_byte:n.end_byte].decode(errors="ignore")
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "call_expression":
             nav = next((c for c in n.children if c.type == "navigation_expression"), None)
             suffix_node = next((c for c in n.children if c.type == "call_suffix"), None)
@@ -1158,10 +1149,6 @@ def _extract_vapor_routes(root: Node, source: bytes, rel_path: str) -> list[dict
                                 "note": None,
                             }
                         )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -1194,7 +1181,7 @@ def _rails_path_and_to(
 def _extract_rails_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "call":
             method_node = n.child_by_field_name("method")
             args = n.child_by_field_name("arguments")
@@ -1235,10 +1222,6 @@ def _extract_rails_routes(root: Node, source: bytes, rel_path: str) -> list[dict
                                 "note": None,
                             }
                         )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -1287,7 +1270,7 @@ def _laravel_group_note(call_node: Node, source: bytes) -> str | None:
 def _extract_laravel_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "scoped_call_expression":
             scope = n.child_by_field_name("scope")
             name = n.child_by_field_name("name")
@@ -1359,10 +1342,6 @@ def _extract_laravel_routes(root: Node, source: bytes, rel_path: str) -> list[di
                                     "note": note,
                                 }
                             )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -1425,7 +1404,7 @@ def _aspnet_class_prefix_note(method_node: Node, source: bytes) -> str | None:
 def _extract_aspnet_attribute_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "method_declaration":
             name_node = n.child_by_field_name("name")
             handler = "unknown"
@@ -1452,10 +1431,6 @@ def _extract_aspnet_attribute_routes(root: Node, source: bytes, rel_path: str) -
                                 "note": _aspnet_class_prefix_note(n, source),
                             }
                         )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 
@@ -1473,7 +1448,7 @@ def _aspnet_minimal_handler_label(arg_wrapper: Node | None, source: bytes) -> st
 def _extract_aspnet_minimal_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
-    def walk(n: Node) -> None:
+    for n in _walk_tree(root):
         if n.type == "invocation_expression":
             func = n.child_by_field_name("function")
             if func is not None and func.type == "member_access_expression":
@@ -1526,10 +1501,6 @@ def _extract_aspnet_minimal_routes(root: Node, source: bytes, rel_path: str) -> 
                                 "note": None,
                             }
                         )
-        for child in n.children:
-            walk(child)
-
-    walk(root)
     return entries
 
 

--- a/src/aletheore/scanner/graph.py
+++ b/src/aletheore/scanner/graph.py
@@ -1484,7 +1484,21 @@ def _kotlin_is_public(node: Node) -> bool:
     property with no `modifiers` node at all parses as fully public,
     same as an interface member in Java, but here it's the ordinary case
     for every top-level and class-member declaration, not a special case.
+
+    Also excludes a local (nested) function: tree-sitter-kotlin uses the
+    exact same node type, function_declaration, for a top-level function
+    and one declared inside another function's body - and Kotlin's local
+    functions can't even carry an explicit visibility modifier (it's a
+    compile error), so every one of them would otherwise fall straight
+    into the "no modifiers node -> public" default above. Real bug this
+    fixes: the same "closure extracted as a top-level public symbol" gap
+    the shared _is_nested_in_function check exists for (see its own
+    docstring), just never wired into this language's own is_public -
+    confirmed directly, not assumed: a `fun outer() { fun inner() {} }`
+    reported inner as is_public=True.
     """
+    if _is_nested_in_function(node):
+        return False
     modifiers = next((c for c in node.children if c.type == "modifiers"), None)
     if modifiers is None:
         return True

--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -624,7 +624,13 @@ def _parse_gradle_kts_pins(
 
     pins: list[tuple[str, str, str]] = []
 
-    def walk(node: Node) -> None:
+    # Iterative, not recursive - same class of fix as graph.py's walk() and
+    # endpoints.py's extractors: a deeply nested build.gradle.kts (long
+    # chained/parenthesized expressions are valid Kotlin) can otherwise blow
+    # past Python's recursion limit and crash the whole scan.
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
         if node.type == "call_expression":
             # No field names on this grammar's call_expression at all
             # (confirmed empirically: child_by_field_name("function") and
@@ -657,10 +663,8 @@ def _parse_gradle_kts_pins(
                                     if resolved and resolved[2]:
                                         group, artifact, version = resolved
                                         pins.append((f"{group}:{artifact}", version, _GRADLE_ECOSYSTEM))
-        for child in node.children:
-            walk(child)
+        stack.extend(reversed(node.children))
 
-    walk(tree.root_node)
     return pins
 
 

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -424,6 +424,57 @@ def test_extract_flask_fastapi_handles_multiple_decorators_on_one_function():
     assert entries[0]["path"] == "/a"
 
 
+def test_extract_flask_fastapi_deeply_nested_handler_body_does_not_crash():
+    # graph.py's own AST walk used to be recursive and blew past Python's
+    # default recursion limit on real, deeply-nested source (confirmed on the
+    # Linux kernel) - fixed in that file, but endpoints.py's extractors kept
+    # their own, separate recursive walk() closures over the same trees and
+    # were never converted, so the identical crash was still reachable via
+    # endpoint mapping. 3000 nesting levels comfortably exceeds the default
+    # limit (1000) while staying trivially parseable.
+    depth = 3000
+    nested_expr = "1" + "".join(f"+({i}" for i in range(depth)) + ")" * depth
+    root, source = parse_python(
+        f'@app.get("/deep")\ndef handler():\n    x = {nested_expr}\n    return x\n'
+    )
+
+    entries = _extract_flask_fastapi_routes(root, source, "app.py")
+
+    assert len(entries) == 1
+    assert entries[0]["path"] == "/deep"
+
+
+def test_extract_flask_fastapi_deeply_nested_module_level_statement_does_not_crash():
+    # Same bug class as the test above, but targeting collect_static_prefixes
+    # specifically: it prunes function/class bodies rather than descending
+    # unconditionally, so it can't reuse the shared _walk_tree() generator and
+    # needed its own, separately-converted iterative stack. Nesting has to
+    # stay at module level (outside any function) for that pruning to matter -
+    # depth kept lower than the 3000 used elsewhere since real module-level
+    # nesting (if/try chains) is inherently shallower than expression nesting,
+    # and this still comfortably exceeds the recursion limit.
+    depth = 1500
+    # Build real nested if-blocks (each level indented one more) rather than
+    # a single flat block, so the AST is actually depth-many levels deep.
+    lines = []
+    for i in range(depth):
+        lines.append("    " * i + f"if True:  # {i}")
+    lines.append("    " * depth + "pass")
+    nested_module_body = "\n".join(lines)
+    source_text = (
+        f'router = APIRouter(prefix="/api")\n'
+        f"{nested_module_body}\n"
+        '@router.get("/deep")\n'
+        "def handler():\n    pass\n"
+    )
+    root, source = parse_python(source_text)
+
+    entries = _extract_flask_fastapi_routes(root, source, "app.py")
+
+    assert len(entries) == 1
+    assert entries[0]["path"] == "/api/deep"
+
+
 def test_extract_django_path_call():
     root, source = parse_python(
         "urlpatterns = [\n"
@@ -1331,6 +1382,25 @@ def test_extract_ktor_ignores_calls_with_no_trailing_lambda():
     entries = _extract_ktor_routes(root, source, "Routes.kt")
 
     assert entries == []
+
+
+def test_extract_ktor_deeply_nested_pass_through_wrappers_does_not_crash():
+    # Same recursion-depth bug class as the other extractors in this file,
+    # but this walk prunes rather than descending unconditionally (it only
+    # recurses into a matched call's own lambda body, threading a prefix
+    # stack), so its iterative conversion needed its own explicit
+    # (node, prefix_stack) stack rather than reusing the plain _walk_tree()
+    # generator the other extractors share - the one place a subtle ordering
+    # or state-threading bug in that conversion would show up.
+    depth = 2000
+    nested = "authenticate { " * depth + 'get("/deep") { respond() } ' + "} " * depth
+    root, source = parse_kotlin(f"fun r() {{ routing {{ {nested} }} }}\n")
+
+    entries = _extract_ktor_routes(root, source, "Routes.kt")
+
+    assert len(entries) == 1
+    assert entries[0]["path"] == "/deep"
+    assert entries[0]["method"] == "GET"
 
 
 def test_map_api_endpoints_extracts_kotlin_ktor_routes(tmp_path):

--- a/src/tests/test_graph_kotlin.py
+++ b/src/tests/test_graph_kotlin.py
@@ -105,6 +105,29 @@ def test_kotlin_default_visibility_is_public_unlike_java(tmp_path):
     assert classes_by_name["TasksRepository"]["is_public"] is True  # class, no modifier
 
 
+def test_kotlin_local_function_nested_inside_another_function_is_not_public(tmp_path):
+    # Real bug: tree-sitter-kotlin uses the exact same node type,
+    # function_declaration, for a top-level function and one declared
+    # inside another function's body - and a Kotlin local function can't
+    # even carry an explicit visibility modifier (compile error), so every
+    # one of them fell into the "no modifiers node -> public" default,
+    # the same "closure extracted as a top-level public symbol" gap
+    # _is_nested_in_function exists to close for every other language,
+    # never wired into Kotlin's own _kotlin_is_public.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Foo.kt").write_text(
+        "fun outer() {\n"
+        "    fun innerHelper() { println(\"hi\") }\n"
+        "    innerHelper()\n"
+        "}\n"
+    )
+    modules, _, _ = build_module_graph(repo)
+    functions_by_name = {f["name"]: f for f in modules[0]["symbols"]["functions"]}
+    assert functions_by_name["outer"]["is_public"] is True
+    assert functions_by_name["innerHelper"]["is_public"] is False
+
+
 def test_build_module_graph_kotlin_import_resolves_despite_filename_mismatch(tmp_path):
     # The real, Kotlin-specific import-resolution gap Java-style same-
     # name-as-file lookup can't handle: TaskRepository.kt exports


### PR DESCRIPTION
## Summary

Continuing the backward gap-audit pass (see #499, #503, #504, all merged). This batch covers #2-#127 - reaching the earliest repo history.

**Batch 1 — Kotlin local functions incorrectly marked public:**

tree-sitter-kotlin uses the exact same node type, `function_declaration`, for a top-level function and one declared inside another function's body — and a Kotlin local function can't even carry an explicit visibility modifier (it's a compile error), so every one of them fell straight into `_kotlin_is_public`'s "no modifiers node → public" default. Same "closure extracted as a top-level public symbol" gap `_is_nested_in_function` already exists to close for every other language, never wired into Kotlin's own check when Kotlin support was added later (#479).

**Batch 2 — hosted dashboard's evidence-read path never checked schema version:**

`repo_history` rows outlive the schema that wrote them. The CLI, MCP server, and `scan_worker.db`'s own (sync) `get_latest_evidence` all version-check evidence before reading it — exactly the class of bug #114 ("enforce evidence schema-version compatibility on every read path") set out to fix. But `app_server/db.py`'s **async** `get_latest_evidence`/`get_recent_history` — the ones the hosted **dashboard** actually calls — never got the same guard: a row written by an older, schema-incompatible build would surface as a raw, unhandled exception deep in dashboard rendering instead of a clean "awaiting re-scan."

Added the same `_version_gated_evidence` pattern already proven on the sync side, wired into both functions. `get_recent_history` drops an incompatible row from the list entirely rather than including it with `evidence=None`.

Updated every test evidence fixture this touched to include a real `aletheore_version` — including the widely-shared `_logged_in_client` helper used across 6 test files — matching production evidence shape.

**Batch 3 — Live Wiki writes for the same repo could race and delete fresh data:**

`_store_wiki_generation`'s prune step (`delete_wiki_subsystems_not_in`) trusts its own evidence snapshot's cluster list to decide what no longer exists and should be removed. A full build's wiki-write and a push/PR-triggered incremental update's wiki-write are enqueued as separate jobs and can land on different scan-worker replicas with zero locking between them — `repo_checkout_lock`'s scope ends before either wiki-write job is even enqueued. If an older-evidence job's write lands after a newer one's, its prune step deletes a subsystem row the newer job just correctly wrote, since it has no way to know that cluster exists.

Added `wiki_write_lock` (`scan_worker/db.py`), the same per-repo Postgres advisory-lock pattern as `repo_checkout_lock`, in its own namespace (7) — these are two independent resources for the same repo, so coupling them would make a slow AI-writing job needlessly block an unrelated checkout, or vice versa. Wrapped around the entire write sequence in `_store_wiki_generation`, including overview regeneration (the overview read happens after the prune, so a concurrent writer landing in that gap would make the overview reflect an inconsistent, half-pruned set too).

**Batch 4 — PR #37's iterative-walk fix never reached endpoints.py, plus a same-repo code-graph write race:**

PR #37 converted `graph.py`'s AST walk from recursive to iterative after a real Linux-kernel source file blew past Python's default recursion limit and crashed the whole scan. `endpoints.py` defines its own, separate set of AST-walking closures (one per supported framework — Flask/FastAPI, Django, Express, Go, Gin, Axum, Spring Boot, Ktor, Vapor, Rails, Laravel, both ASP.NET flavors) parsing the exact same trees, and every one of them was still genuinely recursive — `map_api_endpoints` runs on every file in every scan, so the identical crash was still reachable via endpoint mapping. `vulnerabilities.py`'s Gradle dependency walk had the same shape. Converted all of them to the same iterative pattern `graph.py` already established. Also closed a narrower sibling gap PR #38 left: an incremental-scan `git diff --name-only` call was still a strict decode with no `errors="ignore"`.

Separately: `run_initial_scan_job` synced the durable code graph with no locking at all, and `run_push_scan_job`'s code-graph sync sat just outside its own `repo_checkout_lock` block — a repo connected and then pushed to in quick succession could race two scan-worker replicas' writes and corrupt `code_graph_sync_state.last_synced_sha`, which `_build_unchanged_scan_cache` trusts as ground truth for skipping re-parsing on the next PR scan. Extended both jobs' existing lock usage to cover the code-graph sync too, matching `run_pr_scan_job`'s already-correct span and the `wiki_write_lock` fix from Batch 3.

## Test plan
- [x] `src/tests/` — 1521 passed
- [x] `github-app/tests/` — 1695 passed, 8 skipped, 0 failed (run in isolation)
- [x] New regression tests: Kotlin nested-function visibility; evidence version gate (drop-and-none / keep-and-return-it); `wiki_write_lock` blocking/release/cross-repo/cross-namespace behavior plus the extended namespace-disjointness guard; deeply-nested Python/Kotlin source (3000/2000 levels, mirroring PR #37's own recursion test) proving the converted walks survive and still extract the right route; call-order assertions proving both code-graph sync calls now run strictly inside `repo_checkout_lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr
