### PR TITLE
fix: endpoint health dashboard never disclosed the 64-endpoint monitoring cap

### DIFF
--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request, Response
 
 from aletheore.evidence_resolution import resolve_code_evidence
 from scan_worker.github_api import fetch_file_content
+from scan_worker.jobs import MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET
 from scan_worker.live_wiki import build_file_fallback_detail
 from app_server.admin import (
     _administered_installation_ids_for_session_or_401,
@@ -317,10 +318,24 @@ async def get_dashboard_health(org: str, repo: str, request: Request):
     )
     stale_endpoints = find_stale_endpoints(api_endpoints, health_summary)
 
+    # Real gap found via audit: run_health_check_sweep_job (see
+    # scan_worker.jobs._endpoint_results) silently checks only the first
+    # MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET endpoints found in the repo -
+    # a repo with more real API endpoints than that has some that are
+    # NEVER checked, on any target, ever, with no signal anywhere in this
+    # dashboard before this fix. A customer reasonably reads "12 of 12
+    # endpoints up" as full coverage; it only ever meant "12 of the first
+    # 64 found". total_endpoint_count/monitored_endpoint_count let the
+    # frontend show the real coverage instead of implying completeness.
+    total_endpoint_count = len(api_endpoints)
+    monitored_endpoint_count = min(total_endpoint_count, MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET)
+
     return {
         "repo_full_name": repo_full_name,
         "endpoints": endpoints,
         "stale_endpoints": stale_endpoints,
+        "total_endpoint_count": total_endpoint_count,
+        "monitored_endpoint_count": monitored_endpoint_count,
     }
 
 

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1237,6 +1237,11 @@ async function loadResults() {{
     (groups[key] = groups[key] || []).push(e);
   }});
   let html = '';
+  if (data.monitored_endpoint_count < data.total_endpoint_count) {{
+    html += '<div class="settings-block-hint" style="margin-bottom:10px;">Monitoring the first ' +
+      data.monitored_endpoint_count + ' of ' + data.total_endpoint_count +
+      ' API endpoints found in this repo - the rest are not checked.</div>';
+  }}
   let rowIndex = 0;
   const rowMeta = {{}};
   Object.keys(groups).sort().forEach(function (label) {{

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -1353,6 +1353,49 @@ async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_health_reports_real_endpoint_coverage_against_the_monitoring_cap(
+    pool, monkeypatch
+):
+    # Real gap found via audit: run_health_check_sweep_job only ever checks
+    # the first MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET endpoints found in a
+    # repo - a repo with more real endpoints than that has some that are
+    # NEVER checked, with no signal anywhere in this dashboard before this
+    # fix. total_endpoint_count/monitored_endpoint_count let the frontend
+    # show real coverage instead of implying every endpoint is watched.
+    import app_server.dashboard as dashboard_module
+
+    monkeypatch.setattr(dashboard_module, "MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET", 2)
+    await upsert_installation(pool, 506, "octocat")
+    await set_installation_plan(pool, 506, "air")
+    await insert_repo_history(
+        pool,
+        506,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {"method": "GET", "path": "/a", "file": "a.py", "line": 1},
+                        {"method": "GET", "path": "/b", "file": "b.py", "line": 1},
+                        {"method": "GET", "path": "/c", "file": "c.py", "line": 1},
+                    ]
+                }
+            },
+        },
+    )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[506])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_endpoint_count"] == 3
+    assert body["monitored_endpoint_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_dashboard_health_omits_stale_endpoints_with_recent_success(pool, monkeypatch):
     await upsert_installation(pool, 505, "octocat")
     await set_installation_plan(pool, 505, "air")


### PR DESCRIPTION
## Context
Deep-dive audit of the endpoint health monitoring feature per request: does it work, how does it work, is it wired up, how does a failure get pinpointed, which LLM helps.

## How it actually works (verified end-to-end)
- **Wiring**: `frontend.py`'s Endpoint Health dashboard → `admin.py`'s `health-targets` CRUD API → `health_check_targets` table → `scheduler.py` enqueues `run_health_check_sweep_job` on a **dedicated `health` queue/worker** (`health_worker.py`, its own container in `docker-compose.yml`) every 180s, deliberately isolated from `scans` so a backed-up AI job queue can never stall health checks.
- **Detection**: per target, the scanner's statically-discovered `api_endpoints` get real HTTP checks (`validate_and_pin_https_url` pins the resolved IP against DNS-rebinding, re-validated on every sweep). A reachability/latency/response-shape flip triggers an alert.
- **Pinpointing the location**: fully deterministic — `resolve_code_evidence(kind="endpoint", ...)` matches the failing method+path back to the exact `file:line` the scanner found it at, confidence-tagged, never guessed. No LLM involved in locating the failure.
- **Which LLM helps**: exactly one, and only as a supplement — `PRO_MODEL` (Luna, DeepSeek fallback) generates a plain-English fix suggestion *grounded in* the already-pinpointed file/line/symbol. Spend-gated, cooldown-throttled (1 suggestion per incident, not per flip), degrades to nothing on any failure — never blocks the alert itself.
- **Meta-monitoring**: `run_health_sweep_staleness_check_job` runs on a *different* queue specifically so it can detect the health queue itself going dark (a real production incident already caught this: an 11-day silent gap).
- **Phase 3**: `runtime_events.py` reuses this exact same correlation chain for inbound Sentry-compatible runtime errors (AIR-tier only).

40 existing tests across `test_jobs.py`, `test_correlation.py`, `test_regression_risk.py` verified this all works as designed.

## Real gap found
`scan_worker.jobs._endpoint_results` silently truncates to the first `MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET` (**64**) endpoints found in a repo, per target — every other cap constant in this codebase carries an extensive measured rationale comment; this one had none, a strong signal it was never revisited. A repo with more than 64 real API endpoints has some that are **never checked, on any target, indefinitely**, and the dashboard's "12 of 12 endpoints up" stat only ever counted the checked subset — reading as full coverage when it silently wasn't. Same shape as PR #586's AIRview truncation gap, just on a customer-facing production-monitoring surface instead of an internal LLM context payload.

## Fix
`get_dashboard_health` now returns `total_endpoint_count`/`monitored_endpoint_count` (data the scanner already produced), and the dashboard shows "Monitoring the first N of M API endpoints found in this repo - the rest are not checked" whenever the cap actually bites.

## Test plan
- [x] `pytest github-app/tests/test_dashboard.py` — 71 passed (including a new regression test for the coverage fields)
- [x] `python -c "import app_server.frontend"` — confirms the edited embedded-JS f-string still evaluates cleanly (this file is a known hotspot for brace-escaping breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC6FTd9tYyiPHWXLjMxXqM