### PR TITLE
feat: add aletheore_get_blast_radius MCP tool

### DIFF
--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -25,6 +25,7 @@ from aletheore.managed_audit_client import run_managed_audit_request
 from aletheore.query import (
     ModuleNotFoundInEvidenceError,
     QUERY_FUNCTIONS,
+    find_blast_radius,
     find_code_evidence_for_dependency,
     find_code_evidence_for_endpoint,
     find_code_evidence_for_symbol,
@@ -439,6 +440,31 @@ def _register_neighborhood_tool(mcp_instance: MCPServer, repo_path: Path) -> Non
         )
 
 
+def _register_blast_radius_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_get_blast_radius", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_get_blast_radius(target: str, symbol: str | None = None) -> str:
+        """Everything that would be affected by changing `target` (a file
+        path) - one call instead of manually chasing aletheore_imported_by
+        recursively. Direct AND transitive dependents (a real multi-hop
+        walk, not just one level like aletheore_neighborhood), plus any
+        existing layer-boundary violations already touching a module in
+        that blast radius.
+
+        Pass `symbol` (a function/class name defined in target) to also get
+        confirmed_callers: which of the direct dependents actually CALL
+        that symbol, verified against their real file content - not just
+        "imports the file", which says nothing about which of possibly
+        many exported names is actually used.
+
+        layer_violations are EXISTING violations already on record, not a
+        prediction of what a signature change to `symbol` would newly
+        break - this repo has no per-call-site type/signature data to
+        simulate that against.
+        """
+        evidence = read_evidence(repo_path)
+        return _toon_result(find_blast_radius(evidence, repo_path, target, symbol))
+
+
 _LIST_KIND_TO_FUNCTION = {
     "modules": list_modules,
     "clusters": list_clusters,
@@ -802,6 +828,7 @@ def build_server(
     _register_query_wrapper_tools(mcp_instance, repo_path)
     _register_changes_tool(mcp_instance, repo_path)
     _register_neighborhood_tool(mcp_instance, repo_path)
+    _register_blast_radius_tool(mcp_instance, repo_path)
     _register_list_tool(mcp_instance, repo_path)
     _register_overview_tool(mcp_instance, repo_path)
     _register_search_tool(mcp_instance, repo_path)

--- a/src/aletheore/query.py
+++ b/src/aletheore/query.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -140,6 +141,97 @@ def find_cluster(evidence: dict, target: str | None) -> dict:
 
 def find_layer_violations(evidence: dict, target: str | None) -> dict:
     return evidence["architecture"]["layer_violations"]
+
+
+# Matches scan_worker/flash_review.py's build_blast_radius_context
+# constants (MAX_BLAST_RADIUS_CANDIDATES, MAX_BLAST_RADIUS_CALLERS_SHOWN) -
+# same design, adapted to read local files directly instead of fetching
+# over the GitHub API, so no batching/threading is needed here.
+_BLAST_RADIUS_CONFIRM_CANDIDATES = 40
+_BLAST_RADIUS_CONFIRMED_CALLERS_SHOWN = 10
+_BLAST_RADIUS_MAX_TRANSITIVE = 50
+
+
+def find_blast_radius(
+    evidence: dict, repo_path: Path, target: str, symbol: str | None = None
+) -> dict:
+    """Everything that would be affected by changing `target` - direct and
+    transitive dependents, and any existing layer violations already
+    touching one of them.
+
+    Direct dependents are evidence's own imported_by, unchanged. Transitive
+    dependents are a real BFS over that same imported_by edge set (not
+    just one hop), capped at _BLAST_RADIUS_MAX_TRANSITIVE with a truncated
+    flag rather than silently cut off - a highly-central module (a shared
+    utils file) can have far more transitive dependents than are useful to
+    return in one call, and the flag says so rather than pretending the
+    list is exhaustive.
+
+    With `symbol` given, also confirms which of the direct dependents
+    actually CALL it, not just import the file - mirrors
+    scan_worker/flash_review.py's build_blast_radius_context exactly: a
+    candidate only counts if its real file content contains the symbol
+    name in a call-shaped position (`name(`), the same deliberately
+    high-confidence-only design (a bare "imports the file" says nothing
+    about which of possibly many exported names is actually used).
+    Confirmed against real local content via repo_path, not evidence -
+    evidence has no per-call-site data to check against.
+
+    layer_violations reports EXISTING violations (evidence's own
+    architecture.layer_violations) that already touch a module in this
+    blast radius - not a prospective simulation of what a signature change
+    would newly break, which would need real symbol-level call resolution
+    this scanner doesn't have.
+    """
+    module = _find_module(evidence, target)
+    direct_dependents = list(module.get("imported_by") or [])
+    by_path = {m["path"]: m for m in evidence["repository"]["modules"] if m.get("path")}
+
+    visited = {target, *direct_dependents}
+    transitive_dependents: list[str] = []
+    truncated = False
+    queue = list(direct_dependents)
+    while queue:
+        current = queue.pop(0)
+        for dependent in by_path.get(current, {}).get("imported_by") or []:
+            if dependent in visited:
+                continue
+            visited.add(dependent)
+            if len(transitive_dependents) >= _BLAST_RADIUS_MAX_TRANSITIVE:
+                truncated = True
+                continue
+            transitive_dependents.append(dependent)
+            queue.append(dependent)
+
+    result: dict[str, Any] = {
+        "target": target,
+        "direct_dependents": direct_dependents,
+        "transitive_dependents": transitive_dependents,
+        "transitive_dependents_truncated": truncated,
+    }
+
+    if symbol:
+        call_pattern = re.compile(r"\b" + re.escape(symbol) + r"\s*\(")
+        confirmed_callers: list[str] = []
+        for candidate in direct_dependents[:_BLAST_RADIUS_CONFIRM_CANDIDATES]:
+            if len(confirmed_callers) >= _BLAST_RADIUS_CONFIRMED_CALLERS_SHOWN:
+                break
+            try:
+                content = (repo_path / candidate).read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if call_pattern.search(content):
+                confirmed_callers.append(candidate)
+        result["symbol"] = symbol
+        result["confirmed_callers"] = confirmed_callers
+
+    blast_radius_modules = {target, *direct_dependents, *transitive_dependents}
+    violations = evidence.get("architecture", {}).get("layer_violations", {}).get("violations") or []
+    result["layer_violations"] = [
+        v for v in violations
+        if v.get("from") in blast_radius_modules or v.get("to") in blast_radius_modules
+    ]
+    return result
 
 
 def find_dead_code_evidence(evidence: dict, target: str | None) -> dict:

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -283,7 +283,7 @@ def test_api_mcp_tools_reflects_the_configured_consent_posture(tmp_path):
 
     assert response.status_code == 200
     tools = response.json()
-    assert len(tools) == 30
+    assert len(tools) == 31
     names = {t["name"] for t in tools}
     assert "aletheore_managed_audit" not in names
     assert "aletheore_scan" in names

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -249,6 +249,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_environment_variables",
         "aletheore_changes",
         "aletheore_neighborhood",
+        "aletheore_get_blast_radius",
         "aletheore_list",
         "aletheore_overview",
         "aletheore_search",
@@ -264,7 +265,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_find_evidence_for_dependency",
     }
     assert expected.issubset(names)
-    assert len(names) == 31
+    assert len(names) == 32
     assert "aletheore_answer" not in names
 
 
@@ -817,6 +818,43 @@ async def test_aletheore_neighborhood_raises_for_unknown_module(tmp_path):
 
     with pytest.raises(ToolError):
         await server.call_tool("aletheore_neighborhood", {"target": "does/not/exist.py"})
+
+
+@pytest.mark.asyncio
+async def test_aletheore_get_blast_radius_returns_direct_dependents(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_get_blast_radius", {"target": "b.py"})
+
+    body = tool_result_body(result)["result"]
+    assert body["target"] == "b.py"
+    assert body["direct_dependents"] == ["a.py"]
+    assert "confirmed_callers" not in body
+
+
+@pytest.mark.asyncio
+async def test_aletheore_get_blast_radius_with_symbol_confirms_real_callers(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    (repo / "a.py").write_text("from b import helper\nhelper()\n")
+    server = build_server(repo)
+
+    result = await server.call_tool(
+        "aletheore_get_blast_radius", {"target": "b.py", "symbol": "helper"}
+    )
+
+    body = tool_result_body(result)["result"]
+    assert body["symbol"] == "helper"
+    assert body["confirmed_callers"] == ["a.py"]
+
+
+@pytest.mark.asyncio
+async def test_aletheore_get_blast_radius_raises_for_unknown_module(tmp_path):
+    repo = make_repo_with_evidence(tmp_path)
+    server = build_server(repo)
+
+    with pytest.raises(ToolError):
+        await server.call_tool("aletheore_get_blast_radius", {"target": "does/not/exist.py"})
 
 
 def make_repo_with_files(tmp_path: Path, files: dict[str, str]) -> Path:

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -5,6 +5,7 @@ from aletheore.query import (
     BranchNotFoundInEvidenceError,
     ModuleNotFoundInEvidenceError,
     SymbolNotFoundInEvidenceError,
+    find_blast_radius,
     find_branch,
     find_cluster,
     find_code_evidence_for_dependency,
@@ -316,6 +317,108 @@ def test_find_cluster_raises_for_unknown_path():
 def test_find_layer_violations_returns_the_whole_block_ignoring_target():
     result = find_layer_violations(make_evidence(), None)
     assert result == make_evidence()["architecture"]["layer_violations"]
+
+
+def _blast_radius_evidence():
+    return {
+        "repository": {
+            "modules": [
+                {"path": "core/util.py", "imports": [], "imported_by": ["service/handler.py"]},
+                {
+                    "path": "service/handler.py",
+                    "imports": ["core/util.py"],
+                    "imported_by": ["api/routes.py"],
+                },
+                {
+                    "path": "api/routes.py",
+                    "imports": ["service/handler.py"],
+                    "imported_by": ["web/app.py"],
+                },
+                {"path": "web/app.py", "imports": ["api/routes.py"], "imported_by": []},
+                {"path": "unrelated/other.py", "imports": [], "imported_by": []},
+            ],
+        },
+        "architecture": {
+            "layer_violations": {
+                "convention_detected": True,
+                "layers": [],
+                "violations": [
+                    {"from": "service/handler.py", "to": "web/app.py", "reason": "inner imports outer"},
+                    {"from": "unrelated/other.py", "to": "unrelated/other.py", "reason": "irrelevant"},
+                ],
+            }
+        },
+    }
+
+
+def test_find_blast_radius_returns_direct_and_transitive_dependents(tmp_path):
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
+
+    assert result["target"] == "core/util.py"
+    assert result["direct_dependents"] == ["service/handler.py"]
+    assert set(result["transitive_dependents"]) == {"api/routes.py", "web/app.py"}
+    assert result["transitive_dependents_truncated"] is False
+
+
+def test_find_blast_radius_raises_for_unknown_target(tmp_path):
+    with pytest.raises(ModuleNotFoundInEvidenceError):
+        find_blast_radius(_blast_radius_evidence(), tmp_path, "does/not/exist.py")
+
+
+def test_find_blast_radius_filters_layer_violations_to_the_radius(tmp_path):
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
+
+    # Both endpoints of the kept violation are in util.py's blast radius
+    # (handler.py is direct, app.py is transitive); the unrelated.py
+    # self-violation touches nothing in the radius and must be excluded.
+    assert result["layer_violations"] == [
+        {"from": "service/handler.py", "to": "web/app.py", "reason": "inner imports outer"}
+    ]
+
+
+def test_find_blast_radius_truncates_transitive_dependents_past_the_cap(tmp_path, monkeypatch):
+    import aletheore.query as query_module
+
+    monkeypatch.setattr(query_module, "_BLAST_RADIUS_MAX_TRANSITIVE", 1)
+
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
+
+    assert len(result["transitive_dependents"]) == 1
+    assert result["transitive_dependents_truncated"] is True
+
+
+def test_find_blast_radius_omits_confirmed_callers_without_a_symbol(tmp_path):
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
+    assert "confirmed_callers" not in result
+    assert "symbol" not in result
+
+
+def test_find_blast_radius_confirms_callers_via_real_file_content(tmp_path):
+    """The high-confidence guarantee: a candidate only counts if the real
+    file content actually calls the symbol, not merely imports its module -
+    mirrors scan_worker/flash_review.py's build_blast_radius_context."""
+    (tmp_path / "service").mkdir()
+    (tmp_path / "service" / "handler.py").write_text(
+        "from core.util import parse_config\nresult = parse_config(raw)\n"
+    )
+
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py", symbol="parse_config")
+
+    assert result["symbol"] == "parse_config"
+    assert result["confirmed_callers"] == ["service/handler.py"]
+
+
+def test_find_blast_radius_excludes_a_dependent_that_only_imports_not_calls(tmp_path):
+    (tmp_path / "service").mkdir()
+    # Imports the module but never actually calls parse_config - a bare
+    # "imports the file" relationship must not count as confirmed.
+    (tmp_path / "service" / "handler.py").write_text(
+        "from core.util import parse_config\nother_function()\n"
+    )
+
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py", symbol="parse_config")
+
+    assert result["confirmed_callers"] == []
 
 
 def test_find_dead_code_evidence_returns_the_whole_block_ignoring_target():


### PR DESCRIPTION
## Summary

New compound MCP tool: `aletheore_get_blast_radius(target, symbol=None)` - instead of an agent manually chasing `aletheore_imported_by` recursively, one call returns:

- **`direct_dependents`** - `target`'s own `imported_by`, unchanged.
- **`transitive_dependents`** - a real BFS over that same edge set (not just one hop like the existing `aletheore_neighborhood`), capped at 50 with a `transitive_dependents_truncated` flag rather than silently cut off.
- **`confirmed_callers`** (only when `symbol` is given) - which of the direct dependents actually *call* that symbol, confirmed against real file content, not just "imports the file." Mirrors `scan_worker/flash_review.py`'s `build_blast_radius_context` exactly (same high-confidence-only design: a candidate only counts if its content contains the symbol name in a call-shaped position), adapted to read local files directly instead of fetching over the GitHub API.
- **`layer_violations`** - existing violations (from evidence's own `architecture.layer_violations`) already touching a module in the blast radius. Documented honestly as *existing* violations, not a prospective simulation of what a signature change would newly break - this scanner has no per-call-site type data to simulate that against.

Read-only, no new required effect - registered under the default MCP consent posture alongside `aletheore_neighborhood`.

## Verification
- Verified end-to-end against this repo's own real evidence (not just mocked): `src/aletheore/query.py`'s real direct/transitive dependents, and a real confirmed-caller check on `find_cluster` (correctly confirmed as called in `mcp_server.py`, correctly excluded for `cli.py` which doesn't call it by that name).
- Two tool-inventory assertions (`test_mcp_server.py`, `test_dashboard.py`) updated for the new tool count.
- `test_cli.py::test_query_help_kind_count_matches_the_real_number_of_kinds` is failing on `master` before this branch existed (confirmed via `git stash`) - unrelated to this change, left alone.

## Test plan
- [x] `pytest src/tests/` - 1540 passed, only the pre-existing unrelated failure above
- [x] New unit tests: BFS correctness, truncation, layer-violation filtering, confirmed-caller real-content matching (both positive and negative cases)
- [x] New MCP integration tests: tool wiring, symbol-based confirmation, unknown-module error
- [x] Manual end-to-end check against this repo's real `.aletheore/air.json` and real source files

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr