### PR TITLE
Remove paid-plan gate on database schema mapping

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -429,7 +429,8 @@ def _resolve_check_toggles(
     scan_git_history: bool | None,
     check_licenses: bool | None,
     map_endpoints: bool | None,
-) -> tuple[bool, bool, bool, bool]:
+    map_schema: bool | None,
+) -> tuple[bool, bool, bool, bool, bool]:
     """Each toggle is bool|None from the CLI: None means "no explicit flag
     passed", so the repo's .aletheore.json disabled_checks decides. An
     explicit --check-x/--no-check-x flag always overrides the config,
@@ -440,33 +441,8 @@ def _resolve_check_toggles(
         scan_git_history if scan_git_history is not None else "secrets_history" not in disabled,
         check_licenses if check_licenses is not None else "licenses" not in disabled,
         map_endpoints if map_endpoints is not None else "endpoints" not in disabled,
+        map_schema if map_schema is not None else "schema" not in disabled,
     )
-
-
-_SCHEMA_UNENTITLED_REASON = (
-    "requires a paid plan - run 'aletheore login' to connect an entitled installation"
-)
-
-
-def _resolve_schema_entitlement() -> tuple[bool, str]:
-    """Whether this machine may run schema mapping, and why not if not.
-
-    Resolved from the saved managed-audit token via the existing /v1/whoami,
-    not from a new licensing mechanism - `status` already does exactly this.
-    Any failure (no token, offline, API down, free plan) is treated as
-    unentitled rather than raised: a scan must still produce evidence when
-    the entitlement service is unreachable, it just produces it with the
-    schema section unchecked and a reason saying so.
-    """
-    token = get_api_key("ALETHEORE_API_TOKEN", "aletheore-managed-audit", prompt_fn=lambda _: "")
-    if not token:
-        return False, _SCHEMA_UNENTITLED_REASON
-    who = _fetch_whoami(token)
-    if who is None:
-        return False, "could not reach the entitlement service - schema mapping skipped"
-    if who.get("plan", "free") == "free":
-        return False, _SCHEMA_UNENTITLED_REASON
-    return True, ""
 
 
 def _scan(
@@ -478,13 +454,12 @@ def _scan(
     map_schema: bool | None = None,
 ) -> tuple[int, dict, Path]:
     repo = Path(repo_path).resolve()
-    resolved_vulnerabilities, resolved_git_history, resolved_licenses, resolved_endpoints = (
-        _resolve_check_toggles(repo, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints)
+    (
+        resolved_vulnerabilities, resolved_git_history, resolved_licenses,
+        resolved_endpoints, resolved_schema,
+    ) = _resolve_check_toggles(
+        repo, check_vulnerabilities, scan_git_history, check_licenses, map_endpoints, map_schema
     )
-    if map_schema is False:
-        resolved_schema, schema_reason = False, "skipped (--no-map-schema)"
-    else:
-        resolved_schema, schema_reason = _resolve_schema_entitlement()
 
     console.print(f"Scanning {repo}...")
     try:
@@ -495,7 +470,6 @@ def _scan(
             check_licenses=resolved_licenses,
             map_endpoints=resolved_endpoints,
             map_schema=resolved_schema,
-            map_schema_skip_reason=schema_reason,
             progress=_make_progress_printer(),
         )
     except GitAnalysisError as exc:
@@ -1397,7 +1371,7 @@ def audit(
     map_schema: Optional[bool] = typer.Option(
         None,
         "--map-schema/--no-map-schema",
-        help="map database schema from migrations (paid plans; on by default when entitled)",
+        help="map database schema from migrations (on by default, or set by .aletheore.json's disabled_checks)",
     ),
     map_endpoints: Optional[bool] = typer.Option(
         None,
@@ -1459,7 +1433,7 @@ def scan(
     map_schema: Optional[bool] = typer.Option(
         None,
         "--map-schema/--no-map-schema",
-        help="map database schema from migrations (paid plans; on by default when entitled)",
+        help="map database schema from migrations (on by default, or set by .aletheore.json's disabled_checks)",
     ),
     map_endpoints: Optional[bool] = typer.Option(
         None,

--- a/src/aletheore/repo_config.py
+++ b/src/aletheore/repo_config.py
@@ -2,7 +2,7 @@ import fnmatch
 import json
 from pathlib import Path
 
-DISABLEABLE_CHECKS = {"vulnerabilities", "licenses", "endpoints", "secrets_history"}
+DISABLEABLE_CHECKS = {"vulnerabilities", "licenses", "endpoints", "secrets_history", "schema"}
 SEVERITY_LEVELS = ("critical", "high", "medium", "low")
 
 DEFAULT_CONFIG = {

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -1017,6 +1017,30 @@ def test_main_audit_threads_no_map_schema_flag(tmp_path):
     assert evidence["repository"]["database"]["schema"]["reason"] == "skipped (--no-map-schema)"
 
 
+def test_main_scan_maps_schema_by_default_with_no_entitlement_check(tmp_path, monkeypatch):
+    # Schema mapping used to require a paid-plan entitlement, resolved via a
+    # saved token and a /v1/whoami call - free/offline installs got an empty
+    # schema with "requires a paid plan" even with no flag passed at all. It
+    # now follows the exact same free, opt-out-only pattern as every other
+    # scanner (vulnerabilities/licenses/endpoints/secrets_history).
+    import aletheore.credentials as credentials
+
+    monkeypatch.delenv("ALETHEORE_API_TOKEN", raising=False)
+    monkeypatch.setattr(credentials, "DEFAULT_CREDENTIALS_PATH", Path("/nonexistent/creds.json"))
+
+    repo = tmp_path
+    (repo / "migrations").mkdir()
+    (repo / "migrations" / "001.sql").write_text("CREATE TABLE widgets (id BIGINT PRIMARY KEY);")
+
+    result = runner.invoke(app, ["scan", str(repo)])
+
+    assert result.exit_code == 0
+    evidence = json.loads((repo / ".aletheore" / "air.json").read_text())
+    schema = evidence["repository"]["database"]["schema"]
+    assert schema["checked"] is True
+    assert any(t["name"] == "widgets" for t in schema["tables"])
+
+
 def test_main_managed_audit_threads_no_map_schema_flag(tmp_path):
     repo = tmp_path
     (repo / "main.py").write_text("x = 1\n")


### PR DESCRIPTION
## Summary

Schema mapping (`aletheore scan`'s `database.schema` section) was the only scanner gated behind a paid-plan entitlement check (`/v1/whoami`) — every other scanner (vulnerabilities, secrets, licenses, endpoints, dead code, infrastructure) has always been free, opt-out-only via `.aletheore.json`'s `disabled_checks`.

The gate was added when the underlying parser was a hand-written, not-fully-baked Postgres tokenizer that wasn't ready to ship broadly. It's since been rewritten onto sqlglot and stress-tested across 6 rounds on 14 real repos spanning 4 migration conventions (raw SQL, Alembic, Rails, Django) — see #540 — with a public benchmark ([aletheore-benchmarks#16](https://github.com/Aletheore/aletheore-benchmarks/pull/16)) showing it substantially outperforms a competitor tool that also claims SQL support. The original reason for gating it no longer applies.

## Changes

- Schema mapping now follows the exact same free, opt-out-only pattern as every other scanner: `"schema"` added to `repo_config.py`'s `DISABLEABLE_CHECKS`, resolved through the same `_resolve_check_toggles` `--flag`/`--no-flag`-or-`.aletheore.json` precedence used everywhere else.
- Removed `_resolve_schema_entitlement` and `_SCHEMA_UNENTITLED_REASON` entirely — dead code once nothing calls the entitlement check.
- Updated `--map-schema`/`--no-map-schema` CLI help text on `scan` and `audit` to match the other flags' wording.

## Test plan

- [x] New regression test: `aletheore scan` on a repo with a real migration directory, no API token, no `--map-schema` flag, now returns `checked: True` with the real extracted table — previously would have returned `checked: False, reason: "requires a paid plan..."`
- [x] Full test suite green (1653 passed)
- [x] `--no-map-schema` explicit opt-out still works (existing tests unchanged, still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SNvidnm6JVuEm2CLNoNKr