### PR TITLE
fix: Flash Review hunk-scope correction fired a self-contradictory false positive on every Python class-header hunk

### DIFF
--- a/github-app/scan_worker/flash_review_hunk_scope.py
+++ b/github-app/scan_worker/flash_review_hunk_scope.py
@@ -32,7 +32,23 @@ MAX_HUNK_SCOPE_BYTES = 4_000
 
 def _claimed_scope_name(header_context: str) -> str | None:
     match = _HEADER_SCOPE_NAME_RE.match(header_context.strip())
-    return match.group(1) if match else None
+    if match is None:
+        return None
+    name = match.group(1)
+    # git's own funcname heuristic includes Python's class-header trailing
+    # colon verbatim ("class Foo:" -> claimed name "Foo:"), but
+    # scope_lookup's real AST-derived name is always "Foo" - the colon
+    # alone made this module's own "silent when the header agrees with the
+    # real scope" contract false for every Python class-header hunk: it
+    # fired a self-contradictory correction ("claims 'Foo:', but this is
+    # actually inside 'Foo'") on code that was correctly still inside the
+    # class the header named. The ":" is kept in the character class above
+    # for Ruby's "class Foo::Bar" namespace separator - that shape never
+    # ends in a single trailing colon, only "::" would, so this only ever
+    # strips the real Python case.
+    if name.endswith(":") and not name.endswith("::"):
+        name = name[:-1]
+    return name
 
 
 def _hunk_claims_with_changed_lines(patch: str) -> list[tuple[str, list[int]]]:

--- a/github-app/tests/test_flash_review_hunk_scope.py
+++ b/github-app/tests/test_flash_review_hunk_scope.py
@@ -37,6 +37,47 @@ def test_agreeing_header_and_real_scope_produce_no_fact():
     assert context == ""
 
 
+def test_python_class_header_trailing_colon_agrees_with_real_scope_produces_no_fact():
+    # Real bug found via audit: git's own funcname heuristic includes
+    # Python's class-header trailing colon verbatim in the hunk header
+    # ("class Foo:"), but scope_lookup's real AST-derived name is always
+    # "Foo" (no colon) - the two could never match for any Python
+    # class-header hunk before this fix, firing a self-contradictory
+    # "claims 'Foo:', but this is actually inside 'Foo'" correction on
+    # code that was correctly still inside the class the header named.
+    content = "class Foo:\n    def a(self):\n        pass\n\n    def b(self):\n        pass\n"
+    patch = (
+        "@@ -1,4 +1,5 @@ class Foo:\n"
+        "     def a(self):\n"
+        "         pass\n"
+        " \n"
+        "+    # added comment\n"
+        "     def b(self):\n"
+    )
+    diff_patches = (("x.py", patch),)
+    context = build_hunk_scope_correction_context({"x.py": content}, diff_patches)
+    assert context == ""
+
+
+def test_python_class_header_trailing_colon_genuine_mismatch_still_fires():
+    # The colon-stripping fix above must not swallow a genuine mismatch -
+    # here the header's nearest-preceding-class heuristic still claims
+    # "Foo:", but the real changed line is inside a later class "Bar".
+    content = "class Foo:\n    def a(self):\n        pass\n\nclass Bar:\n    def b(self):\n        pass\n"
+    patch = (
+        "@@ -5,3 +5,4 @@ class Foo:\n"
+        " class Bar:\n"
+        "     def b(self):\n"
+        "         pass\n"
+        "+        # added\n"
+    )
+    diff_patches = (("x.py", patch),)
+    context = build_hunk_scope_correction_context({"x.py": content}, diff_patches)
+    assert "x.py:5" in context
+    assert "lists `Foo` as" in context
+    assert "actually inside `Bar`" in context
+
+
 def test_header_naming_a_def_not_a_class_produces_no_fact():
     # This module only has a real scope_lookup to check a class/module claim
     # against - a def/method header claim isn't something it can verify, so


### PR DESCRIPTION
## Summary
Adversarial audit of `flash_review_hunk_scope.py` found a real bug that broke this module's own documented contract ("silent when git's header agrees with the real scope") for the majority of real Python hunks.

git's own funcname heuristic includes Python's class-header trailing colon verbatim in a hunk header (`@@ ... @@ class Foo:`), but `scope_lookup`'s real AST-derived scope name is always `Foo` (no colon). These two could never match for any Python class-header hunk.

Confirmed by execution: a hunk squarely inside `class Foo:`'s own body fired *"the diff hunk header nearby lists `Foo:` as context, but this location is actually inside `Foo`"* - a nonsensical, self-contradictory correction injected into the review prompt on the common case (any Python class-body edit whose hunk header shows the class line), rather than only on the genuine mismatches this module exists to catch.

## Fix
Strip a lone trailing colon from the claimed name before comparing. Deliberately conditional (not a bare `.rstrip(":")`) so Ruby's `class Foo::Bar` namespace separator - which the same character class already allows - is untouched: it never ends in a single trailing colon, only `::` would.

## Test plan
- [x] Reproduced the false positive by executing `build_hunk_scope_correction_context` directly against a real Python class-header hunk, confirmed fixed
- [x] Verified a genuine mismatch (header claims one class, the real changed line is inside a different one) still fires correctly after the fix
- [x] Added 2 regression tests (agreeing Python class-header case → no fact; genuine Python mismatch → still fires)
- [x] Full `github-app/tests/test_flash_review*.py`: 236/236 passing
- [x] Full `github-app/tests/` suite: 1805 passed, 8 skipped

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK