### PR TITLE
docs: fix stale hosted-embed cap reference in embeddings_api.py

### DIFF
--- a/github-app/app_server/embeddings_api.py
+++ b/github-app/app_server/embeddings_api.py
@@ -118,14 +118,16 @@ def get_jina_client() -> httpx.Client:
     # binding constraint underneath, cutting itself off at half the budget
     # the CLI already tolerates waiting for. Real requests through this
     # endpoint stay well under this ceiling: they're bounded by the CLI's
-    # own HOSTED_EMBED_MAX_CHARS cap (100,000 chars as of #268, ~25,700
-    # tokens at the measured ~3.89 chars/token), and the closest real
-    # measurement above that - 59,903 tokens in 83.24s against jina-embed
-    # post-#267 (2 instances) - leaves ~37s of margin against 120s. The
-    # 88,859-token/124.70s point from that same measurement run is larger
-    # than any request this cap can actually produce; it was one input to
-    # the interpolation in search_index.py's HOSTED_EMBED_MAX_CHARS
-    # comment, not a size this timeout needs to cover.
+    # own HOSTED_EMBED_MAX_TOKENS cap (search_index.py - 50,000 real
+    # tokens, counted directly via the bundled jina tokenizer rather than
+    # estimated from a char count, since the token-based batching rewrite
+    # that replaced the old char-count HOSTED_EMBED_MAX_CHARS cap). 50,000
+    # was chosen to preserve the same ~41% margin against this 120s budget
+    # that the old char cap's own history had already derived (the closest
+    # real measurement, 59,903 tokens in 83.24s against jina-embed
+    # post-#267 (2 instances), leaves ~37s of margin at that size) - so
+    # this timeout's safety margin is unchanged even though the cap it's
+    # measured against no longer exists in char form.
     return httpx.Client(base_url=JINA_EMBED_BASE_URL, timeout=120.0)
 
 


### PR DESCRIPTION
## Summary

Real backward-verification pass on today's 4 merged PRs (#515-#518), using \`aletheore_get_blast_radius\` to check what else references the changed files - found this cross-repo comment drift as a result.

\`embeddings_api.py\`'s \`get_jina_client()\` explains its 120s timeout's safety margin by citing \`search_index.py\`'s \`HOSTED_EMBED_MAX_CHARS\` - a constant #515 removed entirely, replaced with real token-based batching (\`HOSTED_EMBED_MAX_TOKENS\`, 50,000 real tokens via the bundled tokenizer, not a char-count estimate).

The underlying \`timeout=120.0\` value is still correct - 50,000 tokens was chosen specifically to preserve the same ~41% margin against this exact 120s budget the old char cap's history had already derived. Only the comment's factual claim was stale.

## Verification done alongside this (no other changes needed)

- Confirmed all 3 real \`scan_repository()\` call sites (\`cli.py\`, \`mcp_server.py\`, \`watch.py\`) use keyword arguments - the 2 new params #517 added ahead of the existing \`progress\` parameter can't silently shift it.
- Confirmed \`github-app/scan_worker\` never imports \`aletheore.search_index\` and never runs \`aletheore index\` - it only shells out to \`aletheore scan\` as a subprocess, with the new \`analyze_architecture\`/\`check_hotspots\` flags never passed (default \`True\`, unchanged behavior). None of #515-#518 have any functional effect on the production github-app service.
- Confirmed \`watch.py\`'s \`rebuild()\` never calls \`save_snapshot\`, so \`history.py\`'s snapshot-diff logic (which reads \`layer_violations.violations\`) is never exercised during a watch session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)