### PR TITLE
fix: Gin route groups silently dropped their prefix, producing wrong plausible-looking endpoint paths

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -712,8 +712,61 @@ def _extract_go_net_http_routes(root: Node, source: bytes, rel_path: str) -> lis
     return entries
 
 
+def _gin_group_prefix_bindings(root: Node, source: bytes) -> dict[str, str]:
+    """var name -> composed URL prefix for every `x := y.Group("/prefix")`
+    short variable declaration in this file, including nested groups
+    (`v2 := v1.Group("/v2")`).
+
+    A single forward pass is sufficient: Go requires a variable declared
+    before use, and _walk_tree visits nodes in source order, so a group's
+    own receiver binding (if it has one) is already recorded by the time a
+    later declaration composes on top of it. A receiver not found here
+    (e.g. the base `*gin.Engine` returned by gin.Default()/gin.New(), which
+    is never itself the result of a .Group() call) resolves to "" - the
+    same unprefixed behavior every route already had before this existed,
+    so this is purely additive, never a regression for the ungrouped case.
+    """
+    bindings: dict[str, str] = {}
+    for n in _walk_tree(root):
+        if n.type != "short_var_declaration":
+            continue
+        left = n.child_by_field_name("left")
+        right = n.child_by_field_name("right")
+        if left is None or right is None:
+            continue
+        left_names = left.named_children
+        right_exprs = right.named_children
+        if len(left_names) != 1 or left_names[0].type != "identifier":
+            continue
+        if len(right_exprs) != 1 or right_exprs[0].type != "call_expression":
+            continue
+        call = right_exprs[0]
+        func = call.child_by_field_name("function")
+        if func is None or func.type != "selector_expression":
+            continue
+        field = func.child_by_field_name("field")
+        operand = func.child_by_field_name("operand")
+        if field is None or operand is None or operand.type != "identifier":
+            continue
+        if source[field.start_byte : field.end_byte].decode() != "Group":
+            continue
+        args = call.child_by_field_name("arguments")
+        if args is None:
+            continue
+        arg_named = args.named_children
+        if not arg_named or arg_named[0].type != "interpreted_string_literal":
+            continue
+        prefix_literal = _go_string_literal_text(arg_named[0], source)
+        receiver_name = source[operand.start_byte : operand.end_byte].decode()
+        base_prefix = bindings.get(receiver_name, "")
+        var_name = source[left_names[0].start_byte : left_names[0].end_byte].decode()
+        bindings[var_name] = f"{base_prefix.rstrip('/')}/{prefix_literal.strip('/')}"
+    return bindings
+
+
 def _extract_gin_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
+    group_prefixes = _gin_group_prefix_bindings(root, source)
 
     for n in _walk_tree(root):
         if n.type == "call_expression":
@@ -730,10 +783,18 @@ def _extract_gin_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
                                 path = _go_string_literal_text(named[0], source)
                                 handler = _go_handler_name(named, source)
                                 method = "ANY" if field_name == "Any" else field_name
