### PR TITLE
feat: auto-install and auto-start Ollama for local embeddings

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -1027,15 +1027,27 @@ def _try_auto_start_ollama_server(base_url: str = DEFAULT_EMBEDDING_BASE_URL) ->
     start it in the background instead of telling the user to run a
     separate command.
 
-    Started detached (`start_new_session=True` on POSIX puts it in its own
-    process group and session, so it is not a child of this process in any
-    way the OS would clean up together) so it outlives this specific
-    command rather than dying when Aletheore exits. This is deliberate:
-    Aletheore never stops a server it starts, here or anywhere else -
-    restarting it for every single command would cost real startup latency
-    on any repo the user indexes/scans more than once, and there's no way
-    to tell "Aletheore started this" apart from "the user was already
-    running it for something else" well enough to ever safely kill it.
+    Started detached so it outlives this specific command rather than
+    dying when Aletheore exits. This is deliberate: Aletheore never stops
+    a server it starts, here or anywhere else - restarting it for every
+    single command would cost real startup latency on any repo the user
+    indexes/scans more than once, and there's no way to tell "Aletheore
+    started this" apart from "the user was already running it for
+    something else" well enough to ever safely kill it.
+
+    "Detached" means something different per platform, both applied here:
+    on POSIX, `start_new_session=True` puts the child in its own process
+    group and session, so it is not a child of this process in any way
+    the OS would clean up together. On Windows, `start_new_session` does
+    not exist - the equivalent is `CREATE_NEW_PROCESS_GROUP` (so the
+    child does not receive a Ctrl+C/console-close event sent to this
+    process's console, which would otherwise kill it right along with
+    Aletheore) combined with `CREATE_NO_WINDOW` (ollama.exe is a console-
+    subsystem binary; without this it would flash a new console window
+    into existence for a server the user never asked to see). These
+    Windows flags are the documented `subprocess` constants for exactly
+    this "launch a detached background process" case - not independently
+    verified on a real Windows machine, unlike the POSIX path, which was.
 
     Returns True once the server is confirmed actually responding, False
     if `ollama` isn't on PATH, spawning failed, or it never came up within
@@ -1051,7 +1063,11 @@ def _try_auto_start_ollama_server(base_url: str = DEFAULT_EMBEDDING_BASE_URL) ->
     )
     try:
         popen_kwargs: dict = {}
-        if sys.platform != "win32":
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+            )
+        else:
             popen_kwargs["start_new_session"] = True
         subprocess.Popen(
             ["ollama", "serve"],

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -1,4 +1,5 @@
 import hashlib
+import ipaddress
 import os
 import re
 import shutil
@@ -926,6 +927,35 @@ def _ollama_setup_instructions(model: str, base_url: str) -> str:
     )
 
 
+def _is_loopback_base_url(base_url: str) -> bool:
+    """Whether `base_url` points at this machine itself, not some other
+    host on the network.
+
+    Real Flash Review finding on this PR: embed_texts' base_url is a
+    fully general parameter (nothing currently exposes overriding it to
+    point at a remote Ollama, but the function accepts one, and library
+    callers could) - the auto-install/auto-start recovery below only
+    ever makes sense for a LOCAL Ollama. Spawning `ollama serve` on this
+    machine does nothing to fix a remote host being unreachable; it just
+    leaves a pointless, permanently-running local server behind while
+    the real problem (a remote outage, a firewall, a typo'd URL) goes
+    completely unaddressed.
+
+    "localhost" is checked by name first since it is not a valid input to
+    ipaddress.ip_address (it is a hostname, not a literal IP) despite
+    universally resolving to a loopback address.
+    """
+    host = httpx.URL(base_url).host
+    if not host:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 # Real download+install time over an ordinary connection - see
 # OLLAMA_PULL_TIMEOUT_SECONDS' identical reasoning above: generous rather
 # than tight, since failing this just falls back to the same manual
@@ -1119,7 +1149,7 @@ def embed_texts(
         response = client.embeddings.create(model=model, input=texts)
         return [item.embedding for item in response.data]
     except Exception as ollama_exc:
-        if isinstance(ollama_exc, APIConnectionError):
+        if isinstance(ollama_exc, APIConnectionError) and _is_loopback_base_url(base_url):
             if shutil.which("ollama") is None:
                 _try_auto_install_ollama(ollama_install_confirm_fn)
             if shutil.which("ollama") is not None and _try_auto_start_ollama_server(base_url):

--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -926,18 +926,198 @@ def _ollama_setup_instructions(model: str, base_url: str) -> str:
     )
 
 
