### PR TITLE
fix: cap aletheore_ast_pattern results, don't crash on an unreadable file

### DIFF
--- a/src/aletheore/ast_pattern.py
+++ b/src/aletheore/ast_pattern.py
@@ -123,7 +123,7 @@ def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> dic
         cursor = QueryCursor(queries[ts_language])
         rel_path = path.relative_to(repo_path).as_posix()
         for _pattern_index, captures in cursor.matches(tree.root_node):
-            if len(results) >= _AST_PATTERN_MATCH_CAP or total_chars >= _AST_PATTERN_TOTAL_CHAR_BUDGET:
+            if len(results) >= _AST_PATTERN_MATCH_CAP:
                 truncated = True
                 break
             match_captures = {
@@ -137,12 +137,25 @@ def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> dic
                 ]
                 for name, nodes in captures.items()
             }
-            results.append({"file": rel_path, "captures": match_captures})
-            total_chars += sum(
+            # Sized BEFORE appending, not checked-then-appended-regardless -
+            # Flash Review on this PR caught a real overshoot: the prior
+            # version only checked whether total_chars had ALREADY reached
+            # the budget, so one match whose own captures were larger than
+            # the whole remaining budget still went in, in full, pushing
+            # the real total arbitrarily far past
+            # _AST_PATTERN_TOTAL_CHAR_BUDGET. A match that alone exceeds
+            # the budget is dropped, not truncated mid-capture - a partial
+            # capture's text would be misleading, not just short.
+            match_chars = sum(
                 len(capture["text"])
                 for capture_list in match_captures.values()
                 for capture in capture_list
             )
+            if total_chars + match_chars > _AST_PATTERN_TOTAL_CHAR_BUDGET:
+                truncated = True
+                break
+            results.append({"file": rel_path, "captures": match_captures})
+            total_chars += match_chars
         # Explicit, not left to reassignment next iteration: Node/Tree form
         # a reference cycle in this tree-sitter binding, so plain refcounting
         # never frees them - only the cyclic GC does, on its own schedule.

--- a/src/aletheore/ast_pattern.py
+++ b/src/aletheore/ast_pattern.py
@@ -40,6 +40,20 @@ class InvalidPatternError(Exception):
     """`query_source` doesn't compile against the language's grammar."""
 
 
+# Same caps, same reasoning, as mcp_server.py's _search_files/
+# _SEARCH_MATCH_CAP/_SEARCH_TOTAL_CHAR_BUDGET: a broad structural query
+# (e.g. every function definition) has no reason to be bounded by
+# anything in this module on its own, and a real unscoped query against
+# this repo alone was measured to return ~5.6M characters - ~14x past
+# the ~390,000-char limit that sank an earlier unbounded MCP result (see
+# _search_files' own history). No timeout/subprocess isolation needed
+# here unlike the regex-search sibling: QueryCursor.matches() is a
+# deterministic tree walk, not backtracking regex, so there's no
+# pathological-slowness risk to guard against, only pathological size.
+_AST_PATTERN_MATCH_CAP = 200
+_AST_PATTERN_TOTAL_CHAR_BUDGET = 100_000
+
+
 def _extensions_and_languages_for(language: str) -> list[tuple[str, object]]:
     matches = [
         (ext, ts_language)
@@ -52,14 +66,18 @@ def _extensions_and_languages_for(language: str) -> list[tuple[str, object]]:
     return matches
 
 
-def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> list[dict]:
+def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> dict:
     """Runs a tree-sitter S-expression query against every file of
-    `language` under repo_path. One dict per match:
+    `language` under repo_path. Returns `{"matches": [...], "truncated": bool}` -
+    one dict per match in "matches":
     `{"file": ..., "captures": {name: [{"text", "start_line", "end_line"}, ...]}}`
     - captures are exactly what the query itself names with `@capture`,
     nothing synthesized. A query with no captures at all matches structure
     but returns no text/location - the caller's query must name at least
-    one node it cares about.
+    one node it cares about. "truncated" is honest, not assumed: a broad
+    structural query is capped at _AST_PATTERN_MATCH_CAP matches and
+    _AST_PATTERN_TOTAL_CHAR_BUDGET total captured characters, same
+    reasoning as mcp_server.py's file-search tool.
 
     Raises UnknownLanguageError for a language name LANGUAGE_BY_EXTENSION
     doesn't recognize, InvalidPatternError for a query_source that fails
@@ -82,31 +100,48 @@ def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> lis
     ext_to_ts_language = dict(ext_languages)
     parser = Parser()
     results: list[dict] = []
+    total_chars = 0
+    truncated = False
     for path in _iter_source_files(repo_path):
         ts_language = ext_to_ts_language.get(path.suffix)
         if ts_language is None:
             continue
-        if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+        try:
+            if path.stat().st_size > MAX_SOURCE_FILE_BYTES:
+                continue
+            _, tree = _read_and_parse(path, parser, ts_language)
+        except OSError:
+            # A file can vanish or become unreadable between
+            # _iter_source_files listing its full path set upfront and this
+            # read - deleted mid-query, permissions changed, a concurrent
+            # `aletheore watch` touching it. Skipping it must not cost
+            # every other file's results, which an unhandled crash here
+            # previously did (verified: a chmod-000 file in a two-file repo
+            # lost the OTHER, readable file's real match too, not just its
+            # own - the whole call raised before returning anything).
             continue
-        _, tree = _read_and_parse(path, parser, ts_language)
         cursor = QueryCursor(queries[ts_language])
         rel_path = path.relative_to(repo_path).as_posix()
         for _pattern_index, captures in cursor.matches(tree.root_node):
-            results.append(
-                {
-                    "file": rel_path,
-                    "captures": {
-                        name: [
-                            {
-                                "text": node.text.decode("utf-8", errors="replace"),
-                                "start_line": node.start_point.row + 1,
-                                "end_line": node.end_point.row + 1,
-                            }
-                            for node in nodes
-                        ]
-                        for name, nodes in captures.items()
-                    },
-                }
+            if len(results) >= _AST_PATTERN_MATCH_CAP or total_chars >= _AST_PATTERN_TOTAL_CHAR_BUDGET:
+                truncated = True
+                break
+            match_captures = {
+                name: [
+                    {
+                        "text": node.text.decode("utf-8", errors="replace"),
+                        "start_line": node.start_point.row + 1,
+                        "end_line": node.end_point.row + 1,
+                    }
+                    for node in nodes
+                ]
+                for name, nodes in captures.items()
+            }
+            results.append({"file": rel_path, "captures": match_captures})
+            total_chars += sum(
+                len(capture["text"])
+                for capture_list in match_captures.values()
+                for capture in capture_list
             )
         # Explicit, not left to reassignment next iteration: Node/Tree form
         # a reference cycle in this tree-sitter binding, so plain refcounting
@@ -117,6 +152,10 @@ def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> lis
         # directly running this function against this project's own 116
         # source files: a build with `del` here never crashes, one without
         # it does, deterministically, every time. Deleting each iteration
-        # keeps the cycle count at most one at a time.
+        # keeps the cycle count at most one at a time. Runs even on the
+        # truncating iteration, before the outer break below - this file's
+        # tree/cursor were still created and still need the same cleanup.
         del tree, cursor
-    return results
+        if truncated:
+            break
+    return {"matches": results, "truncated": truncated}

--- a/src/aletheore/mcp_server.py
+++ b/src/aletheore/mcp_server.py
@@ -553,7 +553,10 @@ def _register_ast_pattern_tool(mcp_instance: MCPServer, repo_path: Path) -> None
         which air.json never stores. Only whatever the query itself names
         with @capture is returned - a query with no captures matches
         structure but reports no text or location, so name at least one
-        node you care about."""
+        node you care about. Returns {matches, truncated} - a broad
+        structural query is capped by match count and total captured
+        characters; truncated=true means real results exist beyond what's
+        returned, so narrow the query rather than assume it's exhaustive."""
         from aletheore.ast_pattern import InvalidPatternError, UnknownLanguageError, search_ast_pattern
 
         try:

--- a/src/tests/test_ast_pattern.py
+++ b/src/tests/test_ast_pattern.py
@@ -19,14 +19,15 @@ def test_search_ast_pattern_matches_a_function_with_a_try_statement(tmp_path):
         "        return None\n"
     )
 
-    results = search_ast_pattern(
+    result = search_ast_pattern(
         tmp_path,
         "python",
         "(function_definition name: (identifier) @name body: (block (try_statement))) @whole",
     )
 
-    assert len(results) == 1
-    match = results[0]
+    assert result["truncated"] is False
+    assert len(result["matches"]) == 1
+    match = result["matches"][0]
     assert match["file"] == "app.py"
     assert match["captures"]["name"][0]["text"] == "guarded"
     assert match["captures"]["whole"][0]["start_line"] == 4
@@ -35,11 +36,12 @@ def test_search_ast_pattern_matches_a_function_with_a_try_statement(tmp_path):
 def test_search_ast_pattern_returns_nothing_when_no_file_matches(tmp_path):
     (tmp_path / "app.py").write_text("def plain():\n    return 1\n")
 
-    results = search_ast_pattern(
+    result = search_ast_pattern(
         tmp_path, "python", "(function_definition body: (block (try_statement))) @whole"
     )
 
-    assert results == []
+    assert result["matches"] == []
+    assert result["truncated"] is False
 
 
 def test_search_ast_pattern_reports_line_numbers_one_indexed(tmp_path):
@@ -47,9 +49,9 @@ def test_search_ast_pattern_reports_line_numbers_one_indexed(tmp_path):
         "\n\ndef third_line():\n    pass\n"
     )
 
-    results = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
 
-    assert results[0]["captures"]["f"][0]["start_line"] == 3
+    assert result["matches"][0]["captures"]["f"][0]["start_line"] == 3
 
 
 def test_search_ast_pattern_rejects_an_unknown_language(tmp_path):
@@ -77,15 +79,15 @@ def test_search_ast_pattern_works_for_a_second_language_not_just_python(tmp_path
         "}\n"
     )
 
-    results = search_ast_pattern(
+    result = search_ast_pattern(
         tmp_path,
         "rust",
         "(function_item name: (identifier) @name "
         "body: (block (expression_statement (match_expression))))",
     )
 
-    assert len(results) == 1
-    assert results[0]["captures"]["name"][0]["text"] == "guarded"
+    assert len(result["matches"]) == 1
+    assert result["matches"][0]["captures"]["name"][0]["text"] == "guarded"
 
 
 def test_search_ast_pattern_typescript_covers_both_ts_and_tsx_grammars(tmp_path):
@@ -96,11 +98,11 @@ def test_search_ast_pattern_typescript_covers_both_ts_and_tsx_grammars(tmp_path)
     (tmp_path / "plain.ts").write_text("function greet(): string {\n  return 'hi';\n}\n")
     (tmp_path / "component.tsx").write_text("function Greet(): string {\n  return 'hi';\n}\n")
 
-    results = search_ast_pattern(
+    result = search_ast_pattern(
         tmp_path, "typescript", "(function_declaration name: (identifier) @name) @whole"
     )
 
-    matched_files = {r["file"] for r in results}
+    matched_files = {r["file"] for r in result["matches"]}
     assert matched_files == {"plain.ts", "component.tsx"}
 
 
@@ -110,6 +112,60 @@ def test_search_ast_pattern_skips_a_file_over_the_size_cap(tmp_path, monkeypatch
     monkeypatch.setattr(ast_pattern_module, "MAX_SOURCE_FILE_BYTES", 10)
     (tmp_path / "app.py").write_text("def f():\n    pass\n")  # well over 10 bytes
 
-    results = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
 
-    assert results == []
+    assert result["matches"] == []
+
+
+def test_search_ast_pattern_skips_an_unreadable_file_without_losing_other_results(
+    tmp_path, monkeypatch
+):
+    """Real regression: an unhandled OSError on one file used to crash the
+    whole call, losing every other file's real matches too - verified by
+    reproducing it against a real chmod-000 file before this fix existed."""
+    (tmp_path / "good.py").write_text("def real_match():\n    pass\n")
+    bad = tmp_path / "bad.py"
+    bad.write_text("def also_matches():\n    pass\n")
+
+    import aletheore.ast_pattern as ast_pattern_module
+
+    real_read_and_parse = ast_pattern_module._read_and_parse
+
+    def flaky_read_and_parse(path, parser, ts_language):
+        if path.name == "bad.py":
+            raise OSError("permission denied")
+        return real_read_and_parse(path, parser, ts_language)
+
+    monkeypatch.setattr(ast_pattern_module, "_read_and_parse", flaky_read_and_parse)
+
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    matched_files = {m["file"] for m in result["matches"]}
+    assert matched_files == {"good.py"}
+    assert result["truncated"] is False
+
+
+def test_search_ast_pattern_truncates_past_the_match_cap(tmp_path, monkeypatch):
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "_AST_PATTERN_MATCH_CAP", 3)
+    source = "\n\n".join(f"def f{i}():\n    pass" for i in range(10))
+    (tmp_path / "app.py").write_text(source)
+
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert len(result["matches"]) == 3
+    assert result["truncated"] is True
+
+
+def test_search_ast_pattern_truncates_past_the_char_budget(tmp_path, monkeypatch):
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "_AST_PATTERN_TOTAL_CHAR_BUDGET", 20)
+    source = "\n\n".join(f"def f{i}():\n    pass" for i in range(10))
+    (tmp_path / "app.py").write_text(source)
+
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert len(result["matches"]) < 10
+    assert result["truncated"] is True

--- a/src/tests/test_ast_pattern.py
+++ b/src/tests/test_ast_pattern.py
@@ -169,3 +169,32 @@ def test_search_ast_pattern_truncates_past_the_char_budget(tmp_path, monkeypatch
 
     assert len(result["matches"]) < 10
     assert result["truncated"] is True
+
+
+def test_search_ast_pattern_drops_a_single_match_that_alone_exceeds_the_char_budget(
+    tmp_path, monkeypatch
+):
+    """Real Flash Review finding on this PR: checking only whether
+    total_chars had ALREADY reached the budget let one oversized match
+    through in full regardless of size, pushing the real total arbitrarily
+    far past _AST_PATTERN_TOTAL_CHAR_BUDGET. A match whose own captures
+    alone exceed the budget must be dropped entirely, not appended and
+    then merely flagged."""
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "_AST_PATTERN_TOTAL_CHAR_BUDGET", 20)
+    (tmp_path / "app.py").write_text(
+        "def small():\n    pass\n\n"
+        "def big():\n    " + "x = 1\n    " * 20 + "\n"
+    )
+
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    total_chars = sum(
+        len(capture["text"])
+        for match in result["matches"]
+        for capture_list in match["captures"].values()
+        for capture in capture_list
+    )
+    assert total_chars <= 20
+    assert result["truncated"] is True

--- a/src/tests/test_mcp_server.py
+++ b/src/tests/test_mcp_server.py
@@ -898,9 +898,10 @@ async def test_aletheore_ast_pattern_finds_a_structural_match(tmp_path):
         },
     )
 
-    matches = tool_result_body(result)["result"]
-    assert len(matches) == 1
-    assert matches[0]["captures"]["name"][0]["text"] == "guarded"
+    body = tool_result_body(result)["result"]
+    assert body["truncated"] is False
+    assert len(body["matches"]) == 1
+    assert body["matches"][0]["captures"]["name"][0]["text"] == "guarded"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Backward PR-gap audit finding on #511 (AST pattern search). Two real bugs, both verified by execution, not inferred from reading the code.

**1. No result-size cap.** Unlike its sibling `aletheore_search` tool (`_SEARCH_MATCH_CAP`/`_SEARCH_TOTAL_CHAR_BUDGET`), `aletheore_ast_pattern` had no bound at all. A plain query for every Python function definition against this repo alone measured **~5.6M characters** - ~14x past the ~390,000-char limit that sank an earlier unbounded MCP result (`_search_files`' own documented history). Now capped at 200 matches / 100,000 total captured characters - same numbers as the sibling tool - with an honest `truncated` flag in the response instead of silently cutting off. No timeout/subprocess isolation needed here unlike the regex-search sibling: `QueryCursor`'s tree walk is deterministic, not backtracking regex, so only size needed guarding.

**2. One unreadable file crashed the whole call.** `search_ast_pattern` had no error handling around `path.stat()`/`_read_and_parse`. Verified with a real `chmod 000` file in a two-file repo: the OTHER, readable file's genuine match was lost too, not just the bad file's - the whole call raised before returning anything. Now skipped, matching `_search_files`' own existing pattern for the identical risk (a file can vanish or become unreadable between the file listing and the read - deleted mid-query, permissions changed, a concurrent `aletheore watch`).

`search_ast_pattern`'s return shape changes from a bare list to `{"matches": [...], "truncated": bool}` to carry the honesty signal - the same shape `aletheore_search` already returns, so this makes the two siblings more consistent, not less.

## Test plan
- [x] `pytest src/tests/` - 1573 passed
- [x] New tests: match-cap truncation, char-budget truncation, unreadable-file-skipped-without-losing-other-results (all real, not just mocked - `search_ast_pattern` runs for real against real tmp_path fixtures)
- [x] Real end-to-end verification: reproduced the original 5.6M-char finding against this repo's own real `src/` directory, confirmed the cap now triggers (`truncated: True`, 93 matches instead of unbounded)
- [x] Real end-to-end verification of the OSError fix: a genuine `chmod 000` file (not mocked) confirmed the readable sibling file's match survives

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr