### PR TITLE
docs: add direct GitHub App install link to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@
   <a href="https://pepy.tech/projects/aletheore"><img src="https://static.pepy.tech/personalized-badge/aletheore?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads" alt="PyPI Downloads"></a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/apps/aletheore/installations/new"><strong>Install the Aletheore GitHub App</strong></a> — hosted PR review, dashboard, and AIRview docs on top of the same evidence engine.<br>
+  Prefer the free local CLI? Keep reading below.
+</p>
+
 ```bash
 $ pipx install aletheore
 $ aletheore scan .


### PR DESCRIPTION
## Summary
- The repo's README only linked to `aletheore.com` for the hosted GitHub App - a visitor had to go through the marketing site to find the actual install link.
- Adds the real install URL (`github.com/apps/aletheore/installations/new`, already live on the website's pricing/index pages) directly to the README, positioned right below the badges as the first visible call-to-action, before the free-CLI quickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)