### PR TITLE
feat: raise Flash Review's per-file context cap to 100KB, Flash spend cap to $6

### DIFF
--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -54,15 +54,21 @@ PLAN_MONTHLY_PRICE_USD = {
 }
 
 # flash's real spend cap is a deliberately looser fraction of its price
-# than the shared 50% default below (62.5%, $5 of $8 - raised from $6 on
-# 2026-09-01, see paddle_pricing.py's price-swap comment) - real
-# worst-case cost for 1000 reviews of solo Luna generation (no
-# dual-agent verification, compact + trimmed diff) measured at ~$4.34,
-# i.e. ~$3.47 for the 800-review/month cap this tier actually enforces.
-# $5 leaves ~44% headroom over that measured figure (vs. the old $4
-# cap's ~15% over the same $3.47), enough margin for provider price
-# drift or a DeepSeek-fallback call (pricier per input token than Luna)
-# without needing to revisit this constant. See jobs.py's
+# than the shared 50% default below (75%, $6 of $8 - raised from $5 on
+# 2026-09-07 alongside github_api.MAX_CONTEXT_FILE_BYTES's 80KB->100KB
+# raise, which this headroom is specifically sized against). $5's own real
+# worst-case figure: ~$4.34 for 1000 reviews of solo Luna generation (no
+# dual-agent verification, compact + trimmed diff), i.e. ~$3.47 for the
+# 800-review/month cap this tier actually enforces, under the OLD 80KB
+# per-file context cap. Scaling that real figure by the same ratio the
+# 80KB->100KB raise applies to context size (1.25x, not a full 2x -
+# extrapolated from the 40KB->80KB raise's own measured ~2x cost impact,
+# not a fresh re-benchmark) gives an estimated ~$4.34/month under the new
+# 100KB cap. $6 leaves ~28% headroom over that estimate - closer to the
+# original 44% design margin the $5 cap had at 80KB than the ~13% a full
+# 2x raise to 120KB would have left, deliberately: the context-cap raise
+# was picked at 1.25x specifically to keep this margin close to its
+# original size rather than eroding it for a bigger win. See jobs.py's
 # MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH for the real review-count cap
 # (800) this was checked against.
 # air's real spend cap is a deliberately looser fraction of its price than
@@ -78,7 +84,7 @@ PLAN_MONTHLY_PRICE_USD = {
 # to make meaningful progress per catch-up cycle instead of the old cap
 # forcing an artificially small per-sweep batch just to stay under it.
 PLAN_CAP_OVERRIDE_USD = {
-    "flash": 5.00,
+    "flash": 6.00,
     "air": 20.00,
 }
 

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -64,11 +64,16 @@ PLAN_MONTHLY_PRICE_USD = {
 # 80KB->100KB raise applies to context size (1.25x, not a full 2x -
 # extrapolated from the 40KB->80KB raise's own measured ~2x cost impact,
 # not a fresh re-benchmark) gives an estimated ~$4.34/month under the new
-# 100KB cap. $6 leaves ~28% headroom over that estimate - closer to the
-# original 44% design margin the $5 cap had at 80KB than the ~13% a full
-# 2x raise to 120KB would have left, deliberately: the context-cap raise
-# was picked at 1.25x specifically to keep this margin close to its
-# original size rather than eroding it for a bigger win. See jobs.py's
+# 100KB cap. $6 leaves ~38% headroom over that estimate ((6.00-4.34)/4.34) -
+# close to the original 44% design margin the $5 cap had at 80KB, not the
+# thin ~15% a full 2x raise to 120KB would have left (120KB's own estimate:
+# $3.47 x 1.5 = ~$5.21/month, (6.00-5.21)/5.21 = ~15%) - both figures use
+# the same (cap-cost)/cost formula the original 44% used, not (cap-cost)/cap
+# (an earlier version of this comment mixed the two, understating this
+# margin as ~28% and the rejected alternative's as ~13% - found via
+# independent audit). Deliberate: the context-cap raise was picked at
+# 1.25x specifically to keep this margin close to its original size rather
+# than eroding it for a bigger win. See jobs.py's
 # MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH for the real review-count cap
 # (800) this was checked against.
 # air's real spend cap is a deliberately looser fraction of its price than

--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -145,13 +145,19 @@ def files_missing_from_review_context(
 
     fetch_review_file_context stops at MAX_CONTEXT_FILES and skips anything
     over MAX_CONTEXT_FILE_BYTES, so on
-    a PR touching more than 15 files - or any file over 40KB - the excess
+    a PR touching more than 30 files - or any file over 100KB - the excess
     is invisible to the model *and* to the citation check, which passes any
     finding whose file content it doesn't have (see
     _line_citation_content_matches). Without this, "No issues found in this
     diff" was reported identically whether the whole PR was reviewed or
-    only the first 15 files of it, which is the more damaging half of the
+    only the first 30 files of it, which is the more damaging half of the
     problem: silence read as an all-clear.
+
+    (These two thresholds have moved before without this docstring being
+    updated - found stale here at 15 files/40KB, one raise behind the real
+    30 files/80KB it should have said; keep this in sync with github_api.
+    MAX_CONTEXT_FILES/MAX_CONTEXT_FILE_BYTES rather than restating the
+    literal numbers if either changes again.)
     """
     return [path for path in changed_files if path not in file_contents]
 

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -17,10 +17,14 @@ MAX_CONTEXT_FILES = 30
 # TOTAL_BYTES's own history) rather than a fresh re-benchmark: scaling the
 # real $3.47/month figure PLAN_CAP_OVERRIDE_USD's own comment measures
 # (800 reviews/month, current 80KB caps) by the same 1.25x ratio gives an
-# estimated ~$4.34/month under the new cap - ~28% headroom under the new
-# $6 Flash cap (PLAN_CAP_OVERRIDE_USD["flash"]), close to the original 44%
-# design margin the $5 cap was sized against, not the thin ~13% a full 2x
-# raise to 120KB would have left. MAX_CONTEXT_TOTAL_BYTES intentionally
+# estimated ~$4.34/month under the new cap - ~38% headroom under the new
+# $6 Flash cap ((6.00-4.34)/4.34, PLAN_CAP_OVERRIDE_USD["flash"]), close to
+# the original 44% design margin the $5 cap was sized against, not the
+# thin ~15% a full 2x raise to 120KB would have left (its own estimate:
+# $3.47 x 1.5 = ~$5.21/month, (6.00-5.21)/5.21 = ~15% - same (cap-cost)/cost
+# formula the 44% figure uses throughout, not (cap-cost)/cap; an earlier
+# version of this comment mixed the two, understating both figures as
+# ~28%/~13% - found via independent audit). MAX_CONTEXT_TOTAL_BYTES intentionally
 # left unchanged: it's the real aggregate budget per review, and this
 # change is about not dropping one oversized file, not raising how much
 # total content one review can carry.

--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -8,7 +8,23 @@ from aletheore.pr_comment import COMMENT_MARKER
 from aletheore.repo_config import is_ignored
 
 MAX_CONTEXT_FILES = 30
-MAX_CONTEXT_FILE_BYTES = 80_000
+# Raised from 80_000 to 100_000 (1.25x, deliberately not the full 2x the
+# 40_000->80_000 raise below used - this cap has been hit often enough in
+# practice to want headroom, but a full doubling was judged too much real
+# spend for the margin it would eat). Real cost impact extrapolated from
+# the 40KB->80KB raise's own measured ratio (that raise doubled worst-case
+# per-review input cost, ~$0.011->$0.022 at Luna's rate - see MAX_CONTEXT_
+# TOTAL_BYTES's own history) rather than a fresh re-benchmark: scaling the
+# real $3.47/month figure PLAN_CAP_OVERRIDE_USD's own comment measures
+# (800 reviews/month, current 80KB caps) by the same 1.25x ratio gives an
+# estimated ~$4.34/month under the new cap - ~28% headroom under the new
+# $6 Flash cap (PLAN_CAP_OVERRIDE_USD["flash"]), close to the original 44%
+# design margin the $5 cap was sized against, not the thin ~13% a full 2x
+# raise to 120KB would have left. MAX_CONTEXT_TOTAL_BYTES intentionally
+# left unchanged: it's the real aggregate budget per review, and this
+# change is about not dropping one oversized file, not raising how much
+# total content one review can carry.
+MAX_CONTEXT_FILE_BYTES = 100_000
 MAX_CONTEXT_TOTAL_BYTES = 400_000
 
 # Real, measured (not assumed) on Flash Review's own benchmark corpus (25

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -326,6 +326,17 @@ def writing_adapter_chain_for_free_tier(
     logger = logging.getLogger(__name__)
     chain: list[OpenAICompatibleAdapter] = []
 
+    # Groq's real published rate limit for openai/gpt-oss-120b is a tight
+    # 8,000 tokens/minute - Flash Review's own per-file/aggregate context
+    # caps (see github_api.MAX_CONTEXT_FILE_BYTES/MAX_CONTEXT_TOTAL_BYTES,
+    # unconditional here too since fetch_review_file_context isn't
+    # plan-gated) can already exceed that in a single real call regardless
+    # of either cap's exact value - checked when MAX_CONTEXT_FILE_BYTES was
+    # raised 80KB->100KB and confirmed not materially changed by that
+    # raise, since Gemini (next in this chain) has enough headroom to
+    # absorb what Groq rejects. Recorded here, not only in that PR's
+    # description, so a future reader debugging a real Groq rejection
+    # doesn't have to go dig up which PR mentioned it.
     if has_api_key("GROQ_API_KEY", "Groq"):
         chain.append(OpenAICompatibleAdapter(
             name="Groq",

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -50,10 +50,12 @@ def test_base_cap_for_plan_free_or_unknown_plan_has_no_budget():
 
 
 def test_base_cap_for_plan_flash_uses_its_own_explicit_override_not_the_shared_fraction():
-    # Real, deliberate: $5, not $8 * CAP_FRACTION_OF_PRICE (0.5) = $4 -
+    # Real, deliberate: $6, not $8 * CAP_FRACTION_OF_PRICE (0.5) = $4 -
     # flash's real worst-case cost data justified a looser fraction than
     # the shared default, so it's a real override, not derived from price.
-    assert base_cap_for_plan("flash") == 5.00
+    # Raised from $5 alongside MAX_CONTEXT_FILE_BYTES's 80KB->100KB raise -
+    # see PLAN_CAP_OVERRIDE_USD's own comment for the real cost math.
+    assert base_cap_for_plan("flash") == 6.00
 
 
 def test_monthly_cap_for_installation_base_only():


### PR DESCRIPTION
## Summary

`MAX_CONTEXT_FILE_BYTES` (80KB) has caused real, repeated pain this session - large files silently dropped from PR review coverage and citation checking. Raised to 100KB (1.25x, deliberately not the full 2x the last raise, PR #287, used - 40KB→80KB) to keep the Flash spend cap's real headroom close to its original design margin rather than eroding it for a bigger win. Flash's spend cap raised $5→$6 alongside it, sized against real cost math for this specific increase.

## Real cost math

`PLAN_CAP_OVERRIDE_USD`'s own comment documents a real measured figure: ~$3.47/month worst-case for the 800-review/month Flash tier cap, under the old 80KB cap (~44% headroom under the old $5 cap, computed as (cap-cost)/cost). Scaling that by the same 1.25x ratio the byte-cap raise uses (extrapolated from the 40KB→80KB raise's own measured ~2x cost-impact ratio, not a fresh re-benchmark - flagged as an estimate in the comment, not presented as a real remeasurement) gives ~$4.34/month estimated under the new 100KB cap. $6 leaves **~38% headroom** over that ((6.00-4.34)/4.34) - close to the original 44% margin, not the thin **~15%** a full 2x raise to 120KB would have left ($3.47 x 1.5 = ~$5.21/month, (6.00-5.21)/5.21 = ~15% - considered and explicitly rejected).

`MAX_CONTEXT_TOTAL_BYTES` (400KB aggregate budget) deliberately left unchanged - this is about not dropping one oversized file, not raising how much total content one review can carry.

## Free-tier check

Free-tier Flash Review shares this same per-file cap (`fetch_review_file_context` is called unconditionally, not gated on plan). Checked real free-tier provider limits before proceeding: Groq (`openai/gpt-oss-120b`, first in the fallback chain) has a real, tight 8,000 tokens/minute limit the *current* 400KB aggregate cap can already exceed in a single call - this change doesn't make that materially worse since the total cap is unchanged, and the existing fallback chain (Gemini next, ~1M+ TPM headroom) already absorbs Groq's rejections. This limit is now also recorded as a comment at the real call site (`model_tiers.build_free_tier_fallback_chain`), not only here.

## Also fixed

A real stale docstring found while making this change: `files_missing_from_review_context`'s docstring still said "15 files... 40KB" - values from *before* PR #287's doubling to 30/80KB, never updated then either. Now states the real current 30/100KB and points at the real constants instead of restating literal numbers.

## Verification

- Sibling sweep across the whole repo: no other hardcoded references to these values in live code, except inside three historical, point-in-time documents that are correctly left untouched - `STARTUP_AUDIT_REPORT.md` (explicitly marked stale/superseded, 2026-08-10) and two `docs/superpowers/{plans,specs}/` implementation-plan/spec documents dated 2026-07-19 and 2026-08-18 (design records of the *previous* raise, not living reference docs).
- Full `github-app` suite: 1767 passed, 8 skipped (unchanged counts - one existing test updated for the new values, none added/removed).

---

**Edited after an independent recheck found four real inaccuracies in this description's own verification claims** (the code changes themselves were correct throughout - fixed in a follow-up commit, `2a14364`):
- The ~28%/~13% headroom figures above mixed a different formula ((cap-cost)/cap) with the ~44% figure's ((cap-cost)/cost) - corrected above to ~38%/~15%, using one consistent formula. The real margin is healthier than originally stated.
- The sibling-sweep claim named only one of three real exceptions found - corrected above.
- This description originally claimed "two existing tests updated" - only one test was actually changed; corrected above.
- Groq's 8,000 TPM limit was cited only here, not recorded in the codebase - now also a code comment (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
