### PR TITLE
fix: Flash Review's ignored_paths only scrubbed diff text, not changed_files

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -447,6 +447,7 @@ def fetch_pr_changed_files(
     repo_full_name: str,
     base_ref: str,
     head_ref: str,
+    ignored_paths: list[str] = (),
 ) -> list[str]:
     headers = {
         "Authorization": f"token {token}",
@@ -457,7 +458,16 @@ def fetch_pr_changed_files(
         headers=headers,
     )
     response.raise_for_status()
-    return [file["filename"] for file in response.json().get("files", [])]
+    filenames = [file["filename"] for file in response.json().get("files", [])]
+    # Same exclusion fetch_pr_diff already applies to diff text - without
+    # it here too, Flash Review's schema/endpoint context and full-file-
+    # content fetch (both built from this list, see _run_flash_review)
+    # could still surface facts about a path a customer explicitly
+    # configured .aletheore.json's ignored_paths to exclude, even though
+    # the diff text itself was correctly scrubbed.
+    if ignored_paths:
+        filenames = [f for f in filenames if not is_ignored(f, ignored_paths)]
+    return filenames
 
 
 def fetch_pr_context(

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1889,6 +1889,15 @@ def _run_flash_review(
     # everything), matching every other config-read in this codebase's
     # fail-open-on-infra-error discipline - a missing config must never
     # block the review that's this job's actual deliverable.
+    #
+    # Passed to BOTH fetch_pr_diff AND fetch_pr_changed_files below - an
+    # earlier version only threaded it into the diff fetch, so an ignored
+    # file's raw diff text was scrubbed from the prompt but its full
+    # content was still fetched and its schema/endpoint facts (via
+    # build_schema_endpoint_context, which reads from changed_files, not
+    # diff_text) could still surface in commentary about a different,
+    # non-ignored file - the exact leak this whole mechanism exists to
+    # close, just via a second, separate file-listing call.
     try:
         repo_config_text = fetch_file_content(client, token, repo_full_name, ".aletheore.json", ref=head_sha)
     except Exception:  # noqa: BLE001
@@ -1918,7 +1927,9 @@ def _run_flash_review(
             len(diff_budget_omitted_files),
             ", ".join(diff_budget_omitted_files[:10]),
         )
-    changed_files = fetch_pr_changed_files(client, token, repo_full_name, diff_base, head_sha)
+    changed_files = fetch_pr_changed_files(
+        client, token, repo_full_name, diff_base, head_sha, ignored_paths=ignored_paths
+    )
     # GitHub's changed-files listing carries no relevance ordering - sorted
     # once here so every downstream context builder (evidence, dependency
     # impact, referenced symbols, file content) sees the most surgical

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -615,6 +615,38 @@ def test_fetch_pr_changed_files_returns_filenames():
     assert result == ["app.py", "lib.py"]
 
 
+def test_fetch_pr_changed_files_excludes_files_matching_ignored_paths():
+    # Real gap found via audit: fetch_pr_diff's ignored_paths exclusion
+    # (test_fetch_pr_diff_excludes_files_matching_ignored_paths above) was
+    # never mirrored here. _run_flash_review's schema/endpoint context and
+    # full-file-content fetch are both built from THIS list, not diff
+    # text - an ignored file's raw diff text was scrubbed from the prompt,
+    # but its full content was still fetched and its schema/endpoint
+    # facts could still surface in commentary about a different file.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"files": [{"filename": "vendor/lib.js"}, {"filename": "src/app.py"}]},
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    result = fetch_pr_changed_files(
+        client, "tok", "octocat/hello-world", "aaa", "bbb", ignored_paths=["vendor/**"]
+    )
+
+    assert result == ["src/app.py"]
+
+
+def test_fetch_pr_changed_files_with_no_ignored_paths_includes_every_file():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"files": [{"filename": "vendor/lib.js"}]})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    result = fetch_pr_changed_files(client, "tok", "octocat/hello-world", "aaa", "bbb")
+
+    assert result == ["vendor/lib.js"]
+
+
 def test_fetch_file_content_decodes_base64():
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/repos/octocat/hello-world/contents/app.py"

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2436,13 +2436,18 @@ def test_flash_review_job_excludes_aletheore_json_ignored_paths_from_the_diff(mo
         ),
     )
     diff_calls = []