+# Real download+install time over an ordinary connection - see
+# OLLAMA_PULL_TIMEOUT_SECONDS' identical reasoning above: generous rather
+# than tight, since failing this just falls back to the same manual
+# instructions as before either feature existed.
+OLLAMA_INSTALL_TIMEOUT_SECONDS = 300
+
+# How long to wait for a freshly-spawned `ollama serve` to actually bind its
+# port and start answering - real-world local startup is sub-second, this is
+# headroom for a slow/loaded machine, not an expected wait.
+OLLAMA_SERVER_START_TIMEOUT_SECONDS = 30
+
+
+def _default_confirm_ollama_install() -> bool:
+    print(
+        "Ollama isn't installed. Aletheore can install it now (via the official "
+        "installer at https://ollama.com/install.sh) to run local, private "
+        "embeddings - nothing leaves this machine."
+    )
+    return input("Install Ollama now? [y/N]: ").strip().lower() == "y"
+
+
+def _try_auto_install_ollama(confirm_fn: Callable[[], bool] | None = None) -> bool:
+    """Ollama isn't on PATH at all - offers to run the real, official
+    installer Ollama's own docs publish for macOS and Linux
+    (https://ollama.com/install.sh), not a guessed command.
+
+    Windows has no equivalent scripted/silent install Ollama documents -
+    confirmed by checking their docs, same "verify, don't guess" discipline
+    already applied to the digest check above - so this returns False there
+    unconditionally, falling through to the existing manual-instructions
+    message instead.
+
+    Requires explicit confirmation before running anything: installing
+    software on someone's machine is not something this does silently, a
+    meaningfully bigger step than the automatic model pull above (which
+    only downloads model weights into Ollama's own existing data
+    directory, not a system-level install). Returns True only if the
+    installer ran successfully AND `ollama` is actually on PATH
+    afterward - never assumed from a clean exit code alone.
+    """
+    if sys.platform not in ("darwin", "linux"):
+        return False
+    if shutil.which("ollama") is not None:
+        return True
+    confirm = confirm_fn if confirm_fn is not None else _default_confirm_ollama_install
+    if not confirm():
+        return False
+
+    print(
+        "aletheore: installing Ollama via the official installer "
+        "(https://ollama.com/install.sh, this only happens once)...",
+        file=sys.stderr,
+    )
+    try:
+        script = httpx.get(
+            "https://ollama.com/install.sh", timeout=30.0, follow_redirects=True
+        )
+        script.raise_for_status()
+    except httpx.HTTPError as exc:
+        print(
+            f"aletheore: could not download Ollama's installer ({type(exc).__name__}); "
+            "continuing without it",
+            file=sys.stderr,
+        )
+        return False
+
+    try:
+        result = subprocess.run(
+            ["sh"],
+            input=script.text,
+            capture_output=True,
+            text=True,
+            timeout=OLLAMA_INSTALL_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(
+            f"aletheore: Ollama install failed ({type(exc).__name__}); continuing without it",
+            file=sys.stderr,
+        )
+        return False
+    if result.returncode != 0:
+        print(f"aletheore: Ollama install failed: {result.stderr.strip()}", file=sys.stderr)
+        return False
+    if shutil.which("ollama") is None:
+        print(
+            "aletheore: Ollama's installer exited cleanly but 'ollama' still isn't on "
+            "PATH - continuing without it",
+            file=sys.stderr,
+        )
+        return False
+    print("aletheore: Ollama installed", file=sys.stderr)
+    return True
+
+
+def _try_auto_start_ollama_server(base_url: str = DEFAULT_EMBEDDING_BASE_URL) -> bool:
+    """Ollama is installed but its server isn't reachable at `base_url` - a
+    normal state (installed but never launched, or a reboot that didn't
+    bring back a manually-started `ollama serve`), not a real failure - so
+    start it in the background instead of telling the user to run a
+    separate command.
+
+    Started detached (`start_new_session=True` on POSIX puts it in its own
+    process group and session, so it is not a child of this process in any
+    way the OS would clean up together) so it outlives this specific
+    command rather than dying when Aletheore exits. This is deliberate:
+    Aletheore never stops a server it starts, here or anywhere else -
+    restarting it for every single command would cost real startup latency
+    on any repo the user indexes/scans more than once, and there's no way
+    to tell "Aletheore started this" apart from "the user was already
+    running it for something else" well enough to ever safely kill it.
+
+    Returns True once the server is confirmed actually responding, False
+    if `ollama` isn't on PATH, spawning failed, or it never came up within
+    OLLAMA_SERVER_START_TIMEOUT_SECONDS - the caller falls back to the
+    same unavailable-provider handling as any other failure.
+    """
+    if shutil.which("ollama") is None:
+        return False
+    print(
+        "aletheore: Ollama is installed but its server isn't running - starting "
+        "'ollama serve' now...",
+        file=sys.stderr,
+    )
+    try:
+        popen_kwargs: dict = {}
+        if sys.platform != "win32":
+            popen_kwargs["start_new_session"] = True
+        subprocess.Popen(
+            ["ollama", "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            **popen_kwargs,
+        )
+    except OSError as exc:
+        print(
+            f"aletheore: could not start 'ollama serve' ({type(exc).__name__}); "
+            "continuing without it",
+            file=sys.stderr,
+        )
+        return False
+
+    # base_url is the OpenAI-compatible path (".../v1"); polled against
+    # Ollama's own native API root instead, matching
+    # _verify_ollama_model_digest's identical reasoning above.
+    native_root = base_url.rstrip("/").removesuffix("/v1")
+    deadline = time.monotonic() + OLLAMA_SERVER_START_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(f"{native_root}/api/tags", timeout=2.0)
+            if response.status_code == 200:
+                print("aletheore: Ollama server is up", file=sys.stderr)
+                return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.5)
+    print(
+        f"aletheore: 'ollama serve' didn't respond within "
+        f"{OLLAMA_SERVER_START_TIMEOUT_SECONDS}s - continuing without it",
+        file=sys.stderr,
+    )
+    return False
+
+
 def embed_texts(
     texts: list[str],
     base_url: str = DEFAULT_EMBEDDING_BASE_URL,
     model: str = DEFAULT_EMBEDDING_MODEL,
     credentials_path: Path = DEFAULT_CREDENTIALS_PATH,
     confirm_fn: Callable[[], bool] | None = None,
+    ollama_install_confirm_fn: Callable[[], bool] | None = None,
 ) -> list[list[float]]:
     client = OpenAI(base_url=base_url, api_key="not-needed")
     try:
         response = client.embeddings.create(model=model, input=texts)
         return [item.embedding for item in response.data]
     except Exception as ollama_exc:
+        if isinstance(ollama_exc, APIConnectionError):
+            if shutil.which("ollama") is None:
+                _try_auto_install_ollama(ollama_install_confirm_fn)
+            if shutil.which("ollama") is not None and _try_auto_start_ollama_server(base_url):
+                try:
+                    response = client.embeddings.create(model=model, input=texts)
+                    return [item.embedding for item in response.data]
+                except Exception as retry_exc:  # noqa: BLE001
+                    # Replaces the original for every message/chain below,
+                    # same reasoning as the auto-pull retry further down -
+                    # this could now be NotFoundError (server just started
+                    # or installed fresh, model not pulled yet), which
+                    # falls through to that exact handling next.
+                    ollama_exc = retry_exc
+
         if isinstance(ollama_exc, NotFoundError) and _try_auto_pull_ollama_model(model, base_url):
             try:
                 response = client.embeddings.create(model=model, input=texts)

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -25,6 +25,7 @@ from aletheore.search_index import (
     _embed_in_batches,
     _escape_sql_literal,
     _fts_candidates,
+    _is_loopback_base_url,
     _repo_id,
     _reusable_vectors,
     _rrf_fuse,
@@ -307,6 +308,30 @@ def test_embed_texts_installs_then_starts_ollama_when_binary_is_missing(
     mock_auto_start.assert_called_once_with(search_index_module.DEFAULT_EMBEDDING_BASE_URL)
 
 
+@patch("aletheore.search_index._try_auto_install_ollama")
+@patch("aletheore.search_index._try_auto_start_ollama_server")
+@patch("aletheore.search_index.has_api_key", return_value=False)
+@patch("aletheore.search_index.OpenAI")
+def test_embed_texts_never_auto_remediates_a_remote_base_url(
+    mock_openai_class, mock_has_api_key, mock_auto_start, mock_auto_install
+):
+    # Real Flash Review finding: base_url is fully general (accepts any
+    # host, even though nothing currently exposes overriding it to a
+    # remote Ollama) - auto-install/auto-start only ever make sense for a
+    # LOCAL Ollama. A remote host being unreachable must never spawn a
+    # pointless local `ollama serve`, or try installing Ollama locally
+    # either - neither does anything to fix a remote outage.
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.embeddings.create.side_effect = _ollama_connection_error()
+
+    with pytest.raises(EmbeddingProviderUnavailableError):
+        embed_texts(["chunk one"], base_url="http://embeddings.example.com/v1")
+
+    mock_auto_install.assert_not_called()
+    mock_auto_start.assert_not_called()
+
+
 @patch("aletheore.search_index._try_auto_install_ollama", return_value=False)
 @patch("aletheore.search_index.shutil.which", return_value=None)
 @patch("aletheore.search_index.has_api_key", return_value=False)
@@ -501,6 +526,40 @@ def test_try_auto_pull_returns_false_on_nonzero_exit(mock_which, mock_run):
 @patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
 def test_try_auto_pull_returns_false_when_subprocess_raises(mock_which, mock_run):
     assert _try_auto_pull_ollama_model("nomic-embed-text") is False
+
+
+# ---------------------------------------------------------------------------
+# _is_loopback_base_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://localhost:11434/v1",
+        "http://127.0.0.1:11434/v1",
+        "http://127.5.5.5:11434/v1",
+        "http://[::1]:11434/v1",
+    ],
+)
+def test_is_loopback_base_url_recognizes_real_loopback_forms(base_url):
+    assert _is_loopback_base_url(base_url) is True
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://embeddings.example.com/v1",
+        "http://192.168.1.50:11434/v1",
+        "https://10.0.0.5:11434/v1",
+    ],
+)
+def test_is_loopback_base_url_rejects_real_remote_hosts(base_url):
+    assert _is_loopback_base_url(base_url) is False
+
+
+def test_is_loopback_base_url_handles_a_url_with_no_host_gracefully():
+    assert _is_loopback_base_url("not-a-url") is False
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -241,7 +241,14 @@ def test_embed_texts_shows_setup_instructions_when_ollama_unreachable(
         embed_texts(["chunk one"], ollama_install_confirm_fn=lambda: False)
 
     message = str(exc_info.value)
-    assert "ollama.com" in message
+    # Not "ollama.com" - a bare-domain substring check reads to a static
+    # analyzer (CodeQL flagged this exact pre-existing pattern as
+    # py/incomplete-url-substring-sanitization) as an attempted URL-trust
+    # decision, which is genuinely bypassable there ("evil.com/ollama.com"
+    # also contains it) - irrelevant to what this assertion actually
+    # checks (that the setup-instructions hint text was used), but easy
+    # to avoid entirely by asserting on real instructional text instead.
+    assert "Ollama doesn't appear to be running" in message
     assert f"ollama pull {search_index_module.DEFAULT_EMBEDDING_MODEL}" in message
     assert "ollama serve" in message
 
@@ -334,7 +341,9 @@ def test_embed_texts_falls_through_to_setup_instructions_when_auto_start_fails(
     with pytest.raises(EmbeddingProviderUnavailableError) as exc_info:
         embed_texts(["chunk one"])
 
-    assert "ollama.com" in str(exc_info.value)
+    # Not "ollama.com" - see the identical CodeQL note on the sibling
+    # assertion above.
+    assert "Ollama doesn't appear to be running" in str(exc_info.value)
     # Only the original connection error should ever have been attempted -
     # a failed start must not retry the embeddings call at all.
     assert mock_client.embeddings.create.call_count == 1

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -28,7 +28,9 @@ from aletheore.search_index import (
     _repo_id,
     _reusable_vectors,
     _rrf_fuse,
+    _try_auto_install_ollama,
     _try_auto_pull_ollama_model,
+    _try_auto_start_ollama_server,
     build_chunks,
     build_index,
     embed_texts,
@@ -217,14 +219,114 @@ def test_embed_texts_raises_actionable_error_when_auto_pull_fails(
     )
 
 
+@patch("aletheore.search_index.shutil.which", return_value=None)
 @patch("aletheore.search_index.has_api_key", return_value=False)
 @patch("aletheore.search_index.OpenAI")
 def test_embed_texts_shows_setup_instructions_when_ollama_unreachable(
-    mock_openai_class, mock_has_api_key
+    mock_openai_class, mock_has_api_key, mock_which
 ):
     # Distinct from the model-not-found case above: Ollama itself isn't
     # running (or isn't installed) at all, so pulling a model would just
-    # fail too - point the user at real setup steps instead.
+    # fail too - point the user at real setup steps instead. shutil.which
+    # mocked to None (no ollama on PATH, and this platform-gated install
+    # attempt below returns False without prompting since sys.platform
+    # isn't overridden here) so the new auto-install/start attempt below
+    # cleanly declines rather than touching this test machine's real,
+    # actually-installed ollama.
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.embeddings.create.side_effect = _ollama_connection_error()
+
+    with pytest.raises(EmbeddingProviderUnavailableError) as exc_info:
+        embed_texts(["chunk one"], ollama_install_confirm_fn=lambda: False)
+
+    message = str(exc_info.value)
+    assert "ollama.com" in message
+    assert f"ollama pull {search_index_module.DEFAULT_EMBEDDING_MODEL}" in message
+    assert "ollama serve" in message
+
+
+@patch("aletheore.search_index._try_auto_start_ollama_server")
+@patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
+@patch("aletheore.search_index.OpenAI")
+def test_embed_texts_auto_starts_ollama_server_and_retries_when_connection_refused(
+    mock_openai_class, mock_which, mock_auto_start
+):
+    # ollama is already installed (on PATH) but its server isn't running -
+    # a normal first-run or post-reboot state - so this should start it
+    # and retry rather than making the user run 'ollama serve' themselves.
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.embeddings.create.side_effect = [
+        _ollama_connection_error(),
+        MagicMock(data=[MagicMock(embedding=[0.1, 0.2])]),
+    ]
+    mock_auto_start.return_value = True
+
+    result = embed_texts(["chunk one"])
+
+    assert result == [[0.1, 0.2]]
+    mock_auto_start.assert_called_once_with(search_index_module.DEFAULT_EMBEDDING_BASE_URL)
+    assert mock_client.embeddings.create.call_count == 2
+
+
+@patch("aletheore.search_index._try_auto_start_ollama_server")
+@patch("aletheore.search_index._try_auto_install_ollama")
+@patch("aletheore.search_index.shutil.which")
+@patch("aletheore.search_index.OpenAI")
+def test_embed_texts_installs_then_starts_ollama_when_binary_is_missing(
+    mock_openai_class, mock_which, mock_auto_install, mock_auto_start
+):
+    # Nothing on PATH at all (a genuinely fresh machine) - install must run
+    # BEFORE start is even attempted, and start must only be attempted once
+    # the binary is confirmed present afterward.
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.embeddings.create.side_effect = [
+        _ollama_connection_error(),
+        MagicMock(data=[MagicMock(embedding=[0.1, 0.2])]),
+    ]
+    # First check (before install): not on PATH. Second check (after a
+    # successful install): now on PATH.
+    mock_which.side_effect = [None, "/usr/local/bin/ollama"]
+    mock_auto_install.return_value = True
+    mock_auto_start.return_value = True
+
+    confirm = lambda: True  # noqa: E731
+    result = embed_texts(["chunk one"], ollama_install_confirm_fn=confirm)
+
+    assert result == [[0.1, 0.2]]
+    mock_auto_install.assert_called_once_with(confirm)
+    mock_auto_start.assert_called_once_with(search_index_module.DEFAULT_EMBEDDING_BASE_URL)
+
+
+@patch("aletheore.search_index._try_auto_install_ollama", return_value=False)
+@patch("aletheore.search_index.shutil.which", return_value=None)
+@patch("aletheore.search_index.has_api_key", return_value=False)
+@patch("aletheore.search_index.OpenAI")
+def test_embed_texts_does_not_attempt_start_when_install_fails(
+    mock_openai_class, mock_has_api_key, mock_which, mock_auto_install
+):
+    # If install fails (declined, network error, etc.), 'ollama' is still
+    # not on PATH - there is nothing to start, and attempting to would
+    # just be another guaranteed failure.
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.embeddings.create.side_effect = _ollama_connection_error()
+
+    with patch("aletheore.search_index._try_auto_start_ollama_server") as mock_auto_start:
+        with pytest.raises(EmbeddingProviderUnavailableError):
+            embed_texts(["chunk one"])
+        mock_auto_start.assert_not_called()
+
+
+@patch("aletheore.search_index._try_auto_start_ollama_server", return_value=False)
+@patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
+@patch("aletheore.search_index.has_api_key", return_value=False)
+@patch("aletheore.search_index.OpenAI")
+def test_embed_texts_falls_through_to_setup_instructions_when_auto_start_fails(
+    mock_openai_class, mock_has_api_key, mock_which, mock_auto_start
+):
     mock_client = MagicMock()
     mock_openai_class.return_value = mock_client
     mock_client.embeddings.create.side_effect = _ollama_connection_error()
@@ -232,10 +334,38 @@ def test_embed_texts_shows_setup_instructions_when_ollama_unreachable(
     with pytest.raises(EmbeddingProviderUnavailableError) as exc_info:
         embed_texts(["chunk one"])
 
-    message = str(exc_info.value)
-    assert "ollama.com" in message
-    assert f"ollama pull {search_index_module.DEFAULT_EMBEDDING_MODEL}" in message
-    assert "ollama serve" in message
+    assert "ollama.com" in str(exc_info.value)
+    # Only the original connection error should ever have been attempted -
+    # a failed start must not retry the embeddings call at all.
+    assert mock_client.embeddings.create.call_count == 1
+
+
+@patch("aletheore.search_index._try_auto_pull_ollama_model", return_value=True)
+@patch("aletheore.search_index._try_auto_start_ollama_server", return_value=True)
+@patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
+@patch("aletheore.search_index.OpenAI")
+def test_embed_texts_chains_into_auto_pull_after_a_fresh_server_start(
+    mock_openai_class, mock_which, mock_auto_start, mock_auto_pull
+):
+    # A server that just started (or was just installed) has no model
+    # pulled yet either - the retry after auto-start should itself hit
+    # NotFoundError and fall through into the EXISTING auto-pull-and-retry
+    # path, not a dead end. Three calls total: original failure, retry
+    # after start (still missing the model), retry after pull (succeeds).
+    mock_client = MagicMock()
+    mock_openai_class.return_value = mock_client
+    mock_client.embeddings.create.side_effect = [
+        _ollama_connection_error(),
+        _ollama_not_found_error(),
+        MagicMock(data=[MagicMock(embedding=[0.1, 0.2])]),
+    ]
+
+    result = embed_texts(["chunk one"])
+
+    assert result == [[0.1, 0.2]]
+    assert mock_client.embeddings.create.call_count == 3
+    mock_auto_start.assert_called_once()
+    mock_auto_pull.assert_called_once()
 
 
 @patch("aletheore.search_index.shutil.which", return_value=None)
@@ -362,6 +492,166 @@ def test_try_auto_pull_returns_false_on_nonzero_exit(mock_which, mock_run):
 @patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
 def test_try_auto_pull_returns_false_when_subprocess_raises(mock_which, mock_run):
     assert _try_auto_pull_ollama_model("nomic-embed-text") is False
+
+
+# ---------------------------------------------------------------------------
+# _try_auto_install_ollama
+# ---------------------------------------------------------------------------
+
+
+@patch("aletheore.search_index.sys.platform", "darwin")
+@patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
+def test_auto_install_returns_true_immediately_when_already_on_path(mock_which):
+    # Nothing to install - and critically, no confirm prompt should even
+    # be reached, since there is nothing to ask permission for.
+    confirm = MagicMock(return_value=False)
+    assert _try_auto_install_ollama(confirm) is True
+    confirm.assert_not_called()
+
+
+@patch("aletheore.search_index.sys.platform", "win32")
+@patch("aletheore.search_index.shutil.which", return_value=None)
+def test_auto_install_returns_false_on_windows_without_prompting(mock_which):
+    # Ollama documents no equivalent scripted/silent install for Windows -
+    # must not guess at one, and must not even ask, since there's nothing
+    # this code could actually do if the user said yes.
+    confirm = MagicMock(return_value=True)
+    assert _try_auto_install_ollama(confirm) is False
+    confirm.assert_not_called()
+
+
+@patch("aletheore.search_index.httpx.get")
+@patch("aletheore.search_index.sys.platform", "darwin")
+@patch("aletheore.search_index.shutil.which", return_value=None)
+def test_auto_install_does_not_download_anything_when_declined(mock_which, mock_get):
+    assert _try_auto_install_ollama(lambda: False) is False
+    mock_get.assert_not_called()
+
+
+@patch("aletheore.search_index.shutil.which")
+@patch("aletheore.search_index.subprocess.run")
+@patch("aletheore.search_index.httpx.get")
+@patch("aletheore.search_index.sys.platform", "darwin")
+def test_auto_install_downloads_and_runs_the_real_installer_script_on_confirm(
+    mock_get, mock_run, mock_which
+):
+    # Not on PATH before, on PATH after a clean install - the exact script
+    # Ollama's own docs publish, run via `sh`, not a guessed alternative.
+    mock_which.side_effect = [None, "/usr/local/bin/ollama"]
+    mock_get.return_value = MagicMock(text="#!/bin/sh\necho installing", status_code=200)
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    assert _try_auto_install_ollama(lambda: True) is True
+
+    mock_get.assert_called_once_with(
+        "https://ollama.com/install.sh", timeout=30.0, follow_redirects=True
+    )
+    run_args, run_kwargs = mock_run.call_args
+    assert run_args[0] == ["sh"]
+    assert run_kwargs["input"] == "#!/bin/sh\necho installing"
+
+
+@patch("aletheore.search_index.shutil.which", return_value=None)
+@patch("aletheore.search_index.subprocess.run")
+@patch("aletheore.search_index.httpx.get", side_effect=httpx.ConnectError("no network"))
+@patch("aletheore.search_index.sys.platform", "darwin")
+def test_auto_install_returns_false_when_the_installer_cannot_be_downloaded(
+    mock_get, mock_run, mock_which
+):
+    assert _try_auto_install_ollama(lambda: True) is False
+    mock_run.assert_not_called()
+
+
+@patch("aletheore.search_index.shutil.which", return_value=None)
+@patch("aletheore.search_index.subprocess.run", side_effect=OSError("no such file"))
+@patch("aletheore.search_index.httpx.get")
+@patch("aletheore.search_index.sys.platform", "darwin")
+def test_auto_install_returns_false_when_sh_is_unavailable(
+    mock_get, mock_run, mock_which
+):
+    mock_get.return_value = MagicMock(text="#!/bin/sh", status_code=200)
+    assert _try_auto_install_ollama(lambda: True) is False
+
+
+@patch("aletheore.search_index.shutil.which", return_value=None)
+@patch("aletheore.search_index.subprocess.run")
+@patch("aletheore.search_index.httpx.get")
+@patch("aletheore.search_index.sys.platform", "darwin")
+def test_auto_install_returns_false_on_nonzero_install_exit(
+    mock_get, mock_run, mock_which
+):
+    mock_get.return_value = MagicMock(text="#!/bin/sh", status_code=200)
+    mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="permission denied")
+
+    assert _try_auto_install_ollama(lambda: True) is False
+
+
+@patch("aletheore.search_index.shutil.which", return_value=None)
+@patch("aletheore.search_index.subprocess.run")
+@patch("aletheore.search_index.httpx.get")
+@patch("aletheore.search_index.sys.platform", "darwin")
+def test_auto_install_returns_false_when_ollama_still_not_on_path_after_clean_exit(
+    mock_get, mock_run, mock_which
+):
+    # A clean exit code alone is never trusted - only a real, re-checked
+    # PATH lookup counts as success.
+    mock_get.return_value = MagicMock(text="#!/bin/sh", status_code=200)
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    assert _try_auto_install_ollama(lambda: True) is False
+
+
+# ---------------------------------------------------------------------------
+# _try_auto_start_ollama_server
+# ---------------------------------------------------------------------------
+
+
+@patch("aletheore.search_index.shutil.which", return_value=None)
+def test_auto_start_returns_false_when_ollama_not_on_path(mock_which):
+    assert _try_auto_start_ollama_server() is False
+
+
+@patch("aletheore.search_index.time.sleep")
+@patch("aletheore.search_index.httpx.get")
+@patch("aletheore.search_index.subprocess.Popen")
+@patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
+def test_auto_start_spawns_serve_and_returns_true_once_reachable(
+    mock_which, mock_popen, mock_get, mock_sleep
+):
+    mock_get.side_effect = [
+        httpx.ConnectError("not up yet"),
+        MagicMock(status_code=200),
+    ]
+
+    assert _try_auto_start_ollama_server("http://localhost:11434/v1") is True
+
+    popen_args, popen_kwargs = mock_popen.call_args
+    assert popen_args[0] == ["ollama", "serve"]
+    mock_get.assert_called_with("http://localhost:11434/api/tags", timeout=2.0)
+
+
+@patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
+@patch("aletheore.search_index.subprocess.Popen", side_effect=OSError("cannot fork"))
+def test_auto_start_returns_false_when_spawning_fails(mock_popen, mock_which):
+    assert _try_auto_start_ollama_server() is False
+
+
+@patch("aletheore.search_index.time.sleep")
+@patch("aletheore.search_index.time.monotonic")
+@patch("aletheore.search_index.httpx.get", side_effect=httpx.ConnectError("still down"))
+@patch("aletheore.search_index.subprocess.Popen")
+@patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")
+def test_auto_start_gives_up_after_the_timeout(
+    mock_which, mock_popen, mock_get, mock_monotonic, mock_sleep
+):
+    # time.monotonic mocked so this test doesn't actually wait out the
+    # real OLLAMA_SERVER_START_TIMEOUT_SECONDS - one call to establish the
+    # deadline, one in-time while-check (attempt fails), one past-deadline
+    # while-check that ends the loop.
+    mock_monotonic.side_effect = [0.0, 5.0, 999.0]
+
+    assert _try_auto_start_ollama_server() is False
+    assert mock_get.call_count == 1
 
 
 @patch("aletheore.search_index.has_api_key", return_value=False)

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -627,7 +627,38 @@ def test_auto_start_spawns_serve_and_returns_true_once_reachable(
 
     popen_args, popen_kwargs = mock_popen.call_args
     assert popen_args[0] == ["ollama", "serve"]
+    # POSIX detachment: puts the child in its own session so it survives
+    # this process exiting rather than being cleaned up together.
+    assert popen_kwargs.get("start_new_session") is True
     mock_get.assert_called_with("http://localhost:11434/api/tags", timeout=2.0)
+
+
+@patch("aletheore.search_index.subprocess.CREATE_NO_WINDOW", 0x08000000, create=True)
+@patch("aletheore.search_index.subprocess.CREATE_NEW_PROCESS_GROUP", 0x00000200, create=True)
+@patch("aletheore.search_index.sys.platform", "win32")
+@patch("aletheore.search_index.time.sleep")
+@patch("aletheore.search_index.httpx.get")
+@patch("aletheore.search_index.subprocess.Popen")
+@patch("aletheore.search_index.shutil.which", return_value="C:\\ollama\\ollama.exe")
+def test_auto_start_uses_windows_detachment_flags_not_start_new_session(
+    mock_which, mock_popen, mock_get, mock_sleep
+):
+    # Real gap caught by the user: start_new_session doesn't exist on
+    # Windows - the equivalent is CREATE_NEW_PROCESS_GROUP (so a Ctrl+C to
+    # this process's console doesn't kill the detached server too) plus
+    # CREATE_NO_WINDOW (ollama.exe is a console-subsystem binary and would
+    # otherwise flash a visible window into existence). CREATE_NEW_PROCESS_
+    # GROUP/CREATE_NO_WINDOW don't exist on non-Windows `subprocess`
+    # modules at all (confirmed: hasattr is False on macOS/Linux), so
+    # they're patched in here with create=True rather than assumed present.
+    mock_get.return_value = MagicMock(status_code=200)
+
+    assert _try_auto_start_ollama_server() is True
+
+    popen_args, popen_kwargs = mock_popen.call_args
+    assert popen_args[0] == ["ollama", "serve"]
+    assert "start_new_session" not in popen_kwargs
+    assert popen_kwargs.get("creationflags") == 0x08000000 | 0x00000200
 
 
 @patch("aletheore.search_index.shutil.which", return_value="/usr/local/bin/ollama")


### PR DESCRIPTION
## Summary

Local embedding setup previously required the user to manually install Ollama, start its server, and pull the model before `aletheore index` would work - only the "server reachable but model not pulled" case was already automatic (`_try_auto_pull_ollama_model`, existing code). This closes the other two gaps.

## What changed

**`_try_auto_install_ollama`** - when the `ollama` binary isn't on PATH at all, offers (explicit y/N prompt) to run the real, official installer Ollama's own docs publish for macOS/Linux (`https://ollama.com/install.sh`). Windows has no equivalent documented scripted/silent install (confirmed by checking Ollama's own docs), so this returns `False` there unconditionally rather than guessing at an installer flag nothing confirms works - falls through to the existing manual instructions. Never installs silently: this is a meaningfully bigger step than the existing automatic model pull (which only touches Ollama's own data directory), so it's gated on explicit confirmation. Only returns `True` if `ollama` is actually on PATH afterward - never assumed from a clean installer exit code alone.

**`_try_auto_start_ollama_server`** - when the binary is installed but the server isn't reachable, spawns `ollama serve` detached (`start_new_session=True`) so it outlives this specific command, then polls until it responds or times out. Deliberately never stopped by Aletheore: restarting it on every command would cost real startup latency for anyone indexing/scanning a repo more than once, and there's no reliable way to distinguish "Aletheore started this" from "the user already had it running for something else" well enough to ever safely kill it.

Both wire into `embed_texts`'s existing exception-recovery chain as a new `APIConnectionError` branch that runs *before* the existing `NotFoundError`-driven auto-pull check - a freshly-installed-or-started server naturally chains straight into that existing auto-pull path if it also needs the model pulled, with zero special-casing needed for that combination.

## Test plan

- [x] 23 new tests: `_try_auto_install_ollama` and `_try_auto_start_ollama_server` in isolation (subprocess/httpx/shutil mocked - already-installed fast path, Windows unsupported, declined, download failure, `sh` unavailable, non-zero exit, clean-exit-but-still-missing, spawn failure, timeout with deterministic mocked clock), plus `embed_texts` integration tests for the full connection-error → install/start → retry → chains-into-existing-auto-pull flow
- [x] Full `src/tests` suite green: 1753 passed
- [x] `ruff check` clean on both changed files
- [x] **Verified for real, not just mocked**, per explicit request to check and recheck: confirmed via `ps aux` that this dev machine's actual running Ollama process predates this session (not spawned by any test run); ran a real `embed_texts()` call against the real local jina model to confirm the untouched happy path still works end-to-end (returned a real 768-dim vector); called the real, unmocked `_try_auto_install_ollama` against this machine's real PATH to confirm it correctly returns `True` with zero prompting when Ollama is already installed
- [x] Fixed a real bug in my own first draft of these tests before running them: `@patch(target, "explicit_value")` (used for `sys.platform`) injects no mock argument, unlike `@patch(target, return_value=...)` - this had shifted parameter lists in 5 of the new tests, caught and fixed by re-deriving the correct bottom-up decorator/argument order for each one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC6FTd9tYyiPHWXLjMxXqM