### PR TITLE
fix: claude-desktop mcp-install key collision for repos sharing a basename

### DIFF
--- a/src/aletheore/cli.py
+++ b/src/aletheore/cli.py
@@ -1,4 +1,5 @@
 import difflib
+import hashlib
 import json
 import os
 import shutil
@@ -1130,6 +1131,23 @@ def _claude_desktop_config_path() -> Path | None:
     return None
 
 
+def _claude_desktop_server_name(repo_path: Path) -> str:
+    """A key for this repo's entry in Claude Desktop's one global,
+    shared-across-every-project config file.
+
+    Real gap found via audit: keying purely by `repo_path.name` (e.g.
+    "aletheore-backend") still collides for two different repos that
+    happen to share a directory basename - a common real pattern
+    (`~/work/client-a/backend` and `~/work/client-b/backend`), which is
+    exactly the class of silent-overwrite bug this keying scheme was
+    written to prevent, just not fully closed. A short hash of the full
+    resolved path guarantees uniqueness regardless of basename, same
+    convention search_index.py's own per-repo cache key already uses.
+    """
+    digest = hashlib.sha256(str(repo_path.resolve()).encode("utf-8")).hexdigest()[:16]
+    return f"aletheore-{repo_path.name}-{digest}"
+
+
 def _write_json_mcp_client_config(
     config_path: Path, top_level_key: str, entry: dict, *, server_name: str = "aletheore"
 ) -> str:
@@ -1208,9 +1226,11 @@ def _mcp_install(path: str, targets: list[str]) -> int:
                 # entry as plain "aletheore" would mean installing for a
                 # second repo silently overwrites the first repo's entry
                 # under the same key, since both would collide in the one
-                # shared file.
+                # shared file. See _claude_desktop_server_name's own
+                # docstring for why a plain repo_path.name isn't enough.
                 message = _write_json_mcp_client_config(
-                    config_path, "mcpServers", entry, server_name=f"aletheore-{repo_path.name}"
+                    config_path, "mcpServers", entry,
+                    server_name=_claude_desktop_server_name(repo_path),
                 )
         else:
             relative_path, top_level_key, entry_builder = _MCP_CLIENT_CONFIGS[target]
@@ -1267,9 +1287,9 @@ def _mcp_install(path: str, targets: list[str]) -> int:
         else:
             console.print(
                 f"[bold]Claude Desktop:[/bold] wrote a config shared across every project on this "
-                f"machine, keyed as \"aletheore-{repo_path.name}\" so installing for a different repo "
-                "later won't overwrite this one. Fully quit and reopen Claude Desktop to pick it up - "
-                "MCP servers only load at startup."
+                f"machine, keyed as \"{_claude_desktop_server_name(repo_path)}\" so installing for a "
+                "different repo later won't overwrite this one. Fully quit and reopen Claude Desktop "
+                "to pick it up - MCP servers only load at startup."
             )
     return 0
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -18,6 +18,7 @@ from aletheore.cli import (
     _resolve_path,
     _aletheore_command,
     _claude_desktop_config_path,
+    _claude_desktop_server_name,
     _ElapsedTicker,
     _MCP_CLIENT_CONFIGS,
     _make_progress_printer,
@@ -521,9 +522,10 @@ def test_mcp_install_writes_claude_desktop_target(tmp_path, monkeypatch):
     config_path = fake_home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
     assert config_path.exists()
     data = json.loads(config_path.read_text())
-    # Keyed by repo name, not plain "aletheore" - this file is shared across
+    # Keyed by repo name plus a hash of its resolved path, not plain
+    # "aletheore" or just the repo name alone - this file is shared across
     # every project on the machine, unlike every other target's per-repo file.
-    entry = data["mcpServers"][f"aletheore-{install_target.name}"]
+    entry = data["mcpServers"][_claude_desktop_server_name(install_target)]
     assert entry == {"command": "aletheore", "args": ["mcp", str(install_target.resolve())]}
 
 
@@ -544,8 +546,41 @@ def test_mcp_install_claude_desktop_keys_by_repo_so_a_second_repo_does_not_clobb
 
     config_path = fake_home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
     servers = json.loads(config_path.read_text())["mcpServers"]
-    assert servers["aletheore-repo-a"]["args"] == ["mcp", str(repo_a.resolve())]
-    assert servers["aletheore-repo-b"]["args"] == ["mcp", str(repo_b.resolve())]
+    assert servers[_claude_desktop_server_name(repo_a)]["args"] == ["mcp", str(repo_a.resolve())]
+    assert servers[_claude_desktop_server_name(repo_b)]["args"] == ["mcp", str(repo_b.resolve())]
+
+
+def test_mcp_install_claude_desktop_keys_by_full_path_not_just_basename(tmp_path, monkeypatch):
+    # Real bug found via audit: keying purely by repo_path.name still
+    # collided for two different repos sharing a directory basename (a
+    # common real pattern - e.g. `~/work/client-a/backend` and
+    # `~/work/client-b/backend`), silently overwriting one repo's entry
+    # with the other's - exactly the class of bug this keying scheme was
+    # written to prevent, just not fully closed by name alone.
+    fake_home = tmp_path / "fake-home"
+    monkeypatch.setattr("aletheore.cli.sys.platform", "darwin")
+    monkeypatch.setenv("HOME", str(fake_home))
+    _no_command_resolvable(monkeypatch, tmp_path)
+    client_a = tmp_path / "client-a" / "backend"
+    client_b = tmp_path / "client-b" / "backend"
+    client_a.mkdir(parents=True)
+    client_b.mkdir(parents=True)
+
+    runner.invoke(app, ["mcp-install", str(client_a), "--target", "claude-desktop"])
+    runner.invoke(app, ["mcp-install", str(client_b), "--target", "claude-desktop"])
+
+    config_path = fake_home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    servers = json.loads(config_path.read_text())["mcpServers"]
+    key_a = _claude_desktop_server_name(client_a)
+    key_b = _claude_desktop_server_name(client_b)
+    assert key_a != key_b
+    assert servers[key_a]["args"] == ["mcp", str(client_a.resolve())]
+    assert servers[key_b]["args"] == ["mcp", str(client_b.resolve())]
+
+
+def test_claude_desktop_server_name_is_stable_for_the_same_path():
+    path = Path("/some/repo")
+    assert _claude_desktop_server_name(path) == _claude_desktop_server_name(path)
 
 
 def test_mcp_install_skips_claude_desktop_on_unsupported_platform(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Audit of PR #557 ("feat: add Antigravity as an mcp-install target"), which - despite its title - also bundled a second, larger addition: a global `claude-desktop` mcp-install target. Found independently two ways: a research subagent verifying the merged code, and directly reading the diff myself after the user pointed out this addition specifically.

## What was found and fixed

`claude-desktop` writes to Claude Desktop's one config file, which is shared across every project on the machine - unlike every other `mcp-install` target, which writes a per-repo file. The PR itself already recognized and partially fixed a real overwrite risk: keying each entry as `f"aletheore-{repo_path.name}"` instead of a fixed `"aletheore"` key, specifically to avoid a second repo's install silently clobbering the first's entry.

But `repo_path.name` is only the trailing directory component, not a unique identifier. **Two different repositories that happen to share a directory basename** - a very common real pattern, e.g. `~/work/client-a/backend` and `~/work/client-b/backend`, or any two independently-cloned repos that both happen to be named `backend`/`api`/`app` - still collide under this key and silently overwrite each other's entry in the shared global file. This is exactly the class of bug the fix was written to prevent, just with a narrower collision boundary rather than a closed one. The PR's own new test for this (`test_mcp_install_claude_desktop_keys_by_repo_so_a_second_repo_does_not_clobber_the_first`) only exercises two *differently*-named repos (`repo-a`/`repo-b`), so it couldn't have caught the same-basename case.

**Fix**: new `_claude_desktop_server_name(repo_path)` folds a short hash of the repo's full resolved path into the key (the same convention `search_index.py`'s own per-repo cache key already uses elsewhere in this codebase), guaranteeing uniqueness regardless of basename while keeping the key human-readable (e.g. `aletheore-backend-a1b2c3d4...`).

## Test plan

- [x] New test reproducing the actual gap: two repos sharing a basename (`client-a/backend`, `client-b/backend`) now get distinct keys and neither entry is overwritten
- [x] New test confirming the key is stable for a given path (idempotent re-installs don't create duplicate entries)
- [x] Updated the existing tests to assert through the new `_claude_desktop_server_name` helper rather than a hardcoded key string, so they stay correct if the exact key format changes again
- [x] Full `src/tests` suite green: 1736 passed

Separately audited PR #556 (Rails ActiveRecord clustering-edges fix) via the same research subagent - no bug found; it already self-caught one real issue via its own dogfooded Flash Review before merging (a `polymorphic: false` presence-check bug), and correctly handles `belongs_to`/`has_one`/`has_many`/`has_and_belongs_to_many` plus `class_name:` resolution in both Ruby forms.

Not merging - opening for review, per the user's request to keep auditing PRs merged during this session by other concurrent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC6FTd9tYyiPHWXLjMxXqM