### PR TITLE
fix: embedding truncation cap left stale after switching default to jina

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -100,17 +100,26 @@ def _default_confirm_openai_fallback() -> bool:
 # first function doesn't produce one enormous chunk that matches everything.
 MODULE_CHUNK_MAX_LINES = 80
 
-# nomic-embed-text has a hard 2048-token training context, and the hosted
-# side already learned this the expensive way: scan_worker/embedding_client.py
-# records that 6600 chars succeeded and 6990 failed against the real model,
-# and that its cache sat at a 0% hit rate for 38 hours before anyone noticed
-# every call was failing. 5000 keeps that same margin. The constant is
-# restated rather than imported because src/ must not depend on github-app/ -
-# the dependency runs the other way.
+# Was 5000, sized for nomic-embed-text's hard 2048-token training context
+# (scan_worker/embedding_client.py records that 6600 chars succeeded and
+# 6990 failed against that real model). DEFAULT_EMBEDDING_MODEL has since
+# switched to jina-embeddings-v2-base-code (see this file's own history),
+# which supports 8192 tokens - 4x nomic's - but this cap was never
+# re-tuned after that switch, so real function bodies (this is the
+# retrieval-quality path, unlike embedding_client.py's cache-similarity
+# use of the same old number, which stays conservative on purpose since
+# an exact match isn't needed there) were being truncated at only ~18%
+# of the real available context. Re-measured directly against jina's own
+# bundled tokenizer (_hosted_tokenizer, below) on real repo code: 20,000
+# chars tokenizes to ~5,100-5,200 tokens across multiple real files -
+# about a 36% margin under the 8192 real limit, comparable to the
+# original cap's margin under nomic's limit. The constant is restated
+# rather than imported because src/ must not depend on github-app/ - the
+# dependency runs the other way.
 #
 # Truncating rather than skipping: a genuinely large function should still be
 # findable by its opening, which is where the signature and docstring are.
-MAX_EMBEDDING_CHARS = 5000
+MAX_EMBEDDING_CHARS = 20_000
 
 # Directories and suffixes whose contents are not this repository's code.
 # Measured on this repo: one minified bundle (website/vendor/motion.js) was

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -1452,9 +1452,9 @@ def test_vendored_and_minified_files_are_not_indexed(tmp_path):
 
 
 def test_chunk_text_is_truncated_to_the_embedding_limit(tmp_path):
-    """nomic-embed-text has a hard 2048-token context. The hosted side already
-    learned this: 6600 chars succeeded, 6990 failed, and its cache sat at a 0%
-    hit rate for 38 hours because every call was silently failing."""
+    """A genuinely oversized chunk must still be clipped before embedding -
+    see MAX_EMBEDDING_CHARS' own comment for the real jina-tokenizer
+    measurement behind its current value."""
     huge = "x = 1  # " + "y" * 40_000
     (tmp_path / "big.py").write_text(f"def f():\n    {huge}\n")
     evidence = {"repository": {"modules": [{


### PR DESCRIPTION
## Summary

Backward audit of PR #515 (real token-based batching for hosted embedding indexing) and PR #516 (default local embedding switched to jina, matching the hosted model), found via a research subagent that verified the claim directly against this codebase's own already-documented facts, not an external source.

## What was found and fixed

`github-app/scan_worker/embedding_client.py:16` already states, in its own comment, that jina-embeddings-v2-base-code supports an 8192-token context - 4x nomic-embed-text's hard 2048-token limit. But `src/aletheore/search_index.py`'s `MAX_EMBEDDING_CHARS` (the cap used when building chunks for real semantic search/retrieval, a different code path from `embedding_client.py`'s cache-similarity use of the same old number) was never revisited after PR #516 switched the default model - it stayed at 5000, a value whose own comment explicitly derived it from nomic's 2048-token limit.

Measured directly against jina's own bundled tokenizer (`_hosted_tokenizer` - already loaded elsewhere in this same file for the real token-based batching #515 added) on real repository Python files: 5000 chars tokenizes to only ~1,465 tokens - about **18%** of jina's real 8192-token budget. Every chunk over that size (a genuinely large real function) was being truncated at a boundary sized for a model this codebase no longer uses by default, discarding real, embeddable content - directly undercutting the retrieval-quality benefit #516 was switching models to get. Not a crash; a precision/recall regression for large chunks specifically.

**Fix**: re-measured a new value the same way the original was derived - a comfortable margin under the real limit, not the exact edge. 20,000 chars tokenizes to ~5,100-5,200 tokens across multiple real files tested - about a 36% margin under 8192, comparable to the original cap's margin under nomic's 2048.

**Deliberately not touched**: `embedding_client.py`'s own, separate `MAX_EMBEDDING_CHARS = 5000` (used for evidence-packet/Flash-Review similarity-cache embeddings). That constant already carries its own explicit, sound reasoning for staying conservative regardless of the underlying model's real context size - a cache hit is always re-verified against current evidence regardless of how it was found, so an exact-text match isn't needed there the way it is for actual semantic search quality. Different purpose, not the same bug.

## Test plan

- [x] Full `test_search_index.py`: 130 passed (including the existing oversized-chunk truncation test, updated to drop its now-stale nomic-specific docstring - it still exercises real truncation at the new, larger threshold since its fixture is 40,000 chars)
- [x] Full `src/tests` suite green: 1681 passed
- [x] New cap verified against the real, locally-bundled jina tokenizer (no network call needed) rather than assumed from a chars-per-token guess

Part of an ongoing backward audit of recently merged PRs per user request - not merging, opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC6FTd9tYyiPHWXLjMxXqM