### PR TITLE
fix: compiled-language entry points (Go/Rust/Java/C#) always flagged as dead code

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -116,16 +116,31 @@ _KOTLIN_PACKAGE_PATTERN = re.compile(r"^\s*package\s+([\w.]+)", re.MULTILINE)
 # repo in these four languages, not a hypothetical shape.
 _GO_PACKAGE_MAIN_PATTERN = re.compile(r"^\s*package\s+main\b", re.MULTILINE)
 _GO_FUNC_MAIN_PATTERN = re.compile(r"^\s*func\s+main\s*\(", re.MULTILINE)
-_RUST_FN_MAIN_PATTERN = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+main\s*\(", re.MULTILINE)
+# Anchored to column 0 (no leading whitespace), not `^\s*` - a real
+# crate-root fn main() is always unindented; requiring that excludes a
+# nested `mod tests { fn main() {} }`, which rustfmt always indents, from
+# matching as if it were the crate's real entry point.
+_RUST_FN_MAIN_PATTERN = re.compile(r"^(?:pub\s+)?(?:async\s+)?fn\s+main\s*\(", re.MULTILINE)
+# Modifiers can appear in any order and any legal Java main method can carry
+# extras beyond public/static (final, synchronized, strictfp) - e.g. `public
+# final static void main(...)` or `public static synchronized void main(...)`.
+# Two same-line lookaheads (public and static each appear somewhere before
+# void main() on this line) rather than one fixed-order sequence, so real
+# modifier combinations aren't missed - but still scoped to one line/
+# statement, not "anywhere in the file", for the same reason the C# check
+# below requires static and Main to co-occur on one declaration.
 _JAVA_MAIN_METHOD_PATTERN = re.compile(
-    r"^\s*(?:public\s+static|static\s+public)\s+void\s+main\s*\(", re.MULTILINE
+    r"^\s*(?=[^;{}\n]*\bpublic\b)(?=[^;{}\n]*\bstatic\b)[\w\s]*\bvoid\s+main\s*\(",
+    re.MULTILINE,
 )
-# C#'s Main can carry any modifier order/return type (void/int/Task/Task<int>)
-# and an optional access modifier - two independent signals both required
-# (the same bounded-heuristic shape as the Hilt/Dagger check below) rather
-# than one combined regex trying to enumerate every legal signature.
-_CSHARP_STATIC_KEYWORD_PATTERN = re.compile(r"\bstatic\b")
-_CSHARP_MAIN_METHOD_PATTERN = re.compile(r"\bMain\s*\(")
+# C#'s Main can carry any modifier order/return type (void/int/Task/Task<int>).
+# Scoped to one line via a lookahead requiring `static` before `Main(` on the
+# same statement - not two independent whole-file searches, which would also
+# match a file containing an unrelated static helper elsewhere plus a
+# separate instance `void Main()`.
+_CSHARP_MAIN_METHOD_PATTERN = re.compile(
+    r"^\s*(?=[^;{}\n]*\bstatic\b)[\w\s<>]*\bMain\s*\(", re.MULTILINE
+)
 
 _HTML_SCRIPT_SRC_PATTERN = re.compile(r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE)
 
@@ -276,9 +291,7 @@ def _has_csharp_main_method(repo_path: Path, path: str) -> bool:
         content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return False
-    return bool(
-        _CSHARP_STATIC_KEYWORD_PATTERN.search(content) and _CSHARP_MAIN_METHOD_PATTERN.search(content)
-    )
+    return bool(_CSHARP_MAIN_METHOD_PATTERN.search(content))
 
 
 def _has_hilt_dagger_annotation(repo_path: Path, path: str) -> bool:

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -103,6 +103,30 @@ _DAGGER_INSTALL_IN_PATTERN = re.compile(r"^\s*@(?:InstallIn|TestInstallIn)\b", r
 # reason to hand this module just for one line of source.
 _KOTLIN_PACKAGE_PATTERN = re.compile(r"^\s*package\s+([\w.]+)", re.MULTILINE)
 
+# Compiled-language entry points, same category as the Python __main__ guard
+# and Swift @main above: each language's real, unambiguous "the runtime
+# invokes this, no import ever will" convention. Confirmed empirically on
+# each language's own module-graph resolution (build_module_graph correctly
+# resolves ordinary intra-repo imports for all four; a file matching one of
+# these is specifically the one every real deploy invokes directly, which by
+# definition nothing else in the repo imports): a Go package main's func
+# main(), Rust's src/main.rs or any file with a top-level fn main(), a Java
+# class's public static void main(String[] args), and a C# Main method - all
+# looked completely unreachable without this, on every real single-binary
+# repo in these four languages, not a hypothetical shape.
+_GO_PACKAGE_MAIN_PATTERN = re.compile(r"^\s*package\s+main\b", re.MULTILINE)
+_GO_FUNC_MAIN_PATTERN = re.compile(r"^\s*func\s+main\s*\(", re.MULTILINE)
+_RUST_FN_MAIN_PATTERN = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+main\s*\(", re.MULTILINE)
+_JAVA_MAIN_METHOD_PATTERN = re.compile(
+    r"^\s*(?:public\s+static|static\s+public)\s+void\s+main\s*\(", re.MULTILINE
+)
+# C#'s Main can carry any modifier order/return type (void/int/Task/Task<int>)
+# and an optional access modifier - two independent signals both required
+# (the same bounded-heuristic shape as the Hilt/Dagger check below) rather
+# than one combined regex trying to enumerate every legal signature.
+_CSHARP_STATIC_KEYWORD_PATTERN = re.compile(r"\bstatic\b")
+_CSHARP_MAIN_METHOD_PATTERN = re.compile(r"\bMain\s*\(")
+
 _HTML_SCRIPT_SRC_PATTERN = re.compile(r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE)
 
 # A module dispatched by dotted-string name (RQ's queue.enqueue("pkg.mod.func", ...),
@@ -215,6 +239,48 @@ def _has_swift_main_attribute(repo_path: Path, path: str) -> bool:
     return bool(_SWIFT_MAIN_ATTRIBUTE_PATTERN.search(content))
 
 
+def _has_go_main_function(repo_path: Path, path: str) -> bool:
+    if not path.endswith(".go"):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(_GO_PACKAGE_MAIN_PATTERN.search(content) and _GO_FUNC_MAIN_PATTERN.search(content))
+
+
+def _has_rust_main_function(repo_path: Path, path: str) -> bool:
+    if not path.endswith(".rs"):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(_RUST_FN_MAIN_PATTERN.search(content))
+
+
+def _has_java_main_method(repo_path: Path, path: str) -> bool:
+    if not path.endswith(".java"):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(_JAVA_MAIN_METHOD_PATTERN.search(content))
+
+
+def _has_csharp_main_method(repo_path: Path, path: str) -> bool:
+    if not path.endswith(".cs"):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(
+        _CSHARP_STATIC_KEYWORD_PATTERN.search(content) and _CSHARP_MAIN_METHOD_PATTERN.search(content)
+    )
+
+
 def _has_hilt_dagger_annotation(repo_path: Path, path: str) -> bool:
     if not path.endswith((".kt", ".kts", ".java")):
         return False
@@ -290,8 +356,8 @@ def _android_manifest_entry_points(repo_path: Path, ignored_paths: list[str] | N
     return entry_points
 
 
-def _kotlin_package_of(repo_path: Path, path: str) -> str | None:
-    if not path.endswith((".kt", ".kts")):
+def _jvm_package_of(repo_path: Path, path: str) -> str | None:
+    if not path.endswith((".kt", ".kts", ".java")):
         return None
     try:
         content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
@@ -301,13 +367,13 @@ def _kotlin_package_of(repo_path: Path, path: str) -> str | None:
     return match.group(1) if match else None
 
 
-def _kotlin_package_reachable_files(
+def _jvm_package_reachable_files(
     repo_path: Path,
     modules: list[dict],
     android_manifest_entry_points: set[str],
 ) -> set[str]:
-    """Every Kotlin file sharing a package with a file that's reachable
-    some other way - the same blind spot _swift_target_reachable_files
+    """Every Kotlin or Java file sharing a package with a file that's
+    reachable some other way - the same blind spot _swift_target_reachable_files
     above already handles for Swift's whole-target visibility, just at
     package instead of target granularity.
 
@@ -323,11 +389,26 @@ def _kotlin_package_reachable_files(
     over: unreachable itself, but sharing a package with the
     @HiltViewModel-annotated StatisticsViewModel.kt.
 
+    Plain Java has the identical rule (JLS 7.5.1: no import needed for a
+    same-package type) - confirmed directly: two ordinary .java files
+    declaring the same package, one calling the other's static method with
+    zero import, produced zero edge between them in build_module_graph.
+    Originally this function only grouped .kt/.kts files, so every
+    same-package-only-referenced .java file (the ordinary shape for any
+    small-to-medium Java package, not an edge case) still looked
+    unreachable - the exact same blind spot already fixed for Kotlin,
+    silently never extended to the other JVM language this scanner
+    supports. Grouping Kotlin and Java files under the same package name
+    together (rather than keeping two separate maps) is deliberate, not
+    incidental: a real mixed-language Android/JVM project has both
+    languages sharing one package's visibility, by the JVM's own rules.
+
     A package's own reachability is judged by the same signals
     find_dead_code already treats as reachable on their own (imported_by,
-    a manifest entry point, or a Hilt/Dagger annotation) - propagating
-    from an already-independently-reachable sibling is the whole point,
-    so requiring anything more here would just miss the real cases above.
+    a manifest entry point, a Hilt/Dagger annotation, or - Java only - its
+    own public static void main) - propagating from an already-
+    independently-reachable sibling is the whole point, so requiring
+    anything more here would just miss the real cases above.
     Test files are excluded from the grouping entirely (not just left to
     fall through) so a test file's own package-mate status can never leak
     reachability into a production sibling that happens to share its
@@ -339,7 +420,7 @@ def _kotlin_package_reachable_files(
         path = module["path"]
         if is_test_file(path):
             continue
-        package = _kotlin_package_of(repo_path, path)
+        package = _jvm_package_of(repo_path, path)
         if package is not None:
             packages.setdefault(package, []).append(path)
 
@@ -352,6 +433,7 @@ def _kotlin_package_reachable_files(
             modules_by_path.get(path, {}).get("imported_by")
             or path in android_manifest_entry_points
             or _has_hilt_dagger_annotation(repo_path, path)
+            or _has_java_main_method(repo_path, path)
             for path in paths
         )
         if package_is_reachable:
@@ -567,7 +649,7 @@ def find_dead_code(
 
     html_script_entry_points = _html_script_entry_points(repo_path, ignored_paths)
     android_manifest_entry_points = _android_manifest_entry_points(repo_path, ignored_paths)
-    kotlin_package_reachable_files = _kotlin_package_reachable_files(
+    jvm_package_reachable_files = _jvm_package_reachable_files(
         repo_path, modules, android_manifest_entry_points
     )
     swift_reachable_files = _swift_target_reachable_files(repo_path, modules, ignored_paths)
@@ -581,7 +663,7 @@ def find_dead_code(
             continue
         if is_test_file(path):
             continue
-        if path in swift_reachable_files or path in kotlin_package_reachable_files:
+        if path in swift_reachable_files or path in jvm_package_reachable_files:
             continue
         if not module.get("imported_by", []):
             if (
@@ -589,6 +671,10 @@ def find_dead_code(
                 or path in android_manifest_entry_points
                 or _has_main_guard(repo_path, path)
                 or _has_hilt_dagger_annotation(repo_path, path)
+                or _has_go_main_function(repo_path, path)
+                or _has_rust_main_function(repo_path, path)
+                or _has_java_main_method(repo_path, path)
+                or _has_csharp_main_method(repo_path, path)
             ):
                 entry_points_detected.append(path)
                 continue

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -488,6 +488,62 @@ def test_csharp_static_main_method_is_never_unreachable(tmp_path):
     assert "Program.cs" in result["entry_points_detected"]
 
 
+def test_rust_nested_fn_main_in_a_test_module_is_not_a_crate_entry_point(tmp_path):
+    # Flash Review finding on PR #594: the original `^\s*fn\s+main\s*\(`
+    # allowed arbitrary leading whitespace, so a library file's nested
+    # `mod tests { fn main() {} }` (rustfmt always indents block contents)
+    # was treated as if it were the crate's real, unimported binary entry
+    # point. The real fn main() below is unindented (column 0); the one
+    # inside mod tests is indented and must not match.
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "lib.rs").write_text(
+        "pub fn helper() {}\n\n#[cfg(test)]\nmod tests {\n    fn main() {}\n}\n"
+    )
+    modules = [_module("src/lib.rs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "src/lib.rs" in [m["path"] for m in result["unreachable_modules"]]
+    assert "src/lib.rs" not in result["entry_points_detected"]
+
+
+def test_java_main_with_extra_modifiers_in_any_order_is_still_an_entry_point(tmp_path):
+    # Flash Review finding on PR #594: the original pattern only matched
+    # the exact sequences "public static" or "static public" immediately
+    # before "void main(" - real, legal Java main methods can carry extra
+    # modifiers (final, synchronized) in any position, e.g.
+    # `public final static void main(...)` or
+    # `public static synchronized void main(...)`.
+    pkg_dir = tmp_path / "src" / "main" / "java" / "com" / "example"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "Main.java").write_text(
+        "package com.example;\n\npublic class Main {\n"
+        "    public final static synchronized void main(String[] args) {\n"
+        "        Helper.hello();\n    }\n}\n"
+    )
+    modules = [_module("src/main/java/com/example/Main.java")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "src/main/java/com/example/Main.java" in result["entry_points_detected"]
+
+
+def test_csharp_static_helper_and_separate_instance_main_is_not_an_entry_point(tmp_path):
+    # Flash Review finding on PR #594: the original check searched the
+    # whole file independently for "static" and "Main(" as two separate
+    # signals, so a file with an unrelated static helper method AND a
+    # separate non-static instance Main() was wrongly treated as having a
+    # real static entry point - they must co-occur on the same
+    # declaration, not just both appear somewhere in the file.
+    (tmp_path / "Program.cs").write_text(
+        "using System;\n\nclass Program {\n"
+        "    static int Helper() { return 1; }\n"
+        "    void Main() { RunThing(); }\n}\n"
+    )
+    modules = [_module("Program.cs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "Program.cs" in [m["path"] for m in result["unreachable_modules"]]
+    assert "Program.cs" not in result["entry_points_detected"]
+
+
 def test_config_can_add_custom_entry_points(tmp_path):
     modules = [_module("app/worker.py")]
     config = {"dead_code_entry_points": ["app/worker.py"]}

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -393,6 +393,101 @@ def test_swift_target_with_no_reachable_member_stays_unreachable(tmp_path):
     assert "Sources/Orphan/OrphanThing.swift" in paths
 
 
+def test_go_package_main_func_main_is_never_unreachable(tmp_path):
+    # Real bug found via audit: a Go binary's entry point is never imported
+    # by anything in the repo (nothing in Go *can* import package main), so
+    # it always looked unreachable by the plain imported_by signal alone -
+    # same category as Python's __main__ guard and Swift's @main, just for
+    # Go's own real convention (package main + func main()).
+    (tmp_path / "main.go").write_text(
+        "package main\n\nimport \"example.com/app/internal/util\"\n\n"
+        "func main() {\n\tutil.Hello()\n}\n"
+    )
+    modules = [_module("main.go")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "main.go" in result["entry_points_detected"]
+
+
+def test_go_func_main_without_package_main_is_still_unreachable(tmp_path):
+    # A file merely containing a function named "main" in some other
+    # package isn't a real binary entry point - both signals (package main
+    # AND func main()) are required, not just the function name alone.
+    (tmp_path / "helper.go").write_text("package util\n\nfunc main() {}\n")
+    modules = [_module("helper.go")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [m["path"] for m in result["unreachable_modules"]]
+    assert "helper.go" in paths
+
+
+def test_rust_fn_main_is_never_unreachable(tmp_path):
+    # Real bug found via audit: same shape as Go above - Cargo's binary
+    # entry point (src/main.rs's fn main(), or any src/bin/*.rs) is never
+    # imported by anything else in the crate.
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "main.rs").write_text("mod util;\n\nfn main() {\n    util::hello();\n}\n")
+    modules = [_module("src/main.rs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "src/main.rs" in result["entry_points_detected"]
+
+
+def test_java_public_static_void_main_is_never_unreachable(tmp_path):
+    # Real bug found via audit: same shape again for Java's real entry-point
+    # convention - unlike Python's main.py/__main__.py filename heuristic,
+    # Java's entry class can be named anything, so this has to be a content
+    # check on the actual method signature, not a filename.
+    pkg_dir = tmp_path / "src" / "main" / "java" / "com" / "example"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "Main.java").write_text(
+        "package com.example;\n\npublic class Main {\n"
+        "    public static void main(String[] args) {\n        Helper.hello();\n    }\n}\n"
+    )
+    modules = [_module("src/main/java/com/example/Main.java")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "src/main/java/com/example/Main.java" in result["entry_points_detected"]
+
+
+def test_java_package_sibling_of_the_main_method_is_never_unreachable(tmp_path):
+    # Real bug found via audit: same-package Java classes need no import
+    # statement either (JLS 7.5.1), the identical rule the Kotlin package-
+    # propagation fix already covers - but this only grouped .kt/.kts files
+    # before, so Helper.java (referenced only by Main.java, no import)
+    # still looked unreachable even after Main.java itself is recognized as
+    # an entry point.
+    pkg_dir = tmp_path / "src" / "main" / "java" / "com" / "example"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "Main.java").write_text(
+        "package com.example;\n\npublic class Main {\n"
+        "    public static void main(String[] args) {\n        Helper.hello();\n    }\n}\n"
+    )
+    (pkg_dir / "Helper.java").write_text(
+        "package com.example;\n\npublic class Helper {\n    public static void hello() {}\n}\n"
+    )
+    modules = [
+        _module("src/main/java/com/example/Main.java"),
+        _module("src/main/java/com/example/Helper.java"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_csharp_static_main_method_is_never_unreachable(tmp_path):
+    # Real bug found via audit: C#'s Main is the same shape once more - the
+    # process entry point, never imported (C# doesn't even use imports for
+    # local resolution the way Java/Python do).
+    (tmp_path / "Program.cs").write_text(
+        "using System;\n\nclass Program {\n"
+        "    static void Main(string[] args) {\n        Helper.Hello();\n    }\n}\n"
+    )
+    modules = [_module("Program.cs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "Program.cs" in result["entry_points_detected"]
+
+
 def test_config_can_add_custom_entry_points(tmp_path):
     modules = [_module("app/worker.py")]
     config = {"dead_code_entry_points": ["app/worker.py"]}


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/dead_code.py` - confirmed by actually running `build_module_graph` + `find_dead_code` on minimal real repos (not just reading the code), in a non-symlinked directory to rule out macOS `/tmp` artifacts.

**Bug 1: Go/Rust/Java/C# entry points always flagged as dead code.** Python's `__main__` guard and Swift's `@main` are already recognized as real entry points nothing in a repo ever imports - but the same convention was never extended to the other four compiled languages this scanner supports:
- Go: `package main` + `func main()` (e.g. `main.go`)
- Rust: `fn main()` (e.g. `src/main.rs`, or any `src/bin/*.rs`)
- Java: `public static void main(String[] args)` (any class name - unlike Python, this can't be a filename heuristic)
- C#: a `static ... Main(...)` method (e.g. `Program.cs`)

Every one of these looked unreachable on every real single-binary repo in these languages.

**Bug 2: same-package Java classes still looked unreachable even with Bug 1 fixed.** Java has the identical same-package-no-import-required rule (JLS 7.5.1) that this file's Kotlin package-reachability propagation already exists to handle - but it only ever grouped `.kt`/`.kts` files. A class referenced only by its package-mate's `main` method (the ordinary shape for any small Java package) still looked unreachable. Generalized `_kotlin_package_of`/`_kotlin_package_reachable_files` → `_jvm_package_of`/`_jvm_package_reachable_files`, covering both languages under the visibility rule they actually share.

## Test plan
- [x] Constructed real minimal Go/Rust/Java/C# repos on disk and ran the actual scan pipeline end to end, before and after the fix
- [x] Added 6 regression tests (entry-point recognition per language, a Go negative case, and Java same-package propagation)
- [x] Full `src/tests/test_dead_code.py`: 50/50 passing
- [x] Full `src/tests/` suite: 1781/1781 passing
- [x] Confirmed no `github-app/` code references the renamed internal functions (only the public `find_dead_code()` output shape, unchanged)

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK