### PR TITLE
fix: pin click<8.5.0, a real upstream regression breaking --help text

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -49,6 +49,15 @@ dependencies = [
     "python-toon>=0.1.3,<0.2",
     "pyyaml>=6.0,<7.0",
     "typer>=0.24,<0.28",
+    # click only ever arrives transitively via typer, but pinned explicitly
+    # here because 8.5.0 has a real, verified regression: typer.Argument's
+    # own help= text (e.g. the query command's `kind` argument) stops
+    # rendering in --help output entirely, confirmed by bisecting a minimal
+    # typer app across versions - 8.4.2, 8.4.0, and 8.3.3 all render it
+    # correctly, only 8.5.0 doesn't. Real user-facing regression, not just
+    # a test artifact: anyone running `aletheore query --help` with an
+    # unpinned install got argument descriptions silently dropped.
+    "click<8.5.0",
     # `aletheore watch` only. OS-level file events (FSEvents on macOS,
     # inotify on Linux) rather than polling: measured on this repository,
     # walking and stat-ing the tree costs 841 ms for 644 files, so a


### PR DESCRIPTION
## Summary

`click==8.5.0` (very recent release) breaks Typer's rendering of `Argument`'s `help=` text entirely. Verified by bisecting a minimal Typer app across versions: 8.4.2, 8.4.0, and 8.3.3 all render Argument help correctly; only 8.5.0 doesn't.

This is a real, user-facing regression, not just a test artifact - `click` was never explicitly pinned (only arrived transitively via `typer`), so anyone running `aletheore query --help` with a recent/unpinned install silently lost every positional argument's description, including the one explaining what values `kind` accepts:

**Before (click 8.5.0):**
```
╭─ Arguments ──────────────────────────────────────╮
│   kind        [KIND]                              │
│   target      [TARGET]                             │
│   symbol      [SYMBOL]                              │
╰────────────────────────────────────────────────────╯
```

**After (click<8.5.0, resolves to 8.4.2):**
```
╭─ Arguments ────────────────────────────────────────────────────────────────╮
│   kind        [KIND]    one of the 24 query kinds; omit to list them by    │
│                          category                                          │
│   target      [TARGET]  target for kinds that need one (a file path,       │
│                          branch name, ...)                                 │
│   symbol      [SYMBOL]  symbol name for 'symbol-source'                    │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Fixes `test_cli.py::test_query_help_kind_count_matches_the_real_number_of_kinds`, which was failing on `master` before this branch existed (confirmed via `git stash` in an unrelated PR's testing).

`github-app`'s own lockfile also resolves to `click==8.5.0`, but only as a transitive dependency of `cryptography` - it never uses `typer.Argument` or Click's help rendering anywhere, so it isn't actually affected and doesn't need the same pin.

## Test plan
- [x] `pytest src/tests/` - 1541 passed, zero failures
- [x] Manually verified real `aletheore query --help` output before/after the pin

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr