### PR TITLE
fix: cache-hit Flash Review findings with no quotable content never got re-validated

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -808,6 +808,34 @@ def _line_citation_content_matches(finding: dict, file_contents: dict[str, str])
     return any(q in window_text for q in quoted)
 
 
+def _has_verifiable_content_citation(finding: dict, file_contents: dict[str, str] | None) -> bool:
+    """True when _line_citation_content_matches had a real literal quote to
+    check the finding's claimed line against - False when it could only
+    fall back to its own "nothing to check, pass" case (no file_contents
+    fetched for this file, or the finding's issue names no literal quoted
+    string).
+
+    That fallback is the right call for a FRESH finding: false-rejection
+    (dropping a real, correctly-described-but-unquotable bug) is worse
+    than false-acceptance there. It is backwards for a *cached* finding
+    being replayed against a new, merely similar diff (see review_diff's
+    cache_lookup branch) - a logical/omission bug ("X is never done"),
+    which by nature has no specific buggy literal to quote, gets zero real
+    re-validation and can be re-affirmed as still-open forever even after
+    the diff that introduced it is long fixed. Real gap found in
+    production: a finding on Flash Review's own PR #547 ("unsupported
+    events are discarded, never surfaced") kept getting served from cache
+    and passing grounding by this exact route for three pushes after the
+    discard was actually fixed, because its issue text had nothing to
+    quote. Used by review_diff to flag exactly this finding shape for a
+    real re-check instead of trusting the cache indefinitely."""
+    if not file_contents:
+        return False
+    if file_contents.get(finding["file"]) is None:
+        return False
+    return bool(_quoted_strings(finding.get("issue") or ""))
+
+
 _FILE_MARKER_RE = re.compile(r"^--- (.+) ---$")
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
@@ -1222,7 +1250,7 @@ def review_diff(
             logger.warning("flash review cache lookup failed (%s); treating as miss", type(exc).__name__)
             cached = None
         if cached is not None:
-            # Deliberately never re-verified here, even when
+            # Not re-verified wholesale here, even when
             # verify_with_second_model=True: the whole point of the
             # similarity cache is skipping the expensive model work on a
             # repeat/near-repeat diff, and verification is exactly that -
@@ -1230,12 +1258,37 @@ def review_diff(
             # every cache hit would make hits cost real money again,
             # defeating the cache. Grounding still re-runs because it's
             # free and the current diff can differ from whatever was
-            # cached (similarity match, not exact); verification does not
-            # get that same justification since it isn't diff-shape
-            # sensitive in the same way and its cost is what the cache
-            # exists to avoid paying twice.
+            # cached (similarity match, not exact).
             combined = _merge_semantic_findings(cached, semantic_findings)
             kept = _validate_findings(combined, diff_text, file_contents, diff_patches)
+
+            # The one exception: a kept finding grounding could only pass
+            # via its own "nothing to check" fallback (see
+            # _has_verifiable_content_citation) got zero real re-
+            # validation against the *current* diff - on a cache hit
+            # that's the finding shape most likely to have been silently
+            # fixed by whatever made this diff merely similar rather than
+            # identical to what's cached, and it would otherwise be
+            # re-affirmed unchanged forever. Never applies to a semantic
+            # finding (source == "semantic", not "llm") - those are
+            # deterministic, code-verified evidence, not a model guess
+            # that can go stale the way an LLM's prose claim can.
+            # on_verification_usage, not on_usage: this is always a real
+            # DeepSeek call (see verification_adapter), and pricing it at
+            # flash_review_model's rate (Luna, when that's what generated
+            # the original finding) would misprice real DeepSeek tokens at
+            # a different model's cost.
+            needs_recheck = [
+                f for f in kept
+                if f.get("source") == "llm" and not _has_verifiable_content_citation(f, file_contents)
+            ]
+            if needs_recheck:
+                recheck_ids = {id(f) for f in needs_recheck}
+                rechecked = _verify_findings_with_second_model(
+                    needs_recheck, diff_text, on_usage=on_verification_usage
+                )
+                kept = [f for f in kept if id(f) not in recheck_ids] + rechecked
+
             if on_grounding_result is not None:
                 on_grounding_result({"proposed": len(combined), "kept": len(kept)})
             return kept

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -3233,21 +3233,119 @@ def test_review_diff_skips_verification_by_default(mock_verification_adapter, mo
 
 
 @patch("scan_worker.model_tiers.verification_adapter")
-def test_review_diff_never_reverifies_a_cache_hit(mock_verification_adapter):
-    # Real regression this guards: verification is an LLM call, the same
-    # cost class as generation - the whole point of the similarity cache is
-    # skipping that cost on a repeat/near-repeat diff. Re-verifying on every
-    # cache hit would make hits cost real money again, defeating the cache.
-    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
-    cached_findings = [{"file": "app.py", "line": 42, "issue": "cached finding"}]
+def test_review_diff_does_not_reverify_a_cache_hit_finding_with_verifiable_content(
+    mock_verification_adapter,
+):
+    # A cache-hit finding whose issue text quotes a real literal that still
+    # appears at the cited line already got genuine re-validation from
+    # grounding's own content check (see _has_verifiable_content_citation) -
+    # sending it through the LLM verifier too would be a second, unnecessary
+    # real-money call on every such cache hit, defeating the whole point of
+    # the similarity cache.
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('buggy_handle')"
+    cached_findings = [
+        {"file": "app.py", "line": 42, "issue": "the file handle 'buggy_handle' is never closed"}
+    ]
+    file_contents = {"app.py": "\n" * 41 + "f = open('buggy_handle')\n"}
 
     findings = review_diff(
         diff_text,
         cache_lookup=lambda diff: cached_findings,
+        file_contents=file_contents,
         verify_with_second_model=True,
     )
 
     assert findings == [{**cached_findings[0], "source": "llm"}]
+    mock_verification_adapter.assert_not_called()
+
+
+@patch("scan_worker.model_tiers.verification_adapter")
+def test_review_diff_rechecks_a_cache_hit_finding_with_no_quotable_content(mock_verification_adapter):
+    # Real gap this guards (found on Flash Review's own PR #547): a cached
+    # finding describing a logical/omission bug ("X is never done") has no
+    # specific buggy literal to quote, so grounding's content check can only
+    # ever fall back to "nothing to check, pass" for it - zero real
+    # re-validation against the *current* diff, even though a cache hit
+    # means this diff is merely similar to, not identical to, whatever was
+    # originally reviewed. This must get a real recheck instead of being
+    # trusted forever.
+    mock_verifier = MagicMock()
+    mock_verifier.is_available.return_value = True
+    mock_verifier.simple_completion.return_value = '{"verdict": "ACCEPT", "reason": "still there"}'
+    mock_verification_adapter.return_value = mock_verifier
+
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    cached_findings = [{"file": "app.py", "line": 42, "issue": "cached finding, no quoted literal"}]
+
+    findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
+
+    assert findings == [{**cached_findings[0], "source": "llm"}]
+    mock_verifier.simple_completion.assert_called_once()
+
+
+@patch("scan_worker.model_tiers.verification_adapter")
+def test_review_diff_drops_a_cache_hit_finding_the_recheck_rejects(mock_verification_adapter):
+    # The exact PR #547 scenario: a cache-hit finding with no quotable
+    # literal, served again against a new diff that actually fixed the bug
+    # it describes. Without the recheck this survives forever, silently
+    # re-affirmed on every subsequent similar push; with it, a REJECT
+    # verdict finally lets it drop out - the same as _post_flash_review_
+    # finding_comments treating "not reproposed" as fixed.
+    mock_verifier = MagicMock()
+    mock_verifier.is_available.return_value = True
+    mock_verifier.simple_completion.return_value = '{"verdict": "REJECT", "reason": "already fixed"}'
+    mock_verification_adapter.return_value = mock_verifier
+
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    cached_findings = [{"file": "app.py", "line": 42, "issue": "cached finding, no quoted literal"}]
+
+    findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
+
+    assert findings == []
+
+
+@patch("scan_worker.model_tiers.verification_adapter")
+def test_review_diff_cache_hit_recheck_prices_as_verification_not_generation(mock_verification_adapter):
+    # on_verification_usage, not on_usage: the recheck always calls
+    # verification_adapter (always DeepSeek), so pricing it at
+    # flash_review_model's rate - Luna, whenever that generated the
+    # original cached finding - would misprice real DeepSeek tokens at a
+    # different, likely more expensive model's cost.
+    mock_verifier = MagicMock()
+    mock_verifier.is_available.return_value = True
+    mock_verifier.simple_completion.return_value = '{"verdict": "ACCEPT", "reason": "still there"}'
+    mock_verification_adapter.return_value = mock_verifier
+
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    cached_findings = [{"file": "app.py", "line": 42, "issue": "cached finding, no quoted literal"}]
+    generation_usage = MagicMock()
+    verification_usage = MagicMock()
+
+    review_diff(
+        diff_text,
+        cache_lookup=lambda diff: cached_findings,
+        on_usage=generation_usage,
+        on_verification_usage=verification_usage,
+    )
+
+    mock_verification_adapter.assert_called_once_with(on_usage=verification_usage)
+
+
+@patch("scan_worker.model_tiers.verification_adapter")
+def test_review_diff_never_sends_a_cached_semantic_finding_to_the_recheck(mock_verification_adapter):
+    # semantic_findings are deterministic, code-verified evidence (see
+    # find_semantic_regressions), not a model guess that can go stale the
+    # way an LLM's prose claim can - even with no quoted literal and no
+    # file_contents, a cached finding tagged "source": "semantic" must
+    # never be sent through the fallible LLM recheck.
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+f = open('x')"
+    cached_findings = [
+        {"file": "app.py", "line": 42, "issue": "no quoted literal here", "source": "semantic"}
+    ]
+
+    findings = review_diff(diff_text, cache_lookup=lambda diff: cached_findings)
+
+    assert findings == cached_findings
     mock_verification_adapter.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Real production gap found while independently re-checking PR #547's own Flash Review findings after fixing all four (see that PR's history): finding #4 (a discarded-events bug in `flash_review_schema_context.py`) kept getting silently re-affirmed as still-open on the very push that fixed it, and on the push after that.

Verified directly against production logs on the scan-worker host: **zero LLM provider calls** (no `httpx2` activity to `api.deepseek.com` or `api.openai.com`) during the review job that supposedly re-confirmed the finding. The "still there" verdict never came from any fresh model reasoning about the fixed code at all.

## Root cause

Flash Review's similarity cache (`flash_review_cache.py`) serves findings from a past diff whenever a new diff's embedding scores ≥0.92 cosine similarity against it. My fix's diff, touching the same functions in the same file as the bug it fixed, cleared that bar easily.

The cache module's own docstring requires callers to re-validate before serving a cached finding, and `review_diff` does call `_validate_findings` (grounding) on every cache hit — but grounding's content check (`_line_citation_content_matches`) only verifies findings whose `issue` text quotes a real literal string (≥8 chars, in `'...'` or `"..."`). When there's nothing to quote, it unconditionally returns `True` ("nothing to check, don't false-reject a correct-but-unquotable finding").

That fallback is the right call for a **fresh** finding. It's backwards for a **cache hit**: a finding describing a logical/omission bug ("X is never done") never has a literal to quote by nature, so it gets zero real re-validation against the current diff and can be re-affirmed as still-open indefinitely — even long after the exact diff that fixes it.

## Fix

- Added `_has_verifiable_content_citation`, which reports whether grounding's content check had a real quote to verify against (vs. having fallen through to its own "nothing to check" case).
- In `review_diff`'s cache-hit branch, any kept finding that is LLM-sourced (not semantic — those are deterministic, code-verified evidence, not a model guess that goes stale the same way) and lacks a verifiable citation now gets a real, targeted re-check via the existing `_verify_findings_with_second_model` (ACCEPT/UNCERTAIN kept, REJECT dropped, fails open on error).
- This reuses the exact same ACCEPT/REJECT/UNCERTAIN mechanism already used for fresh findings on AIR-tier plans — applied here regardless of tier, since this closes a correctness bug, not a premium quality feature.
- Priced via `on_verification_usage` (always real DeepSeek cost), not `on_usage` (would misprice these tokens at `flash_review_model`'s rate — e.g. Luna — whenever that's what originally generated the cached finding).
- Deliberately narrow: only fires for the specific finding shape grounding cannot content-verify at all, not every cache hit. A cache-hit finding with a real quoted literal that still matches nearby content is untouched, preserving the cache's whole cost-saving point for the common case.

## Test plan

- [x] Rewrote `test_review_diff_never_reverifies_a_cache_hit` (which asserted the now-fixed bug's exact behavior) into `test_review_diff_does_not_reverify_a_cache_hit_finding_with_verifiable_content`, using a finding with real quotable content that should still skip re-verification.
- [x] New: recheck fires and ACCEPT keeps a non-quotable cache-hit finding.
- [x] New: REJECT drops it (the exact PR #547 scenario).
- [x] New: the recheck is priced via `on_verification_usage`, not `on_usage`.
- [x] New: a cached semantic-sourced finding is never sent to the recheck.
- [x] 188/188 in `test_flash_review.py`.
- [x] Full `github-app` suite: 1029 passed / 698 skipped (no local Postgres) / 3 failed — all pre-existing local-Redis-unavailable gaps (`test_llm_suggestion_opt_out`, `test_migrate`, `test_redis_client`), confirmed unrelated (same 3 failures present before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)