### PR TITLE
fix: Teams/Slack webhook platform detection uses hostname, not substring match

### DIFF
--- a/github-app/scan_worker/slack.py
+++ b/github-app/scan_worker/slack.py
@@ -1,6 +1,7 @@
 import json
 import re
 import urllib.request
+from urllib.parse import urlparse
 
 from aletheore.healthcheck import opener_for
 from app_server.url_validation import validate_and_pin_https_url
@@ -39,6 +40,9 @@ def _post_to_webhook(webhook_url: str, payload: dict) -> None:
         pass
 
 
+_TEAMS_HOSTNAME_SUFFIXES = ("logic.azure.com", "office.com", "teams.microsoft.com")
+
+
 def _detect_platform(webhook_url: str) -> str:
     # Slack incoming webhooks are always hooks.slack.com. Modern Teams
     # webhooks are Power Automate "Workflows" (logic.azure.com); the
@@ -47,8 +51,19 @@ def _detect_platform(webhook_url: str) -> str:
     # still has one working. Anything unrecognized defaults to Slack's
     # plain {"text": ...} shape, since that's the only format this
     # webhook field has ever actually sent.
-    url_lower = webhook_url.lower()
-    if "logic.azure.com" in url_lower or "office.com" in url_lower or "teams.microsoft.com" in url_lower:
+    #
+    # Matched against the URL's actual hostname (and only as an exact
+    # match or a real subdomain, via a "." boundary), not a substring
+    # search over the whole URL - a plain `"office.com" in url_lower`
+    # also matches a lookalike host like "notoffice.com.evil.example" or
+    # a path/query segment that happens to contain the text, misrouting
+    # the payload shape for a webhook that isn't actually Teams (flagged
+    # by CodeQL as py/incomplete-url-substring-sanitization). Delivery
+    # itself was never at risk here - _post_to_webhook only ever sends to
+    # the exact address validate_and_pin_https_url resolved and pinned -
+    # this only picks which JSON shape gets sent.
+    hostname = (urlparse(webhook_url).hostname or "").lower()
+    if any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in _TEAMS_HOSTNAME_SUFFIXES):
         return "teams"
     return "slack"
 

--- a/github-app/tests/test_slack.py
+++ b/github-app/tests/test_slack.py
@@ -304,6 +304,18 @@ def test_detect_platform_defaults_to_slack_for_unknown_url():
     assert _detect_platform("https://example.com/my-webhook") == "slack"
 
 
+def test_detect_platform_does_not_match_lookalike_hostname():
+    # notoffice.com.evil.example contains the substring "office.com" but
+    # is not office.com or a subdomain of it - regression test for the
+    # substring-match bug this hostname-based check replaced.
+    assert _detect_platform("https://notoffice.com.evil.example/webhook") == "slack"
+
+
+def test_detect_platform_does_not_match_path_containing_teams_hostname():
+    # The suspicious text is in the path/query, not the actual hostname.
+    assert _detect_platform("https://example.com/office.com/webhook?x=teams.microsoft.com") == "slack"
+
+
 def test_slack_markdown_to_adaptive_card_markdown_converts_bold():
     assert _slack_markdown_to_adaptive_card_markdown("*Aletheore*: new findings") == "**Aletheore**: new findings"
 


### PR DESCRIPTION
## Summary
- `_detect_platform` matched `"office.com"` (etc.) as a substring anywhere in the full webhook URL, so a lookalike host (`notoffice.com.evil.example`) or the text appearing in a path/query segment could misroute the payload shape. Flagged by CodeQL as `py/incomplete-url-substring-sanitization` (GitHub code-scanning alerts #34/#35/#36).
- Delivery itself was never at risk — `_post_to_webhook` only ever sends to the exact address `validate_and_pin_https_url` resolved and pinned. This only affected which JSON shape (Slack `{"text": ...}` vs. Teams Adaptive Card) got sent for a given webhook.
- Now parses the URL's real hostname and matches it exactly or as a genuine subdomain (`.` boundary), instead of substring-searching the whole URL string.

## Test plan
- [x] `pytest tests/test_slack.py` — 26 passed, including 2 new regression tests (lookalike hostname, suspicious text in path/query)
- [x] Existing Teams-detection tests (`logic.azure.com`, `outlook.office.com`) still pass under the new hostname-based check

🤖 Generated with [Claude Code](https://claude.com/claude-code)