+                                operand = func.child_by_field_name("operand")
+                                receiver_name = (
+                                    source[operand.start_byte : operand.end_byte].decode()
+                                    if operand is not None and operand.type == "identifier"
+                                    else None
+                                )
+                                prefix = group_prefixes.get(receiver_name, "") if receiver_name else ""
+                                full_path = f"{prefix.rstrip('/')}/{path.lstrip('/')}" if prefix else path
                                 entries.append(
                                     {
                                         "method": method,
-                                        "path": path,
+                                        "path": full_path,
                                         "framework": "gin",
                                         "file": rel_path,
                                         "line": n.start_point[0] + 1,

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -712,21 +712,65 @@ def _extract_go_net_http_routes(root: Node, source: bytes, rel_path: str) -> lis
     return entries
 
 
-def _gin_group_prefix_bindings(root: Node, source: bytes) -> dict[str, str]:
-    """var name -> composed URL prefix for every `x := y.Group("/prefix")`
-    short variable declaration in this file, including nested groups
-    (`v2 := v1.Group("/v2")`).
+# Go's `:=` short declarations are scoped to the function they're declared
+# in (or visible to a nested closure referencing an outer variable), never
+# to a sibling function that merely happens to reuse the same identifier -
+# real Go code does this routinely (every route-registration function in a
+# typical gin app names its own local group variable "v1", "admin", "api").
+_GO_FUNCTION_SCOPE_TYPES = {"function_declaration", "method_declaration", "func_literal"}
 
-    A single forward pass is sufficient: Go requires a variable declared
-    before use, and _walk_tree visits nodes in source order, so a group's
-    own receiver binding (if it has one) is already recorded by the time a
-    later declaration composes on top of it. A receiver not found here
-    (e.g. the base `*gin.Engine` returned by gin.Default()/gin.New(), which
-    is never itself the result of a .Group() call) resolves to "" - the
-    same unprefixed behavior every route already had before this existed,
-    so this is purely additive, never a regression for the ungrouped case.
+
+def _go_scope_chain(node: Node, root: Node) -> list[int]:
+    """Ids of every function-scope boundary enclosing `node`, innermost
+    first, always ending with the file's own root id (for a `:=` at file
+    scope, which Go doesn't actually allow but costs nothing to fall back
+    to safely)."""
+    chain: list[int] = []
+    current = node.parent
+    while current is not None:
+        if current.type in _GO_FUNCTION_SCOPE_TYPES:
+            chain.append(current.id)
+        current = current.parent
+    chain.append(root.id)
+    return chain
+
+
+def _resolve_group_prefix(
+    bindings: dict[tuple[int, str], str], node: Node, root: Node, var_name: str
+) -> str:
+    for scope_id in _go_scope_chain(node, root):
+        prefix = bindings.get((scope_id, var_name))
+        if prefix is not None:
+            return prefix
+    return ""
+
+
+def _gin_group_prefix_bindings(root: Node, source: bytes) -> dict[tuple[int, str], str]:
+    """(enclosing-function-scope id, var name) -> composed URL prefix for
+    every `x := y.Group("/prefix")` short variable declaration in this
+    file, including nested groups (`v2 := v1.Group("/v2")`).
+
+    Keyed by scope, not by name alone: a flat file-wide `{name: prefix}`
+    map means a later, unrelated `v1 := other.Group("/admin")` in a
+    completely different function silently overwrites the map entry for
+    every earlier route that used "v1" as its own, differently-scoped
+    group variable - found via Flash Review, confirmed against a real
+    two-function gin router file where this produced a wrong, plausible-
+    looking `/admin` prefix on routes that were never actually grouped
+    under `/admin` at all.
+
+    A single forward pass is still sufficient within each scope: Go
+    requires a variable declared before use, and _walk_tree visits nodes
+    in source order, so a group's own receiver binding (if it has one) is
+    already recorded by the time a later declaration in the same or an
+    enclosing scope composes on top of it. A receiver not found in any
+    enclosing scope (e.g. the base `*gin.Engine` returned by
+    gin.Default()/gin.New(), which is never itself the result of a
+    .Group() call) resolves to "" - the same unprefixed behavior every
+    route already had before this existed, so this is purely additive,
+    never a regression for the ungrouped case.
     """
-    bindings: dict[str, str] = {}
+    bindings: dict[tuple[int, str], str] = {}
     for n in _walk_tree(root):
         if n.type != "short_var_declaration":
             continue
@@ -758,9 +802,10 @@ def _gin_group_prefix_bindings(root: Node, source: bytes) -> dict[str, str]:
             continue
         prefix_literal = _go_string_literal_text(arg_named[0], source)
         receiver_name = source[operand.start_byte : operand.end_byte].decode()
-        base_prefix = bindings.get(receiver_name, "")
+        base_prefix = _resolve_group_prefix(bindings, n, root, receiver_name)
         var_name = source[left_names[0].start_byte : left_names[0].end_byte].decode()
-        bindings[var_name] = f"{base_prefix.rstrip('/')}/{prefix_literal.strip('/')}"
+        scope_id = _go_scope_chain(n, root)[0]
+        bindings[(scope_id, var_name)] = f"{base_prefix.rstrip('/')}/{prefix_literal.strip('/')}"
     return bindings
 
 
@@ -789,7 +834,11 @@ def _extract_gin_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
                                     if operand is not None and operand.type == "identifier"
                                     else None
                                 )
-                                prefix = group_prefixes.get(receiver_name, "") if receiver_name else ""
+                                prefix = (
+                                    _resolve_group_prefix(group_prefixes, n, root, receiver_name)
+                                    if receiver_name
+                                    else ""
+                                )
                                 full_path = f"{prefix.rstrip('/')}/{path.lstrip('/')}" if prefix else path
                                 entries.append(
                                     {

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -821,6 +821,70 @@ def test_extract_gin_ignores_unrelated_selector_calls():
     assert entries == []
 
 
+def test_extract_gin_composes_a_route_group_prefix():
+    # Real bug found via audit: router.Group("/prefix") was completely
+    # untracked - a route registered on the group's returned variable
+    # silently emitted its bare, unprefixed path instead of the real one,
+    # the same failure class already fixed 4 times for FastAPI (router-
+    # mount-prefix loss/contamination) - Gin route groups are the
+    # standard, near-universal way real Gin APIs are organized.
+    root, source = parse_go(
+        'func main() {\n'
+        '\trouter := gin.Default()\n'
+        '\tv1 := router.Group("/api/v1")\n'
+        '\tv1.GET("/users", getUsers)\n'
+        '\tv1.POST("/users", createUser)\n'
+        '}\n'
+    )
+
+    entries = _extract_gin_routes(root, source, "main.go")
+
+    paths = [(e["method"], e["path"]) for e in entries]
+    assert paths == [("GET", "/api/v1/users"), ("POST", "/api/v1/users")]
+
+
+def test_extract_gin_composes_a_nested_route_group_prefix():
+    root, source = parse_go(
+        'func main() {\n'
+        '\trouter := gin.Default()\n'
+        '\tv1 := router.Group("/api/v1")\n'
+        '\tadmin := v1.Group("/admin")\n'
+        '\tadmin.DELETE("/users/:id", deleteUser)\n'
+        '}\n'
+    )
+
+    entries = _extract_gin_routes(root, source, "main.go")
+
+    assert entries == [
+        {
+            "method": "DELETE",
+            "path": "/api/v1/admin/users/:id",
+            "framework": "gin",
+            "file": "main.go",
+            "line": 5,
+            "handler": "deleteUser",
+            "unresolved": False,
+            "note": None,
+        }
+    ]
+
+
+def test_extract_gin_ungrouped_route_on_the_base_router_is_unaffected():
+    # The group-prefix fix must be purely additive: a route on a variable
+    # that was never the result of a .Group() call resolves to "" (its
+    # prior, unprefixed behavior), not a crash or a spurious prefix.
+    root, source = parse_go(
+        'func main() {\n'
+        '\trouter := gin.Default()\n'
+        '\trouter.GET("/health", healthCheck)\n'
+        '}\n'
+    )
+
+    entries = _extract_gin_routes(root, source, "main.go")
+
+    assert entries[0]["path"] == "/health"
+
+
 def test_extract_axum_single_route():
     root, source = parse_rust(
         'fn main() { let app = Router::new().route("/health", get(health_handler)); }\n'

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -885,6 +885,33 @@ def test_extract_gin_ungrouped_route_on_the_base_router_is_unaffected():
     assert entries[0]["path"] == "/health"
 
 
+def test_extract_gin_group_var_reused_in_another_function_does_not_bleed_across():
+    # Flash Review finding on PR #597: the original binding table was keyed
+    # only by identifier text, file-wide - a later, unrelated
+    # `v1 := other.Group("/admin")` in a second function overwrote the map
+    # entry for the first function's own "v1", so routes registered under
+    # the FIRST v1 (never actually grouped under /admin) were reported with
+    # the SECOND function's /admin prefix. Each function reusing the
+    # idiomatic "v1" group-variable name is real, common Gin code, not a
+    # contrived shape.
+    root, source = parse_go(
+        'func registerPublicRoutes(router *gin.Engine) {\n'
+        '\tv1 := router.Group("/api/v1")\n'
+        '\tv1.GET("/users", getUsers)\n'
+        '}\n'
+        '\n'
+        'func registerAdminRoutes(router *gin.Engine) {\n'
+        '\tv1 := router.Group("/admin")\n'
+        '\tv1.DELETE("/users/:id", deleteUser)\n'
+        '}\n'
+    )
+
+    entries = _extract_gin_routes(root, source, "main.go")
+
+    paths = [(e["method"], e["path"]) for e in entries]
+    assert paths == [("GET", "/api/v1/users"), ("DELETE", "/admin/users/:id")]
+
+
 def test_extract_axum_single_route():
     root, source = parse_rust(
         'fn main() { let app = Router::new().route("/health", get(health_handler)); }\n'


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/endpoints.py` found a real bug: `_extract_gin_routes` had no notion of `router.Group("/prefix")` at all - no composition, no flag.

Confirmed by execution:
```go
v1 := router.Group("/api/v1")
v1.GET("/users", getUsers)
```
mapped to `GET /users`, not the real `GET /api/v1/users` - the group prefix vanished with zero trace.

This is the same bug class already fixed 4 times for FastAPI (#232, #333, #339, #429: router-mount-prefix loss/contamination), and Gin route groups are the standard, near-universal way real Gin APIs are organized (versioning, resource grouping) - not an edge case.

Worse than the FastAPI case in one respect: Laravel's `Route::group()` and Spring's class-level `@RequestMapping` have the identical un-composed shape in this codebase, but both are transparently flagged with a `note` explaining the prefix wasn't resolved. Gin was the one framework that neither composed the prefix nor flagged it - a silently wrong, plausible-looking absolute path is a worse failure mode than "flagged as incomplete."

## Fix
Track `x := y.Group("/prefix")` short variable declaration bindings in a single forward pass (Go requires declare-before-use, so no backtracking is needed), including nested groups (`v2 := v1.Group("/v2")`), and compose the resolved prefix into each route call's path. A receiver never bound by a `.Group()` call (the base `*gin.Engine`, or any other untracked variable) resolves to `""` - the same unprefixed behavior every route already had, so this is purely additive for the ungrouped case.

## Test plan
- [x] Constructed real Gin route-group source and ran `_extract_gin_routes` directly, confirming the wrong path before the fix and the correct composed path after
- [x] Added 3 regression tests: basic group composition, nested group composition, and an ungrouped-route-unaffected guard
- [x] Full `src/tests/test_endpoints.py`: 80/80 passing
- [x] Full `src/tests/` suite: 1778/1778 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK