### PR TITLE
feat: model ORM migration schema changes for Django, Rails, and Alembic

### DIFF
--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -468,7 +468,8 @@ def _django_model_operations(
             if model_name is None:
                 continue
             events.append(
-                {"kind": "remove_table", "table": _django_table_name(app_label, model_name)}
+                {"kind": "remove_table", "table": _django_table_name(app_label, model_name),
+                 "file": rel_path, "line": line}
             )
             continue
 
@@ -482,7 +483,8 @@ def _django_model_operations(
             events.append(
                 {"kind": "rename_table",
                  "old_table": _django_table_name(app_label, old_name),
-                 "new_table": _django_table_name(app_label, new_name)}
+                 "new_table": _django_table_name(app_label, new_name),
+                 "file": rel_path, "line": line}
             )
             continue
 
@@ -495,7 +497,7 @@ def _django_model_operations(
                 continue
             events.append(
                 {"kind": "remove_index", "table": _django_table_name(app_label, model_name),
-                 "name": index_name}
+                 "name": index_name, "file": rel_path, "line": line}
             )
             continue
 
@@ -665,7 +667,6 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
                 continue
             columns: list[dict] = []
             relations: list[dict] = []
-            has_pk = False
             for member in positional[1:]:
                 if member.type != "call":
                     continue
@@ -673,8 +674,6 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
                 if member_name == "Column":
                     column, relation = _alembic_column_from_call(member, source, rel_path, line)
                     if column is not None:
-                        if column["primary_key"]:
-                            has_pk = True
                         columns.append(column)
                     if relation is not None:
                         relations.append({**relation, "from_column": relation["from_column"]})
@@ -696,12 +695,9 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
                                  "to_column": to_column, "on_delete": None,
                                  "file": rel_path, "line": line}
                             )
-            if not has_pk:
-                columns.insert(
-                    0,
-                    {"name": "id", "type": "INTEGER", "primary_key": True, "nullable": False,
-                     "unique": True, "default": None, "file": rel_path, "line": line},
-                )
+            # Unlike Django's AutoField or Rails' create_table default,
+            # Alembic/SQLAlchemy never synthesizes an id column - a table
+            # created without an explicit primary key genuinely has none.
             events.append(
                 {"kind": "create_table", "table": table, "file": rel_path, "line": line,
                  "columns": columns, "relations": relations}
@@ -769,7 +765,9 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
                 continue
             table = _py_string_text(positional[0], source)
             if table:
-                events.append({"kind": "remove_table", "table": table})
+                events.append(
+                    {"kind": "remove_table", "table": table, "file": rel_path, "line": line}
+                )
             continue
 
         if op_name == "drop_column":
@@ -817,7 +815,10 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
                 _py_string_text(positional[1], source) if len(positional) > 1 else None
             )
             if index_name and table:
-                events.append({"kind": "remove_index", "table": table, "name": index_name})
+                events.append(
+                    {"kind": "remove_index", "table": table, "name": index_name,
+                     "file": rel_path, "line": line}
+                )
             continue
 
         if op_name == "rename_table":
@@ -827,7 +828,8 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
             new_table = _py_string_text(positional[1], source)
             if old_table and new_table:
                 events.append(
-                    {"kind": "rename_table", "old_table": old_table, "new_table": new_table}
+                    {"kind": "rename_table", "old_table": old_table, "new_table": new_table,
+                     "file": rel_path, "line": line}
                 )
             continue
 
@@ -1200,7 +1202,8 @@ def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[di
         if not positional:
             return []
         table = _rb_symbol_text(positional[0], source)
-        return [{"kind": "remove_table", "table": table}] if table else []
+        return [{"kind": "remove_table", "table": table, "file": rel_path, "line": line}] \
+            if table else []
 
     if method == "rename_column":
         if len(positional) < 3:
@@ -1218,7 +1221,8 @@ def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[di
             return []
         old_table = _rb_symbol_text(positional[0], source)
         new_table = _rb_symbol_text(positional[1], source)
-        return [{"kind": "rename_table", "old_table": old_table, "new_table": new_table}] \
+        return [{"kind": "rename_table", "old_table": old_table, "new_table": new_table,
+                 "file": rel_path, "line": line}] \
             if old_table and new_table else []
 
     if method == "change_column":
@@ -1253,7 +1257,8 @@ def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[di
             index_name = f"index_{table}_on_{col_name}" if col_name else None
         if not table or not index_name:
             return []
-        return [{"kind": "remove_index", "table": table, "name": index_name}]
+        return [{"kind": "remove_index", "table": table, "name": index_name,
+                 "file": rel_path, "line": line}]
 
     if method == "change_table":
         return _rails_change_table_events(call, source, rel_path)

--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -8,41 +8,62 @@ three (all three are explicitly recognized ORMs in `scanner/detect.py`'s
 cases in `_detect_migration_directories`) previously produced a schema
 that silently looked identical to "no schema at all."
 
-This module produces the same event shapes `schema_map.py`'s SQL replay
-loop already merges (`create_table` / `add_column` / `create_index`
-/ `unsupported`), but pre-built rather than raw SQL text - each ORM's own
-call syntax is walked directly with tree-sitter rather than routed through
-the SQL tokenizer, since none of these three is SQL.
+This module produces the same event shapes `schema_map.py`'s replay loop
+already merges (`create_table` / `add_column` / `create_index` /
+`remove_column` / `alter_column` / `rename_column` / `remove_table` /
+`rename_table` / `remove_index` / `raw_sql` / `unsupported`), but
+pre-built rather than raw SQL text - each ORM's own call syntax is walked
+directly with tree-sitter rather than routed through the SQL tokenizer,
+since none of these three is SQL. The one exception is `raw_sql`: Django's
+`RunSQL`, Alembic's `op.execute`, and Rails' `execute` all accept a literal
+SQL string, which is handed to schema_map.py's own Postgres parser and
+replayed exactly like a real `.sql` file's statement - not re-implemented
+here.
 
 Scope, deliberately narrower than each framework's full DSL, mirroring
-schema_map.py's own restraint: only the operations real migrations
-commonly use to define shape. Everything else becomes an `unsupported`
-entry rather than a guess.
+schema_map.py's own restraint: model every operation with a clear,
+unambiguous DDL meaning; record anything else as `unsupported` rather
+than guess. What's still `unsupported`, and why each one specifically:
 
-- Django: `CreateModel` and `AddField` (with the implicit `id` primary key
-  Django adds when no field is marked `primary_key=True`), `ForeignKey`/
-  `OneToOneField` as relations, `AddIndex` best-effort. `ManyToManyField`
-  (an implicit through-table), `AlterField`, `RemoveField`, `RenameField`,
-  `DeleteModel`, and `RunSQL`/`RunPython` are recorded as unsupported, not
-  modeled. Table names follow Django's default `<app_label>_<model>`
-  convention (app_label taken from the migration file's own app directory);
-  an explicit `Meta.db_table` override is not read.
-- Rails: `create_table` blocks, `t.<type>`, `t.references`/`t.belongs_to`,
-  `t.timestamps`, standalone `add_column`/`add_index`/`add_foreign_key`.
-  Pluralization (for `references`' implied target table) is a simple
-  regular-noun heuristic, not a full inflector - irregular plurals
-  (`person` -> `people`) will resolve wrong.
-  `change_table`/`remove_column`/`drop_table`/`rename_column` are recorded
-  as unsupported.
-- Alembic: `op.create_table`, `op.add_column`, `op.create_index`,
-  `op.create_foreign_key`, and an inline `sa.ForeignKey(...)`/
-  `sa.ForeignKeyConstraint(...)` inside either. Only statements inside
-  `def upgrade():` are read; `downgrade()` is ignored. Alembic orders
-  migrations via each file's own `revision`/`down_revision` chain, not
-  filename - this module does not resolve that graph and instead sorts
-  files by path like every other migration source, which is a known,
-  documented approximation, not the guaranteed real replay order.
-  `op.drop_*`/`op.alter_column`/`op.execute` are recorded as unsupported.
+- Django: `RunPython` (arbitrary code - not statically modelable),
+  `AlterModelOptions`/`AlterUniqueTogether`/`AlterModelTable` (legacy
+  APIs superseded by `Meta.constraints`/per-field `db_column`, rare in
+  real migrations), `ManyToManyField` (an implicit through-table this
+  module does not construct). Everything else - `CreateModel`, `AddField`,
+  `RemoveField`, `AlterField`, `RenameField`, `DeleteModel`, `RenameModel`,
+  `AddIndex`, `RemoveIndex`, `RunSQL` - is modeled, including the implicit
+  `id` primary key Django adds when no field is marked `primary_key=True`.
+  Table names follow Django's default `<app_label>_<model>` convention
+  (app_label taken from the migration file's own app directory); an
+  explicit `Meta.db_table` override on `CreateModel` itself is not read.
+- Rails: `create_join_table` (the implicit join-table name follows a
+  real but fiddlier alphabetical-pluralization rule not worth the added
+  surface) and `remove_foreign_key` (relations are not individually
+  addressable for removal without risking dropping the wrong one when a
+  table has more than one FK to the same target) are recorded, not
+  modeled. Everything else - `create_table`/`change_table` blocks,
+  `t.<type>`/`t.references`/`t.belongs_to`/`t.timestamps`, standalone
+  `add_column`/`remove_column`/`rename_column`/`change_column`/
+  `change_column_null`/`change_column_default`/`add_index`/`remove_index`/
+  `add_foreign_key`/`drop_table`/`rename_table`/`execute` - is modeled.
+  Any Ruby method call that isn't a recognized Rails migration DSL method
+  (`_RAILS_KNOWN_METHODS`) is silently ignored rather than flagged, so a
+  seed-data helper or a `reversible`/`say` wrapper doesn't drown real
+  findings in noise. Pluralization (for `references`'/`belongs_to`'s
+  implied target table) is a simple regular-noun heuristic, not a full
+  inflector - irregular plurals (`person` -> `people`) resolve wrong.
+- Alembic: `op.drop_constraint` (constraint names are not tracked
+  precisely enough on relations to resolve which one to remove) is
+  recorded, not modeled. Everything else - `op.create_table`,
+  `op.add_column`, `op.create_index`, `op.create_foreign_key` (plus an
+  inline `sa.ForeignKey(...)`/`sa.ForeignKeyConstraint(...)` inside
+  either), `op.drop_table`, `op.drop_column`, `op.alter_column`,
+  `op.drop_index`, `op.rename_table`, `op.execute` - is modeled. Only
+  statements inside `def upgrade():` are read; `downgrade()` is ignored.
+  Alembic orders migrations via each file's own `revision`/`down_revision`
+  chain, not filename - this module does not resolve that graph and
+  instead sorts files by path like every other migration source, which is
+  a known, documented approximation, not the guaranteed real replay order.
 """
 
 from __future__ import annotations
@@ -57,10 +78,14 @@ _DJANGO_SNIFF_MARKERS = (b"django.db", b"migrations.Migration")
 
 _DJANGO_PK_FIELD_TYPES = {"AUTOFIELD", "BIGAUTOFIELD", "SMALLAUTOFIELD"}
 _DJANGO_RELATION_FIELD_TYPES = {"FOREIGNKEY", "ONETOONEFIELD"}
+# Genuinely unmodelable (RunPython: arbitrary code) or metadata-only with no
+# DB-shape effect (AlterModelOptions covers things like `ordering`/
+# `verbose_name`; AlterUniqueTogether/AlterModelTable are legacy Django <2.2
+# APIs superseded by Meta.constraints/db_table on the field itself, rare
+# enough in real migrations that modeling them is not worth the added
+# surface - still recorded, not silently dropped).
 _DJANGO_UNSUPPORTED_OPS = {
-    "AlterField", "RemoveField", "RenameField", "DeleteModel",
-    "RenameModel", "AlterModelOptions", "AlterUniqueTogether",
-    "RunSQL", "RunPython", "RemoveIndex", "AlterModelTable",
+    "AlterModelOptions", "AlterUniqueTogether", "RunPython", "AlterModelTable",
 }
 
 _RAILS_TYPE_METHODS = {
@@ -68,15 +93,24 @@ _RAILS_TYPE_METHODS = {
     "datetime", "timestamp", "time", "date", "binary", "boolean", "json",
     "jsonb", "uuid",
 }
-_RAILS_UNSUPPORTED_METHODS = {
-    "change_table", "remove_column", "drop_table", "rename_column",
-    "rename_table", "change_column", "remove_index",
+# create_join_table's implicit table name follows a real but fiddlier rule
+# (the two model names, alphabetically sorted, pluralized, underscore-
+# joined) - real and common enough to name explicitly rather than silently
+# drop, not common enough to be worth the added surface here.
+_RAILS_UNSUPPORTED_METHODS = {"create_join_table"}
+# The full set of recognized Rails migration DSL methods (modeled ones plus
+# the unsupported ones above) - anything else encountered is ordinary Ruby
+# (a seed-data helper, `reversible`/`up_only` wrappers, `say`, application
+# code) and must be silently ignored, not flagged, or every migration file
+# would drown in false "unsupported" noise for non-schema calls.
+_RAILS_KNOWN_METHODS = _RAILS_UNSUPPORTED_METHODS | {
+    "create_table", "add_column", "add_index", "add_foreign_key",
+    "remove_column", "drop_table", "rename_column", "rename_table",
+    "change_column", "remove_index", "change_table", "remove_foreign_key",
+    "change_column_null", "change_column_default", "execute",
 }
 
-_ALEMBIC_UNSUPPORTED_OPS = {
-    "drop_table", "drop_column", "alter_column", "execute", "drop_index",
-    "drop_constraint", "rename_table",
-}
+_ALEMBIC_UNSUPPORTED_OPS = {"drop_constraint"}
 
 
 def _py_parser() -> Parser:
@@ -371,6 +405,127 @@ def _django_model_operations(
             )
             continue
 
+        if op_name == "RemoveField":
+            model_node = _py_kwarg(args, "model_name", source)
+            name_node = _py_kwarg(args, "name", source)
+            model_name = _py_string_text(model_node, source) if model_node else None
+            fname = _py_string_text(name_node, source) if name_node else None
+            if model_name is None or fname is None:
+                continue
+            events.append(
+                {"kind": "remove_column", "table": _django_table_name(app_label, model_name),
+                 "name": fname, "file": rel_path, "line": line}
+            )
+            continue
+
+        if op_name == "AlterField":
+            model_node = _py_kwarg(args, "model_name", source)
+            name_node = _py_kwarg(args, "name", source)
+            field_node = _py_kwarg(args, "field", source)
+            model_name = _py_string_text(model_node, source) if model_node else None
+            fname = _py_string_text(name_node, source) if name_node else None
+            if model_name is None or fname is None or field_node is None or field_node.type != "call":
+                continue
+            table = _django_table_name(app_label, model_name)
+            column, relation = _django_column_from_field(
+                fname, field_node, source, rel_path, line,
+                app_label=app_label, current_model=model_name,
+            )
+            events.append(
+                {"kind": "alter_column", "table": table, "name": column["name"],
+                 "changes": {
+                     "type": column["type"], "nullable": column["nullable"],
+                     "unique": column["unique"], "default": column["default"],
+                 },
+                 "file": rel_path, "line": line}
+            )
+            if relation is not None:
+                events.append({"kind": "add_relation", "table": table, "relation": relation,
+                                "file": rel_path, "line": line})
+            continue
+
+        if op_name == "RenameField":
+            model_node = _py_kwarg(args, "model_name", source)
+            old_node = _py_kwarg(args, "old_name", source)
+            new_node = _py_kwarg(args, "new_name", source)
+            model_name = _py_string_text(model_node, source) if model_node else None
+            old_name = _py_string_text(old_node, source) if old_node else None
+            new_name = _py_string_text(new_node, source) if new_node else None
+            if model_name is None or old_name is None or new_name is None:
+                continue
+            events.append(
+                {"kind": "rename_column", "table": _django_table_name(app_label, model_name),
+                 "old_name": old_name, "new_name": new_name, "file": rel_path, "line": line}
+            )
+            continue
+
+        if op_name == "DeleteModel":
+            name_node = _py_kwarg(args, "name", source)
+            if name_node is None:
+                positional = _py_positional(args)
+                name_node = positional[0] if positional else None
+            model_name = _py_string_text(name_node, source) if name_node else None
+            if model_name is None:
+                continue
+            events.append(
+                {"kind": "remove_table", "table": _django_table_name(app_label, model_name)}
+            )
+            continue
+
+        if op_name == "RenameModel":
+            old_node = _py_kwarg(args, "old_name", source)
+            new_node = _py_kwarg(args, "new_name", source)
+            old_name = _py_string_text(old_node, source) if old_node else None
+            new_name = _py_string_text(new_node, source) if new_node else None
+            if old_name is None or new_name is None:
+                continue
+            events.append(
+                {"kind": "rename_table",
+                 "old_table": _django_table_name(app_label, old_name),
+                 "new_table": _django_table_name(app_label, new_name)}
+            )
+            continue
+
+        if op_name == "RemoveIndex":
+            model_node = _py_kwarg(args, "model_name", source)
+            name_node = _py_kwarg(args, "name", source)
+            model_name = _py_string_text(model_node, source) if model_node else None
+            index_name = _py_string_text(name_node, source) if name_node else None
+            if model_name is None or index_name is None:
+                continue
+            events.append(
+                {"kind": "remove_index", "table": _django_table_name(app_label, model_name),
+                 "name": index_name}
+            )
+            continue
+
+        if op_name == "RunSQL":
+            sql_node = _py_kwarg(args, "sql", source)
+            if sql_node is None:
+                positional = _py_positional(args)
+                sql_node = positional[0] if positional else None
+            if sql_node is None:
+                continue
+            # `sql=` is a single string or a list of (query,) / (query, params)
+            # entries - RunSQL replays them in order, same as separate
+            # statements in one .sql file would.
+            statements: list[str] = []
+            if sql_node.type == "string":
+                text = _py_string_text(sql_node, source)
+                if text:
+                    statements.append(text)
+            elif sql_node.type == "list":
+                for entry in sql_node.named_children:
+                    target = entry.named_children[0] if entry.type == "tuple" and entry.named_children else entry
+                    text = _py_string_text(target, source)
+                    if text:
+                        statements.append(text)
+            if statements:
+                events.append(
+                    {"kind": "raw_sql", "sql": "\n".join(statements), "file": rel_path, "line": line}
+                )
+            continue
+
         if op_name in _DJANGO_UNSUPPORTED_OPS:
             events.append(
                 {"kind": "unsupported", "file": rel_path, "line": line,
@@ -433,7 +588,7 @@ def extract_django_migrations(
                 ):
                     events.extend(_django_model_operations(right, source, rel_path, app_label))
                     continue
-            stack.extend(node.children)
+            stack.extend(reversed(node.children))
 
     return events, sources
 
@@ -609,6 +764,81 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
                     )
             continue
 
+        if op_name == "drop_table":
+            if not positional:
+                continue
+            table = _py_string_text(positional[0], source)
+            if table:
+                events.append({"kind": "remove_table", "table": table})
+            continue
+
+        if op_name == "drop_column":
+            if len(positional) < 2:
+                continue
+            table = _py_string_text(positional[0], source)
+            col_name = _py_string_text(positional[1], source)
+            if table and col_name:
+                events.append(
+                    {"kind": "remove_column", "table": table, "name": col_name,
+                     "file": rel_path, "line": line}
+                )
+            continue
+
+        if op_name == "alter_column":
+            if len(positional) < 2:
+                continue
+            table = _py_string_text(positional[0], source)
+            col_name = _py_string_text(positional[1], source)
+            if not table or not col_name:
+                continue
+            changes: dict = {}
+            type_kw = _py_kwarg(args, "type_", source)
+            if type_kw is not None and type_kw.type == "call":
+                changes["type"] = (_py_call_name(type_kw, source) or "UNKNOWN").upper()
+            nullable_kw = _py_kwarg(args, "nullable", source)
+            if nullable_kw is not None:
+                changes["nullable"] = nullable_kw.type == "true"
+            default_kw = _py_kwarg(args, "server_default", source)
+            if default_kw is not None:
+                changes["default"] = _py_scalar_default(default_kw, source)
+            if changes:
+                events.append(
+                    {"kind": "alter_column", "table": table, "name": col_name,
+                     "changes": changes, "file": rel_path, "line": line}
+                )
+            continue
+
+        if op_name == "drop_index":
+            if not positional:
+                continue
+            index_name = _py_string_text(positional[0], source)
+            table_kw = _py_kwarg(args, "table_name", source)
+            table = _py_string_text(table_kw, source) if table_kw else (
+                _py_string_text(positional[1], source) if len(positional) > 1 else None
+            )
+            if index_name and table:
+                events.append({"kind": "remove_index", "table": table, "name": index_name})
+            continue
+
+        if op_name == "rename_table":
+            if len(positional) < 2:
+                continue
+            old_table = _py_string_text(positional[0], source)
+            new_table = _py_string_text(positional[1], source)
+            if old_table and new_table:
+                events.append(
+                    {"kind": "rename_table", "old_table": old_table, "new_table": new_table}
+                )
+            continue
+
+        if op_name == "execute":
+            if not positional:
+                continue
+            text = _py_string_text(positional[0], source)
+            if text:
+                events.append({"kind": "raw_sql", "sql": text, "file": rel_path, "line": line})
+            continue
+
         if op_name in _ALEMBIC_UNSUPPORTED_OPS:
             events.append(
                 {"kind": "unsupported", "file": rel_path, "line": line,
@@ -642,7 +872,7 @@ def extract_alembic_migrations(
                 continue
             sources.append(rel_path)
             tree = parser.parse(source)
-            stack = list(tree.root_node.children)
+            stack = list(reversed(tree.root_node.children))
             while stack:
                 node = stack.pop()
                 if node.type == "function_definition":
@@ -652,7 +882,7 @@ def extract_alembic_migrations(
                         if body is not None:
                             events.extend(_alembic_upgrade_events(body, source, rel_path))
                     continue
-                stack.extend(node.children)
+                stack.extend(reversed(node.children))
     return events, sources
 
 
@@ -817,6 +1047,85 @@ def _rails_create_table_events(call: Node, source: bytes, rel_path: str) -> list
     ]
 
 
+def _rails_change_table_events(call: Node, source: bytes, rel_path: str) -> list[dict]:
+    """`change_table :table do |t| ... end` - the same `t.<type>`/
+    `t.references`/`t.timestamps` calls create_table's block accepts, plus
+    `t.remove`/`t.rename`, applied to an existing table rather than a new
+    one."""
+    args = _rb_args(call)
+    positional = [a for a in args if a.type != "pair"]
+    if not positional:
+        return []
+    table = _rb_symbol_text(positional[0], source)
+    if not table:
+        return []
+
+    events: list[dict] = []
+    do_block = call.child_by_field_name("block") or next(
+        (c for c in call.children if c.type == "do_block"), None
+    )
+    if do_block is None:
+        return []
+    body = do_block.child_by_field_name("body")
+    inner_calls = body.named_children if body is not None else []
+    for inner in inner_calls:
+        if inner.type != "call":
+            continue
+        method = _rb_call_name(inner, source)
+        inner_line = inner.start_point[0] + 1
+        inner_args = _rb_args(inner)
+        inner_positional = [a for a in inner_args if a.type != "pair"]
+
+        if method == "remove":
+            for target in inner_positional:
+                col_name = _rb_symbol_text(target, source)
+                if col_name:
+                    events.append(
+                        {"kind": "remove_column", "table": table, "name": col_name,
+                         "file": rel_path, "line": inner_line}
+                    )
+            continue
+        if method == "rename":
+            if len(inner_positional) >= 2:
+                old_name = _rb_symbol_text(inner_positional[0], source)
+                new_name = _rb_symbol_text(inner_positional[1], source)
+                if old_name and new_name:
+                    events.append(
+                        {"kind": "rename_column", "table": table, "old_name": old_name,
+                         "new_name": new_name, "file": rel_path, "line": inner_line}
+                    )
+            continue
+        if method == "index":
+            if inner_positional:
+                col_name = _rb_symbol_text(inner_positional[0], source)
+                if col_name:
+                    events.append(
+                        {"kind": "create_index", "table": table,
+                         "name": f"index_{table}_on_{col_name}", "columns": [col_name],
+                         "unique": _rb_bool_kwarg(inner_args, "unique", source) is True,
+                         "file": rel_path, "line": inner_line}
+                    )
+            continue
+        if method == "timestamps":
+            for tcol in ("created_at", "updated_at"):
+                events.append(
+                    {"kind": "add_column", "table": table, "file": rel_path, "line": inner_line,
+                     "column": {"name": tcol, "type": "DATETIME", "primary_key": False,
+                                "nullable": False, "unique": False, "default": None,
+                                "file": rel_path, "line": inner_line},
+                     "relation": None}
+                )
+            continue
+        column, relation = _rails_column_from_typed_call(inner, source, rel_path, inner_line)
+        if column is not None:
+            events.append(
+                {"kind": "add_column", "table": table, "file": rel_path, "line": inner_line,
+                 "column": column, "relation": relation}
+            )
+
+    return events
+
+
 def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[dict]:
     method = _rb_call_name(call, source)
     line = call.start_point[0] + 1
@@ -877,11 +1186,115 @@ def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[di
                               "on_delete": on_delete.upper() if on_delete else None,
                               "file": rel_path, "line": line}}]
 
-    if method in _RAILS_UNSUPPORTED_METHODS:
-        return [{"kind": "unsupported", "file": rel_path, "line": line,
-                 "statement": f"{method}(...) not modeled"}]
+    if method == "remove_column":
+        if len(positional) < 2:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        col_name = _rb_symbol_text(positional[1], source)
+        if not table or not col_name:
+            return []
+        return [{"kind": "remove_column", "table": table, "name": col_name,
+                 "file": rel_path, "line": line}]
 
-    return []
+    if method == "drop_table":
+        if not positional:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        return [{"kind": "remove_table", "table": table}] if table else []
+
+    if method == "rename_column":
+        if len(positional) < 3:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        old_name = _rb_symbol_text(positional[1], source)
+        new_name = _rb_symbol_text(positional[2], source)
+        if not table or not old_name or not new_name:
+            return []
+        return [{"kind": "rename_column", "table": table, "old_name": old_name,
+                 "new_name": new_name, "file": rel_path, "line": line}]
+
+    if method == "rename_table":
+        if len(positional) < 2:
+            return []
+        old_table = _rb_symbol_text(positional[0], source)
+        new_table = _rb_symbol_text(positional[1], source)
+        return [{"kind": "rename_table", "old_table": old_table, "new_table": new_table}] \
+            if old_table and new_table else []
+
+    if method == "change_column":
+        if len(positional) < 3:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        col_name = _rb_symbol_text(positional[1], source)
+        col_type = _rb_symbol_text(positional[2], source)
+        if not table or not col_name or not col_type:
+            return []
+        null_kw = _rb_bool_kwarg(args, "null", source)
+        changes = {"type": col_type.upper()}
+        if null_kw is not None:
+            changes["nullable"] = null_kw
+        return [{"kind": "alter_column", "table": table, "name": col_name, "changes": changes,
+                 "file": rel_path, "line": line}]
+
+    if method == "remove_index":
+        if not positional:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        name_kw = _rb_kwarg(args, "name", source)
+        if name_kw is not None:
+            index_name = _rb_symbol_text(name_kw, source)
+        elif len(positional) > 1:
+            col_kw = positional[1]
+            col_name = _rb_symbol_text(col_kw, source)
+            index_name = f"index_{table}_on_{col_name}" if col_name else None
+        else:
+            column_kw = _rb_kwarg(args, "column", source)
+            col_name = _rb_symbol_text(column_kw, source) if column_kw else None
+            index_name = f"index_{table}_on_{col_name}" if col_name else None
+        if not table or not index_name:
+            return []
+        return [{"kind": "remove_index", "table": table, "name": index_name}]
+
+    if method == "change_table":
+        return _rails_change_table_events(call, source, rel_path)
+
+    if method == "remove_foreign_key":
+        if len(positional) < 2:
+            return []
+        from_table = _rb_symbol_text(positional[0], source)
+        to_table = _rb_symbol_text(positional[1], source)
+        if not from_table or not to_table:
+            return []
+        return [{"kind": "unsupported", "file": rel_path, "line": line,
+                 "statement": f"remove_foreign_key({from_table}, {to_table}) not modeled "
+                               "(relations are not individually addressable for removal)"}]
+
+    if method in ("change_column_null", "change_column_default"):
+        if len(positional) < 3:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        col_name = _rb_symbol_text(positional[1], source)
+        if not table or not col_name:
+            return []
+        value_node = positional[2]
+        if method == "change_column_null":
+            changes = {"nullable": value_node.type == "true"}
+        else:
+            changes = {"default": _rb_text(value_node, source)}
+        return [{"kind": "alter_column", "table": table, "name": col_name, "changes": changes,
+                 "file": rel_path, "line": line}]
+
+    if method == "execute":
+        if not positional:
+            return []
+        text = _rb_symbol_text(positional[0], source)
+        return [{"kind": "raw_sql", "sql": text, "file": rel_path, "line": line}] if text else []
+
+    if method not in _RAILS_KNOWN_METHODS:
+        return []
+
+    return [{"kind": "unsupported", "file": rel_path, "line": line,
+             "statement": f"{method}(...) not modeled"}]
 
 
 def extract_rails_migrations(
@@ -908,6 +1321,11 @@ def extract_rails_migrations(
                 continue
             sources.append(rel_path)
             tree = parser.parse(source)
+            # A plain (non-reversed) push+pop here would visit sibling
+            # statements in reverse source order - confirmed via a real
+            # multi-statement `change` block (rename_column, rename_table,
+            # drop_table all in one method): events came out drop/rename/
+            # rename instead of source order, silently reordering replay.
             stack = [tree.root_node]
             while stack:
                 node = stack.pop()
@@ -916,6 +1334,9 @@ def extract_rails_migrations(
                     if name == "create_table":
                         events.extend(_rails_create_table_events(node, source, rel_path))
                         continue
+                    if name == "change_table":
+                        events.extend(_rails_change_table_events(node, source, rel_path))
+                        continue
                     events.extend(_rails_top_level_events(node, source, rel_path))
-                stack.extend(node.children)
+                stack.extend(reversed(node.children))
     return events, sources

--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -1,0 +1,921 @@
+"""ORM-native migration parsing: Django, Rails, and Alembic.
+
+`schema_map.py`'s `extract_schema` only ever reads raw `.sql` files. Django
+migrations are `.py`, Rails migrations are `.rb`, Alembic migrations are
+`.py` too - none of them are `.sql`, so a repository using any of these
+three (all three are explicitly recognized ORMs in `scanner/detect.py`'s
+`DB_ORM_MARKERS_PY`, and their migration directories are hardcoded special
+cases in `_detect_migration_directories`) previously produced a schema
+that silently looked identical to "no schema at all."
+
+This module produces the same event shapes `schema_map.py`'s SQL replay
+loop already merges (`create_table` / `add_column` / `create_index`
+/ `unsupported`), but pre-built rather than raw SQL text - each ORM's own
+call syntax is walked directly with tree-sitter rather than routed through
+the SQL tokenizer, since none of these three is SQL.
+
+Scope, deliberately narrower than each framework's full DSL, mirroring
+schema_map.py's own restraint: only the operations real migrations
+commonly use to define shape. Everything else becomes an `unsupported`
+entry rather than a guess.
+
+- Django: `CreateModel` and `AddField` (with the implicit `id` primary key
+  Django adds when no field is marked `primary_key=True`), `ForeignKey`/
+  `OneToOneField` as relations, `AddIndex` best-effort. `ManyToManyField`
+  (an implicit through-table), `AlterField`, `RemoveField`, `RenameField`,
+  `DeleteModel`, and `RunSQL`/`RunPython` are recorded as unsupported, not
+  modeled. Table names follow Django's default `<app_label>_<model>`
+  convention (app_label taken from the migration file's own app directory);
+  an explicit `Meta.db_table` override is not read.
+- Rails: `create_table` blocks, `t.<type>`, `t.references`/`t.belongs_to`,
+  `t.timestamps`, standalone `add_column`/`add_index`/`add_foreign_key`.
+  Pluralization (for `references`' implied target table) is a simple
+  regular-noun heuristic, not a full inflector - irregular plurals
+  (`person` -> `people`) will resolve wrong.
+  `change_table`/`remove_column`/`drop_table`/`rename_column` are recorded
+  as unsupported.
+- Alembic: `op.create_table`, `op.add_column`, `op.create_index`,
+  `op.create_foreign_key`, and an inline `sa.ForeignKey(...)`/
+  `sa.ForeignKeyConstraint(...)` inside either. Only statements inside
+  `def upgrade():` are read; `downgrade()` is ignored. Alembic orders
+  migrations via each file's own `revision`/`down_revision` chain, not
+  filename - this module does not resolve that graph and instead sorts
+  files by path like every other migration source, which is a known,
+  documented approximation, not the guaranteed real replay order.
+  `op.drop_*`/`op.alter_column`/`op.execute` are recorded as unsupported.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tree_sitter import Node, Parser
+
+from aletheore.scanner.graph import PY_LANGUAGE, RUBY_LANGUAGE
+
+_DJANGO_SNIFF_MARKERS = (b"django.db", b"migrations.Migration")
+
+_DJANGO_PK_FIELD_TYPES = {"AUTOFIELD", "BIGAUTOFIELD", "SMALLAUTOFIELD"}
+_DJANGO_RELATION_FIELD_TYPES = {"FOREIGNKEY", "ONETOONEFIELD"}
+_DJANGO_UNSUPPORTED_OPS = {
+    "AlterField", "RemoveField", "RenameField", "DeleteModel",
+    "RenameModel", "AlterModelOptions", "AlterUniqueTogether",
+    "RunSQL", "RunPython", "RemoveIndex", "AlterModelTable",
+}
+
+_RAILS_TYPE_METHODS = {
+    "string", "text", "integer", "bigint", "float", "decimal", "numeric",
+    "datetime", "timestamp", "time", "date", "binary", "boolean", "json",
+    "jsonb", "uuid",
+}
+_RAILS_UNSUPPORTED_METHODS = {
+    "change_table", "remove_column", "drop_table", "rename_column",
+    "rename_table", "change_column", "remove_index",
+}
+
+_ALEMBIC_UNSUPPORTED_OPS = {
+    "drop_table", "drop_column", "alter_column", "execute", "drop_index",
+    "drop_constraint", "rename_table",
+}
+
+
+def _py_parser() -> Parser:
+    parser = Parser()
+    parser.language = PY_LANGUAGE
+    return parser
+
+
+def _rb_parser() -> Parser:
+    parser = Parser()
+    parser.language = RUBY_LANGUAGE
+    return parser
+
+
+def looks_like_django_migration(source: bytes) -> bool:
+    return any(marker in source for marker in _DJANGO_SNIFF_MARKERS)
+
+
+def django_app_label(rel_path: str) -> str:
+    """`<app>/migrations/0001_initial.py` -> `app`."""
+    parts = Path(rel_path).parts
+    try:
+        idx = parts.index("migrations")
+    except ValueError:
+        return parts[0] if parts else ""
+    return parts[idx - 1] if idx > 0 else ""
+
+
+def _django_table_name(app_label: str, model_name: str) -> str:
+    return f"{app_label}_{model_name.lower()}"
+
+
+# ---------------------------------------------------------------------------
+# Shared Python call/argument helpers (Django + Alembic)
+# ---------------------------------------------------------------------------
+
+
+def _py_text(node: Node, source: bytes) -> str:
+    return source[node.start_byte : node.end_byte].decode(errors="replace")
+
+
+def _py_string_text(node: Node, source: bytes) -> str | None:
+    if node.type != "string":
+        return None
+    content = next((c for c in node.children if c.type == "string_content"), None)
+    if content is None:
+        return ""
+    return source[content.start_byte : content.end_byte].decode(errors="replace")
+
+
+def _py_call_name(call: Node, source: bytes) -> str | None:
+    """The trailing name of a call's function - `sa.Column(...)` -> `Column`,
+    `create_table(...)` -> `create_table`."""
+    func = call.child_by_field_name("function")
+    if func is None:
+        return None
+    if func.type == "attribute":
+        attr = func.child_by_field_name("attribute")
+        return _py_text(attr, source) if attr is not None else None
+    if func.type == "identifier":
+        return _py_text(func, source)
+    return None
+
+
+def _py_call_receiver(call: Node, source: bytes) -> str | None:
+    func = call.child_by_field_name("function")
+    if func is None or func.type != "attribute":
+        return None
+    obj = func.child_by_field_name("object")
+    return _py_text(obj, source) if obj is not None else None
+
+
+def _py_args(call: Node) -> list[Node]:
+    args = call.child_by_field_name("arguments")
+    if args is None:
+        return []
+    return list(args.named_children)
+
+
+def _py_positional(args: list[Node]) -> list[Node]:
+    return [a for a in args if a.type != "keyword_argument"]
+
+
+def _py_kwarg(args: list[Node], name: str, source: bytes) -> Node | None:
+    for arg in args:
+        if arg.type != "keyword_argument":
+            continue
+        name_node = arg.child_by_field_name("name")
+        if name_node is not None and _py_text(name_node, source) == name:
+            return arg.child_by_field_name("value")
+    return None
+
+
+def _py_bool_kwarg(args: list[Node], name: str, source: bytes) -> bool:
+    value = _py_kwarg(args, name, source)
+    return value is not None and value.type == "true"
+
+
+def _py_walk_calls(root: Node):
+    """Every `call` node under `root`, not descending into nested
+    `function_definition`s (used to keep Alembic's upgrade()/downgrade()
+    bodies separate)."""
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type == "call":
+            yield node
+        for child in reversed(node.children):
+            stack.append(child)
+
+
+def _py_scalar_default(node: Node, source: bytes) -> str | None:
+    if node.type == "none":
+        return None
+    text = _py_text(node, source)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Django
+# ---------------------------------------------------------------------------
+
+
+def _django_resolve_target_table(target_text: str, app_label: str, current_model: str) -> str:
+    """`to=` on a ForeignKey/OneToOneField is always a string in Django
+    migrations (never a live class reference, to avoid app-loading-order
+    issues during replay): "self" (same model), "Model" (same app), or
+    "app_label.Model" (cross-app)."""
+    if target_text.lower() == "self":
+        return _django_table_name(app_label, current_model)
+    if "." in target_text:
+        target_app, target_model = target_text.split(".", 1)
+        return _django_table_name(target_app, target_model)
+    return _django_table_name(app_label, target_text)
+
+
+def _django_column_from_field(
+    field_name: str, field_call: Node, source: bytes, rel_path: str, line: int,
+    app_label: str = "", current_model: str = "",
+) -> tuple[dict, dict | None]:
+    field_type = _py_call_name(field_call, source) or "UNKNOWN"
+    args = _py_args(field_call)
+
+    column = {
+        "name": field_name,
+        "type": field_type.upper(),
+        "primary_key": _py_bool_kwarg(args, "primary_key", source),
+        "nullable": _py_bool_kwarg(args, "null", source),
+        "unique": _py_bool_kwarg(args, "unique", source),
+        "default": None,
+        "file": rel_path,
+        "line": line,
+    }
+    default_node = _py_kwarg(args, "default", source)
+    if default_node is not None:
+        column["default"] = _py_scalar_default(default_node, source)
+    if column["primary_key"]:
+        column["nullable"] = False
+
+    relation = None
+    if field_type.upper() in _DJANGO_RELATION_FIELD_TYPES:
+        target = _py_kwarg(args, "to", source)
+        if target is None:
+            positional = _py_positional(args)
+            target = positional[0] if positional else None
+        target_raw = _py_string_text(target, source) if target is not None else None
+        target_text = (
+            _django_resolve_target_table(target_raw, app_label, current_model)
+            if target_raw
+            else None
+        )
+        on_delete_node = _py_kwarg(args, "on_delete", source)
+        on_delete = None
+        if on_delete_node is not None:
+            on_delete_name = (
+                on_delete_node.child_by_field_name("attribute")
+                if on_delete_node.type == "attribute"
+                else None
+            )
+            on_delete = _py_text(
+                on_delete_name if on_delete_name is not None else on_delete_node, source
+            ).upper()
+        column["name"] = f"{field_name}_id"
+        relation = {
+            "from_column": column["name"],
+            "to_table": target_text,
+            "to_column": "id",
+            "on_delete": on_delete,
+            "file": rel_path,
+            "line": line,
+        }
+
+    return column, relation
+
+
+def _django_model_operations(
+    operations_list: Node, source: bytes, rel_path: str, app_label: str
+) -> list[dict]:
+    events: list[dict] = []
+
+    for op_call in operations_list.named_children:
+        if op_call.type != "call":
+            continue
+        op_name = _py_call_name(op_call, source)
+        line = op_call.start_point[0] + 1
+        args = _py_args(op_call)
+
+        if op_name == "CreateModel":
+            name_node = _py_kwarg(args, "name", source)
+            model_name = _py_string_text(name_node, source) if name_node else None
+            fields_node = _py_kwarg(args, "fields", source)
+            if model_name is None or fields_node is None or fields_node.type != "list":
+                continue
+            table = _django_table_name(app_label, model_name)
+            columns: list[dict] = []
+            relations: list[dict] = []
+            has_pk = False
+            for field_tuple in fields_node.named_children:
+                if field_tuple.type != "tuple" or len(field_tuple.named_children) < 2:
+                    continue
+                fname_node, fcall_node = field_tuple.named_children[0], field_tuple.named_children[1]
+                fname = _py_string_text(fname_node, source)
+                if fname is None or fcall_node.type != "call":
+                    continue
+                column, relation = _django_column_from_field(
+                    fname, fcall_node, source, rel_path, field_tuple.start_point[0] + 1,
+                    app_label=app_label, current_model=model_name,
+                )
+                if column["primary_key"] or (_py_call_name(fcall_node, source) or "").upper() in _DJANGO_PK_FIELD_TYPES:
+                    has_pk = True
+                columns.append(column)
+                if relation is not None:
+                    relations.append(relation)
+            if not has_pk:
+                columns.insert(
+                    0,
+                    {
+                        "name": "id", "type": "AUTOFIELD", "primary_key": True,
+                        "nullable": False, "unique": True, "default": None,
+                        "file": rel_path, "line": line,
+                    },
+                )
+            events.append(
+                {
+                    "kind": "create_table", "table": table, "file": rel_path, "line": line,
+                    "columns": columns, "relations": relations,
+                }
+            )
+            continue
+
+        if op_name == "AddField":
+            model_node = _py_kwarg(args, "model_name", source)
+            name_node = _py_kwarg(args, "name", source)
+            field_node = _py_kwarg(args, "field", source)
+            model_name = _py_string_text(model_node, source) if model_node else None
+            fname = _py_string_text(name_node, source) if name_node else None
+            if model_name is None or fname is None or field_node is None or field_node.type != "call":
+                continue
+            table = _django_table_name(app_label, model_name)
+            column, relation = _django_column_from_field(
+                fname, field_node, source, rel_path, line,
+                app_label=app_label, current_model=model_name,
+            )
+            events.append(
+                {"kind": "add_column", "table": table, "file": rel_path, "line": line,
+                 "column": column, "relation": relation}
+            )
+            continue
+
+        if op_name == "AddIndex":
+            model_node = _py_kwarg(args, "model_name", source)
+            index_node = _py_kwarg(args, "index", source)
+            model_name = _py_string_text(model_node, source) if model_node else None
+            if model_name is None or index_node is None or index_node.type != "call":
+                continue
+            table = _django_table_name(app_label, model_name)
+            index_args = _py_args(index_node)
+            fields_node = _py_kwarg(index_args, "fields", source)
+            field_names = []
+            if fields_node is not None and fields_node.type == "list":
+                for f in fields_node.named_children:
+                    text = _py_string_text(f, source)
+                    if text:
+                        field_names.append(text)
+            name_node = _py_kwarg(index_args, "name", source)
+            index_name = _py_string_text(name_node, source) if name_node else None
+            if not index_name:
+                index_name = f"{table}_{'_'.join(field_names) or 'idx'}_idx"
+            events.append(
+                {"kind": "create_index", "table": table, "name": index_name,
+                 "columns": field_names, "unique": False, "file": rel_path, "line": line}
+            )
+            continue
+
+        if op_name in _DJANGO_UNSUPPORTED_OPS:
+            events.append(
+                {"kind": "unsupported", "file": rel_path, "line": line,
+                 "statement": f"migrations.{op_name}(...) not modeled"}
+            )
+
+    return events
+
+
+def extract_django_migrations(
+    repo_path: Path, migration_directories: list[str]
+) -> tuple[list[dict], list[str]]:
+    """Every Django-style `.py` migration under the given directories.
+
+    Only directories that both match the generic `migrations` marker (not
+    `alembic/versions` or `db/migrate`, which are handled separately) and
+    whose files actually look like Django migrations are read - a
+    `migrations/` directory belonging to some other tool should not be
+    mis-parsed as Django.
+    """
+    events: list[dict] = []
+    sources: list[str] = []
+    parser = _py_parser()
+    files: list[Path] = []
+    for directory in migration_directories:
+        if directory in ("alembic/versions", "db/migrate"):
+            continue
+        base = repo_path / directory
+        if not base.is_dir():
+            continue
+        for candidate in base.glob("*.py"):
+            if candidate.is_symlink() or not candidate.is_file() or candidate.name == "__init__.py":
+                continue
+            files.append(candidate)
+
+    for path in sorted(files, key=lambda p: p.relative_to(repo_path).as_posix()):
+        rel_path = path.relative_to(repo_path).as_posix()
+        try:
+            source = path.read_bytes()
+        except OSError:
+            continue
+        if not looks_like_django_migration(source):
+            continue
+        sources.append(rel_path)
+        app_label = django_app_label(rel_path)
+        tree = parser.parse(source)
+        # `operations = [...]` is a module-level assignment inside the
+        # Migration class body, found by walking assignments rather than
+        # calls.
+        stack = [tree.root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == "assignment":
+                left = node.child_by_field_name("left")
+                right = node.child_by_field_name("right")
+                if (
+                    left is not None and left.type == "identifier"
+                    and _py_text(left, source) == "operations"
+                    and right is not None and right.type == "list"
+                ):
+                    events.extend(_django_model_operations(right, source, rel_path, app_label))
+                    continue
+            stack.extend(node.children)
+
+    return events, sources
+
+
+# ---------------------------------------------------------------------------
+# Alembic
+# ---------------------------------------------------------------------------
+
+
+def _alembic_column_from_call(
+    col_call: Node, source: bytes, rel_path: str, line: int
+) -> tuple[dict | None, dict | None]:
+    args = _py_args(col_call)
+    positional = _py_positional(args)
+    if not positional:
+        return None, None
+    name = _py_string_text(positional[0], source)
+    if name is None:
+        return None, None
+
+    col_type = "UNKNOWN"
+    relation = None
+    for arg in positional[1:]:
+        if arg.type != "call":
+            continue
+        call_name = _py_call_name(arg, source) or ""
+        if call_name == "ForeignKey":
+            fk_args = _py_positional(_py_args(arg))
+            target = _py_string_text(fk_args[0], source) if fk_args else None
+            if target and "." in target:
+                to_table, to_column = target.rsplit(".", 1)
+                relation = {
+                    "from_column": name, "to_table": to_table, "to_column": to_column,
+                    "on_delete": None, "file": rel_path, "line": line,
+                }
+        elif col_type == "UNKNOWN":
+            col_type = call_name.upper()
+
+    column = {
+        "name": name, "type": col_type,
+        "primary_key": _py_bool_kwarg(args, "primary_key", source),
+        "nullable": not _py_bool_kwarg(args, "primary_key", source),
+        "unique": _py_bool_kwarg(args, "unique", source),
+        "default": None,
+        "file": rel_path, "line": line,
+    }
+    nullable_kw = _py_kwarg(args, "nullable", source)
+    if nullable_kw is not None:
+        column["nullable"] = nullable_kw.type == "true"
+    default_node = _py_kwarg(args, "server_default", source) or _py_kwarg(args, "default", source)
+    if default_node is not None:
+        column["default"] = _py_scalar_default(default_node, source)
+
+    return column, relation
+
+
+def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) -> list[dict]:
+    events: list[dict] = []
+
+    for call in _py_walk_calls(upgrade_body):
+        receiver = _py_call_receiver(call, source)
+        if receiver != "op":
+            continue
+        op_name = _py_call_name(call, source)
+        line = call.start_point[0] + 1
+        args = _py_args(call)
+        positional = _py_positional(args)
+
+        if op_name == "create_table":
+            if not positional:
+                continue
+            table = _py_string_text(positional[0], source)
+            if table is None:
+                continue
+            columns: list[dict] = []
+            relations: list[dict] = []
+            has_pk = False
+            for member in positional[1:]:
+                if member.type != "call":
+                    continue
+                member_name = _py_call_name(member, source)
+                if member_name == "Column":
+                    column, relation = _alembic_column_from_call(member, source, rel_path, line)
+                    if column is not None:
+                        if column["primary_key"]:
+                            has_pk = True
+                        columns.append(column)
+                    if relation is not None:
+                        relations.append({**relation, "from_column": relation["from_column"]})
+                elif member_name == "ForeignKeyConstraint":
+                    fk_args = _py_positional(_py_args(member))
+                    if len(fk_args) >= 2 and fk_args[0].type == "list" and fk_args[1].type == "list":
+                        local_cols = [
+                            _py_string_text(c, source) for c in fk_args[0].named_children
+                        ]
+                        remote_cols = [
+                            _py_string_text(c, source) for c in fk_args[1].named_children
+                        ]
+                        for local_col, remote in zip(local_cols, remote_cols):
+                            if not local_col or not remote or "." not in remote:
+                                continue
+                            to_table, to_column = remote.rsplit(".", 1)
+                            relations.append(
+                                {"from_column": local_col, "to_table": to_table,
+                                 "to_column": to_column, "on_delete": None,
+                                 "file": rel_path, "line": line}
+                            )
+            if not has_pk:
+                columns.insert(
+                    0,
+                    {"name": "id", "type": "INTEGER", "primary_key": True, "nullable": False,
+                     "unique": True, "default": None, "file": rel_path, "line": line},
+                )
+            events.append(
+                {"kind": "create_table", "table": table, "file": rel_path, "line": line,
+                 "columns": columns, "relations": relations}
+            )
+            continue
+
+        if op_name == "add_column":
+            if len(positional) < 2 or positional[1].type != "call":
+                continue
+            table = _py_string_text(positional[0], source)
+            column, relation = _alembic_column_from_call(positional[1], source, rel_path, line)
+            if table is None or column is None:
+                continue
+            events.append(
+                {"kind": "add_column", "table": table, "file": rel_path, "line": line,
+                 "column": column, "relation": relation}
+            )
+            continue
+
+        if op_name == "create_index":
+            if len(positional) < 2:
+                continue
+            index_name = _py_string_text(positional[0], source)
+            table = _py_string_text(positional[1], source)
+            cols_node = positional[2] if len(positional) > 2 else None
+            columns = []
+            if cols_node is not None and cols_node.type == "list":
+                columns = [c for c in (_py_string_text(n, source) for n in cols_node.named_children) if c]
+            unique = _py_bool_kwarg(args, "unique", source)
+            if index_name and table:
+                events.append(
+                    {"kind": "create_index", "table": table, "name": index_name,
+                     "columns": columns, "unique": unique, "file": rel_path, "line": line}
+                )
+            continue
+
+        if op_name == "create_foreign_key":
+            if len(positional) < 5:
+                continue
+            source_table = _py_string_text(positional[1], source)
+            target_table = _py_string_text(positional[2], source)
+            local_cols_node, remote_cols_node = positional[3], positional[4]
+            if (
+                source_table and target_table
+                and local_cols_node.type == "list" and remote_cols_node.type == "list"
+            ):
+                local_cols = [_py_string_text(c, source) for c in local_cols_node.named_children]
+                remote_cols = [_py_string_text(c, source) for c in remote_cols_node.named_children]
+                ondelete_node = _py_kwarg(args, "ondelete", source)
+                on_delete = _py_string_text(ondelete_node, source) if ondelete_node else None
+                for local_col, remote_col in zip(local_cols, remote_cols):
+                    if not local_col or not remote_col:
+                        continue
+                    events.append(
+                        {"kind": "add_relation", "table": source_table, "file": rel_path, "line": line,
+                         "relation": {"from_column": local_col, "to_table": target_table,
+                                      "to_column": remote_col,
+                                      "on_delete": on_delete.upper() if on_delete else None,
+                                      "file": rel_path, "line": line}}
+                    )
+            continue
+
+        if op_name in _ALEMBIC_UNSUPPORTED_OPS:
+            events.append(
+                {"kind": "unsupported", "file": rel_path, "line": line,
+                 "statement": f"op.{op_name}(...) not modeled"}
+            )
+
+    return events
+
+
+def extract_alembic_migrations(
+    repo_path: Path, migration_directories: list[str]
+) -> tuple[list[dict], list[str]]:
+    events: list[dict] = []
+    sources: list[str] = []
+    parser = _py_parser()
+    for directory in migration_directories:
+        if directory != "alembic/versions" and not directory.endswith("/alembic/versions"):
+            continue
+        base = repo_path / directory
+        if not base.is_dir():
+            continue
+        files = sorted(
+            (f for f in base.glob("*.py") if f.is_file() and not f.is_symlink()),
+            key=lambda p: p.relative_to(repo_path).as_posix(),
+        )
+        for path in files:
+            rel_path = path.relative_to(repo_path).as_posix()
+            try:
+                source = path.read_bytes()
+            except OSError:
+                continue
+            sources.append(rel_path)
+            tree = parser.parse(source)
+            stack = list(tree.root_node.children)
+            while stack:
+                node = stack.pop()
+                if node.type == "function_definition":
+                    name_node = node.child_by_field_name("name")
+                    if name_node is not None and _py_text(name_node, source) == "upgrade":
+                        body = node.child_by_field_name("body")
+                        if body is not None:
+                            events.extend(_alembic_upgrade_events(body, source, rel_path))
+                    continue
+                stack.extend(node.children)
+    return events, sources
+
+
+# ---------------------------------------------------------------------------
+# Rails
+# ---------------------------------------------------------------------------
+
+
+def _rb_text(node: Node, source: bytes) -> str:
+    return source[node.start_byte : node.end_byte].decode(errors="replace")
+
+
+def _rb_symbol_text(node: Node, source: bytes) -> str | None:
+    if node.type == "simple_symbol":
+        return _rb_text(node, source).lstrip(":")
+    if node.type == "string":
+        content = next((c for c in node.children if c.type == "string_content"), None)
+        return source[content.start_byte : content.end_byte].decode(errors="replace") if content else ""
+    return None
+
+
+def _rb_call_name(call: Node, source: bytes) -> str | None:
+    method = call.child_by_field_name("method")
+    return _rb_text(method, source) if method is not None else None
+
+
+def _rb_args(call: Node) -> list[Node]:
+    args = call.child_by_field_name("arguments")
+    if args is None:
+        return []
+    return list(args.named_children)
+
+
+def _rb_kwarg(args: list[Node], name: str, source: bytes) -> Node | None:
+    for arg in args:
+        if arg.type != "pair":
+            continue
+        key = arg.child_by_field_name("key")
+        if key is None:
+            continue
+        key_text = _rb_text(key, source).lstrip(":")
+        if key_text == name:
+            return arg.child_by_field_name("value")
+    return None
+
+
+def _rb_bool_kwarg(args: list[Node], name: str, source: bytes) -> bool | None:
+    value = _rb_kwarg(args, name, source)
+    if value is None:
+        return None
+    return value.type == "true"
+
+
+_IRREGULAR_SUFFIXES = (("y", "ies"), ("s", "ses"), ("x", "xes"), ("ch", "ches"), ("sh", "shes"))
+
+
+def _pluralize(word: str) -> str:
+    """A regular-noun heuristic, not a real inflector - see module docstring."""
+    lower = word.lower()
+    for suffix, replacement in _IRREGULAR_SUFFIXES:
+        if lower.endswith(suffix) and suffix != "s":
+            return lower[: -len(suffix)] + replacement
+    if lower.endswith("s"):
+        return lower
+    return lower + "s"
+
+
+def _rails_column_from_typed_call(
+    call: Node, source: bytes, rel_path: str, line: int
+) -> tuple[dict | None, dict | None]:
+    method = _rb_call_name(call, source)
+    args = _rb_args(call)
+    positional = [a for a in args if a.type != "pair"]
+
+    if method in ("references", "belongs_to"):
+        if not positional:
+            return None, None
+        ref_name = _rb_symbol_text(positional[0], source)
+        if not ref_name:
+            return None, None
+        fk_flag = _rb_bool_kwarg(args, "foreign_key", source)
+        column = {
+            "name": f"{ref_name}_id", "type": "BIGINT", "primary_key": False,
+            "nullable": _rb_bool_kwarg(args, "null", source) is not False,
+            "unique": False, "default": None, "file": rel_path, "line": line,
+        }
+        relation = None
+        if fk_flag is not False:
+            relation = {
+                "from_column": column["name"], "to_table": _pluralize(ref_name),
+                "to_column": "id", "on_delete": None, "file": rel_path, "line": line,
+            }
+        return column, relation
+
+    if method not in _RAILS_TYPE_METHODS:
+        return None, None
+    if not positional:
+        return None, None
+    col_name = _rb_symbol_text(positional[0], source)
+    if not col_name:
+        return None, None
+    null_kw = _rb_bool_kwarg(args, "null", source)
+    default_node = _rb_kwarg(args, "default", source)
+    column = {
+        "name": col_name, "type": method.upper(), "primary_key": False,
+        "nullable": null_kw is not False,
+        "unique": _rb_bool_kwarg(args, "unique", source) is True,
+        "default": _rb_text(default_node, source) if default_node is not None else None,
+        "file": rel_path, "line": line,
+    }
+    return column, None
+
+
+def _rails_create_table_events(call: Node, source: bytes, rel_path: str) -> list[dict]:
+    args = _rb_args(call)
+    positional = [a for a in args if a.type != "pair"]
+    if not positional:
+        return []
+    table = _rb_symbol_text(positional[0], source)
+    if not table:
+        return []
+    line = call.start_point[0] + 1
+    id_disabled = _rb_bool_kwarg(args, "id", source) is False
+
+    columns: list[dict] = []
+    relations: list[dict] = []
+    if not id_disabled:
+        columns.append(
+            {"name": "id", "type": "BIGINT", "primary_key": True, "nullable": False,
+             "unique": True, "default": None, "file": rel_path, "line": line}
+        )
+
+    do_block = call.child_by_field_name("block") or next(
+        (c for c in call.children if c.type == "do_block"), None
+    )
+    if do_block is not None:
+        body = do_block.child_by_field_name("body")
+        inner_calls = body.named_children if body is not None else []
+        for inner in inner_calls:
+            if inner.type != "call" or _rb_call_name(inner, source) == "":
+                continue
+            method = _rb_call_name(inner, source)
+            if method == "timestamps":
+                for tcol in ("created_at", "updated_at"):
+                    columns.append(
+                        {"name": tcol, "type": "DATETIME", "primary_key": False,
+                         "nullable": False, "unique": False, "default": None,
+                         "file": rel_path, "line": inner.start_point[0] + 1}
+                    )
+                continue
+            column, relation = _rails_column_from_typed_call(
+                inner, source, rel_path, inner.start_point[0] + 1
+            )
+            if column is not None:
+                columns.append(column)
+            if relation is not None:
+                relations.append(relation)
+
+    return [
+        {"kind": "create_table", "table": table, "file": rel_path, "line": line,
+         "columns": columns, "relations": relations}
+    ]
+
+
+def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[dict]:
+    method = _rb_call_name(call, source)
+    line = call.start_point[0] + 1
+    args = _rb_args(call)
+    positional = [a for a in args if a.type != "pair"]
+
+    if method == "add_column":
+        if len(positional) < 3:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        col_name = _rb_symbol_text(positional[1], source)
+        col_type = _rb_symbol_text(positional[2], source)
+        if not table or not col_name or not col_type:
+            return []
+        null_kw = _rb_bool_kwarg(args, "null", source)
+        default_node = _rb_kwarg(args, "default", source)
+        column = {
+            "name": col_name, "type": col_type.upper(), "primary_key": False,
+            "nullable": null_kw is not False,
+            "unique": _rb_bool_kwarg(args, "unique", source) is True,
+            "default": _rb_text(default_node, source) if default_node is not None else None,
+            "file": rel_path, "line": line,
+        }
+        return [{"kind": "add_column", "table": table, "file": rel_path, "line": line,
+                 "column": column, "relation": None}]
+
+    if method == "add_index":
+        if len(positional) < 2:
+            return []
+        table = _rb_symbol_text(positional[0], source)
+        cols_node = positional[1]
+        if cols_node.type == "array":
+            columns = [c for c in (_rb_symbol_text(n, source) for n in cols_node.named_children) if c]
+        else:
+            single = _rb_symbol_text(cols_node, source)
+            columns = [single] if single else []
+        if not table or not columns:
+            return []
+        name_kw = _rb_kwarg(args, "name", source)
+        index_name = _rb_symbol_text(name_kw, source) if name_kw else f"index_{table}_on_{'_'.join(columns)}"
+        return [{"kind": "create_index", "table": table, "name": index_name,
+                 "columns": columns, "unique": _rb_bool_kwarg(args, "unique", source) is True,
+                 "file": rel_path, "line": line}]
+
+    if method == "add_foreign_key":
+        if len(positional) < 2:
+            return []
+        from_table = _rb_symbol_text(positional[0], source)
+        to_table = _rb_symbol_text(positional[1], source)
+        if not from_table or not to_table:
+            return []
+        col_kw = _rb_kwarg(args, "column", source)
+        from_column = _rb_symbol_text(col_kw, source) if col_kw else f"{to_table[:-1]}_id"
+        on_delete_kw = _rb_kwarg(args, "on_delete", source)
+        on_delete = _rb_symbol_text(on_delete_kw, source) if on_delete_kw else None
+        return [{"kind": "add_relation", "table": from_table, "file": rel_path, "line": line,
+                 "relation": {"from_column": from_column, "to_table": to_table, "to_column": "id",
+                              "on_delete": on_delete.upper() if on_delete else None,
+                              "file": rel_path, "line": line}}]
+
+    if method in _RAILS_UNSUPPORTED_METHODS:
+        return [{"kind": "unsupported", "file": rel_path, "line": line,
+                 "statement": f"{method}(...) not modeled"}]
+
+    return []
+
+
+def extract_rails_migrations(
+    repo_path: Path, migration_directories: list[str]
+) -> tuple[list[dict], list[str]]:
+    events: list[dict] = []
+    sources: list[str] = []
+    parser = _rb_parser()
+    for directory in migration_directories:
+        if directory != "db/migrate" and not directory.endswith("/db/migrate"):
+            continue
+        base = repo_path / directory
+        if not base.is_dir():
+            continue
+        files = sorted(
+            (f for f in base.glob("*.rb") if f.is_file() and not f.is_symlink()),
+            key=lambda p: p.relative_to(repo_path).as_posix(),
+        )
+        for path in files:
+            rel_path = path.relative_to(repo_path).as_posix()
+            try:
+                source = path.read_bytes()
+            except OSError:
+                continue
+            sources.append(rel_path)
+            tree = parser.parse(source)
+            stack = [tree.root_node]
+            while stack:
+                node = stack.pop()
+                if node.type == "call":
+                    name = _rb_call_name(node, source)
+                    if name == "create_table":
+                        events.extend(_rails_create_table_events(node, source, rel_path))
+                        continue
+                    events.extend(_rails_top_level_events(node, source, rel_path))
+                stack.extend(node.children)
+    return events, sources

--- a/src/aletheore/schema_map.py
+++ b/src/aletheore/schema_map.py
@@ -800,6 +800,15 @@ def extract_schema(repo_path: Path, migration_directories: list[str]) -> dict:
     unsupported: list[dict] = []
     sources: list[str] = []
 
+    # Parse every source's events first, grouped per file, without applying
+    # any of them yet - replaying is deferred to a single pass below, sorted
+    # by path across ALL sources together. A repo that adopted an ORM
+    # partway through its history (or vice versa) mixes .sql migrations with
+    # Django/Rails/Alembic ones; applying every .sql file before any ORM
+    # migration - regardless of which one actually came first by path -
+    # would run a later SQL statement against a table an earlier ORM
+    # migration hadn't created yet.
+    sql_events_by_file: dict[str, list[dict]] = {}
     for path in _iter_migration_files(repo_path, migration_directories):
         rel_path = path.relative_to(repo_path).as_posix()
         try:
@@ -815,10 +824,11 @@ def extract_schema(repo_path: Path, migration_directories: list[str]) -> dict:
         sources.append(rel_path)
         parsed = _parse_file(text, rel_path)
         unsupported.extend(parsed["unsupported"])
-        _apply_sql_events(tables, relations, indexes, unsupported, rel_path, parsed["events"])
+        sql_events_by_file[rel_path] = parsed["events"]
 
-    dialects: list[str] = ["postgresql"] if sources else []
+    dialects: list[str] = ["postgresql"] if sql_events_by_file else []
 
+    orm_events_by_file: dict[str, list[dict]] = {}
     for extractor, dialect_name in (
         (extract_django_migrations, "django"),
         (extract_rails_migrations, "rails"),
@@ -828,7 +838,22 @@ def extract_schema(repo_path: Path, migration_directories: list[str]) -> dict:
         if orm_sources:
             dialects.append(dialect_name)
             sources.extend(orm_sources)
-            _merge_orm_events(tables, relations, indexes, unsupported, orm_events)
+            for event in orm_events:
+                orm_events_by_file.setdefault(event["file"], []).append(event)
+
+    # A given path is exactly one of SQL or ORM (the extension alone
+    # decides), so this is an unambiguous per-file dispatch - just replayed
+    # in path order across both groups together, matching how each group
+    # already ordered itself internally.
+    for rel_path in sorted(set(sql_events_by_file) | set(orm_events_by_file)):
+        if rel_path in sql_events_by_file:
+            _apply_sql_events(
+                tables, relations, indexes, unsupported, rel_path, sql_events_by_file[rel_path]
+            )
+        else:
+            _merge_orm_events(
+                tables, relations, indexes, unsupported, orm_events_by_file[rel_path]
+            )
 
     # Sorted on every axis so identical migrations always produce identical
     # evidence. Columns keep their declaration order - that is the schema's

--- a/src/aletheore/schema_map.py
+++ b/src/aletheore/schema_map.py
@@ -661,9 +661,129 @@ def _merge_orm_events(
                 {"name": event["name"], "table": event["table"], "columns": event["columns"],
                  "unique": event["unique"], "file": event["file"], "line": event["line"]}
             )
+        elif kind == "remove_column":
+            table = tables.get(event["table"])
+            if table is not None:
+                table["columns"] = [c for c in table["columns"] if c["name"] != event["name"]]
+        elif kind == "alter_column":
+            table = tables.get(event["table"])
+            column = None if table is None else next(
+                (c for c in table["columns"] if c["name"] == event["name"]), None
+            )
+            if column is not None:
+                for field in ("type", "nullable", "unique", "default"):
+                    if field in event["changes"]:
+                        column[field] = event["changes"][field]
+        elif kind == "rename_column":
+            table = tables.get(event["table"])
+            column = None if table is None else next(
+                (c for c in table["columns"] if c["name"] == event["old_name"]), None
+            )
+            if column is not None:
+                column["name"] = event["new_name"]
+        elif kind == "remove_table":
+            tables.pop(event["table"], None)
+            relations[:] = [
+                r for r in relations
+                if r["from_table"] != event["table"] and r["to_table"] != event["table"]
+            ]
+            indexes[:] = [i for i in indexes if i["table"] != event["table"]]
+        elif kind == "rename_table":
+            table = tables.pop(event["old_table"], None)
+            if table is not None:
+                table["name"] = event["new_table"]
+                tables[event["new_table"]] = table
+                for relation in relations:
+                    if relation["from_table"] == event["old_table"]:
+                        relation["from_table"] = event["new_table"]
+                    if relation["to_table"] == event["old_table"]:
+                        relation["to_table"] = event["new_table"]
+                for index in indexes:
+                    if index["table"] == event["old_table"]:
+                        index["table"] = event["new_table"]
+        elif kind == "remove_index":
+            indexes[:] = [
+                i for i in indexes
+                if not (i["table"] == event["table"] and i["name"] == event["name"])
+            ]
+        elif kind == "raw_sql":
+            parsed = _parse_file(event["sql"], event["file"])
+            unsupported.extend(parsed["unsupported"])
+            _apply_sql_events(tables, relations, indexes, unsupported, event["file"], parsed["events"])
         elif kind == "unsupported":
             unsupported.append(
                 {"file": event["file"], "line": event["line"], "statement": event["statement"]}
+            )
+
+
+def _apply_sql_events(
+    tables: dict[str, dict],
+    relations: list[dict],
+    indexes: list[dict],
+    unsupported: list[dict],
+    rel_path: str,
+    events: list[dict],
+) -> None:
+    """The Postgres-DDL replay loop, factored out so a raw SQL string that
+    arrives via an ORM escape hatch (Django's RunSQL, Alembic's op.execute)
+    replays through the exact same logic a real .sql migration file does."""
+    for event in events:
+        if event["kind"] == "create_table":
+            # CREATE TABLE IF NOT EXISTS on a table an earlier migration
+            # already created is a no-op in Postgres, so it must be one
+            # here too - re-applying it would duplicate every column.
+            if event["table"] in tables:
+                continue
+            columns: list[dict] = []
+            for definition in _split_top_level(event["body"]):
+                column, relation = _parse_column_definition(definition, rel_path, event["line"])
+                if column is not None:
+                    columns.append(column)
+                if relation is not None:
+                    relations.append({"from_table": event["table"], **relation})
+            tables[event["table"]] = {
+                "name": event["table"],
+                "columns": columns,
+                "file": rel_path,
+                "line": event["line"],
+            }
+        elif event["kind"] == "add_column":
+            table = tables.get(event["table"])
+            if table is None:
+                # An ALTER against a table no CREATE was seen for: the
+                # migration set is partial (a squashed baseline, or a
+                # table created outside these directories). Recorded
+                # rather than inventing a table with one column, which
+                # would render as a phantom node in the diagram.
+                unsupported.append(
+                    {
+                        "file": rel_path,
+                        "line": event["line"],
+                        "statement": _summarize(
+                            f"ALTER TABLE {event['table']} ADD COLUMN on an unknown table"
+                        ),
+                    }
+                )
+                continue
+            column, relation = _parse_column_definition(event["body"], rel_path, event["line"])
+            if column is not None and not any(c["name"] == column["name"] for c in table["columns"]):
+                table["columns"].append(column)
+            if relation is not None:
+                relations.append({"from_table": event["table"], **relation})
+        elif event["kind"] == "create_index":
+            index_columns = [
+                _strip_identifier(part.split()[0]) if part.split() else ""
+                for part in _split_top_level(event["body"])
+            ]
+            indexes.append(
+                {
+                    "name": event["name"],
+                    "table": event["table"],
+                    "columns": [c for c in index_columns if c],
+                    "unique": event["unique"],
+                    "file": rel_path,
+                    "line": event["line"],
+                }
             )
 
 
@@ -695,65 +815,7 @@ def extract_schema(repo_path: Path, migration_directories: list[str]) -> dict:
         sources.append(rel_path)
         parsed = _parse_file(text, rel_path)
         unsupported.extend(parsed["unsupported"])
-
-        for event in parsed["events"]:
-            if event["kind"] == "create_table":
-                # CREATE TABLE IF NOT EXISTS on a table an earlier migration
-                # already created is a no-op in Postgres, so it must be one
-                # here too - re-applying it would duplicate every column.
-                if event["table"] in tables:
-                    continue
-                columns: list[dict] = []
-                for definition in _split_top_level(event["body"]):
-                    column, relation = _parse_column_definition(definition, rel_path, event["line"])
-                    if column is not None:
-                        columns.append(column)
-                    if relation is not None:
-                        relations.append({"from_table": event["table"], **relation})
-                tables[event["table"]] = {
-                    "name": event["table"],
-                    "columns": columns,
-                    "file": rel_path,
-                    "line": event["line"],
-                }
-            elif event["kind"] == "add_column":
-                table = tables.get(event["table"])
-                if table is None:
-                    # An ALTER against a table no CREATE was seen for: the
-                    # migration set is partial (a squashed baseline, or a
-                    # table created outside these directories). Recorded
-                    # rather than inventing a table with one column, which
-                    # would render as a phantom node in the diagram.
-                    unsupported.append(
-                        {
-                            "file": rel_path,
-                            "line": event["line"],
-                            "statement": _summarize(
-                                f"ALTER TABLE {event['table']} ADD COLUMN on an unknown table"
-                            ),
-                        }
-                    )
-                    continue
-                column, relation = _parse_column_definition(event["body"], rel_path, event["line"])
-                if column is not None and not any(c["name"] == column["name"] for c in table["columns"]):
-                    table["columns"].append(column)
-                if relation is not None:
-                    relations.append({"from_table": event["table"], **relation})
-            elif event["kind"] == "create_index":
-                index_columns = [
-                    _strip_identifier(part.split()[0]) if part.split() else ""
-                    for part in _split_top_level(event["body"])
-                ]
-                indexes.append(
-                    {
-                        "name": event["name"],
-                        "table": event["table"],
-                        "columns": [c for c in index_columns if c],
-                        "unique": event["unique"],
-                        "file": rel_path,
-                        "line": event["line"],
-                    }
-                )
+        _apply_sql_events(tables, relations, indexes, unsupported, rel_path, parsed["events"])
 
     dialects: list[str] = ["postgresql"] if sources else []
 

--- a/src/aletheore/schema_map.py
+++ b/src/aletheore/schema_map.py
@@ -27,6 +27,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from aletheore.orm_migrations import (
+    extract_alembic_migrations,
+    extract_django_migrations,
+    extract_rails_migrations,
+)
+
 class _Cursor:
     """A forward-only reader over one migration file.
 
@@ -615,6 +621,52 @@ def _iter_migration_files(repo_path: Path, migration_directories: list[str]) -> 
     return sorted(files, key=lambda path: path.relative_to(repo_path).as_posix())
 
 
+def _merge_orm_events(
+    tables: dict[str, dict],
+    relations: list[dict],
+    indexes: list[dict],
+    unsupported: list[dict],
+    events: list[dict],
+) -> None:
+    """Folds pre-built ORM events (Django/Rails/Alembic - see
+    orm_migrations.py) into the same accumulators the SQL replay loop above
+    fills, with the same semantics: a CREATE on a table that already exists
+    is a no-op, an ADD COLUMN only applies to a table already known, columns
+    keep declaration order."""
+    for event in events:
+        kind = event["kind"]
+        if kind == "create_table":
+            if event["table"] in tables:
+                continue
+            tables[event["table"]] = {
+                "name": event["table"], "columns": event["columns"],
+                "file": event["file"], "line": event["line"],
+            }
+            for relation in event["relations"]:
+                relations.append({"from_table": event["table"], **relation})
+        elif kind == "add_column":
+            table = tables.get(event["table"])
+            column = event.get("column")
+            if table is not None and column is not None and not any(
+                c["name"] == column["name"] for c in table["columns"]
+            ):
+                table["columns"].append(column)
+            relation = event.get("relation")
+            if relation is not None:
+                relations.append({"from_table": event["table"], **relation})
+        elif kind == "add_relation":
+            relations.append({"from_table": event["table"], **event["relation"]})
+        elif kind == "create_index":
+            indexes.append(
+                {"name": event["name"], "table": event["table"], "columns": event["columns"],
+                 "unique": event["unique"], "file": event["file"], "line": event["line"]}
+            )
+        elif kind == "unsupported":
+            unsupported.append(
+                {"file": event["file"], "line": event["line"], "statement": event["statement"]}
+            )
+
+
 def extract_schema(repo_path: Path, migration_directories: list[str]) -> dict:
     """Replay migration DDL into the schema it defines.
 
@@ -703,6 +755,19 @@ def extract_schema(repo_path: Path, migration_directories: list[str]) -> dict:
                     }
                 )
 
+    dialects: list[str] = ["postgresql"] if sources else []
+
+    for extractor, dialect_name in (
+        (extract_django_migrations, "django"),
+        (extract_rails_migrations, "rails"),
+        (extract_alembic_migrations, "alembic"),
+    ):
+        orm_events, orm_sources = extractor(repo_path, migration_directories)
+        if orm_sources:
+            dialects.append(dialect_name)
+            sources.extend(orm_sources)
+            _merge_orm_events(tables, relations, indexes, unsupported, orm_events)
+
     # Sorted on every axis so identical migrations always produce identical
     # evidence. Columns keep their declaration order - that is the schema's
     # own order and carries meaning a sort would destroy.
@@ -714,7 +779,7 @@ def extract_schema(repo_path: Path, migration_directories: list[str]) -> dict:
     return {
         "checked": True,
         "reason": None,
-        "dialect": "postgresql",
+        "dialect": sorted(set(dialects)) or None,
         "tables": ordered_tables,
         "relations": relations,
         "indexes": indexes,

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
     assert create["relations"][0]["on_delete"] == "SET_NULL"
 
 
-def test_django_add_field_and_add_index_and_unsupported(tmp_path):
+def test_django_add_field_and_add_index(tmp_path):
     repo = write_files(
         tmp_path,
         {
@@ -133,7 +133,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(model_name='post', name='slug', field=models.SlugField(unique=True)),
         migrations.AddIndex(model_name='post', index=models.Index(fields=['slug'], name='post_slug_idx')),
-        migrations.RemoveField(model_name='post', name='old_field'),
     ]
 """,
         },
@@ -148,9 +147,99 @@ class Migration(migrations.Migration):
     assert index["columns"] == ["slug"]
     assert index["unique"] is False
     assert index["file"] == "blog/migrations/0002_add_bits.py"
-    assert len(result["unsupported"]) == 1
-    assert "RemoveField" in result["unsupported"][0]["statement"]
     assert result["dialect"] == ["django"]
+
+
+def test_django_remove_field_alter_field_rename_field_delete_model(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[
+                ('id', models.AutoField(primary_key=True)),
+                ('title', models.CharField(max_length=100)),
+                ('old_field', models.TextField()),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Draft',
+            fields=[('id', models.AutoField(primary_key=True))],
+        ),
+    ]
+""",
+            "blog/migrations/0002_alter_bits.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.RemoveField(model_name='post', name='old_field'),
+        migrations.AlterField(model_name='post', name='title', field=models.CharField(max_length=300, unique=True)),
+        migrations.RenameField(model_name='post', old_name='title', new_name='headline'),
+        migrations.DeleteModel(name='Draft'),
+    ]
+""",
+        },
+    )
+    result = extract_schema(repo, ["blog/migrations"])
+    table = next(t for t in result["tables"] if t["name"] == "blog_post")
+    names = [c["name"] for c in table["columns"]]
+    assert "old_field" not in names
+    assert "title" not in names
+    headline = next(c for c in table["columns"] if c["name"] == "headline")
+    assert headline["type"] == "CHARFIELD"
+    assert headline["unique"] is True
+    assert not any(t["name"] == "blog_draft" for t in result["tables"])
+    assert result["unsupported"] == []
+
+
+def test_django_run_sql_replays_through_sql_parser(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.RunSQL(sql="CREATE TABLE legacy (id BIGINT PRIMARY KEY, note TEXT);"),
+    ]
+"""
+        },
+    )
+    result = extract_schema(repo, ["blog/migrations"])
+    assert [t["name"] for t in result["tables"]] == ["legacy"]
+    assert [c["name"] for c in result["tables"][0]["columns"]] == ["id", "note"]
+
+
+def test_django_run_python_and_alter_model_options_stay_unsupported(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations
+
+def seed_data(apps, schema_editor):
+    pass
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.RunPython(seed_data),
+        migrations.AlterModelOptions(name='post', options={'ordering': ['-id']}),
+    ]
+"""
+        },
+    )
+    events, _ = extract_django_migrations(repo, ["blog/migrations"])
+    assert len(events) == 2
+    assert all(e["kind"] == "unsupported" for e in events)
+    assert "RunPython" in events[0]["statement"]
+    assert "AlterModelOptions" in events[1]["statement"]
 
 
 def test_non_django_migrations_directory_is_ignored(tmp_path):
@@ -236,6 +325,7 @@ class CreatePosts < ActiveRecord::Migration[7.0]
   def change
     create_table :posts do |t|
       t.string :title
+      t.string :old
     end
   end
 end
@@ -257,6 +347,7 @@ end
     views = next(c for c in table["columns"] if c["name"] == "views")
     assert views["nullable"] is False
     assert views["default"] == "0"
+    assert not any(c["name"] == "old" for c in table["columns"])
     assert len(result["indexes"]) == 1
     index = result["indexes"][0]
     assert index["name"] == "idx_posts_title"
@@ -267,8 +358,147 @@ end
     fk = next(r for r in result["relations"] if r["from_column"] == "account_id")
     assert fk["to_table"] == "accounts"
     assert fk["on_delete"] == "CASCADE"
-    assert len(result["unsupported"]) == 1
-    assert "remove_column" in result["unsupported"][0]["statement"]
+    assert result["unsupported"] == []
+
+
+def test_rails_rename_column_rename_table_drop_table(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_things.rb": """
+class CreateThings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :widgets do |t|
+      t.string :name
+    end
+    create_table :scratch do |t|
+      t.string :x
+    end
+  end
+end
+""",
+            "db/migrate/20230102000000_alter_things.rb": """
+class AlterThings < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :widgets, :name, :label
+    rename_table :widgets, :gadgets
+    drop_table :scratch
+  end
+end
+""",
+        },
+    )
+    result = extract_schema(repo, ["db/migrate"])
+    table_names = [t["name"] for t in result["tables"]]
+    assert "gadgets" in table_names
+    assert "widgets" not in table_names
+    assert "scratch" not in table_names
+    gadgets = next(t for t in result["tables"] if t["name"] == "gadgets")
+    assert [c["name"] for c in gadgets["columns"]] == ["id", "label"]
+
+
+def test_rails_change_table_block(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_posts.rb": """
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.string :subtitle
+    end
+  end
+end
+""",
+            "db/migrate/20230102000000_change_posts.rb": """
+class ChangePosts < ActiveRecord::Migration[7.0]
+  def change
+    change_table :posts do |t|
+      t.remove :subtitle
+      t.rename :title, :headline
+      t.integer :views
+      t.timestamps
+    end
+  end
+end
+""",
+        },
+    )
+    result = extract_schema(repo, ["db/migrate"])
+    table = next(t for t in result["tables"] if t["name"] == "posts")
+    names = [c["name"] for c in table["columns"]]
+    assert "subtitle" not in names
+    assert "title" not in names
+    assert set(["headline", "views", "created_at", "updated_at"]) <= set(names)
+
+
+def test_rails_change_column_and_null_and_default(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_posts.rb": """
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.string :views
+    end
+  end
+end
+""",
+            "db/migrate/20230102000000_alter_posts.rb": """
+class AlterPosts < ActiveRecord::Migration[7.0]
+  def change
+    change_column :posts, :views, :integer
+    change_column_null :posts, :views, false
+    change_column_default :posts, :views, 0
+  end
+end
+""",
+        },
+    )
+    result = extract_schema(repo, ["db/migrate"])
+    table = next(t for t in result["tables"] if t["name"] == "posts")
+    views = next(c for c in table["columns"] if c["name"] == "views")
+    assert views["type"] == "INTEGER"
+    assert views["nullable"] is False
+    assert views["default"] == "0"
+
+
+def test_rails_execute_replays_through_sql_parser(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_raw.rb": """
+class Raw < ActiveRecord::Migration[7.0]
+  def change
+    execute "CREATE TABLE legacy (id BIGINT PRIMARY KEY, note TEXT);"
+  end
+end
+"""
+        },
+    )
+    result = extract_schema(repo, ["db/migrate"])
+    assert [t["name"] for t in result["tables"]] == ["legacy"]
+
+
+def test_rails_create_join_table_and_remove_foreign_key_stay_unsupported(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_misc.rb": """
+class Misc < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :posts, :tags
+    remove_foreign_key :posts, :accounts
+  end
+end
+"""
+        },
+    )
+    events, _ = extract_rails_migrations(repo, ["db/migrate"])
+    assert len(events) == 2
+    assert all(e["kind"] == "unsupported" for e in events)
 
 
 # ---------------------------------------------------------------------------
@@ -341,7 +571,63 @@ def upgrade():
     assert result["dialect"] == ["alembic"]
 
 
-def test_alembic_unsupported_ops_recorded(tmp_path):
+def test_alembic_drop_table_and_execute_are_modeled(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('legacy', sa.Column('id', sa.Integer(), primary_key=True))
+    op.execute("CREATE TABLE audit (id INTEGER PRIMARY KEY, note TEXT);")
+    op.drop_table('legacy')
+"""
+        },
+    )
+    result = extract_schema(repo, ["alembic/versions"])
+    table_names = [t["name"] for t in result["tables"]]
+    assert "legacy" not in table_names
+    assert "audit" in table_names
+
+
+def test_alembic_drop_column_alter_column_drop_index_rename_table(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('accounts',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(length=50), nullable=True),
+        sa.Column('legacy_flag', sa.Boolean()),
+    )
+    op.create_index('ix_accounts_name', 'accounts', ['name'])
+    op.drop_column('accounts', 'legacy_flag')
+    op.alter_column('accounts', 'name', nullable=False, type_=sa.String(length=100))
+    op.drop_index('ix_accounts_name', table_name='accounts')
+    op.rename_table('accounts', 'users')
+"""
+        },
+    )
+    result = extract_schema(repo, ["alembic/versions"])
+    table_names = [t["name"] for t in result["tables"]]
+    assert "users" in table_names
+    assert "accounts" not in table_names
+    users = next(t for t in result["tables"] if t["name"] == "users")
+    names = [c["name"] for c in users["columns"]]
+    assert "legacy_flag" not in names
+    name_col = next(c for c in users["columns"] if c["name"] == "name")
+    assert name_col["nullable"] is False
+    assert name_col["type"] == "STRING"
+    assert result["indexes"] == []
+
+
+def test_alembic_drop_constraint_stays_unsupported(tmp_path):
     repo = write_files(
         tmp_path,
         {
@@ -349,14 +635,14 @@ def test_alembic_unsupported_ops_recorded(tmp_path):
 from alembic import op
 
 def upgrade():
-    op.drop_table('legacy')
-    op.execute("UPDATE accounts SET active = true")
+    op.drop_constraint('fk_accounts_user_id', 'accounts', type_='foreignkey')
 """
         },
     )
     events, _ = extract_alembic_migrations(repo, ["alembic/versions"])
-    assert len(events) == 2
-    assert all(e["kind"] == "unsupported" for e in events)
+    assert len(events) == 1
+    assert events[0]["kind"] == "unsupported"
+    assert "drop_constraint" in events[0]["statement"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -1,0 +1,385 @@
+from pathlib import Path
+
+from aletheore.orm_migrations import (
+    extract_alembic_migrations,
+    extract_django_migrations,
+    extract_rails_migrations,
+)
+from aletheore.schema_map import extract_schema
+
+
+def write_files(tmp_path: Path, files: dict[str, str]) -> Path:
+    for rel_path, body in files.items():
+        path = tmp_path / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Django
+# ---------------------------------------------------------------------------
+
+
+def test_django_create_model_infers_table_name_and_implicit_pk(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[
+                ('title', models.CharField(max_length=200)),
+                ('published', models.BooleanField(default=False)),
+            ],
+        ),
+    ]
+"""
+        },
+    )
+    events, sources = extract_django_migrations(repo, ["blog/migrations"])
+    assert sources == ["blog/migrations/0001_initial.py"]
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert create["table"] == "blog_post"
+    names = [c["name"] for c in create["columns"]]
+    # No field in the migration is marked primary_key=True, so Django's
+    # implicit `id` column must be injected first.
+    assert names == ["id", "title", "published"]
+    assert create["columns"][0]["primary_key"] is True
+    assert create["columns"][2]["default"] == "False"
+
+
+def test_django_foreign_key_resolves_to_real_table_name(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[
+                ('id', models.AutoField(primary_key=True)),
+                ('author', models.ForeignKey(to='accounts.User', on_delete=models.CASCADE)),
+            ],
+        ),
+    ]
+"""
+        },
+    )
+    events, _ = extract_django_migrations(repo, ["blog/migrations"])
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert len(create["relations"]) == 1
+    relation = create["relations"][0]
+    assert relation["from_column"] == "author_id"
+    assert relation["to_table"] == "accounts_user"
+    assert relation["to_column"] == "id"
+    assert relation["on_delete"] == "CASCADE"
+    assert relation["file"] == "blog/migrations/0001_initial.py"
+    assert any(c["name"] == "author_id" for c in create["columns"])
+
+
+def test_django_self_referential_foreign_key(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "org/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Employee',
+            fields=[
+                ('id', models.AutoField(primary_key=True)),
+                ('manager', models.ForeignKey(to='self', on_delete=models.SET_NULL, null=True)),
+            ],
+        ),
+    ]
+"""
+        },
+    )
+    events, _ = extract_django_migrations(repo, ["org/migrations"])
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert create["relations"][0]["to_table"] == "org_employee"
+    assert create["relations"][0]["on_delete"] == "SET_NULL"
+
+
+def test_django_add_field_and_add_index_and_unsupported(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[('id', models.AutoField(primary_key=True))],
+        ),
+    ]
+""",
+            "blog/migrations/0002_add_bits.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.AddField(model_name='post', name='slug', field=models.SlugField(unique=True)),
+        migrations.AddIndex(model_name='post', index=models.Index(fields=['slug'], name='post_slug_idx')),
+        migrations.RemoveField(model_name='post', name='old_field'),
+    ]
+""",
+        },
+    )
+    result = extract_schema(repo, ["blog/migrations"])
+    table = next(t for t in result["tables"] if t["name"] == "blog_post")
+    assert any(c["name"] == "slug" and c["unique"] for c in table["columns"])
+    assert len(result["indexes"]) == 1
+    index = result["indexes"][0]
+    assert index["name"] == "post_slug_idx"
+    assert index["table"] == "blog_post"
+    assert index["columns"] == ["slug"]
+    assert index["unique"] is False
+    assert index["file"] == "blog/migrations/0002_add_bits.py"
+    assert len(result["unsupported"]) == 1
+    assert "RemoveField" in result["unsupported"][0]["statement"]
+    assert result["dialect"] == ["django"]
+
+
+def test_non_django_migrations_directory_is_ignored(tmp_path):
+    """A `migrations/` directory that isn't Django (no django import, no
+    Migration class) must not be mis-parsed."""
+    repo = write_files(
+        tmp_path,
+        {"tool/migrations/0001_something.py": "print('not django at all')\n"},
+    )
+    events, sources = extract_django_migrations(repo, ["tool/migrations"])
+    assert events == []
+    assert sources == []
+
+
+# ---------------------------------------------------------------------------
+# Rails
+# ---------------------------------------------------------------------------
+
+
+def test_rails_create_table_with_references_and_timestamps(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_posts.rb": """
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.string :title, null: false
+      t.text :body
+      t.references :author, foreign_key: true
+      t.timestamps
+    end
+  end
+end
+"""
+        },
+    )
+    events, sources = extract_rails_migrations(repo, ["db/migrate"])
+    assert sources == ["db/migrate/20230101000000_create_posts.rb"]
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert create["table"] == "posts"
+    names = [c["name"] for c in create["columns"]]
+    assert names == ["id", "title", "body", "author_id", "created_at", "updated_at"]
+    assert create["columns"][0]["primary_key"] is True
+    assert create["columns"][1]["nullable"] is False
+    assert create["columns"][2]["nullable"] is True
+    assert len(create["relations"]) == 1
+    relation = create["relations"][0]
+    assert relation["from_column"] == "author_id"
+    assert relation["to_table"] == "authors"
+    assert relation["to_column"] == "id"
+    assert relation["on_delete"] is None
+    assert relation["file"] == "db/migrate/20230101000000_create_posts.rb"
+
+
+def test_rails_id_false_omits_primary_key(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_join.rb": """
+class CreateJoin < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts_tags, id: false do |t|
+      t.integer :post_id
+      t.integer :tag_id
+    end
+  end
+end
+"""
+        },
+    )
+    events, _ = extract_rails_migrations(repo, ["db/migrate"])
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert [c["name"] for c in create["columns"]] == ["post_id", "tag_id"]
+
+
+def test_rails_standalone_add_column_add_index_add_foreign_key(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_posts.rb": """
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.string :title
+    end
+  end
+end
+""",
+            "db/migrate/20230102000000_alter_posts.rb": """
+class AlterPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :posts, :views, :integer, null: false, default: 0
+    add_index :posts, [:title], unique: true, name: "idx_posts_title"
+    add_foreign_key :posts, :accounts, column: :account_id, on_delete: :cascade
+    remove_column :posts, :old
+  end
+end
+""",
+        },
+    )
+    result = extract_schema(repo, ["db/migrate"])
+    table = next(t for t in result["tables"] if t["name"] == "posts")
+    views = next(c for c in table["columns"] if c["name"] == "views")
+    assert views["nullable"] is False
+    assert views["default"] == "0"
+    assert len(result["indexes"]) == 1
+    index = result["indexes"][0]
+    assert index["name"] == "idx_posts_title"
+    assert index["table"] == "posts"
+    assert index["columns"] == ["title"]
+    assert index["unique"] is True
+    assert index["file"] == "db/migrate/20230102000000_alter_posts.rb"
+    fk = next(r for r in result["relations"] if r["from_column"] == "account_id")
+    assert fk["to_table"] == "accounts"
+    assert fk["on_delete"] == "CASCADE"
+    assert len(result["unsupported"]) == 1
+    assert "remove_column" in result["unsupported"][0]["statement"]
+
+
+# ---------------------------------------------------------------------------
+# Alembic
+# ---------------------------------------------------------------------------
+
+
+def test_alembic_create_table_only_reads_upgrade(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('accounts',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(length=100), nullable=False),
+    )
+
+def downgrade():
+    op.drop_table('accounts')
+"""
+        },
+    )
+    events, sources = extract_alembic_migrations(repo, ["alembic/versions"])
+    assert sources == ["alembic/versions/abc123_init.py"]
+    kinds = [e["kind"] for e in events]
+    assert kinds == ["create_table"]
+    create = events[0]
+    assert create["table"] == "accounts"
+    assert [c["name"] for c in create["columns"]] == ["id", "name"]
+    assert create["columns"][0]["primary_key"] is True
+    assert create["columns"][1]["type"] == "STRING"
+
+
+def test_alembic_inline_foreign_key_and_add_column_and_index(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('accounts', sa.Column('id', sa.Integer(), primary_key=True))
+""",
+            "alembic/versions/def456_add_posts.py": """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('posts',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('account_id', sa.Integer(), sa.ForeignKey('accounts.id'), nullable=False),
+    )
+    op.add_column('posts', sa.Column('title', sa.String(length=200), nullable=True))
+    op.create_index('ix_posts_title', 'posts', ['title'], unique=False)
+"""
+        },
+    )
+    result = extract_schema(repo, ["alembic/versions"])
+    posts = next(t for t in result["tables"] if t["name"] == "posts")
+    assert [c["name"] for c in posts["columns"]] == ["id", "account_id", "title"]
+    fk = next(r for r in result["relations"] if r["from_column"] == "account_id")
+    assert fk["to_table"] == "accounts"
+    assert fk["to_column"] == "id"
+    assert result["indexes"][0]["name"] == "ix_posts_title"
+    assert result["dialect"] == ["alembic"]
+
+
+def test_alembic_unsupported_ops_recorded(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+
+def upgrade():
+    op.drop_table('legacy')
+    op.execute("UPDATE accounts SET active = true")
+"""
+        },
+    )
+    events, _ = extract_alembic_migrations(repo, ["alembic/versions"])
+    assert len(events) == 2
+    assert all(e["kind"] == "unsupported" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# extract_schema integration: dialect list + no cross-parser interference
+# ---------------------------------------------------------------------------
+
+
+def test_extract_schema_reports_dialect_list(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "app/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(name='Thing', fields=[('id', models.AutoField(primary_key=True))]),
+    ]
+"""
+        },
+    )
+    result = extract_schema(repo, ["app/migrations"])
+    assert result["dialect"] == ["django"]
+
+    empty = extract_schema(repo, [])
+    assert empty["dialect"] is None

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -669,3 +669,58 @@ class Migration(migrations.Migration):
 
     empty = extract_schema(repo, [])
     assert empty["dialect"] is None
+
+
+def test_alembic_create_table_without_explicit_pk_gets_no_implicit_id(tmp_path):
+    # Alembic/SQLAlchemy never synthesizes an id column the way Django's
+    # AutoField or Rails' create_table default does - a table genuinely
+    # created without one has no primary key at all.
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_audit.py": """
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('audit', sa.Column('message', sa.Text()))
+"""
+        },
+    )
+    events, _ = extract_alembic_migrations(repo, ["alembic/versions"])
+    assert len(events) == 1
+    create = events[0]
+    assert create["table"] == "audit"
+    assert [c["name"] for c in create["columns"]] == ["message"]
+
+
+def test_extract_schema_replays_mixed_sql_and_orm_sources_in_path_order(tmp_path):
+    # A Django migration creates `app_item`; a raw .sql migration then
+    # alters it. "app/migrations/..." sorts before "db/sql/..." so the
+    # correct replay order is Django-first. Applying every .sql file before
+    # any ORM migration (regardless of path) would run the ALTER before the
+    # table exists, dropping the column into `unsupported` instead of the
+    # schema.
+    repo = write_files(
+        tmp_path,
+        {
+            "app/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Item',
+            fields=[('id', models.AutoField(primary_key=True))],
+        ),
+    ]
+""",
+            "db/sql/0002_add_description.sql": (
+                "ALTER TABLE app_item ADD COLUMN description text;"
+            ),
+        },
+    )
+    result = extract_schema(repo, ["app/migrations", "db/sql"])
+    item = next(t for t in result["tables"] if t["name"] == "app_item")
+    assert [c["name"] for c in item["columns"]] == ["id", "description"]
+    assert result["unsupported"] == []


### PR DESCRIPTION
## Summary

`schema_map.py`'s `detect_database()` already recognized Django/Rails/Alembic ORMs and their migration directories, but `extract_schema()` only ever globbed `*.sql` files — Django migrations are `.py`, Rails migrations are `.rb`, Alembic migrations are `.py`, so a real repo using any of the three silently produced an empty schema (correct `orm_frameworks`/`migration_directories`, but the migration files themselves were never opened).

Adds `orm_migrations.py`: tree-sitter-based parsers for all three frameworks, producing the same event shapes `schema_map.py`'s SQL replay loop already merges.

- **Django**: `CreateModel`/`AddField`/`AddIndex` (with implicit `id` PK), then `RemoveField`, `AlterField`, `RenameField`, `DeleteModel`, `RenameModel`, `RemoveIndex`, and `RunSQL` (its `sql=` now replays through the existing Postgres parser instead of being discarded). `RunPython` and legacy metadata-only ops (`AlterModelOptions`, `AlterUniqueTogether`, `AlterModelTable`) stay unsupported — genuinely unmodelable or no DB-shape effect.
- **Rails**: `create_table`/`t.<type>`/`references`/`add_foreign_key`, then `remove_column`, `drop_table`, `rename_column`, `rename_table`, `change_column`/`change_column_null`/`change_column_default`, `remove_index`, `change_table` blocks, and `execute` (same raw-SQL replay). `create_join_table` and `remove_foreign_key` stay unsupported (ambiguous which relation to drop).
- **Alembic**: `op.create_table`/`add_column`/`create_index`/`create_foreign_key`, then `op.drop_table`, `op.drop_column`, `op.alter_column`, `op.drop_index`, `op.rename_table`, `op.execute`. `op.drop_constraint` stays unsupported (constraint names aren't tracked precisely enough to resolve which one to remove).

`dialect` becomes a sorted list (e.g. `["django"]`, `["alembic", "postgresql"]`) instead of a hardcoded `"postgresql"` string — confirmed via grep that nothing else in the codebase branches on its type.

## Real bug found and fixed

The Rails (and two other) event-discovery walk used a stack-based traversal that pushed `node.children` without reversing them first — popping from the end of an un-reversed list visits siblings in **reverse source order**. Reproduced with a real 3-statement `change` block (`rename_column`, `rename_table`, `drop_table`): events came out `drop → rename → rename`, silently reordering replay. Fixed by reversing children before pushing, in all 3 places this pattern appeared in the file (not just the one that was first found).

## Test plan

Independently re-verified this session, not just re-running the branch's own tests:

- [x] Full suite: 1613 passed (confirmed exact match)
- [x] Rails traversal-order bug: reproduced the exact failure mode with a fresh 3-op migration, confirmed the fix now returns events in correct source order (`rename_column → rename_table → remove_table`)
- [x] Diff-confirmed the reversed-stack fix applies in all 3 places the buggy pattern occurred, not just Rails
- [x] Django `RunSQL` replay verified end-to-end: fed a raw `CREATE TABLE widgets (id serial PRIMARY KEY, name text)`, confirmed it produces a correctly-typed table (`id` SERIAL PK, `name` TEXT) in the final extracted schema — actually flows through the existing Postgres parser, not just claimed
- [x] Confirmed the shared `docs/deploy-2026-09-04` branch was left clean — no partial ORM code leaked into `schema_map.py` there
- [x] Correction: this branch's own commit messages claim "31 new tests" — actual count is 22 (`test_orm_migrations.py`, no parametrization, no other test file touched; confirmed by both direct count and the exact 1591→1613 suite delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)