### PR TITLE
fix: ast_pattern batch isolation only caught BrokenProcessPool, no timeout

### DIFF
--- a/src/aletheore/ast_pattern.py
+++ b/src/aletheore/ast_pattern.py
@@ -40,6 +40,17 @@ one batch's worker, not the whole call: caught as BrokenProcessPool,
 every earlier batch's real results are kept, the remainder is marked
 truncated - the same honest-truncation contract _AST_PATTERN_MATCH_CAP/
 _AST_PATTERN_TOTAL_CHAR_BUDGET already use, not a silent gap. Verified
+
+CORRECTION (backward audit, this session): the original fix only caught
+BrokenProcessPool, so any OTHER exception inside a batch's worker (a bug
+in match/capture processing, MemoryError/RecursionError on a pathological
+file) propagated out of search_ast_pattern entirely, discarding every
+earlier batch's real results - not the honest-truncation contract the
+rest of this docstring claims. A hung worker (an infinite loop, not a
+crash) had no time bound at all either. Both fixed: future.result() now
+takes a timeout, and any exception (not just BrokenProcessPool) marks the
+result truncated and returns what was already collected, same as a
+segfault.
 against the exact case that crashed above: `(try_statement) @try` against
 Django's real tree, 20 consecutive runs, 0 crashes (see
 benchmarks/ast-pattern-benchmark/ for the full before/after methodology).
@@ -70,6 +81,7 @@ graph regardless of how many calls the parent process lives through.
 """
 
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 
@@ -108,6 +120,15 @@ _AST_PATTERN_TOTAL_CHAR_BUDGET = 100_000
 # here just changes how often a batch's worker gets recycled, not whether
 # results are silently incomplete.
 _AST_PATTERN_BATCH_SIZE = 200
+
+# A segfault (BrokenProcessPool) is fast and already caught below - this
+# bounds the other failure mode a crash doesn't cover: a worker that never
+# returns at all (an infinite loop or blocked I/O inside a pathological
+# file/query combination). Generous on purpose - a real batch of 200 files
+# is not expected to approach this - since the cost of guessing too low is
+# a real in-progress batch getting killed, not silent incompleteness (same
+# honest-truncation contract as every other cap in this module).
+_AST_PATTERN_BATCH_TIMEOUT_SECONDS = 60.0
 
 
 def _extensions_and_languages_for(language: str) -> list[tuple[str, object]]:
@@ -273,13 +294,39 @@ def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> dic
                 chars_remaining,
             )
             try:
-                batch_results, batch_chars, batch_truncated = future.result()
+                batch_results, batch_chars, batch_truncated = future.result(
+                    timeout=_AST_PATTERN_BATCH_TIMEOUT_SECONDS
+                )
             except BrokenProcessPool:
                 # This batch's worker segfaulted (see module docstring's
                 # FIX note). Every earlier batch's results are real and
                 # already in `results` - kept, not discarded. This batch's
                 # own in-flight work is lost, same as any other
                 # truncation: honest, not silent.
+                truncated = True
+                break
+            except FutureTimeoutError:
+                # Not a crash - the worker is still alive but exceeded its
+                # time budget, a failure mode BrokenProcessPool does not
+                # catch. Best-effort terminate it: the executor's own
+                # shutdown() (below, at the `with` block's exit) waits for
+                # every worker to actually exit, which would block for
+                # exactly as long as the hang lasts otherwise - defeating
+                # the point of a timeout. `_processes` is private API, so
+                # this is wrapped defensively rather than assumed stable.
+                try:
+                    for process in executor._processes.values():
+                        process.terminate()
+                except Exception:
+                    pass
+                truncated = True
+                break
+            except Exception:
+                # Any other failure inside this batch's worker (a bug in
+                # match/capture processing, MemoryError/RecursionError on a
+                # pathological file) must not discard every earlier
+                # batch's real, already-collected results - same
+                # honest-truncation contract as a segfault or a timeout.
                 truncated = True
                 break
             results.extend(batch_results)

--- a/src/aletheore/ast_pattern.py
+++ b/src/aletheore/ast_pattern.py
@@ -80,6 +80,7 @@ down at call end, so nothing carries over into the next call's object
 graph regardless of how many calls the parent process lives through.
 """
 
