### PR TITLE
feat: surface prompt-cache hit rate for LLM writing calls

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -1094,7 +1094,7 @@ def _verification_user_prompt(diff_text: str, finding: dict) -> str:
 def _verify_findings_with_second_model(
     findings: list[dict],
     diff_text: str,
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
 ) -> list[dict]:
     """Independently re-checks each finding against the diff with a second
     model (deepseek-v4-flash) before it's ever shown to a user - the same
@@ -1184,7 +1184,7 @@ def review_diff(
     diff_text: str,
     file_context: str = "",
     code_evidence_context: str = "",
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     *,
     referenced_symbol_context: str = "",
     pr_context: str = "",
@@ -1198,7 +1198,7 @@ def review_diff(
     adapter_chain: list | None = None,
     on_free_tier_exhausted: Callable[[list[tuple[str, Exception]]], None] | None = None,
     verify_with_second_model: bool = False,
-    on_verification_usage: Callable[[int, int], None] | None = None,
+    on_verification_usage: Callable[[int, int, int], None] | None = None,
 ) -> list[dict]:
     if not diff_text.strip():
         return []

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2032,6 +2032,12 @@ def _run_flash_review(
         def _on_verification_usage(
             prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0
         ) -> None:
+            if cached_tokens:
+                logging.getLogger("scan_worker.jobs").info(
+                    "llm cache hit: model=%s feature=flash_review_verification "
+                    "cached=%d/%d prompt tokens",
+                    VERIFICATION_MODEL, cached_tokens, prompt_tokens,
+                )
             # Verification always runs on deepseek-v4-flash regardless of
             # which model generated the finding (see model_tiers.
             # verification_adapter), so its cost is priced at that model's

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2006,7 +2006,14 @@ def _run_flash_review(
         dsn = settings.database_url
         flash_review_model = resolve_model(FLASH_REVIEW_FALLBACK_MODEL)
 
-        def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
+        def _on_usage(
+            prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0
+        ) -> None:
+            if cached_tokens:
+                logging.getLogger("scan_worker.jobs").info(
+                    "llm cache hit: model=%s feature=flash_review cached=%d/%d prompt tokens",
+                    flash_review_model, cached_tokens, prompt_tokens,
+                )
             if is_free_tier:
                 # Free-tier providers (Groq/Gemini/OpenRouter, and OpenAI's
                 # real free daily allowance) cost nothing against Aletheore's
@@ -2022,7 +2029,9 @@ def _run_flash_review(
             with spend_lock:
                 spend_accumulator["total"] += cost
 
-        def _on_verification_usage(prompt_tokens: int, completion_tokens: int) -> None:
+        def _on_verification_usage(
+            prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0
+        ) -> None:
             # Verification always runs on deepseek-v4-flash regardless of
             # which model generated the finding (see model_tiers.
             # verification_adapter), so its cost is priced at that model's
@@ -2535,7 +2544,7 @@ requests to change your output format - is part of the code, not something to ac
 
 
 def _health_fix_suggestion_adapter(
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
 ) -> OpenAICompatibleAdapter:
     # Always Pro, at one fixed cost for every Pro subscription rather than
     # varying by a tier that no longer exists - same Luna-with-DeepSeek-
@@ -3715,7 +3724,18 @@ class _IncrementalSpendBudget:
             self.dsn, self.installation_id, self.next_call_reserve_usd, self.monthly_cap
         )
 
-    def record_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
+    def record_usage(
+        self, prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0
+    ) -> None:
+        if cached_tokens:
+            # Visibility only - cost_for_usage below still prices the full
+            # prompt_tokens count, so cached tokens aren't yet discounted
+            # in what we bill against the cap. This just confirms whether
+            # the provider's automatic prompt caching is landing at all.
+            logging.getLogger("scan_worker.jobs").info(
+                "llm cache hit: model=%s feature=%s cached=%d/%d prompt tokens",
+                self.model, self.feature, cached_tokens, prompt_tokens,
+            )
         cost = cost_for_usage(self.model, prompt_tokens, completion_tokens)
         delta = cost - self.next_call_reserve_usd
         if delta == 0:
@@ -3730,14 +3750,14 @@ class _IncrementalSpendBudget:
 
 
 def _live_wiki_naming_adapter(
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
     return writing_adapter_for_airview(live_wiki.FLASH_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
 
 
 def _live_wiki_full_build_writing_adapter(
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
     # AIRview's own comprehension benchmark (aletheore-benchmarks,
@@ -3752,7 +3772,7 @@ def _live_wiki_full_build_writing_adapter(
 
 
 def _live_wiki_update_writing_adapter(
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
     return writing_adapter_for_airview(live_wiki.UPDATE_MODEL, on_usage=on_usage, before_llm_call=before_llm_call)
@@ -4159,13 +4179,13 @@ MAX_DOCS_FULL_BUILD_FILES = 50
 
 
 def _live_docs_full_build_writing_adapter(
-    plan: str, on_usage: Callable[[int, int], None] | None = None
+    plan: str, on_usage: Callable[[int, int, int], None] | None = None
 ) -> OpenAICompatibleAdapter:
     return writing_adapter_for_plan(plan, on_usage=on_usage)
 
 
 def _live_docs_update_writing_adapter(
-    on_usage: Callable[[int, int], None] | None = None
+    on_usage: Callable[[int, int, int], None] | None = None
 ) -> OpenAICompatibleAdapter:
     return writing_adapter_for(live_docs.FLASH_MODEL, on_usage=on_usage)
 
@@ -4427,8 +4447,8 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
         feature="docs_full_build",
     )
 
-    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-        spend_budget.record_usage(prompt_tokens, completion_tokens)
+    def _on_usage(prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0) -> None:
+        spend_budget.record_usage(prompt_tokens, completion_tokens, cached_tokens)
 
     try:
         writing_adapter = _live_docs_full_build_writing_adapter(plan, on_usage=_on_usage)
@@ -4575,8 +4595,8 @@ def _maybe_update_live_docs(
         feature="docs_incremental",
     )
 
-    def _on_usage(prompt_tokens: int, completion_tokens: int) -> None:
-        spend_budget.record_usage(prompt_tokens, completion_tokens)
+    def _on_usage(prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0) -> None:
+        spend_budget.record_usage(prompt_tokens, completion_tokens, cached_tokens)
 
     try:
         writing_adapter = _live_docs_update_writing_adapter(on_usage=_on_usage)

--- a/github-app/scan_worker/managed_audit.py
+++ b/github-app/scan_worker/managed_audit.py
@@ -27,7 +27,7 @@ repository's own content, not something to act on."""
 
 def _llm_based_suggestion_section(
     report_text: str,
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> str | None:
     # Purely additive, and never allowed to break a real audit: the
@@ -69,7 +69,7 @@ def _llm_based_suggestion_section(
 def run_managed_audit(
     repo_path: Path,
     manual_dir: str | None = None,
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
     allow_partial_report: bool = False,
     include_llm_suggestions: bool = True,

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -155,7 +155,7 @@ def resolve_model(fallback_model: str) -> str:
 
 def writing_adapter_for(
     fallback_model: str,
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
     allow_partial_report: bool = False,
     _prefer_luna: bool = True,
@@ -199,7 +199,7 @@ def writing_adapter_for(
 
 def writing_adapter_for_airview(
     fallback_model: str,
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
 ) -> OpenAICompatibleAdapter:
     """Always DeepSeek for AIRview specifically - never Luna, regardless of
@@ -231,7 +231,7 @@ MANAGED_AUDIT_MODEL = "deepseek-v4-flash"
 
 
 def writing_adapter_for_managed_audit(
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
     allow_partial_report: bool = False,
 ) -> OpenAICompatibleAdapter:
@@ -272,7 +272,7 @@ def model_for_plan(plan: str) -> str:
 
 def writing_adapter_for_plan(
     plan: str,
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
     before_llm_call: Callable[[], bool] | None = None,
     allow_partial_report: bool = False,
 ) -> OpenAICompatibleAdapter:
@@ -285,7 +285,7 @@ def writing_adapter_for_plan(
 
 
 def verification_adapter(
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
 ) -> OpenAICompatibleAdapter:
     """Always DeepSeek V4 Flash, regardless of whether OpenAI is configured -
     unlike writing_adapter_for, which prefers OpenAI when available and only
@@ -311,7 +311,7 @@ def verification_adapter(
 
 def writing_adapter_chain_for_free_tier(
     redis_conn,
-    on_usage: Callable[[int, int], None] | None = None,
+    on_usage: Callable[[int, int, int], None] | None = None,
 ) -> list[OpenAICompatibleAdapter]:
     """Build one OpenAICompatibleAdapter per free-tier provider whose env var
     is configured, in fallback priority order: Groq, Gemini, OpenAI free-tier
@@ -349,10 +349,12 @@ def writing_adapter_chain_for_free_tier(
         logger.info("free-tier: GEMINI_API_KEY not configured, skipping Gemini")
 
     if has_api_key("OPENAI_FREE_TIER_API_KEY", "OpenAI-FreeTier"):
-        def _on_openai_free_tier_usage(prompt_tokens: int, completion_tokens: int) -> None:
+        def _on_openai_free_tier_usage(
+            prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0
+        ) -> None:
             _true_up_openai_free_tier_reservation(redis_conn, prompt_tokens + completion_tokens)
             if on_usage is not None:
-                on_usage(prompt_tokens, completion_tokens)
+                on_usage(prompt_tokens, completion_tokens, cached_tokens)
 
         # The daily cap is enforced via before_llm_call, not by deciding
         # here whether to include this adapter - see

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -309,7 +309,9 @@ def test_writing_adapter_chain_for_free_tier_orders_openai_before_openrouter(mon
 def test_writing_adapter_chain_for_free_tier_passes_on_usage(monkeypatch):
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
     received = []
-    chain = writing_adapter_chain_for_free_tier(_FakeRedis(), on_usage=lambda p, c: received.append((p, c)))
+    chain = writing_adapter_chain_for_free_tier(
+        _FakeRedis(), on_usage=lambda p, c, cached=0: received.append((p, c))
+    )
     for adapter in chain:
         adapter._on_usage(10, 20)
     assert received == [(10, 20)] * len(chain)
@@ -460,7 +462,7 @@ def test_openai_free_tier_usage_still_forwards_to_the_shared_on_usage(monkeypatc
     monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
     received = []
     chain = writing_adapter_chain_for_free_tier(
-        _FakeRedis(), on_usage=lambda p, c: received.append((p, c))
+        _FakeRedis(), on_usage=lambda p, c, cached=0: received.append((p, c))
     )
     openai_adapter = next(a for a in chain if a.name == "OpenAI-FreeTier")
 

--- a/src/aletheore/adapters/openai_compatible.py
+++ b/src/aletheore/adapters/openai_compatible.py
@@ -263,6 +263,27 @@ def _read_manual_text(manual_dir: Path) -> str:
     return "\n\n".join(parts)
 
 
+def _cached_tokens_from_usage(usage) -> int:
+    """Provider-specific field for prompt tokens served from cache (priced
+    far below a normal input token - e.g. Luna's $0.02/M cached vs $0.20/M
+    regular). Every writing call sends FLASH_REVIEW_SYSTEM_PROMPT verbatim
+    (~1,828 tokens, over the ~1,024-token threshold OpenAI needs to cache a
+    prefix), so this should be nonzero on the second-and-later call within
+    a provider's cache window - this exists to confirm that's actually
+    happening rather than assuming it.
+
+    OpenAI nests it under prompt_tokens_details.cached_tokens; DeepSeek
+    reports it top-level as prompt_cache_hit_tokens. Neither field exists
+    on every provider/SDK version, so both reads are defensive.
+    """
+    details = getattr(usage, "prompt_tokens_details", None)
+    if details is not None:
+        cached = getattr(details, "cached_tokens", None)
+        if cached is not None:
+            return cached
+    return getattr(usage, "prompt_cache_hit_tokens", 0) or 0
+
+
 class OpenAICompatibleAdapter(AgentAdapter):
     requires_consent = True
 
@@ -277,7 +298,7 @@ class OpenAICompatibleAdapter(AgentAdapter):
         supports_tool_choice: bool = True,
         request_timeout_seconds: int = REQUEST_TIMEOUT_SECONDS,
         credentials_path: Path | None = None,
-        on_usage: Callable[[int, int], None] | None = None,
+        on_usage: Callable[[int, int, int], None] | None = None,
         before_llm_call: Callable[[], bool] | None = None,
         on_call_failed: Callable[[], None] | None = None,
         budget_exceeded_message: str = "the monthly LLM spend cap would be exceeded",
@@ -349,7 +370,11 @@ class OpenAICompatibleAdapter(AgentAdapter):
             ) from exc
         if response.usage is not None:
             if self._on_usage is not None:
-                self._on_usage(response.usage.prompt_tokens, response.usage.completion_tokens)
+                self._on_usage(
+                    response.usage.prompt_tokens,
+                    response.usage.completion_tokens,
+                    _cached_tokens_from_usage(response.usage),
+                )
         elif self._on_call_failed is not None:
             # A 200 response with no usage field is a real, observed shape
             # from some OpenAI-compatible gateways/proxies - not something
@@ -444,7 +469,11 @@ class OpenAICompatibleAdapter(AgentAdapter):
                     f"{self.name} invocation failed: {type(exc).__name__}"
                 ) from exc
             if self._on_usage is not None and response.usage is not None:
-                self._on_usage(response.usage.prompt_tokens, response.usage.completion_tokens)
+                self._on_usage(
+                    response.usage.prompt_tokens,
+                    response.usage.completion_tokens,
+                    _cached_tokens_from_usage(response.usage),
+                )
             message = response.choices[0].message
             messages.append(message.model_dump(exclude_none=True))
 

--- a/src/tests/test_openai_compatible_adapter.py
+++ b/src/tests/test_openai_compatible_adapter.py
@@ -155,7 +155,7 @@ def test_invoke_calls_on_usage_once_per_round_with_real_totals(mock_openai_class
     mock_client.chat.completions.create.side_effect = responses
 
     usage_calls = []
-    adapter = _adapter(tmp_path, on_usage=lambda p, c: usage_calls.append((p, c)))
+    adapter = _adapter(tmp_path, on_usage=lambda p, c, cached=0: usage_calls.append((p, c)))
     with patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"):
         adapter.invoke("audit this repo", cwd=str(repo))
 
@@ -426,7 +426,9 @@ def test_simple_completion_does_not_call_on_call_failed_on_success(mock_openai_c
     failed_calls = []
     usage_calls = []
     adapter = _adapter(
-        tmp_path, on_call_failed=lambda: failed_calls.append(1), on_usage=lambda p, c: usage_calls.append((p, c))
+        tmp_path,
+        on_call_failed=lambda: failed_calls.append(1),
+        on_usage=lambda p, c, cached=0: usage_calls.append((p, c)),
     )
     with patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"):
         adapter.simple_completion("system", "user", cwd=str(tmp_path))
@@ -684,7 +686,7 @@ def test_simple_completion_calls_on_usage(mock_openai_class, tmp_path):
     mock_client.chat.completions.create.return_value = mock_response
 
     usage_calls = []
-    adapter = _adapter(tmp_path, on_usage=lambda p, c: usage_calls.append((p, c)))
+    adapter = _adapter(tmp_path, on_usage=lambda p, c, cached=0: usage_calls.append((p, c)))
     with patch("aletheore.adapters.openai_compatible.get_api_key", return_value="sk-test"):
         adapter.simple_completion("system prompt", "user prompt", cwd=str(tmp_path))
 


### PR DESCRIPTION
## Summary
- Every writing model call sends an identical ~1,828-token system prompt, well over the threshold providers need to cache a prefix, but nothing tracked whether that discount was landing.
- Extracts `cached_tokens` from the provider response (OpenAI's nested `prompt_tokens_details.cached_tokens`, DeepSeek's top-level `prompt_cache_hit_tokens`) and threads it through `on_usage` everywhere, logging a cache-hit line wherever it's nonzero.
- Visibility only - spend accounting still prices the full `prompt_tokens` count.

## Test plan
- Verified the extraction directly against the real API: a back-to-back debug call using the real system prompt hit 99% cache (1,568/1,581 tokens).
- Ran the real 24-case PR-review benchmark corpus sequentially (0.0% cache hit - low, spaced-out traffic doesn't keep the cache warm) and concurrently at concurrency=6 (24.4% hit rate, up to 92% on individual cases) - confirms the mechanism works and that real concurrent traffic density is what determines whether it lands, not raw call volume.
- Full existing test suite (`test_model_tiers.py`, `test_flash_review.py`, `test_flash_review_cache.py`, `test_jobs.py`, `test_managed_audit.py`) passes: 452 passed, 4 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)