### PR TITLE
feat: let customers choose which endpoints get health-checked past the 64 cap

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -25,6 +25,7 @@ from app_server.http_client import get_github_api_client
 from app_server.email_client import send_transactional_email
 from app_server.email_queue import enqueue_transactional_email
 from app_server.email_templates import deletion_otp_email
+from scan_worker.jobs import MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET
 from scan_worker.pushover import send_pushover_alert
 from app_server.db import (
     DEFAULT_HEALTH_CHECK_TARGET_LIMIT,
@@ -40,6 +41,7 @@ from app_server.db import (
     create_deletion_otp_code,
     delete_session,
     get_docs_repo_commit_settings,
+    get_endpoint_health_selection,
     get_extra_seats,
     get_flash_review_count_this_month,
     get_github_user_email,
@@ -59,6 +61,7 @@ from app_server.db import (
     record_installation_access,
     remove_health_check_target,
     remove_installation_member,
+    replace_endpoint_health_selection,
     revoke_api_token,
     set_docs_repo_commit_enabled,
     set_llm_suggestions_enabled,
@@ -148,6 +151,19 @@ class AddHealthCheckTargetRequest(BaseModel):
     label: str = Field(min_length=1, max_length=100, pattern=_LABEL_PATTERN)
     base_url: str
     latency_threshold_ms: int | None = None
+
+
+class EndpointSelectionEntry(BaseModel):
+    method: str = Field(min_length=1, max_length=16)
+    path: str = Field(min_length=1, max_length=2048)
+
+
+class SetEndpointHealthSelectionRequest(BaseModel):
+    # Bounded well above MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET (only the
+    # first that many, in stable (path, method) order, are ever actually
+    # checked - see jobs._candidate_endpoints) - this just bounds one
+    # request's real size, not how many a customer is allowed to select.
+    selections: list[EndpointSelectionEntry] = Field(max_length=2000)
 
 
 class CreateCliTokenRequest(BaseModel):
@@ -1041,6 +1057,91 @@ async def remove_health_check_target_route(org: str, repo: str, target_id: int, 
         {"repo_full_name": f"{org}/{repo}", "target_id": target_id},
     )
     return {"ok": True}
+
+
+def _monitored_endpoint_keys(
+    api_endpoints: list[dict], selected_keys: set[tuple[str, str]]
+) -> set[tuple[str, str]]:
+    """Exactly which (method, path) keys the next real sweep will check -
+    the SAME candidate-then-cap logic as scan_worker.jobs._candidate_
+    endpoints/_endpoint_results, kept here as its own small function
+    rather than inlined so the two can never silently drift apart, since
+    this dashboard's whole point is to show real, not assumed, coverage.
+    """
+    if selected_keys:
+        candidates = sorted(
+            (e for e in api_endpoints if (e.get("method"), e.get("path")) in selected_keys),
+            key=lambda e: (e.get("path") or "", e.get("method") or ""),
+        )
+    else:
+        candidates = api_endpoints
+    return {
+        (e.get("method"), e.get("path"))
+        for e in candidates[:MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET]
+    }
+
+
+@admin_router.get("/admin/{org}/{repo}/health-endpoints")
+async def list_health_check_endpoints_route(org: str, repo: str, request: Request):
+    """Every API endpoint this repo's last scan found, with which ones are
+    actually being health-checked right now and why - lets a customer see
+    real coverage and, once a repo has more endpoints than
+    MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET, choose exactly which ones
+    matter to them instead of Aletheore silently picking for them (see
+    migration 060's own comment)."""
+    installation = await _require_admin_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    installation_id = installation["installation_id"]
+    repo_full_name = f"{org}/{repo}"
+
+    evidence = await get_latest_evidence(pool, installation_id, repo_full_name)
+    api_endpoints = (
+        (evidence or {}).get("repository", {}).get("api_endpoints", {}).get("endpoints", [])
+    )
+    selection_rows = await get_endpoint_health_selection(pool, installation_id, repo_full_name)
+    selected_keys = {(row["endpoint_method"], row["endpoint_path"]) for row in selection_rows}
+    monitored_keys = _monitored_endpoint_keys(api_endpoints, selected_keys)
+
+    endpoints = [
+        {
+            "method": e.get("method"),
+            "path": e.get("path"),
+            "file": e.get("file"),
+            "line": e.get("line"),
+            "monitored": (e.get("method"), e.get("path")) in monitored_keys,
+        }
+        for e in api_endpoints
+    ]
+    return {
+        "endpoints": endpoints,
+        "mode": "manual" if selected_keys else "auto",
+        "cap": MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET,
+        "total_endpoint_count": len(api_endpoints),
+        "monitored_endpoint_count": len(monitored_keys),
+    }
+
+
+@admin_router.put("/admin/{org}/{repo}/health-endpoints")
+async def set_health_check_endpoints_route(
+    org: str, repo: str, request: Request, body: SetEndpointHealthSelectionRequest
+):
+    """Replaces this repo's entire endpoint selection in one call - see
+    replace_endpoint_health_selection's own docstring for why a bulk
+    replace, not per-endpoint toggle calls. An empty `selections` list
+    resets the repo back to the default first-N-in-scan-order behavior."""
+    installation = await _require_admin_installation(request, org, repo)
+    pool = request.app.state.db_pool
+    installation_id = installation["installation_id"]
+    repo_full_name = f"{org}/{repo}"
+
+    selections = [(entry.method, entry.path) for entry in body.selections]
+    await replace_endpoint_health_selection(pool, installation_id, repo_full_name, selections)
+    session = await get_current_session(request)
+    await record_admin_action(
+        pool, installation_id, session["github_login"], "endpoint_health_selection_changed",
+        {"repo_full_name": repo_full_name, "selected_count": len(selections)},
+    )
+    return {"ok": True, "selected_count": len(selections)}
 
 
 @admin_router.put("/admin/{org}/{repo}/llm-suggestions")

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -25,7 +25,7 @@ from app_server.http_client import get_github_api_client
 from app_server.email_client import send_transactional_email
 from app_server.email_queue import enqueue_transactional_email
 from app_server.email_templates import deletion_otp_email
-from scan_worker.jobs import MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET
+from scan_worker.jobs import MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET, rank_endpoints_by_selection
 from scan_worker.pushover import send_pushover_alert
 from app_server.db import (
     DEFAULT_HEALTH_CHECK_TARGET_LIMIT,
@@ -1062,19 +1062,18 @@ async def remove_health_check_target_route(org: str, repo: str, target_id: int, 
 def _monitored_endpoint_keys(
     api_endpoints: list[dict], selected_keys: set[tuple[str, str]]
 ) -> set[tuple[str, str]]:
-    """Exactly which (method, path) keys the next real sweep will check -
-    the SAME candidate-then-cap logic as scan_worker.jobs._candidate_
-    endpoints/_endpoint_results, kept here as its own small function
-    rather than inlined so the two can never silently drift apart, since
-    this dashboard's whole point is to show real, not assumed, coverage.
+    """Exactly which (method, path) keys the next real sweep will check.
+
+    Calls scan_worker.jobs.rank_endpoints_by_selection directly rather
+    than reimplementing the ranking here - an earlier version of this
+    function duplicated that logic (candidate-then-cap) as its own
+    parallel copy, real drift risk found via self-review even though the
+    two happened to agree at the time: this dashboard's whole point is to
+    show real, not assumed, coverage, so "the same logic, trust me" is
+    exactly the gap a shared function closes structurally instead of by
+    convention.
     """
-    if selected_keys:
-        candidates = sorted(
-            (e for e in api_endpoints if (e.get("method"), e.get("path")) in selected_keys),
-            key=lambda e: (e.get("path") or "", e.get("method") or ""),
-        )
-    else:
-        candidates = api_endpoints
+    candidates = rank_endpoints_by_selection(api_endpoints, selected_keys)
     return {
         (e.get("method"), e.get("path"))
         for e in candidates[:MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET]
@@ -1100,7 +1099,22 @@ async def list_health_check_endpoints_route(org: str, repo: str, request: Reques
     )
     selection_rows = await get_endpoint_health_selection(pool, installation_id, repo_full_name)
     selected_keys = {(row["endpoint_method"], row["endpoint_path"]) for row in selection_rows}
-    monitored_keys = _monitored_endpoint_keys(api_endpoints, selected_keys)
+    # candidates is the real "eligible to be monitored" set BEFORE the cap -
+    # every endpoint in auto mode, or exactly the still-real selected ones
+    # in manual mode (see rank_endpoints_by_selection). Real bug found via
+    # self-review: the frontend's "still capped" caveat on the manual-mode
+    # message used to compare total_endpoint_count (the whole repo) against
+    # the cap, which is wrong in manual mode - a repo with 200 endpoints
+    # where a customer explicitly selected 5 would misleadingly claim their
+    # 5-endpoint selection was "still capped at 64", even though nothing of
+    # theirs was cut off. candidate_count lets the frontend ask the right
+    # question: was THIS candidate set (not the whole repo) larger than the
+    # cap.
+    candidates = rank_endpoints_by_selection(api_endpoints, selected_keys)
+    monitored_keys = {
+        (e.get("method"), e.get("path"))
+        for e in candidates[:MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET]
+    }
 
     endpoints = [
         {
@@ -1117,6 +1131,7 @@ async def list_health_check_endpoints_route(org: str, repo: str, request: Reques
         "mode": "manual" if selected_keys else "auto",
         "cap": MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET,
         "total_endpoint_count": len(api_endpoints),
+        "candidate_count": len(candidates),
         "monitored_endpoint_count": len(monitored_keys),
     }
 

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -7,11 +7,11 @@ from fastapi import APIRouter, HTTPException, Request, Response
 
 from aletheore.evidence_resolution import resolve_code_evidence
 from scan_worker.github_api import fetch_file_content
-from scan_worker.jobs import MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET
 from scan_worker.live_wiki import build_file_fallback_detail
 from app_server.admin import (
     _administered_installation_ids_for_session_or_401,
     _github_http_client,
+    _monitored_endpoint_keys,
     _repo_installation_id,
     _require_admin_installation,
     _require_seat_if_paid,
@@ -24,6 +24,7 @@ from app_server.db import (
     count_monthly_scanned_repos,
     get_docs_build_status,
     get_endpoint_health_history,
+    get_endpoint_health_selection,
     get_endpoint_health_summary_since,
     get_endpoint_uptime_pct_since,
     get_installation,
@@ -327,14 +328,23 @@ async def get_dashboard_health(org: str, repo: str, request: Request):
     # endpoints up" as full coverage; it only ever meant "12 of the first
     # 64 found". total_endpoint_count/monitored_endpoint_count let the
     # frontend show the real coverage instead of implying completeness.
-    total_endpoint_count = len(api_endpoints)
-    monitored_endpoint_count = min(total_endpoint_count, MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET)
+    #
+    # _monitored_endpoint_keys is the SAME candidate-then-cap logic
+    # scan_worker.jobs._candidate_endpoints/_endpoint_results uses to
+    # decide what actually gets checked - once a customer has made an
+    # explicit endpoint selection (see admin.py's health-endpoints routes,
+    # migration 060), monitored_endpoint_count must reflect THEIR choice,
+    # not just "the first N found", or this count would silently drift
+    # from what the next real sweep does.
+    selection_rows = await get_endpoint_health_selection(pool, installation_id, repo_full_name)
+    selected_keys = {(row["endpoint_method"], row["endpoint_path"]) for row in selection_rows}
+    monitored_endpoint_count = len(_monitored_endpoint_keys(api_endpoints, selected_keys))
 
     return {
         "repo_full_name": repo_full_name,
         "endpoints": endpoints,
         "stale_endpoints": stale_endpoints,
-        "total_endpoint_count": total_endpoint_count,
+        "total_endpoint_count": len(api_endpoints),
         "monitored_endpoint_count": monitored_endpoint_count,
     }
 

--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request, Response
 
 from aletheore.evidence_resolution import resolve_code_evidence
 from scan_worker.github_api import fetch_file_content
+from scan_worker.jobs import MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET
 from scan_worker.live_wiki import build_file_fallback_detail
 from app_server.admin import (
     _administered_installation_ids_for_session_or_401,
@@ -317,10 +318,24 @@ async def get_dashboard_health(org: str, repo: str, request: Request):
     )
     stale_endpoints = find_stale_endpoints(api_endpoints, health_summary)
 
+    # Real gap found via audit: run_health_check_sweep_job (see
+    # scan_worker.jobs._endpoint_results) silently checks only the first
+    # MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET endpoints found in the repo -
+    # a repo with more real API endpoints than that has some that are
+    # NEVER checked, on any target, ever, with no signal anywhere in this
+    # dashboard before this fix. A customer reasonably reads "12 of 12
+    # endpoints up" as full coverage; it only ever meant "12 of the first
+    # 64 found". total_endpoint_count/monitored_endpoint_count let the
+    # frontend show the real coverage instead of implying completeness.
+    total_endpoint_count = len(api_endpoints)
+    monitored_endpoint_count = min(total_endpoint_count, MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET)
+
     return {
         "repo_full_name": repo_full_name,
         "endpoints": endpoints,
         "stale_endpoints": stale_endpoints,
+        "total_endpoint_count": total_endpoint_count,
+        "monitored_endpoint_count": monitored_endpoint_count,
     }
 
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -1077,6 +1077,59 @@ async def count_health_check_targets(pool: asyncpg.Pool, installation_id: int, r
     return row["n"]
 
 
+# A repo with more real API endpoints than jobs.MAX_HEALTH_CHECK_ENDPOINTS_
+# PER_TARGET has some that are never health-checked by default (whichever
+# happen to be first in scan order) - this table is how a customer chooses
+# WHICH ones instead. Presence of a row is the whole signal (see migration
+# 060's own comment): no rows for a repo means "no explicit preference yet,
+# use the default first-N", any rows at all means "monitor exactly these".
+async def get_endpoint_health_selection(
+    pool: asyncpg.Pool, installation_id: int, repo_full_name: str
+) -> list[dict]:
+    rows = await pool.fetch(
+        """
+        SELECT endpoint_method, endpoint_path
+        FROM endpoint_health_selection
+        WHERE installation_id = $1 AND repo_full_name = $2
+        """,
+        installation_id,
+        repo_full_name,
+    )
+    return [dict(row) for row in rows]
+
+
+async def replace_endpoint_health_selection(
+    pool: asyncpg.Pool,
+    installation_id: int,
+    repo_full_name: str,
+    selections: list[tuple[str, str]],
+) -> None:
+    """Atomically replaces the entire selection set for one repo - the
+    natural shape for a "check the boxes you want, hit Save" UI, not N
+    separate toggle calls that could interleave with a concurrent save.
+    An empty `selections` list is how a customer resets a repo back to the
+    default first-N behavior (deletes every row, same as never having
+    selected anything).
+    """
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "DELETE FROM endpoint_health_selection WHERE installation_id = $1 AND repo_full_name = $2",
+                installation_id,
+                repo_full_name,
+            )
+            if selections:
+                await conn.executemany(
+                    """
+                    INSERT INTO endpoint_health_selection
+                        (installation_id, repo_full_name, endpoint_method, endpoint_path)
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT (installation_id, repo_full_name, endpoint_method, endpoint_path) DO NOTHING
+                    """,
+                    [(installation_id, repo_full_name, method, path) for method, path in selections],
+                )
+
+
 def _version_gated_evidence(
     installation_id: int, repo_full_name: str, raw: object
 ) -> dict | None:

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1099,6 +1099,13 @@ HEALTH_HTML = _page_head("Endpoint health — {repo} — Aletheore") + _shell(
     </section>
     <section class="section">
       <div class="section-head">
+        <div class="section-title"><i class="ti ti-list-check" aria-hidden="true"></i>Monitored endpoints</div>
+        <span class="section-sub" id="endpoints-usage"></span>
+      </div>
+      <div class="section-body" id="endpoints-body"><div class="empty-state">Loading&hellip;</div></div>
+    </section>
+    <section class="section">
+      <div class="section-head">
         <div class="section-title"><i class="ti ti-activity" aria-hidden="true"></i>Results</div>
         <span class="section-sub">Most recent check per endpoint, per target</span>
       </div>
@@ -1238,9 +1245,9 @@ async function loadResults() {{
   }});
   let html = '';
   if (data.monitored_endpoint_count < data.total_endpoint_count) {{
-    html += '<div class="settings-block-hint" style="margin-bottom:10px;">Monitoring the first ' +
+    html += '<div class="settings-block-hint" style="margin-bottom:10px;">Monitoring ' +
       data.monitored_endpoint_count + ' of ' + data.total_endpoint_count +
-      ' API endpoints found in this repo - the rest are not checked.</div>';
+      ' API endpoints found in this repo - see "Monitored endpoints" above to choose which.</div>';
   }}
   let rowIndex = 0;
   const rowMeta = {{}};
@@ -1315,8 +1322,82 @@ async function toggleEndpointHistory(rowId) {{
   panel.innerHTML = html;
 }}
 
+function renderEndpointRows(endpoints) {{
+  return endpoints.map(function (e, i) {{
+    return '<label class="health-endpoint-row" style="display:flex;align-items:center;gap:8px;padding:5px 0;font-size:12.5px;">' +
+      '<input type="checkbox" class="endpoint-select-checkbox" data-index="' + i + '"' +
+      (e.monitored ? ' checked' : '') + '>' +
+      '<span class="chip" style="min-width:44px;text-align:center;">' + escapeHtml(e.method || '') + '</span>' +
+      '<span>' + escapeHtml(e.path || '') + '</span></label>';
+  }}).join('');
+}}
+
+async function loadEndpoints() {{
+  const res = await apiGet(adminBase + '/health-endpoints');
+  const body = document.getElementById('endpoints-body');
+  const usage = document.getElementById('endpoints-usage');
+  if (!res) return;
+  if (res.status === 402) {{ body.innerHTML = '<div class="empty-state">Available on paid plans.</div>'; usage.textContent = ''; return; }}
+  if (!res.ok) {{ body.innerHTML = '<div class="empty-state">Unavailable.</div>'; return; }}
+  const data = await res.json();
+  window._healthEndpoints = data.endpoints || [];
+  usage.textContent = data.monitored_endpoint_count + ' of ' + data.total_endpoint_count + ' monitored';
+  if (data.endpoints.length === 0) {{
+    body.innerHTML = '<div class="empty-state">No API endpoints found in this repo yet.</div>';
+    return;
+  }}
+  const atCap = data.total_endpoint_count > data.cap;
+  let html = '';
+  if (data.mode === 'auto' && atCap) {{
+    html += '<div class="settings-block-hint" style="margin-bottom:8px;">This repo has more endpoints (' +
+      data.total_endpoint_count + ') than Aletheore checks at once (' + data.cap + ') - the first ' +
+      data.cap + ' below (in scan order) are monitored by default. Uncheck/check below and Save to choose exactly which ones instead.</div>';
+  }} else if (data.mode === 'manual') {{
+    html += '<div class="settings-block-hint" style="margin-bottom:8px;">You have chosen exactly which endpoints are monitored below' +
+      (atCap ? ' (still capped at ' + data.cap + ' at a time)' : '') + '.</div>';
+  }}
+  html += '<details><summary style="cursor:pointer;font-size:12.5px;color:var(--muted);">Choose endpoints (' +
+    data.endpoints.length + ')</summary><div style="margin-top:8px;max-height:320px;overflow-y:auto;">' +
+    renderEndpointRows(data.endpoints) + '</div>' +
+    '<div class="form-row" style="margin-top:8px;">' +
+    '<button class="btn" onclick="saveEndpointSelection()">Save selection</button>' +
+    (data.mode === 'manual' ? '<button class="btn" onclick="resetEndpointSelection()">Reset to automatic</button>' : '') +
+    '</div><div id="endpoints-status" class="settings-block-hint"></div></details>';
+  body.innerHTML = html;
+}}
+
+async function saveEndpointSelection() {{
+  const status = document.getElementById('endpoints-status');
+  const checked = Array.from(document.querySelectorAll('.endpoint-select-checkbox:checked'));
+  const selections = checked.map(function (el) {{
+    const e = window._healthEndpoints[parseInt(el.dataset.index, 10)];
+    return {{ method: e.method, path: e.path }};
+  }});
+  status.textContent = 'Saving...';
+  const res = await fetch(adminBase + '/health-endpoints', {{
+    method: 'PUT', headers: {{ 'Content-Type': 'application/json' }},
+    body: JSON.stringify({{ selections: selections }}),
+  }});
+  if (!res.ok) {{ status.textContent = 'Could not save.'; return; }}
+  loadEndpoints();
+  loadResults();
+}}
+
+async function resetEndpointSelection() {{
+  const status = document.getElementById('endpoints-status');
+  status.textContent = 'Resetting...';
+  const res = await fetch(adminBase + '/health-endpoints', {{
+    method: 'PUT', headers: {{ 'Content-Type': 'application/json' }},
+    body: JSON.stringify({{ selections: [] }}),
+  }});
+  if (!res.ok) {{ status.textContent = 'Could not reset.'; return; }}
+  loadEndpoints();
+  loadResults();
+}}
+
 loadTargets();
 loadResults();
+loadEndpoints();
 loadPlanBadge();
 </script>
 """

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1237,6 +1237,11 @@ async function loadResults() {{
     (groups[key] = groups[key] || []).push(e);
   }});
   let html = '';
+  if (data.monitored_endpoint_count < data.total_endpoint_count) {{
+    html += '<div class="settings-block-hint" style="margin-bottom:10px;">Monitoring the first ' +
+      data.monitored_endpoint_count + ' of ' + data.total_endpoint_count +
+      ' API endpoints found in this repo - the rest are not checked.</div>';
+  }}
   let rowIndex = 0;
   const rowMeta = {{}};
   Object.keys(groups).sort().forEach(function (label) {{

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -1346,7 +1346,13 @@ async function loadEndpoints() {{
     body.innerHTML = '<div class="empty-state">No API endpoints found in this repo yet.</div>';
     return;
   }}
-  const atCap = data.total_endpoint_count > data.cap;
+  // candidate_count is the real "eligible to be monitored" set BEFORE the
+  // cap - every endpoint in auto mode, or exactly the still-real selected
+  // ones in manual mode. Using total_endpoint_count (the whole repo) here
+  // instead would be wrong in manual mode: a repo with 200 endpoints where
+  // a customer selected only 5 would wrongly claim their 5-endpoint
+  // selection was "still capped", even though nothing of theirs was cut off.
+  const atCap = data.candidate_count > data.cap;
   let html = '';
   if (data.mode === 'auto' && atCap) {{
     html += '<div class="settings-block-hint" style="margin-bottom:8px;">This repo has more endpoints (' +
@@ -1354,7 +1360,7 @@ async function loadEndpoints() {{
       data.cap + ' below (in scan order) are monitored by default. Uncheck/check below and Save to choose exactly which ones instead.</div>';
   }} else if (data.mode === 'manual') {{
     html += '<div class="settings-block-hint" style="margin-bottom:8px;">You have chosen exactly which endpoints are monitored below' +
-      (atCap ? ' (still capped at ' + data.cap + ' at a time)' : '') + '.</div>';
+      (atCap ? ' (your selection has more than ' + data.cap + ' - only the first ' + data.cap + ', sorted by path, are checked)' : '') + '.</div>';
   }}
   html += '<details><summary style="cursor:pointer;font-size:12.5px;color:var(--muted);">Choose endpoints (' +
     data.endpoints.length + ')</summary><div style="margin-top:8px;max-height:320px;overflow-y:auto;">' +

--- a/github-app/migrations/060_endpoint_health_selection.sql
+++ b/github-app/migrations/060_endpoint_health_selection.sql
@@ -1,0 +1,22 @@
+-- Lets a customer explicitly choose which endpoints get health-checked
+-- when a repo has more real API endpoints than
+-- jobs.MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET (64). Presence of a row is
+-- the whole signal - there is no boolean column, because "not selected"
+-- and "not monitored" are the same fact: once a customer has made ANY
+-- explicit selection for a repo, exactly the endpoints with a row here
+-- are monitored (see jobs._candidate_endpoints), and a repo with zero
+-- rows falls back to today's default (the first N endpoints in scan
+-- order), unchanged. Emptying the selection entirely (deleting every
+-- row) is how a customer resets a repo back to that default.
+CREATE TABLE IF NOT EXISTS endpoint_health_selection (
+    id                BIGSERIAL PRIMARY KEY,
+    installation_id   BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    repo_full_name    TEXT NOT NULL,
+    endpoint_method   TEXT NOT NULL,
+    endpoint_path     TEXT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (installation_id, repo_full_name, endpoint_method, endpoint_path)
+);
+
+CREATE INDEX IF NOT EXISTS endpoint_health_selection_lookup
+ON endpoint_health_selection (installation_id, repo_full_name);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -928,6 +928,27 @@ def get_last_endpoint_health(
             return result
 
 
+def get_endpoint_health_selection(dsn: str, installation_id: int, repo_full_name: str) -> set[tuple[str, str]]:
+    """Sync (psycopg) counterpart to app_server.db.get_endpoint_health_selection,
+    for the sweep job (run_health_check_sweep_job) rather than an async
+    admin route. Returns a set of (method, path) for cheap membership
+    checks against the scanner's own endpoint list - see
+    jobs._candidate_endpoints, which treats an empty set as "no explicit
+    preference, use the default first-N" the same way the admin side does.
+    """
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT endpoint_method, endpoint_path
+                FROM endpoint_health_selection
+                WHERE installation_id = %s AND repo_full_name = %s
+                """,
+                (installation_id, repo_full_name),
+            )
+            return {(row[0], row[1]) for row in cur.fetchall()}
+
+
 def list_recent_endpoint_incidents(
     dsn: str,
     installation_id: int,

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -70,6 +70,7 @@ from scan_worker.db import (
     get_flash_review_finding_comments,
     managed_audit_definitely_still_cooling_down,
     get_docs_repo_commit_settings,
+    get_endpoint_health_selection,
     get_endpoint_health_summary,
     get_extra_seats,
     get_flash_review_count_this_month,
@@ -216,6 +217,18 @@ HEALTH_CHECK_DOWN_RETRY_DELAY_SECONDS = 2.0
 # reachability notification itself) still fire every time, only the LLM
 # call is throttled.
 HEALTH_FIX_SUGGESTION_COOLDOWN_SECONDS = 1800
+# Bounds one target's real HTTP-checking time within a single
+# HEALTH_SWEEP_SOFT_DEADLINE_SECONDS tick, and - since run_health_check_
+# sweep_job iterates every paying installation's every target serially in
+# one process - bounds how much of that shared budget one repo with an
+# unusually large API surface can consume at every OTHER customer's
+# expense. Originally applied blindly to whichever endpoints happened to
+# be first in the scan's own (arbitrary) evidence order, with no way for
+# a customer to choose otherwise and no visibility that some endpoints
+# were never checked at all - see _candidate_endpoints and migration 060
+# (endpoint_health_selection): a customer can now explicitly choose which
+# endpoints matter to them once a repo has more than this many, instead
+# of Aletheore silently picking for them.
 MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET = 64
 HEALTH_SWEEP_SOFT_DEADLINE_SECONDS = 540
 HEALTH_SWEEP_ROTATION_KEY = "health_sweep:target_rotation"
@@ -2421,15 +2434,44 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
             )
 
 
-def _endpoint_results(evidence: dict, base_url: str, pinned_ip: str) -> list[dict]:
+def _candidate_endpoints(dsn: str, installation_id: int, repo_full_name: str, endpoints: list[dict]) -> list[dict]:
+    """Which endpoints from this scan's real, full list are actually
+    eligible to be health-checked, before the MAX_HEALTH_CHECK_ENDPOINTS_
+    PER_TARGET cap below narrows that further.
+
+    No selection rows for this repo (the default, unchanged from before
+    this existed): every endpoint is a candidate, in scan order - the cap
+    below picks the first N. Any selection rows at all: ONLY the selected
+    endpoints are candidates, sorted by (path, method) for a stable,
+    predictable order when a customer selects more than the cap allows -
+    "which ones win" must never depend on evidence's own arbitrary scan
+    order once a customer has made an explicit choice. A selected
+    (method, path) that no longer exists in this scan's evidence (the
+    route was renamed or removed in code) is silently absent from the
+    candidates - selection rows are additive intent, not a promise that a
+    now-stale selection survives forever; the dashboard's own coverage
+    count reads directly off what actually gets checked, not off the
+    stored selection size.
+    """
+    selection = get_endpoint_health_selection(dsn, installation_id, repo_full_name)
+    if not selection:
+        return endpoints
+    candidates = [e for e in endpoints if (e.get("method"), e.get("path")) in selection]
+    return sorted(candidates, key=lambda e: (e.get("path") or "", e.get("method") or ""))
+
+
+def _endpoint_results(
+    dsn: str, installation_id: int, repo_full_name: str, evidence: dict, base_url: str, pinned_ip: str
+) -> list[dict]:
     endpoints = evidence.get("repository", {}).get("api_endpoints", {}).get("endpoints", [])
     if not endpoints:
         return []
-    checked_endpoints = endpoints[:MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET]
-    if len(endpoints) > len(checked_endpoints):
+    candidates = _candidate_endpoints(dsn, installation_id, repo_full_name, endpoints)
+    checked_endpoints = candidates[:MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET]
+    if len(candidates) > len(checked_endpoints):
         logging.getLogger("scan_worker.jobs").warning(
-            "health check target has %s endpoints; checking first %s this sweep",
-            len(endpoints),
+            "health check target has %s monitorable endpoints; checking first %s this sweep",
+            len(candidates),
             len(checked_endpoints),
         )
     results = run_healthcheck(checked_endpoints, base_url, pinned_ip=pinned_ip).get("results", [])
@@ -2984,7 +3026,7 @@ def _run_health_check_sweep_for_target(
     if evidence is None:
         return
 
-    for entry in _endpoint_results(evidence, base_url, pinned_ip):
+    for entry in _endpoint_results(dsn, installation_id, repo_full_name, evidence, base_url, pinned_ip):
         if entry.get("skipped"):
             continue
         method = entry["method"]

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2434,30 +2434,51 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
             )
 
 
-def _candidate_endpoints(dsn: str, installation_id: int, repo_full_name: str, endpoints: list[dict]) -> list[dict]:
-    """Which endpoints from this scan's real, full list are actually
-    eligible to be health-checked, before the MAX_HEALTH_CHECK_ENDPOINTS_
-    PER_TARGET cap below narrows that further.
+def rank_endpoints_by_selection(
+    endpoints: list[dict], selected_keys: set[tuple[str, str]]
+) -> list[dict]:
+    """Which endpoints from a scan's real, full list are candidates for
+    health-checking, and in what order - pure ranking, no I/O and no
+    MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET cap (each caller applies that
+    slice itself, since _endpoint_results also needs the pre-cap count for
+    its own "more than N found" log line).
 
-    No selection rows for this repo (the default, unchanged from before
-    this existed): every endpoint is a candidate, in scan order - the cap
-    below picks the first N. Any selection rows at all: ONLY the selected
-    endpoints are candidates, sorted by (path, method) for a stable,
-    predictable order when a customer selects more than the cap allows -
-    "which ones win" must never depend on evidence's own arbitrary scan
-    order once a customer has made an explicit choice. A selected
-    (method, path) that no longer exists in this scan's evidence (the
-    route was renamed or removed in code) is silently absent from the
-    candidates - selection rows are additive intent, not a promise that a
-    now-stale selection survives forever; the dashboard's own coverage
-    count reads directly off what actually gets checked, not off the
-    stored selection size.
+    Not private (no leading underscore), and deliberately the ONLY place
+    this ranking is computed: app_server.admin's health-endpoints route
+    needs the identical answer to show a customer real, not assumed,
+    monitoring coverage - two independently-written copies of this logic
+    (one here, one in admin.py) would be exactly the kind of sibling
+    implementation that silently drifts apart the first time only one of
+    them gets updated. _candidate_endpoints below is this function's only
+    caller in this file; admin.py imports and calls this one directly.
+
+    No selected_keys: every endpoint is a candidate, in scan order. Any
+    selected_keys at all: ONLY the selected endpoints are candidates,
+    sorted by (path, method) for a stable, predictable order when a
+    customer selects more than the cap allows - "which ones win" must
+    never depend on evidence's own arbitrary scan order once a customer
+    has made an explicit choice. A selected (method, path) that no longer
+    exists in this scan's evidence (the route was renamed or removed in
+    code) is silently absent from the candidates - selection rows are
+    additive intent, not a promise that a now-stale selection survives
+    forever; a coverage count built from this function's real output
+    already reflects that, not the raw stored selection size.
     """
-    selection = get_endpoint_health_selection(dsn, installation_id, repo_full_name)
-    if not selection:
+    if not selected_keys:
         return endpoints
-    candidates = [e for e in endpoints if (e.get("method"), e.get("path")) in selection]
+    candidates = [e for e in endpoints if (e.get("method"), e.get("path")) in selected_keys]
     return sorted(candidates, key=lambda e: (e.get("path") or "", e.get("method") or ""))
+
+
+def _candidate_endpoints(dsn: str, installation_id: int, repo_full_name: str, endpoints: list[dict]) -> list[dict]:
+    """This scan's real endpoints, ranked by rank_endpoints_by_selection
+    against whatever this repo's stored selection (if any) says - see that
+    function's own docstring for the full reasoning. This wrapper is only
+    what differs between the real sweep and admin.py's read route: fetching
+    the selection itself, which the sweep does synchronously against dsn
+    and admin.py does asynchronously against its own pool beforehand."""
+    selection = get_endpoint_health_selection(dsn, installation_id, repo_full_name)
+    return rank_endpoints_by_selection(endpoints, selection)
 
 
 def _endpoint_results(

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -19,6 +19,7 @@ from app_server.admin import (
     _build_updated_seat_items,
     _has_real_admin_permission,
     _looks_like_email,
+    _monitored_endpoint_keys,
     _repo_installation_id,
 )
 from app_server.auth import decrypt_access_token, encrypt_access_token, sign_session_id
@@ -919,6 +920,28 @@ async def test_remove_health_check_target(pool, monkeypatch):
     assert page.json()["health_targets"] == []
 
 
+def test_monitored_endpoint_keys_delegates_to_the_shared_ranking_function():
+    # Real drift risk found via self-review: an earlier version of
+    # _monitored_endpoint_keys reimplemented the candidate-then-cap
+    # ranking as its own parallel copy of scan_worker.jobs.
+    # rank_endpoints_by_selection - two independently-written copies of
+    # "what counts as monitored" is exactly the kind of sibling logic
+    # that silently drifts the first time only one of them gets updated.
+    # This confirms admin.py now calls the shared function directly
+    # rather than reimplementing it.
+    from scan_worker.jobs import rank_endpoints_by_selection
+
+    endpoints = [
+        {"method": "GET", "path": "/a"},
+        {"method": "GET", "path": "/b"},
+        {"method": "GET", "path": "/c"},
+    ]
+    selected = {("GET", "/c"), ("GET", "/a")}
+    expected = {(e["method"], e["path"]) for e in rank_endpoints_by_selection(endpoints, selected)}
+
+    assert _monitored_endpoint_keys(endpoints, selected) == expected == {("GET", "/a"), ("GET", "/c")}
+
+
 @pytest.mark.asyncio
 async def test_list_health_check_endpoints_defaults_to_auto_mode(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch, installation_id=506)
@@ -1018,8 +1041,52 @@ async def test_set_health_check_endpoints_switches_to_manual_mode(pool, monkeypa
     body = get_response.json()
     assert body["mode"] == "manual"
     assert body["monitored_endpoint_count"] == 1
+    assert body["candidate_count"] == 1
     monitored = {e["path"]: e["monitored"] for e in body["endpoints"]}
     assert monitored == {"/a": False, "/b": True}
+
+
+@pytest.mark.asyncio
+async def test_candidate_count_reflects_the_selection_not_the_whole_repo(pool, monkeypatch):
+    # Real bug found via self-review: an earlier version of the frontend's
+    # "still capped" caveat compared total_endpoint_count (the whole repo)
+    # against the cap, even in manual mode - a repo with more endpoints
+    # than the cap where a customer explicitly selected FEWER than the cap
+    # would wrongly report as still-capped, even though nothing of their
+    # selection was cut off. candidate_count must reflect the real
+    # candidate set (the selection, once one exists), not the repo total.
+    monkeypatch.setattr("app_server.admin.MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET", 2)
+    client = await _logged_in_client(pool, monkeypatch, installation_id=510)
+    await insert_repo_history(
+        pool,
+        510,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {"method": "GET", "path": "/a"},
+                        {"method": "GET", "path": "/b"},
+                        {"method": "GET", "path": "/c"},
+                    ]
+                }
+            },
+        },
+    )
+    async with client:
+        await client.put(
+            "/admin/octocat/hello-world/health-endpoints",
+            json={"selections": [{"method": "GET", "path": "/a"}]},
+        )
+        get_response = await client.get("/admin/octocat/hello-world/health-endpoints")
+
+    body = get_response.json()
+    assert body["mode"] == "manual"
+    assert body["total_endpoint_count"] == 3  # the whole repo - more than the cap (2)
+    assert body["candidate_count"] == 1  # the real candidate set - the one selected endpoint
+    assert body["monitored_endpoint_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -920,6 +920,149 @@ async def test_remove_health_check_target(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_health_check_endpoints_defaults_to_auto_mode(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, installation_id=506)
+    await insert_repo_history(
+        pool,
+        506,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {"method": "GET", "path": "/a", "file": "a.py", "line": 1},
+                        {"method": "GET", "path": "/b", "file": "b.py", "line": 1},
+                    ]
+                }
+            },
+        },
+    )
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/health-endpoints")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["mode"] == "auto"
+    assert body["total_endpoint_count"] == 2
+    assert body["monitored_endpoint_count"] == 2
+    assert all(e["monitored"] for e in body["endpoints"])
+
+
+@pytest.mark.asyncio
+async def test_list_health_check_endpoints_respects_the_cap_in_auto_mode(pool, monkeypatch):
+    monkeypatch.setattr("app_server.admin.MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET", 1)
+    client = await _logged_in_client(pool, monkeypatch, installation_id=507)
+    await insert_repo_history(
+        pool,
+        507,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {"method": "GET", "path": "/a", "file": "a.py", "line": 1},
+                        {"method": "GET", "path": "/b", "file": "b.py", "line": 1},
+                    ]
+                }
+            },
+        },
+    )
+    async with client:
+        response = await client.get("/admin/octocat/hello-world/health-endpoints")
+
+    body = response.json()
+    assert body["mode"] == "auto"
+    assert body["monitored_endpoint_count"] == 1
+    monitored = [e["path"] for e in body["endpoints"] if e["monitored"]]
+    assert monitored == ["/a"]
+
+
+@pytest.mark.asyncio
+async def test_set_health_check_endpoints_switches_to_manual_mode(pool, monkeypatch):
+    # Real feature this closes: a repo with more real endpoints than the
+    # cap previously had no way for the customer to choose which ones get
+    # checked - Aletheore always silently picked the first N in whatever
+    # arbitrary order the scan happened to produce them in.
+    monkeypatch.setattr("app_server.admin.MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET", 1)
+    client = await _logged_in_client(pool, monkeypatch, installation_id=508)
+    await insert_repo_history(
+        pool,
+        508,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {"method": "GET", "path": "/a", "file": "a.py", "line": 1},
+                        {"method": "GET", "path": "/b", "file": "b.py", "line": 1},
+                    ]
+                }
+            },
+        },
+    )
+    async with client:
+        set_response = await client.put(
+            "/admin/octocat/hello-world/health-endpoints",
+            json={"selections": [{"method": "GET", "path": "/b"}]},
+        )
+        get_response = await client.get("/admin/octocat/hello-world/health-endpoints")
+
+    assert set_response.status_code == 200
+    assert set_response.json()["selected_count"] == 1
+    body = get_response.json()
+    assert body["mode"] == "manual"
+    assert body["monitored_endpoint_count"] == 1
+    monitored = {e["path"]: e["monitored"] for e in body["endpoints"]}
+    assert monitored == {"/a": False, "/b": True}
+
+
+@pytest.mark.asyncio
+async def test_set_health_check_endpoints_empty_selection_resets_to_auto_mode(pool, monkeypatch):
+    client = await _logged_in_client(pool, monkeypatch, installation_id=509)
+    await insert_repo_history(
+        pool,
+        509,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/a"}]}},
+        },
+    )
+    async with client:
+        await client.put(
+            "/admin/octocat/hello-world/health-endpoints",
+            json={"selections": [{"method": "GET", "path": "/a"}]},
+        )
+        reset_response = await client.put(
+            "/admin/octocat/hello-world/health-endpoints", json={"selections": []}
+        )
+        get_response = await client.get("/admin/octocat/hello-world/health-endpoints")
+
+    assert reset_response.status_code == 200
+    assert get_response.json()["mode"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_health_check_endpoints_requires_login(pool):
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        get_response = await client.get("/admin/octocat/hello-world/health-endpoints")
+        put_response = await client.put(
+            "/admin/octocat/hello-world/health-endpoints", json={"selections": []}
+        )
+    assert get_response.status_code == 401
+    assert put_response.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_set_webhook_url_rejects_internal_address(pool, monkeypatch):
     client = await _logged_in_client(pool, monkeypatch)
     monkeypatch.setattr(

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -1362,9 +1362,13 @@ async def test_dashboard_health_reports_real_endpoint_coverage_against_the_monit
     # NEVER checked, with no signal anywhere in this dashboard before this
     # fix. total_endpoint_count/monitored_endpoint_count let the frontend
     # show real coverage instead of implying every endpoint is watched.
-    import app_server.dashboard as dashboard_module
+    #
+    # monitored_endpoint_count is computed via app_server.admin's
+    # _monitored_endpoint_keys (see get_dashboard_health), so the cap this
+    # test overrides lives on the admin module now, not dashboard's own.
+    import app_server.admin as admin_module
 
-    monkeypatch.setattr(dashboard_module, "MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET", 2)
+    monkeypatch.setattr(admin_module, "MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET", 2)
     await upsert_installation(pool, 506, "octocat")
     await set_installation_plan(pool, 506, "air")
     await insert_repo_history(

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -1353,6 +1353,49 @@ async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_health_reports_real_endpoint_coverage_against_the_monitoring_cap(
+    pool, monkeypatch
+):
+    # Real gap found via audit: run_health_check_sweep_job only ever checks
+    # the first MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET endpoints found in a
+    # repo - a repo with more real endpoints than that has some that are
+    # NEVER checked, with no signal anywhere in this dashboard before this
+    # fix. total_endpoint_count/monitored_endpoint_count let the frontend
+    # show real coverage instead of implying every endpoint is watched.
+    import app_server.dashboard as dashboard_module
+
+    monkeypatch.setattr(dashboard_module, "MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET", 2)
+    await upsert_installation(pool, 506, "octocat")
+    await set_installation_plan(pool, 506, "air")
+    await insert_repo_history(
+        pool,
+        506,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {"method": "GET", "path": "/a", "file": "a.py", "line": 1},
+                        {"method": "GET", "path": "/b", "file": "b.py", "line": 1},
+                        {"method": "GET", "path": "/c", "file": "c.py", "line": 1},
+                    ]
+                }
+            },
+        },
+    )
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[506])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_endpoint_count"] == 3
+    assert body["monitored_endpoint_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_dashboard_health_omits_stale_endpoints_with_recent_success(pool, monkeypatch):
     await upsert_installation(pool, 505, "octocat")
     await set_installation_plan(pool, 505, "air")

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3753,6 +3753,13 @@ def _patch_sweep(
         lambda dsn, iid, repo: evidence
         or {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
     )
+    # Empty by default (no explicit selection - the pre-existing "check
+    # everything the scan found, in scan order" behavior every test below
+    # already assumes) - see test_jobs.py's own dedicated selection tests
+    # for the non-empty case.
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: set()
+    )
     default_first = result_entry or {
         "method": "GET",
         "path": "/x",
@@ -3780,6 +3787,119 @@ def _patch_sweep(
     sent = []
     monkeypatch.setattr("scan_worker.jobs.send_health_alert", lambda url, msg, **k: sent.append(msg))
     return sent
+
+
+def test_candidate_endpoints_uses_scan_order_with_no_selection(monkeypatch):
+    from scan_worker.jobs import _candidate_endpoints
+
+    monkeypatch.setattr("scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: set())
+    endpoints = [{"method": "GET", "path": "/a"}, {"method": "GET", "path": "/b"}]
+
+    assert _candidate_endpoints("dsn", 1, "o/r", endpoints) == endpoints
+
+
+def test_candidate_endpoints_uses_only_selected_ones_when_present(monkeypatch):
+    # Real feature this covers: once a customer has selected ANY endpoints
+    # (see migration 060/admin.py's health-endpoints routes), only those
+    # are candidates - an unselected endpoint is never checked even if
+    # there's room under the cap, so a customer's explicit choice is
+    # respected exactly, not just used as a tiebreaker.
+    from scan_worker.jobs import _candidate_endpoints
+
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: {("GET", "/b")}
+    )
+    endpoints = [
+        {"method": "GET", "path": "/a"},
+        {"method": "GET", "path": "/b"},
+        {"method": "GET", "path": "/c"},
+    ]
+
+    assert _candidate_endpoints("dsn", 1, "o/r", endpoints) == [{"method": "GET", "path": "/b"}]
+
+
+def test_candidate_endpoints_sorts_selected_ones_for_a_stable_order(monkeypatch):
+    # A selection larger than MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET still
+    # needs a deterministic "which ones win" order - sorted by (path,
+    # method), not evidence's own arbitrary scan order, so the answer
+    # never depends on scan-to-scan reordering once a customer has chosen.
+    from scan_worker.jobs import _candidate_endpoints
+
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection",
+        lambda dsn, iid, repo: {("GET", "/z"), ("GET", "/a"), ("POST", "/a")},
+    )
+    endpoints = [
+        {"method": "GET", "path": "/z"},
+        {"method": "POST", "path": "/a"},
+        {"method": "GET", "path": "/a"},
+    ]
+
+    assert _candidate_endpoints("dsn", 1, "o/r", endpoints) == [
+        {"method": "GET", "path": "/a"},
+        {"method": "POST", "path": "/a"},
+        {"method": "GET", "path": "/z"},
+    ]
+
+
+def test_candidate_endpoints_drops_a_selected_endpoint_no_longer_in_evidence(monkeypatch):
+    # A selected (method, path) that no longer exists in the current scan
+    # (the route was renamed or removed in code) is silently absent from
+    # the candidates - a stale selection row is not a promise the route
+    # still exists.
+    from scan_worker.jobs import _candidate_endpoints
+
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection",
+        lambda dsn, iid, repo: {("GET", "/removed")},
+    )
+    endpoints = [{"method": "GET", "path": "/a"}]
+
+    assert _candidate_endpoints("dsn", 1, "o/r", endpoints) == []
+
+
+def test_sweep_only_checks_selected_endpoints_when_a_selection_exists(monkeypatch):
+    sent = _patch_sweep(
+        monkeypatch,
+        prior=None,
+        evidence={
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {"method": "GET", "path": "/a"},
+                        {"method": "GET", "path": "/x"},
+                    ]
+                }
+            }
+        },
+        result_entry={
+            "method": "GET",
+            "path": "/x",
+            "reachable": True,
+            "status_code": 200,
+            "latency_ms": 90.0,
+            "response_shape": None,
+        },
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: {("GET", "/x")}
+    )
+    checked = []
+
+    def spying_healthcheck(endpoints, base_url, pinned_ip=None):
+        checked.extend(e["path"] for e in endpoints)
+        return {"results": [
+            {"method": "GET", "path": "/x", "reachable": True, "status_code": 200,
+             "latency_ms": 90.0, "response_shape": None}
+        ]}
+
+    monkeypatch.setattr("scan_worker.jobs.run_healthcheck", spying_healthcheck)
+
+    from scan_worker.jobs import run_health_check_sweep_job
+
+    run_health_check_sweep_job()
+
+    assert checked == ["/x"]
 
 
 def test_send_alerts_if_configured_sends_email_when_alert_email_set(monkeypatch):
@@ -4496,6 +4616,9 @@ def test_sweep_isolates_one_targets_failure_from_others(monkeypatch):
 
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", fake_get_latest_evidence)
     monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: set()
+    )
+    monkeypatch.setattr(
         "scan_worker.jobs.run_healthcheck",
         lambda endpoints, base_url, pinned_ip=None: {
             "results": [{"method": "GET", "path": "/x", "reachable": True, "status_code": 200, "latency_ms": 90.0}]
@@ -4595,6 +4718,9 @@ def test_sweep_proceeds_when_target_url_still_passes_validation(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.get_latest_evidence",
         lambda dsn, iid, repo: {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: set()
     )
     monkeypatch.setattr(
         "scan_worker.jobs.run_healthcheck",
@@ -4719,6 +4845,9 @@ def test_sweep_checks_every_target_independently(monkeypatch):
         "scan_worker.jobs.get_latest_evidence",
         lambda dsn, iid, repo: {"repository": {"api_endpoints": {"endpoints": [{"method": "GET", "path": "/x"}]}}},
     )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: set()
+    )
 
     def fake_healthcheck(endpoints, base_url, pinned_ip=None):
         reachable = base_url == "https://staging.example.com"
@@ -4809,6 +4938,9 @@ def test_sweep_schedules_down_retries_without_blocking_later_targets(monkeypatch
         }
 
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", fake_evidence)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_endpoint_health_selection", lambda dsn, iid, repo: set()
+    )
 
     def fake_healthcheck(endpoints, base_url, pinned_ip=None):
         if base_url == "https://slow.example.com":

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3789,6 +3789,40 @@ def _patch_sweep(
     return sent
 
 
+def test_rank_endpoints_by_selection_uses_scan_order_with_no_selection():
+    from scan_worker.jobs import rank_endpoints_by_selection
+
+    endpoints = [{"method": "GET", "path": "/a"}, {"method": "GET", "path": "/b"}]
+    assert rank_endpoints_by_selection(endpoints, set()) == endpoints
+
+
+def test_rank_endpoints_by_selection_filters_and_sorts():
+    # This is the single, shared source of truth _candidate_endpoints (the
+    # real sweep) and app_server.admin's _monitored_endpoint_keys (the
+    # dashboard's read route) both call directly - real drift risk found
+    # via self-review: an earlier version had admin.py reimplement this
+    # same filter+sort as its own parallel copy.
+    from scan_worker.jobs import rank_endpoints_by_selection
+
+    endpoints = [
+        {"method": "GET", "path": "/z"},
+        {"method": "POST", "path": "/a"},
+        {"method": "GET", "path": "/a"},
+    ]
+    result = rank_endpoints_by_selection(endpoints, {("GET", "/z"), ("GET", "/a")})
+    assert result == [
+        {"method": "GET", "path": "/a"},
+        {"method": "GET", "path": "/z"},
+    ]
+
+
+def test_rank_endpoints_by_selection_drops_a_selected_endpoint_no_longer_present():
+    from scan_worker.jobs import rank_endpoints_by_selection
+
+    endpoints = [{"method": "GET", "path": "/a"}]
+    assert rank_endpoints_by_selection(endpoints, {("GET", "/removed")}) == []
+
+
 def test_candidate_endpoints_uses_scan_order_with_no_selection(monkeypatch):
     from scan_worker.jobs import _candidate_endpoints
 

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -24,6 +24,7 @@ from scan_worker.db import (
     delete_wiki_subsystems_not_in,
     email_already_sent,
     get_dismissed_identity_keys,
+    get_endpoint_health_selection,
     get_endpoint_health_summary,
     get_flash_review_finding_comments,
     insert_flash_review_finding_comment,
@@ -106,6 +107,44 @@ async def test_list_health_check_targets_all_filters_by_plan(pool):
     targets = list_health_check_targets_all(TEST_DATABASE_URL)
     installation_ids = {t["installation_id"] for t in targets}
     assert installation_ids == {301}
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_health_selection_empty_by_default(pool):
+    await _insert_installation(pool, 350, "sel-default", plan="air")
+
+    selection = get_endpoint_health_selection(TEST_DATABASE_URL, 350, "sel-default/repo")
+    assert selection == set()
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_health_selection_returns_selected_pairs(pool):
+    await _insert_installation(pool, 351, "sel-set", plan="air")
+    await pool.execute(
+        """
+        INSERT INTO endpoint_health_selection (installation_id, repo_full_name, endpoint_method, endpoint_path)
+        VALUES ($1, $2, $3, $4), ($1, $2, $5, $6)
+        """,
+        351, "sel-set/repo", "GET", "/a", "POST", "/b",
+    )
+
+    selection = get_endpoint_health_selection(TEST_DATABASE_URL, 351, "sel-set/repo")
+    assert selection == {("GET", "/a"), ("POST", "/b")}
+
+
+@pytest.mark.asyncio
+async def test_get_endpoint_health_selection_scoped_per_repo(pool):
+    await _insert_installation(pool, 352, "sel-scope", plan="air")
+    await pool.execute(
+        """
+        INSERT INTO endpoint_health_selection (installation_id, repo_full_name, endpoint_method, endpoint_path)
+        VALUES ($1, $2, $3, $4)
+        """,
+        352, "sel-scope/other-repo", "GET", "/a",
+    )
+
+    selection = get_endpoint_health_selection(TEST_DATABASE_URL, 352, "sel-scope/repo")
+    assert selection == set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context
Recreated as a fresh PR targeting master directly - the original #589 was based on #588's branch, which GitHub auto-closed this PR when it deleted #588's branch after squash-merging it. Same content, not re-reviewed from scratch (already reviewed and verified against #588 merged into master).

Follow-up from discussion after #588: once a repo has more API endpoints than `MAX_HEALTH_CHECK_ENDPOINTS_PER_TARGET` (64), Aletheore silently monitored whichever 64 happened to be first in the scanner's own (arbitrary) evidence order, with no way for the customer to choose otherwise. This closes that gap with real, explicit customer control.

## What's new
- **Migration 060**: `endpoint_health_selection` (installation_id, repo_full_name, endpoint_method, endpoint_path). Presence of a row is the whole signal. No rows = default first-N behavior, unchanged. Any rows = "monitor exactly these", sorted by (path, method) for a stable order if a customer selects more than the cap.
- **`scan_worker/db.py` / `app_server/db.py`**: sync and async `get_endpoint_health_selection`, plus async `replace_endpoint_health_selection` (atomic bulk replace).
- **`scan_worker/jobs.py`**: `rank_endpoints_by_selection` is the single shared ranking function both the real sweep and the admin read route call, so the dashboard's coverage count can never drift from what the next sweep actually checks.
- **`admin.py`**: `GET`/`PUT /admin/{org}/{repo}/health-endpoints` - list every discovered endpoint with its real monitored state, bulk-replace the selection. AIR-tier gated via the existing `_require_admin_installation` (same 402 as every other admin dashboard route).
- **`dashboard.py`**: `monitored_endpoint_count` reflects the real selection-aware count.
- **`frontend.py`**: new "Monitored endpoints" section - checkboxes, Save, Reset to automatic.

Includes a self-review follow-up fix (extracted duplicated ranking logic into the shared `rank_endpoints_by_selection`, fixed a real `candidate_count` vs `total_endpoint_count` bug in the "still capped" message).

## Test plan
- [x] `pytest github-app/tests/test_jobs.py` — 214 passed
- [x] `pytest github-app/tests/test_admin.py github-app/tests/test_dashboard.py github-app/tests/test_scan_worker_db.py` — 316 passed
- [x] `pytest github-app/tests/test_migrate.py` — 4 passed
- [x] `python -c "import app_server.frontend"` — the edited embedded-JS f-string still evaluates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)