+import logging
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from concurrent.futures.process import BrokenProcessPool
@@ -93,6 +94,9 @@ from aletheore.scanner.graph import (
     _iter_source_files,
     _read_and_parse,
 )
+
+
+logger = logging.getLogger("aletheore.ast_pattern")
 
 
 class UnknownLanguageError(Exception):
@@ -318,7 +322,18 @@ def search_ast_pattern(repo_path: Path, language: str, query_source: str) -> dic
                     for process in executor._processes.values():
                         process.terminate()
                 except Exception:
-                    pass
+                    # `_processes` is private API - if a future Python
+                    # version renames/removes it, this must degrade to
+                    # "the timeout still bounds our own wait, the worker
+                    # may linger a bit longer than ideal" rather than
+                    # crashing the whole search. Logged, not silent -
+                    # a real Flash Review finding on this PR: swallowing
+                    # this with a bare `pass` gave no way to notice if
+                    # the private API ever actually broke.
+                    logger.warning(
+                        "ast_pattern: could not terminate a hung batch worker "
+                        "after timeout (best-effort only)", exc_info=True,
+                    )
                 truncated = True
                 break
             except Exception:

--- a/src/tests/test_ast_pattern.py
+++ b/src/tests/test_ast_pattern.py
@@ -7,6 +7,53 @@ from aletheore.ast_pattern import (
 )
 
 
+class _FakeFuture:
+    """Stands in for concurrent.futures.Future so batch-outcome handling
+    (BrokenProcessPool / timeout / any other exception) can be exercised
+    deterministically and fast - a real segfault or a real hung worker is
+    exactly what this module's own docstring says is probabilistic and
+    needs a real large repo to reproduce even then, unsuitable for a fast
+    unit test."""
+
+    def __init__(self, value=None, exc=None):
+        self._value = value
+        self._exc = exc
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._value
+
+
+class _FakeProcess:
+    def __init__(self):
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+
+
+class _FakeExecutor:
+    """Stands in for ProcessPoolExecutor - submit() hands back the next
+    pre-scripted future in order, one per real batch search_ast_pattern
+    would submit."""
+
+    def __init__(self, futures):
+        self.futures = list(futures)
+        self.submitted_calls = []
+        self._processes = {"fake-pid": _FakeProcess()}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def submit(self, fn, *args, **kwargs):
+        self.submitted_calls.append((fn, args, kwargs))
+        return self.futures.pop(0)
+
+
 def test_search_ast_pattern_matches_a_function_with_a_try_statement(tmp_path):
     (tmp_path / "app.py").write_text(
         "def plain():\n"
@@ -197,3 +244,94 @@ def test_search_ast_pattern_drops_a_single_match_that_alone_exceeds_the_char_bud
     )
     assert total_chars <= 20
     assert result["truncated"] is True
