### PR TITLE
fix: secret scanner missed SECRET_KEY/*_TOKEN assignments, one of the most common real credential shapes

### DIFF
--- a/src/aletheore/secrets.py
+++ b/src/aletheore/secrets.py
@@ -147,12 +147,42 @@ SECRET_PATTERNS = [
             # negative by direct testing: 'os.environ["API_KEY"] = "sk-..."' never
             # matched, the same failure shape the quoted-key fix above already covers
             # for a plain dict literal.
-            r"(?i)(?:^|[\s_.'\"-])(PASSWORD|SECRET|API_KEY)['\"]?\]?\s*[:=]\s*"
+            #
+            # TOKEN and SECRET_KEY were added to the keyword alternation as their own
+            # real-world-confirmed gaps. TOKEN alone (not just the pre-existing
+            # PASSWORD/SECRET/API_KEY) covers AUTH_TOKEN=/ACCESS_TOKEN=/API_TOKEN=/bare
+            # TOKEN= via the existing "_" left-boundary - every one of those was a
+            # silent false negative before (nothing in the old keyword list matched an
+            # opaque bearer/session token unless its VALUE happened to match a
+            # format-specific pattern like gh*_/xox*-, which an arbitrary token never
+            # will). SECRET_KEY is added explicitly rather than relying on bare "SECRET"
+            # matching a "_KEY" suffix: Django's and Flask's own settings variable is
+            # named exactly SECRET_KEY, and "SECRET" alone does NOT match at that
+            # position (it's followed by "_KEY=", not the separator) - confirmed
+            # directly: SECRET_KEY="django-insecure-..." matched zero findings before
+            # this fix despite SECRET being in the keyword list. A bare "KEY" was
+            # deliberately NOT added: PUBLIC_KEY="ssh-rsa ..." is a real, common, and
+            # genuinely non-secret shape (public keys are meant to be public) that a
+            # bare KEY keyword would false-positive on.
+            r"(?i)(?:^|[\s_.'\"-])(PASSWORD|SECRET|SECRET_KEY|API_KEY|TOKEN)['\"]?\]?\s*[:=]\s*"
             r"['\"]?([A-Za-z0-9+/=_.-]{16,})['\"]?(?=\s|$|[,#;)}\]])"
         ),
         2,
     ),
 ]
+
+
+def _overlaps_a_specific_pattern_match(
+    value_span: tuple[int, int], claimed_spans: list[tuple[int, int]]
+) -> bool:
+    """True if `value_span` overlaps a span a dedicated, more specific
+    pattern already matched on this same line. generic_credential_assignment
+    is deliberately last in SECRET_PATTERNS, so callers only ever check this
+    for it - it can never suppress a dedicated pattern's own finding, only
+    its own redundant one.
+    """
+    start, end = value_span
+    return any(start < claimed_end and claimed_start < end for claimed_start, claimed_end in claimed_spans)
 
 
 def iter_all_files(repo_path: Path, ignored_paths: list[str] | None = None):
@@ -421,8 +451,23 @@ def find_secrets(repo_path: Path, baseline: list[dict] | None = None) -> dict:
         rel_path = path.relative_to(repo_path).as_posix()
         lines = text.splitlines()
         for line_no, line in enumerate(lines, start=1):
+            claimed_spans: list[tuple[int, int]] = []
             for pattern_name, pattern, value_group in SECRET_PATTERNS:
                 for match in pattern.finditer(line):
+                    value_span = match.span(value_group)
+                    if pattern_name == "generic_credential_assignment" and _overlaps_a_specific_pattern_match(
+                        value_span, claimed_spans
+                    ):
+                        # A dedicated pattern (github_token, aws_access_key_id, ...)
+                        # already matched this exact value on this line - e.g.
+                        # "token: ghs_..." matches both github_token AND, now that
+                        # TOKEN is a generic keyword, generic_credential_assignment
+                        # too. Without this, one real secret produced two findings
+                        # for the same value under two different pattern names,
+                        # which reads as the scanner double-counting rather than as
+                        # two real, independent secrets.
+                        continue
+                    claimed_spans.append(value_span)
                     value = match.group(value_group)
                     match_preview = _redact(value, f"{rel_path}:{pattern_name}")
                     likely_placeholder = _is_likely_placeholder(rel_path, value, pattern_name)
@@ -531,8 +576,15 @@ def find_secrets_in_history(
                 continue
 
             content = line[1:]
+            claimed_spans: list[tuple[int, int]] = []
             for pattern_name, pattern, value_group in SECRET_PATTERNS:
                 for match in pattern.finditer(content):
+                    value_span = match.span(value_group)
+                    if pattern_name == "generic_credential_assignment" and _overlaps_a_specific_pattern_match(
+                        value_span, claimed_spans
+                    ):
+                        continue  # see find_secrets' identical check for why
+                    claimed_spans.append(value_span)
                     value = match.group(value_group)
                     match_preview = _redact(value, f"{current_file}:{pattern_name}")
                     findings.append(

--- a/src/tests/test_secrets.py
+++ b/src/tests/test_secrets.py
@@ -402,6 +402,52 @@ def test_find_secrets_detects_dotted_attribute_credential_assignment(tmp_path):
     assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 2
 
 
+def test_find_secrets_detects_token_and_secret_key_keywords(tmp_path):
+    # Real bug found via audit: TOKEN wasn't in the keyword alternation at
+    # all, so AUTH_TOKEN=/ACCESS_TOKEN=/API_TOKEN=/bare TOKEN= were all
+    # silently invisible unless the value itself happened to match a
+    # format-specific pattern (gh*_/xox*-), which an arbitrary opaque
+    # token never will. SECRET_KEY= was invisible too, for a subtler
+    # reason: "SECRET" is in the keyword list, but SECRET_KEY= has "_KEY="
+    # right after "SECRET", not the separator, so the existing "SECRET"
+    # alternative never matched at that position - SECRET_KEY is Django's
+    # and Flask's own settings variable name, not a hypothetical shape.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "settings.py").write_text(
+        "SECRET_KEY = 'django-insecure-abc123def456ghi789jkl012mno345pqr'\n"
+        "AUTH_TOKEN = 'abc123def456ghi789jkl012mno345pqrstuvwx'\n"
+        "ACCESS_TOKEN = 'abc123def456ghi789jkl012mno345pqrstuvwx'\n"
+        "TOKEN = 'abc123def456ghi789jkl012mno345pqrstuvwx'\n"
+    )
+
+    findings = find_secrets(repo)["findings"]
+
+    assert sum(f["pattern"] == "generic_credential_assignment" for f in findings) == 4
+
+
+def test_find_secrets_does_not_flag_a_bare_key_or_token_as_a_field_name(tmp_path):
+    # A bare "KEY" keyword was deliberately not added alongside TOKEN/
+    # SECRET_KEY above: PUBLIC_KEY="ssh-rsa ..." is a real, common shape
+    # that is genuinely NOT a secret (public keys are meant to be public),
+    # and would false-positive under a bare KEY keyword. Separately,
+    # "TOKEN" only matches when it's immediately followed by the
+    # keyword/separator boundary - a field NAME like
+    # CSRF_TOKEN_FIELD_NAME= (TOKEN followed by "_FIELD_NAME", not "=")
+    # must not match either.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "settings.py").write_text(
+        "PUBLIC_KEY = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC'\n"
+        "CSRF_TOKEN_FIELD_NAME = 'csrfmiddlewaretoken1234567890'\n"
+        "MAX_TOKEN_LENGTH = 4096\n"
+    )
+
+    findings = find_secrets(repo)["findings"]
+
+    assert findings == []
+
+
 def test_find_secrets_detects_quoted_key_credential_assignment(tmp_path):
     # Regression: neither the left-boundary class nor the post-keyword gap
     # before ':'/'=' accounted for the keyword's own closing quote, and the


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/secrets.py` found a real, high-impact false-negative gap: the `generic_credential_assignment` keyword alternation was `(PASSWORD|SECRET|API_KEY)` only.

- `AUTH_TOKEN=`/`ACCESS_TOKEN=`/`API_TOKEN=`/bare `TOKEN=` all produced zero findings unless the value happened to match a format-specific pattern (`gh*_`/`xox*-`) - an arbitrary opaque token never will.
- `SECRET_KEY=` produced zero findings too, for a subtler reason: `SECRET` is a keyword, but `SECRET_KEY=` has `_KEY=` right after `SECRET`, not the separator, so the existing `SECRET` alternative never matched at that position. `SECRET_KEY` is Django's and Flask's own settings variable name, not a hypothetical shape.

## Fix
Added `TOKEN` and `SECRET_KEY` to the keyword alternation. Bare `KEY` was deliberately **not** added - `PUBLIC_KEY="ssh-rsa ..."` is a real, common, and genuinely non-secret shape (public keys are meant to be public) that a bare `KEY` keyword would false-positive on.

Fixing this surfaced a second, narrower issue: adding `TOKEN` as a keyword means a line like GitHub's own published OpenAPI example (`token: ghs_...`) now matches **both** the dedicated `github_token` pattern and `generic_credential_assignment`, double-reporting the same single real secret - caught by a pre-existing test regressing from 3 to 4 findings on that exact fixture. Added a small per-line overlap check (`generic_credential_assignment` is deliberately last in `SECRET_PATTERNS`) so a value already matched by a dedicated pattern is never also reported as a redundant generic finding, in both `find_secrets` and `find_secrets_in_history`.

## Test plan
- [x] Constructed real credential-shaped source and ran `find_secrets` directly, confirming each case before/after the fix
- [x] Added 2 regression tests: keyword coverage (`SECRET_KEY`/`*_TOKEN` family), and the `PUBLIC_KEY`/field-name false-positive guard
- [x] Full `src/tests/test_secrets.py`: 46/46 passing (including the pre-existing GitHub OpenAPI example test, which caught the double-count issue)
- [x] Full `src/tests/` suite: 1777/1777 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK