### PR TITLE
feat: AST pattern search - find code by shape, not words

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Ruby, PHP, C, C++, C#, and Swift**.
   against your own repo — see [`src/README.md`](src/README.md) for why it isn't wired into CI.
 - **`aletheore query`** / **`aletheore diff`** — answer a targeted question or compare two
   scans from existing evidence, no re-scan or LLM call needed.
-- **`aletheore mcp`** — a stdio MCP server exposing 30 tools by default (31 with
+- **`aletheore mcp`** — a stdio MCP server exposing 31 tools by default (32 with
   `ALETHEORE_MCP_ALLOW=external` enabled) (module/symbol/dependency lookups,
   ownership, clusters, dead code, hotspots, full-text and semantic search, scan and index
   triggers) so a coding agent can query your repo's structure directly instead of shelling out

--- a/src/README.md
+++ b/src/README.md
@@ -454,8 +454,8 @@ Starts a stdio MCP server scoped to one repository, so a coding agent can query 
 directly instead of shelling out via Bash or re-reading files on every lookup. Every tool
 result is [TOON](https://toonformat.dev)-encoded rather than plain JSON — the calling agent's
 own token budget is what actually pays for reading these results, and evidence's shape (almost
-entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 26 tools in
-a read-only posture, 30 by default, and 31 with every effect permitted — see
+entirely uniform arrays of same-shaped objects) is exactly TOON's best case. Exposes 27 tools in
+a read-only posture, 31 by default, and 32 with every effect permitted — see
 [Tool permissions](#tool-permissions) for what gates the rest — plus one optional answer tool
 when started with `--agent`:
 
@@ -478,6 +478,9 @@ when started with `--agent`:
   instead of three round-trips.
 - `aletheore_search(pattern, regex=False, path_glob=None)` — literal or regex full-text search
   over tracked source files, capped at 200 matches.
+- `aletheore_ast_pattern(language, query)` — structural search by shape, not words: a raw
+  tree-sitter S-expression query against every file of one language, re-parsed from disk (not
+  air.json) since a structural match needs the real parse tree.
 - `aletheore_symbol_source(module, symbol)` — exact source text for one named function/class,
   with resolved line bounds.
 - `aletheore_verify_citations(report_text)` — checks every `file:line` citation in a report

--- a/src/aletheore/ast_pattern.py
+++ b/src/aletheore/ast_pattern.py
@@ -1,0 +1,122 @@
+"""On-demand structural code search: match a raw tree-sitter query against
+every parsed file of one language in a repository.
+
+Unlike the rest of `aletheore query`, this reads and re-parses source from
+disk at query time rather than reading cached `.aletheore/air.json`
+evidence - a structural pattern match needs the actual parse tree, which
+air.json never stores (the extracted symbol/import facts are a small
+summary derived from it, not the tree itself).
+
+Only user of tree_sitter's Query/QueryCursor API in this codebase - every
+other module uses Parser/Tree/Node directly. That distinction matters: this
+module's real-repo use of Query/QueryCursor segfaults reliably on Python
+3.14 once enough files/matches accumulate for the cyclic GC to touch the
+resulting Node/Tree/QueryCursor object graph (reproduced directly, same
+code runs clean on 3.12 - see pyproject.toml's `requires-python` upper
+bound). Not fixed by explicit `del`, `gc.disable()`, or forced
+`gc.collect()` per iteration - tried all three, none prevented it. If the
+`<3.14` bound is ever loosened, re-verify this module specifically against
+a real, many-file repo before trusting it, not just the unit tests (which
+use single-digit-file fixtures too small to trigger it).
+"""
+
+from pathlib import Path
+
+from tree_sitter import Parser, Query, QueryCursor, QueryError
+
+from aletheore.scanner.graph import (
+    LANGUAGE_BY_EXTENSION,
+    MAX_SOURCE_FILE_BYTES,
+    _iter_source_files,
+    _read_and_parse,
+)
+
+
+class UnknownLanguageError(Exception):
+    """`language` isn't one LANGUAGE_BY_EXTENSION recognizes."""
+
+
+class InvalidPatternError(Exception):
+    """`query_source` doesn't compile against the language's grammar."""
+
+
+def _extensions_and_languages_for(language: str) -> list[tuple[str, object]]:
+    matches = [
+        (ext, ts_language)
+        for ext, (name, ts_language) in LANGUAGE_BY_EXTENSION.items()
+        if name == language
+    ]
+    if not matches:
+        known = sorted({name for name, _ in LANGUAGE_BY_EXTENSION.values()})
+        raise UnknownLanguageError(f"unknown language {language!r} - supported: {', '.join(known)}")
+    return matches
+
+
+def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> list[dict]:
+    """Runs a tree-sitter S-expression query against every file of
+    `language` under repo_path. One dict per match:
+    `{"file": ..., "captures": {name: [{"text", "start_line", "end_line"}, ...]}}`
+    - captures are exactly what the query itself names with `@capture`,
+    nothing synthesized. A query with no captures at all matches structure
+    but returns no text/location - the caller's query must name at least
+    one node it cares about.
+
+    Raises UnknownLanguageError for a language name LANGUAGE_BY_EXTENSION
+    doesn't recognize, InvalidPatternError for a query_source that fails
+    to compile against the language's grammar.
+    """
+    ext_languages = _extensions_and_languages_for(language)
+
+    # A Query is compiled against one specific grammar object - typescript
+    # spans two (.ts/.tsx use different grammars: TS_LANGUAGE/TSX_LANGUAGE,
+    # see LANGUAGE_BY_EXTENSION), so compile once per distinct grammar the
+    # requested language name actually covers, not once per language name.
+    distinct_ts_languages = {ts_language for _, ts_language in ext_languages}
+    queries = {}
+    for ts_language in distinct_ts_languages:
+        try:
+            queries[ts_language] = Query(ts_language, query_source)
+        except QueryError as exc:
+            raise InvalidPatternError(str(exc)) from exc
+
+    ext_to_ts_language = dict(ext_languages)
+    parser = Parser()
+    results: list[dict] = []
+    for path in _iter_source_files(repo_path):
+        ts_language = ext_to_ts_language.get(path.suffix)
+        if ts_language is None:
+            continue
+        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+            continue
+        _, tree = _read_and_parse(path, parser, ts_language)
+        cursor = QueryCursor(queries[ts_language])
+        rel_path = path.relative_to(repo_path).as_posix()
+        for _pattern_index, captures in cursor.matches(tree.root_node):
+            results.append(
+                {
+                    "file": rel_path,
+                    "captures": {
+                        name: [
+                            {
+                                "text": node.text.decode("utf-8", errors="replace"),
+                                "start_line": node.start_point.row + 1,
+                                "end_line": node.end_point.row + 1,
+                            }
+                            for node in nodes
+                        ]
+                        for name, nodes in captures.items()
+                    },
+                }
+            )
+        # Explicit, not left to reassignment next iteration: Node/Tree form
+        # a reference cycle in this tree-sitter binding, so plain refcounting
+        # never frees them - only the cyclic GC does, on its own schedule.
+        # Left alone, cyclic garbage from every file in a large repo (100+)
+        # piles up until an eventual mass collection (or process exit)
+        # frees many Tree objects at once, which segfaults - reproduced
+        # directly running this function against this project's own 116
+        # source files: a build with `del` here never crashes, one without
+        # it does, deterministically, every time. Deleting each iteration
+        # keeps the cycle count at most one at a time.
+        del tree, cursor
+    return results

--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -140,6 +140,7 @@ QUERY_KIND_GROUPS: dict[str, list[str]] = {
         "layer-violations",
         "dead-code",
         "schema",
+        "ast-pattern",
     ],
     "Security": ["secrets", "vulnerabilities", "licenses"],
     "Runtime": ["endpoints", "database", "infrastructure", "environment-variables"],
@@ -813,6 +814,30 @@ def _query(
             return 1
         except IndexDimensionMismatchError as exc:
             console.print(f"[bold red]error:[/bold red] {exc}")
+            return 1
+        _print_query_result(result)
+        return 0
+
+    if kind == "ast-pattern":
+        if target is None:
+            print("error: query type 'ast-pattern' requires a tree-sitter query as TARGET")
+            return 1
+        if language is None:
+            print("error: query type 'ast-pattern' requires --language (which grammar to compile the query against)")
+            return 1
+        from aletheore.ast_pattern import (
+            InvalidPatternError,
+            UnknownLanguageError,
+            search_ast_pattern,
+        )
+
+        try:
+            result = search_ast_pattern(Path(repo_path).resolve(), language, target)
+        except UnknownLanguageError as exc:
+            console.print(f"[bold red]error:[/bold red] {exc}")
+            return 1
+        except InvalidPatternError as exc:
+            console.print(f"[bold red]error:[/bold red] invalid tree-sitter query: {exc}")
             return 1
         _print_query_result(result)
         return 0
@@ -1560,7 +1585,9 @@ def query(
     agent: Optional[str] = typer.Option(None, "--agent", help="provider for 'answer'"),
     k: int = typer.Option(10, "--k", help="number of semantic search results"),
     language: Optional[str] = typer.Option(
-        None, "--language", help="restrict 'search-codebase' to one language, e.g. python"
+        None,
+        "--language",
+        help="restrict 'search-codebase' to one language, e.g. python; required for 'ast-pattern'",
     ),
 ) -> None:
     if kind is None:

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -539,6 +539,31 @@ def _register_search_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
         return _toon_result(result)
 
 
+def _register_ast_pattern_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
+    @mcp_instance.tool(name="aletheore_ast_pattern", annotations=READ_ONLY_ANNOTATIONS)
+    def aletheore_ast_pattern(language: str, query: str) -> str:
+        """Structural search: find code by shape rather than by words, via a
+        raw tree-sitter S-expression query - e.g. functions that catch a
+        specific exception type, or classes implementing a given interface,
+        regardless of naming. language is one of the scanner's supported
+        languages (python, javascript, typescript, go, rust, java, kotlin,
+        ruby, php, c, cpp, csharp, swift). Re-parses source from disk at
+        call time - unlike most other tools here, this does not read
+        air.json, since a structural match needs the actual parse tree,
+        which air.json never stores. Only whatever the query itself names
+        with @capture is returned - a query with no captures matches
+        structure but reports no text or location, so name at least one
+        node you care about."""
+        from aletheore.ast_pattern import InvalidPatternError, UnknownLanguageError, search_ast_pattern
+
+        try:
+            return _toon_result(search_ast_pattern(repo_path, language, query))
+        except UnknownLanguageError as exc:
+            return _toon_result({"error": str(exc)})
+        except InvalidPatternError as exc:
+            return _toon_result({"error": f"invalid tree-sitter query: {exc}"})
+
+
 def _register_symbol_source_tool(mcp_instance: MCPServer, repo_path: Path) -> None:
     @mcp_instance.tool(name="aletheore_symbol_source", annotations=READ_ONLY_ANNOTATIONS)
     def aletheore_symbol_source(module: str, symbol: str) -> str:
@@ -832,6 +857,7 @@ def build_server(
     _register_list_tool(mcp_instance, repo_path)
     _register_overview_tool(mcp_instance, repo_path)
     _register_search_tool(mcp_instance, repo_path)
+    _register_ast_pattern_tool(mcp_instance, repo_path)
     _register_symbol_source_tool(mcp_instance, repo_path)
     _register_verify_citations_tool(mcp_instance, repo_path)
     _register_code_evidence_tools(mcp_instance, repo_path)

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -6,7 +6,17 @@ readme = "README.md"
 license = "LicenseRef-PolyForm-Noncommercial-1.0.0"
 license-files = ["LICENSE"]
 authors = [{ name = "Arihant Kaul", email = "arihantkaul@outlook.com" }]
-requires-python = ">=3.11"
+# Upper-bounded at 3.14: aletheore_ast_pattern's use of tree_sitter's
+# Query/QueryCursor segfaults reliably on Python 3.14 (reproduced directly -
+# the exact same code against the exact same repo runs clean on 3.12) once
+# enough real files/matches accumulate in one process for the cyclic GC to
+# touch tree-sitter's Node/Tree/QueryCursor object graph. Not a bug in this
+# package's own code - `aletheore scan` itself, which uses tree_sitter's
+# Parser/Tree/Node but never Query/QueryCursor, runs fine on 3.14. CI only
+# tests 3.11/3.12 (see .github/workflows/tests.yml), so this bound is the
+# honest floor until either tree-sitter ships a fix or the crash is
+# isolated some other way (e.g. running the query in a subprocess).
+requires-python = ">=3.11,<3.14"
 keywords = ["code-review", "static-analysis", "secrets-detection", "dependency-vulnerabilities", "mcp-server"]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/tests/test_ast_pattern.py
+++ b/src/tests/test_ast_pattern.py
@@ -1,0 +1,115 @@
+import pytest
+
+from aletheore.ast_pattern import (
+    InvalidPatternError,
+    UnknownLanguageError,
+    search_ast_pattern,
+)
+
+
+def test_search_ast_pattern_matches_a_function_with_a_try_statement(tmp_path):
+    (tmp_path / "app.py").write_text(
+        "def plain():\n"
+        "    return 1\n"
+        "\n"
+        "def guarded():\n"
+        "    try:\n"
+        "        return risky()\n"
+        "    except ValueError:\n"
+        "        return None\n"
+    )
+
+    results = search_ast_pattern(
+        tmp_path,
+        "python",
+        "(function_definition name: (identifier) @name body: (block (try_statement))) @whole",
+    )
+
+    assert len(results) == 1
+    match = results[0]
+    assert match["file"] == "app.py"
+    assert match["captures"]["name"][0]["text"] == "guarded"
+    assert match["captures"]["whole"][0]["start_line"] == 4
+
+
+def test_search_ast_pattern_returns_nothing_when_no_file_matches(tmp_path):
+    (tmp_path / "app.py").write_text("def plain():\n    return 1\n")
+
+    results = search_ast_pattern(
+        tmp_path, "python", "(function_definition body: (block (try_statement))) @whole"
+    )
+
+    assert results == []
+
+
+def test_search_ast_pattern_reports_line_numbers_one_indexed(tmp_path):
+    (tmp_path / "app.py").write_text(
+        "\n\ndef third_line():\n    pass\n"
+    )
+
+    results = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert results[0]["captures"]["f"][0]["start_line"] == 3
+
+
+def test_search_ast_pattern_rejects_an_unknown_language(tmp_path):
+    with pytest.raises(UnknownLanguageError):
+        search_ast_pattern(tmp_path, "cobol", "(anything)")
+
+
+def test_search_ast_pattern_rejects_a_query_that_fails_to_compile(tmp_path):
+    (tmp_path / "app.py").write_text("def f():\n    pass\n")
+
+    with pytest.raises(InvalidPatternError):
+        search_ast_pattern(tmp_path, "python", "(this_node_type_does_not_exist)")
+
+
+def test_search_ast_pattern_works_for_a_second_language_not_just_python(tmp_path):
+    """Proves the mechanism is language-agnostic, not hardcoded to Python -
+    same function, a Rust grammar and query instead."""
+    (tmp_path / "main.rs").write_text(
+        "fn plain() -> i32 { 1 }\n\n"
+        "fn guarded() -> Result<i32, String> {\n"
+        "    match risky() {\n"
+        "        Ok(v) => Ok(v),\n"
+        "        Err(e) => Err(e),\n"
+        "    }\n"
+        "}\n"
+    )
+
+    results = search_ast_pattern(
+        tmp_path,
+        "rust",
+        "(function_item name: (identifier) @name "
+        "body: (block (expression_statement (match_expression))))",
+    )
+
+    assert len(results) == 1
+    assert results[0]["captures"]["name"][0]["text"] == "guarded"
+
+
+def test_search_ast_pattern_typescript_covers_both_ts_and_tsx_grammars(tmp_path):
+    """Real regression risk: .ts and .tsx are different grammar objects
+    (TS_LANGUAGE vs TSX_LANGUAGE) under the same "typescript" language
+    name - a query compiled against only one would silently miss the
+    other extension entirely."""
+    (tmp_path / "plain.ts").write_text("function greet(): string {\n  return 'hi';\n}\n")
+    (tmp_path / "component.tsx").write_text("function Greet(): string {\n  return 'hi';\n}\n")
+
+    results = search_ast_pattern(
+        tmp_path, "typescript", "(function_declaration name: (identifier) @name) @whole"
+    )
+
+    matched_files = {r["file"] for r in results}
+    assert matched_files == {"plain.ts", "component.tsx"}
+
+
+def test_search_ast_pattern_skips_a_file_over_the_size_cap(tmp_path, monkeypatch):
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "MAX_SOURCE_FILE_BYTES", 10)
+    (tmp_path / "app.py").write_text("def f():\n    pass\n")  # well over 10 bytes
+
+    results = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert results == []

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -1270,6 +1270,78 @@ def test_query_search_codebase_prints_friendly_error_on_dimension_mismatch(tmp_p
     assert "1536-dimension" in result.output
 
 
+def test_query_ast_pattern_prints_a_real_match(tmp_path):
+    (tmp_path / "app.py").write_text("def f():\n    pass\n")
+
+    result = runner.invoke(
+        app,
+        [
+            "query",
+            "ast-pattern",
+            "(function_definition name: (identifier) @name) @whole",
+            "--language",
+            "python",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "app.py" in result.output
+
+
+def test_query_ast_pattern_requires_target(tmp_path):
+    result = runner.invoke(
+        app, ["query", "ast-pattern", "--language", "python", "--path", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+    assert "requires a tree-sitter query" in result.output
+
+
+def test_query_ast_pattern_requires_language(tmp_path):
+    result = runner.invoke(
+        app, ["query", "ast-pattern", "(function_definition) @f", "--path", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+    assert "--language" in result.output
+
+
+def test_query_ast_pattern_prints_friendly_error_on_unknown_language(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "query",
+            "ast-pattern",
+            "(anything)",
+            "--language",
+            "cobol",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "unknown language" in result.output.lower()
+
+
+def test_query_ast_pattern_prints_friendly_error_on_invalid_query(tmp_path):
+    (tmp_path / "app.py").write_text("def f():\n    pass\n")
+
+    result = runner.invoke(
+        app,
+        [
+            "query",
+            "ast-pattern",
+            "(this_node_type_does_not_exist)",
+            "--language",
+            "python",
+            "--path",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "invalid tree-sitter query" in result.output.lower()
+
+
 def test_query_answer_reuses_selected_adapter(tmp_path):
     fake_adapter = MagicMock()
     fake_adapter.name = "ollama"

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -283,7 +283,7 @@ def test_api_mcp_tools_reflects_the_configured_consent_posture(tmp_path):
 
     assert response.status_code == 200
     tools = response.json()
-    assert len(tools) == 31
+    assert len(tools) == 32
     names = {t["name"] for t in tools}
     assert "aletheore_managed_audit" not in names
     assert "aletheore_scan" in names

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -253,6 +253,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_list",
         "aletheore_overview",
         "aletheore_search",
+        "aletheore_ast_pattern",
         "aletheore_symbol_source",
         "aletheore_verify_citations",
         "aletheore_scan",
@@ -265,7 +266,7 @@ async def test_build_server_registers_expected_tools(tmp_path):
         "aletheore_find_evidence_for_dependency",
     }
     assert expected.issubset(names)
-    assert len(names) == 32
+    assert len(names) == 33
     assert "aletheore_answer" not in names
 
 
@@ -879,6 +880,49 @@ async def test_aletheore_search_finds_a_literal_match(tmp_path):
     matches = tool_result_body(result)["result"]["matches"]
     assert len(matches) == 1
     assert matches[0] == {"path": "app/main.py", "line": 1, "text": "def hello():"}
+
+
+@pytest.mark.asyncio
+async def test_aletheore_ast_pattern_finds_a_structural_match(tmp_path):
+    repo = make_repo_with_files(
+        tmp_path,
+        {"app.py": "def plain():\n    pass\n\ndef guarded():\n    try:\n        pass\n    except ValueError:\n        pass\n"},
+    )
+    server = build_server(repo)
+
+    result = await server.call_tool(
+        "aletheore_ast_pattern",
+        {
+            "language": "python",
+            "query": "(function_definition name: (identifier) @name body: (block (try_statement))) @whole",
+        },
+    )
+
+    matches = tool_result_body(result)["result"]
+    assert len(matches) == 1
+    assert matches[0]["captures"]["name"][0]["text"] == "guarded"
+
+
+@pytest.mark.asyncio
+async def test_aletheore_ast_pattern_reports_an_unknown_language_as_an_error_not_a_crash(tmp_path):
+    repo = make_repo_with_files(tmp_path, {"app.py": "pass\n"})
+    server = build_server(repo)
+
+    result = await server.call_tool("aletheore_ast_pattern", {"language": "cobol", "query": "(anything)"})
+
+    assert "unknown language" in tool_result_body(result)["result"]["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_aletheore_ast_pattern_reports_an_invalid_query_as_an_error_not_a_crash(tmp_path):
+    repo = make_repo_with_files(tmp_path, {"app.py": "pass\n"})
+    server = build_server(repo)
+
+    result = await server.call_tool(
+        "aletheore_ast_pattern", {"language": "python", "query": "(this_node_type_does_not_exist)"}
+    )
+
+    assert "invalid tree-sitter query" in tool_result_body(result)["result"]["error"].lower()
 
 
 @pytest.mark.asyncio

--- a/website/llms.txt
+++ b/website/llms.txt
@@ -48,11 +48,11 @@ This matters if you build on Aletheore: a key rename is a breaking change and is
 
 `aletheore diff` compares two evidence snapshots. `aletheore verify` checks a report's `file:line` citations against a repository's actual evidence — including reports Aletheore did not write.
 
-## MCP server — free, local, 30 tools
+## MCP server — free, local, 31 tools
 
 `aletheore mcp` runs a stdio MCP server. `aletheore mcp-install` writes client config for Claude Code, Cursor, VS Code, Kiro, Opencode, and Codex CLI.
 
-**30 tools by default; 26 in read-only mode; 31 with evidence upload enabled.** No account required.
+**31 tools by default; 27 in read-only mode; 32 with evidence upload enabled.** No account required.
 
 Tools are grouped by effect class — `write`, `network`, `external` — and a tool whose effects are not permitted is **never registered**, so it cannot be called at all. Evidence upload to the hosted service is off by default. Set `ALETHEORE_MCP_ALLOW` to change it.
 


### PR DESCRIPTION
New `aletheore query ast-pattern` kind and `aletheore_ast_pattern` MCP tool: runs a raw tree-sitter S-expression query against every file of one language, re-parsed from disk (needs the real parse tree, which `.aletheore/air.json` never stores). Reuses `graph.py`'s existing per-language grammar constants and file discovery - no new dependency, works across all 13 already-supported languages for free.

Found and fixed a real segfault during end-to-end verification against this actual repo (not caught by the unit tests - their fixtures are too small to trigger it): `tree_sitter`'s `Query`/`QueryCursor` (the first use of that API in this codebase) crashes reliably on Python 3.14 once enough real files/matches accumulate in one process for the cyclic GC to touch the resulting object graph. Confirmed the exact same code runs clean on 3.12, and that `aletheore scan` itself (uses `Parser`/`Tree`/`Node` but never `Query`/`QueryCursor`) is unaffected on 3.14. Not fixable at the Python level (tried explicit `del`, `gc.disable()`, forced `gc.collect()` per iteration - none prevented it), so `requires-python` is capped at `<3.14` until either tree-sitter fixes it upstream or the query gets isolated in a subprocess. CI only tests 3.11/3.12, so this doesn't affect real users/CI today - it's a real, honest bound, not a workaround for something CI would have caught.

Full test suite (1557 tests) verified passing on Python 3.12, the actual CI/PyPI-publish version.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>