+    changed_files_calls = []
 
     def fake_fetch_pr_diff(client, token, repo, base, head, ignored_paths=()):
         diff_calls.append(list(ignored_paths))
         return "--- app.py ---\n+bug"
 
+    def fake_fetch_pr_changed_files(client, token, repo, base, head, ignored_paths=()):
+        changed_files_calls.append(list(ignored_paths))
+        return ["app.py"]
+
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", fake_fetch_pr_diff)
-    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", fake_fetch_pr_changed_files)
     monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
     monkeypatch.setattr("scan_worker.jobs.review_diff", lambda diff_text, file_context="", **kwargs: [])
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
@@ -2467,6 +2472,13 @@ def test_flash_review_job_excludes_aletheore_json_ignored_paths_from_the_diff(mo
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
     assert diff_calls == [["vendor/**"]]
+    # Real bug found via audit: an earlier version of this fix only
+    # threaded ignored_paths into fetch_pr_diff, not fetch_pr_changed_files -
+    # an ignored file's raw diff text was scrubbed from the prompt, but
+    # its full content was still fetched and its schema/endpoint facts
+    # (which build_schema_endpoint_context reads from changed_files, not
+    # diff_text) could still leak into the review.
+    assert changed_files_calls == [["vendor/**"]]
 
 
 def test_flash_review_comment_body_prefixes_the_symbol_when_present():


### PR DESCRIPTION
## Summary

Backward audit of PR #504 (fix: Flash Review never consulted `.aletheore.json`'s `ignored_paths`), found via a research subagent that traced every place `_run_flash_review` lists PR files, not just the one #504 touched.

## What was found and fixed

`_run_flash_review` makes two separate GitHub API calls to learn what files are in a PR:

1. `fetch_pr_diff` (jobs.py:1897) - #504 correctly threaded `ignored_paths` into this one, filtering ignored files out of the diff text.
2. `fetch_pr_changed_files` (jobs.py:1921) - a **separate** call returning the PR's changed-file list, used to drive full-content fetching for review, `build_code_evidence_context`, `build_dependency_impact_context`, `build_blast_radius_context`, and **`build_schema_endpoint_context`**. This one had no `ignored_paths` parameter at all and was never filtered.

**Concrete leak this closes**: a customer configures `.aletheore.json` to ignore `vendor/**`. A vendored migration file changes in a PR. Flash Review's diff text correctly omits it - but its full content is still fetched, and if it defines a database table, that table's schema facts can still be injected into `build_schema_endpoint_context` and surface in commentary about a *different*, non-ignored file that references the same table. This is exactly the kind of leak #504's own stated goal ("a customer who configured an ignored path still got Flash Review PR comments about exactly that path") was meant to close - just via a second file-listing path that fix never reached.

**Fix**: gave `fetch_pr_changed_files` the same `ignored_paths` parameter and filtering `fetch_pr_diff` already has (mirroring its exact pattern, including reusing the same `is_ignored` helper), and threaded the same `ignored_paths` value `_run_flash_review` already computes into both calls.

## Test plan

- [x] New `github_api.py`-level tests: `fetch_pr_changed_files` excludes matching paths when `ignored_paths` is given, includes everything when it's not (mirroring the existing `fetch_pr_diff` test pair)
- [x] Extended #504's own end-to-end job test (`test_flash_review_job_excludes_aletheore_json_ignored_paths_from_the_diff`) to also assert `fetch_pr_changed_files` now receives the same `ignored_paths` `fetch_pr_diff` does - this is the test that would have caught the original gap
- [x] Full `github-app` test suite green: 1747 passed, 8 skipped

Part of an ongoing backward audit of recently merged PRs per user request - not merging, opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC6FTd9tYyiPHWXLjMxXqM