+
+
+def test_search_ast_pattern_keeps_earlier_batches_when_a_later_worker_raises(tmp_path, monkeypatch):
+    """Real bug found via audit: only BrokenProcessPool was caught, so any
+    OTHER exception inside a batch's worker (a bug in match/capture
+    processing, MemoryError/RecursionError on a pathological file)
+    propagated out of search_ast_pattern entirely, discarding every
+    earlier batch's real, already-collected results instead of honoring
+    the same truncation contract a segfault gets."""
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "_AST_PATTERN_BATCH_SIZE", 1)
+    (tmp_path / "a.py").write_text("def f():\n    pass\n")
+    (tmp_path / "b.py").write_text("def g():\n    pass\n")
+
+    futures = [
+        _FakeFuture(value=([{"file": "a.py", "captures": {}}], 10, False)),
+        _FakeFuture(exc=RuntimeError("simulated worker bug")),
+    ]
+    fake_executor = _FakeExecutor(futures)
+    monkeypatch.setattr(ast_pattern_module, "ProcessPoolExecutor", lambda *a, **k: fake_executor)
+
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert result["matches"] == [{"file": "a.py", "captures": {}}]
+    assert result["truncated"] is True
+
+
+def test_search_ast_pattern_terminates_and_truncates_on_a_hung_worker(tmp_path, monkeypatch):
+    """Real bug found via audit: a hung worker (an infinite loop, not a
+    crash) had no time bound at all - future.result() was called with no
+    timeout. On a timeout, the still-alive worker process must be
+    terminated too, or the executor's own shutdown() at the `with` block's
+    exit would block waiting for it to exit, for exactly as long as the
+    hang lasts - defeating the timeout's purpose."""
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "_AST_PATTERN_BATCH_SIZE", 1)
+    (tmp_path / "a.py").write_text("def f():\n    pass\n")
+
+    fake_executor = _FakeExecutor([_FakeFuture(exc=ast_pattern_module.FutureTimeoutError())])
+    monkeypatch.setattr(ast_pattern_module, "ProcessPoolExecutor", lambda *a, **k: fake_executor)
+
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert result["matches"] == []
+    assert result["truncated"] is True
+    assert all(p.terminated for p in fake_executor._processes.values())
+
+
+def test_search_ast_pattern_still_honors_broken_process_pool(tmp_path, monkeypatch):
+    from concurrent.futures.process import BrokenProcessPool
+
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "_AST_PATTERN_BATCH_SIZE", 1)
+    (tmp_path / "a.py").write_text("def f():\n    pass\n")
+    (tmp_path / "b.py").write_text("def g():\n    pass\n")
+
+    futures = [
+        _FakeFuture(value=([{"file": "a.py", "captures": {}}], 10, False)),
+        _FakeFuture(exc=BrokenProcessPool("simulated segfault")),
+    ]
+    fake_executor = _FakeExecutor(futures)
+    monkeypatch.setattr(ast_pattern_module, "ProcessPoolExecutor", lambda *a, **k: fake_executor)
+
+    result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert result["matches"] == [{"file": "a.py", "captures": {}}]
+    assert result["truncated"] is True
+
+
+def test_search_ast_pattern_uses_a_fresh_worker_process_per_batch(tmp_path, monkeypatch):
+    """max_tasks_per_child=1 is load-bearing (see module docstring) - the
+    default reuses one worker across every submitted batch, which would
+    recreate the exact unbounded in-process accumulation the batching fix
+    exists to prevent."""
+    import aletheore.ast_pattern as ast_pattern_module
+
+    captured_kwargs = {}
+
+    def fake_process_pool_executor(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return _FakeExecutor([_FakeFuture(value=([], 0, False))])
+
+    (tmp_path / "a.py").write_text("def f():\n    pass\n")
+    monkeypatch.setattr(ast_pattern_module, "ProcessPoolExecutor", fake_process_pool_executor)
+
+    search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert captured_kwargs.get("max_tasks_per_child") == 1

--- a/src/tests/test_ast_pattern.py
+++ b/src/tests/test_ast_pattern.py
@@ -54,6 +54,20 @@ class _FakeExecutor:
         return self.futures.pop(0)
 
 
+class _BrokenProcessesExecutor(_FakeExecutor):
+    """Simulates `_processes` being unavailable - e.g. a future Python
+    version renaming/removing the private attribute the best-effort
+    timeout termination relies on."""
+
+    @property
+    def _processes(self):
+        raise AttributeError("simulated: _processes no longer exists")
+
+    @_processes.setter
+    def _processes(self, value):
+        pass
+
+
 def test_search_ast_pattern_matches_a_function_with_a_try_statement(tmp_path):
     (tmp_path / "app.py").write_text(
         "def plain():\n"
@@ -292,6 +306,32 @@ def test_search_ast_pattern_terminates_and_truncates_on_a_hung_worker(tmp_path, 
     assert result["matches"] == []
     assert result["truncated"] is True
     assert all(p.terminated for p in fake_executor._processes.values())
+
+
+def test_search_ast_pattern_logs_but_does_not_crash_if_termination_itself_fails(
+    tmp_path, monkeypatch, caplog
+):
+    """Real Flash Review finding on this PR: the best-effort termination's
+    own `except Exception: pass` swallowed a failure with zero logging -
+    if `_processes` (private API) ever becomes unavailable, there would
+    be no way to notice. Must degrade to "still bounded by the timeout,
+    just couldn't terminate the worker" - never crash the whole search,
+    and never stay silent about it either."""
+    import aletheore.ast_pattern as ast_pattern_module
+
+    monkeypatch.setattr(ast_pattern_module, "_AST_PATTERN_BATCH_SIZE", 1)
+    (tmp_path / "a.py").write_text("def f():\n    pass\n")
+
+    fake_executor = _BrokenProcessesExecutor(
+        [_FakeFuture(exc=ast_pattern_module.FutureTimeoutError())]
+    )
+    monkeypatch.setattr(ast_pattern_module, "ProcessPoolExecutor", lambda *a, **k: fake_executor)
+
+    with caplog.at_level("WARNING", logger="aletheore.ast_pattern"):
+        result = search_ast_pattern(tmp_path, "python", "(function_definition) @f")
+
+    assert result == {"matches": [], "truncated": True}
+    assert any("could not terminate" in record.message for record in caplog.records)
 
 
 def test_search_ast_pattern_still_honors_broken_process_pool(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Backward audit of PR #511 (AST pattern search feature), #521 (result cap + crash resilience), and #537 (batched subprocess isolation for a real tree-sitter segfault), run against the real merged code with a research subagent that verified every claim directly against the installed `tree_sitter` package and the actual source, not the PR descriptions.

## What was found and fixed

`#537`'s batch isolation fix only actually isolated one specific failure mode - a segfault (`BrokenProcessPool`). Two real gaps in the same mechanism:

1. **Any non-`BrokenProcessPool` exception discarded every earlier batch's real results.** `future.result()` was wrapped in `except BrokenProcessPool` only. A bug in match/capture processing, a `MemoryError`/`RecursionError` on a pathological file, or any other worker-side exception propagated straight out of `search_ast_pattern`, losing every batch's already-collected, real matches - not the "every earlier batch's real results are kept" contract the module's own docstring documents. Fixed: any exception now marks the result `truncated` and returns what was already collected, exactly like the segfault path already did.

2. **No timeout on `future.result()` at all.** A hung worker (an infinite loop, blocked I/O) had no time bound, unlike a segfault, which is fast and was already caught. Added `_AST_PATTERN_BATCH_TIMEOUT_SECONDS = 60.0` and a best-effort `process.terminate()` on timeout - without actually terminating the process, the executor's own `shutdown(wait=True)` at the `with` block's exit would block for exactly as long as the hang lasts, defeating the point of the timeout.

**Also found**: zero test coverage existed for the batch isolation mechanism itself - the actual subject of #537. Reverting `max_tasks_per_child=1` (called "load-bearing, not a tuning knob" in the module's own comment), the `except BrokenProcessPool` handling, or cross-batch cap accumulation would all have passed the full test suite silently. Added 5 new tests using a fake `ProcessPoolExecutor`/`Future` pair - a real segfault or hang is exactly what the module's own docstring says is probabilistic and needs a real large repo (Django's ~2,930-file tree) to reproduce even then, unsuitable for a fast unit test - covering: a generic exception keeps earlier batches, a timeout terminates the worker, the existing `BrokenProcessPool` behavior still holds, and `max_tasks_per_child=1` is actually passed through to the real executor.

**Investigated, not fixed (documented, no clean API exists):** the match cap (`_AST_PATTERN_MATCH_CAP`) doesn't reduce per-file query cost, only formatting cost after the fact. Confirmed directly against the installed `tree_sitter` package: `QueryCursor.matches()` eagerly materializes every match for a file before the cap-checking loop even starts iterating - there's no lazy/limited variant in the public API. Cross-file and cross-batch savings (skipping subsequent files/batches once the cap triggers) are real and unaffected; only a single file with a very large number of matches still pays its full per-file query cost regardless of the cap. Documented this precisely in the module docstring rather than attempting a workaround with no clean implementation.

## Test plan

- [x] 5 new tests in `test_ast_pattern.py`, all using a fake executor/future to exercise the new exception/timeout handling deterministically and fast (a real crash repro would be flaky/slow and is the module's own stated reason for not being unit-testable directly)
- [x] Full `test_ast_pattern.py`: 16/16 passed
- [x] Full `src/tests` suite green: 1685 passed
- [x] Manually verified the real (non-mocked) `ProcessPoolExecutor` path still works end-to-end after the change (a real subprocess batch, real match, real result)

Part of an ongoing backward audit of recently merged PRs per user request - not merging, opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC6FTd9tYyiPHWXLjMxXqM