### PR TITLE
fix: repo's own license silently undetected for Rust, PHP, Ruby, C#, and Java

### DIFF
--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -237,7 +237,20 @@ def detect_repo_license(repo_path: Path) -> dict:
 
     for gemspec in sorted(repo_path.glob("*.gemspec")):
         text = gemspec.read_text(encoding="utf-8", errors="ignore")
-        match = _GEMSPEC_LICENSE_RE.search(text)
+        # Drop full-line Ruby comments before searching - otherwise a
+        # commented-out assignment (a stale `# s.license = "GPL-3.0"` left
+        # behind from an earlier relicensing, a real thing to find in a
+        # gemspec's history) can be the first match _GEMSPEC_LICENSE_RE
+        # finds if it appears before the real, active assignment,
+        # fabricating the wrong repo license entirely. Only strips a line
+        # whose first non-whitespace character is "#" - not an inline
+        # trailing comment - since a license string is never expected to
+        # contain a literal "#" itself, this is enough without a full
+        # Ruby-comment/string-literal parse.
+        active_text = "\n".join(
+            line for line in text.splitlines() if not line.lstrip().startswith("#")
+        )
+        match = _GEMSPEC_LICENSE_RE.search(active_text)
         if match:
             return {
                 "category": categorize_license(match.group(1)),

--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -103,6 +103,23 @@ _PERMISSIVE_MARKERS = (
 )
 
 
+# Ruby gemspecs are executable Ruby, not structured data - `s.license =
+# "MIT"`/`spec.licenses = ["MIT"]` (both the singular and Array-plural forms
+# are real, valid RubyGems specification attributes) are extracted the same
+# lightweight-regex way `_MAIN_GUARD_PATTERN`-style content checks elsewhere
+# in this codebase read a single, unambiguous line rather than fully
+# parsing the file.
+_GEMSPEC_LICENSE_RE = re.compile(r"\.licenses?\s*=\s*(?:\[\s*)?['\"]([^'\"]+)['\"]")
+
+# .NET SDK-style csproj: <PackageLicenseExpression>MIT</PackageLicenseExpression>.
+# The other real NuGet convention, <PackageLicenseFile>, names a bundled file
+# rather than an SPDX expression - not handled here, the same way pyproject.toml's
+# "license-file"-only shape isn't a machine-readable identifier this function can use.
+_CSPROJ_LICENSE_EXPRESSION_RE = re.compile(
+    r"<PackageLicenseExpression>\s*([^<]+?)\s*</PackageLicenseExpression>"
+)
+
+
 def _contains_marker(text: str, marker: str) -> bool:
     # A bare substring check breaks on real license *text* (as opposed to a short
     # SPDX-style string like "MPL-2.0", which is what these markers are also used
@@ -174,6 +191,86 @@ def detect_repo_license(repo_path: Path) -> dict:
                 "category": categorize_license(license_field),
                 "detected_from": f"package.json: {license_field}",
             }
+
+    # Every one of these 5 has a working dependency-license fetcher already
+    # in this same file (_fetch_crates_license, _fetch_packagist_license,
+    # _fetch_rubygems_license, _fetch_nuget_license, _fetch_maven_license) -
+    # but the repo's-OWN-license path above only ever checked pyproject.toml
+    # and package.json, so a Rust/PHP/Ruby/C#/Java repo with a real,
+    # machine-readable license field fell all the way through to the
+    # LICENSE-file text fallback (or "unknown" with no LICENSE file at all),
+    # despite this scanner otherwise fully supporting all 12 of these
+    # languages. Confirmed as a real, silent gap by direct testing, not
+    # hypothetical - the same "one ecosystem quietly unhandled while its
+    # siblings work" shape already found for Gin route groups this session.
+    cargo_toml = repo_path / "Cargo.toml"
+    if cargo_toml.exists():
+        try:
+            data = tomllib.loads(cargo_toml.read_text(encoding="utf-8", errors="ignore"))
+        except tomllib.TOMLDecodeError:
+            data = {}
+        license_field = data.get("package", {}).get("license")
+        if isinstance(license_field, str):
+            return {
+                "category": categorize_license(license_field),
+                "detected_from": f"Cargo.toml: {license_field}",
+            }
+
+    composer_json = repo_path / "composer.json"
+    if composer_json.exists():
+        try:
+            data = json.loads(composer_json.read_text(encoding="utf-8", errors="ignore"))
+        except json.JSONDecodeError:
+            data = {}
+        license_field = data.get("license")
+        # Composer's schema allows a bare string or a dual/multi-license
+        # array ("license": ["MIT", "GPL-2.0"]) - matches how
+        # _fetch_packagist_license already treats the identical shape from
+        # Packagist's own API response (licenses[0] if licenses else None).
+        if isinstance(license_field, list) and license_field:
+            license_field = license_field[0]
+        if isinstance(license_field, str):
+            return {
+                "category": categorize_license(license_field),
+                "detected_from": f"composer.json: {license_field}",
+            }
+
+    for gemspec in sorted(repo_path.glob("*.gemspec")):
+        text = gemspec.read_text(encoding="utf-8", errors="ignore")
+        match = _GEMSPEC_LICENSE_RE.search(text)
+        if match:
+            return {
+                "category": categorize_license(match.group(1)),
+                "detected_from": f"{gemspec.name}: {match.group(1)}",
+            }
+
+    for csproj in sorted(repo_path.rglob("*.csproj")):
+        text = csproj.read_text(encoding="utf-8", errors="ignore")
+        match = _CSPROJ_LICENSE_EXPRESSION_RE.search(text)
+        if match:
+            rel = csproj.relative_to(repo_path).as_posix()
+            return {
+                "category": categorize_license(match.group(1)),
+                "detected_from": f"{rel}: {match.group(1)}",
+            }
+
+    pom_xml = repo_path / "pom.xml"
+    if pom_xml.exists():
+        try:
+            root = ElementTree.fromstring(pom_xml.read_text(encoding="utf-8", errors="ignore"))
+        except ElementTree.ParseError:
+            root = None
+        if root is not None:
+            # A real, hand-written repo pom.xml doesn't always declare the
+            # xmlns Maven Central's own served POMs always carry -
+            # namespaced lookup first, falling back to a bare (no-prefix)
+            # lookup so an unnamespaced pom.xml isn't silently missed.
+            license_name = root.find(".//m:licenses/m:license/m:name", _MAVEN_POM_NS)
+            if license_name is None:
+                license_name = root.find(".//licenses/license/name")
+            if license_name is not None and license_name.text and license_name.text.strip():
+                text = license_name.text.strip()
+                return {"category": categorize_license(text), "detected_from": f"pom.xml: {text}"}
 
     # LICENSE.rst added after this benchmark's real-repo stress test:
     # Flask's own real repo uses exactly this filename (a common

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -165,6 +165,27 @@ def test_detect_repo_license_from_gemspec(tmp_path):
     assert "app.gemspec" in result["detected_from"]
 
 
+def test_detect_repo_license_from_gemspec_ignores_a_commented_out_assignment(tmp_path):
+    # Flash Review finding on PR #598: the gemspec regex searched the raw
+    # file text without excluding comments, so a commented-out assignment
+    # left over from an earlier relicensing (a real thing to find in a
+    # gemspec's history) could be matched before the real, active one if
+    # it appears first in the file, fabricating the wrong repo license.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.gemspec").write_text(
+        "Gem::Specification.new do |s|\n"
+        '  # s.license = "GPL-3.0"\n'
+        '  s.license = "MIT"\n'
+        "end\n"
+    )
+
+    result = detect_repo_license(repo)
+
+    assert result["category"] == "permissive"
+    assert "MIT" in result["detected_from"]
+
+
 def test_detect_repo_license_from_csproj_nested_in_a_project_directory(tmp_path):
     # Real bug found via audit: same gap for C#. Uses rglob (not a
     # root-level check) since a real .csproj almost never sits at a .NET

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -123,6 +123,82 @@ def test_detect_repo_license_from_package_json(tmp_path):
     assert "package.json" in result["detected_from"]
 
 
+def test_detect_repo_license_from_cargo_toml(tmp_path):
+    # Real bug found via audit: this scanner already has a working
+    # dependency-license fetcher for Rust (_fetch_crates_license), but the
+    # repo's-OWN-license path only ever checked pyproject.toml/package.json
+    # - a Rust repo's own real, machine-readable Cargo.toml license field
+    # was silently invisible.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "Cargo.toml").write_text('[package]\nname = "app"\nversion = "0.1.0"\nlicense = "MIT"\n')
+
+    result = detect_repo_license(repo)
+
+    assert result["category"] == "permissive"
+    assert "Cargo.toml" in result["detected_from"]
+
+
+def test_detect_repo_license_from_composer_json_dual_license_array(tmp_path):
+    # Real bug found via audit: same gap as Cargo.toml above, for PHP.
+    # Composer's schema allows a dual/multi-license array, matching how
+    # _fetch_packagist_license already treats the identical shape.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "composer.json").write_text(json.dumps({"name": "vendor/app", "license": ["MIT", "GPL-2.0"]}))
+
+    result = detect_repo_license(repo)
+
+    assert result["category"] == "permissive"
+    assert "composer.json" in result["detected_from"]
+
+
+def test_detect_repo_license_from_gemspec(tmp_path):
+    # Real bug found via audit: same gap for Ruby.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.gemspec").write_text('Gem::Specification.new do |s|\n  s.license = "MIT"\nend\n')
+
+    result = detect_repo_license(repo)
+
+    assert result["category"] == "permissive"
+    assert "app.gemspec" in result["detected_from"]
+
+
+def test_detect_repo_license_from_csproj_nested_in_a_project_directory(tmp_path):
+    # Real bug found via audit: same gap for C#. Uses rglob (not a
+    # root-level check) since a real .csproj almost never sits at a .NET
+    # solution's repo root - matches how vulnerabilities.py's own
+    # csproj dependency parser already searches.
+    repo = tmp_path / "repo"
+    (repo / "src" / "MyApp").mkdir(parents=True)
+    (repo / "src" / "MyApp" / "MyApp.csproj").write_text(
+        "<Project><PropertyGroup><PackageLicenseExpression>Apache-2.0"
+        "</PackageLicenseExpression></PropertyGroup></Project>"
+    )
+
+    result = detect_repo_license(repo)
+
+    assert result["category"] == "permissive"
+    assert "MyApp.csproj" in result["detected_from"]
+
+
+def test_detect_repo_license_from_pom_xml_without_a_namespace_declaration(tmp_path):
+    # Real bug found via audit: same gap for Java, plus a real, hand-
+    # written pom.xml commonly omits the xmlns Maven Central's own served
+    # POMs always carry - the namespaced lookup alone would silently miss it.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pom.xml").write_text(
+        "<project><licenses><license><name>MIT License</name></license></licenses></project>"
+    )
+
+    result = detect_repo_license(repo)
+
+    assert result["category"] == "permissive"
+    assert "pom.xml" in result["detected_from"]
+
+
 # The real, verbatim opening of the Apache License 2.0 (as published at
 # apache.org/licenses/LICENSE-2.0.txt) - not a hand-typed guess at what an
 # Apache license file looks like. This used to be read live from this


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/licenses.py` found a real gap: `detect_repo_license()` only ever checked `pyproject.toml` and `package.json` for the repo's own machine-readable license field before falling back to LICENSE-file text.

This scanner already has a working *dependency*-license fetcher for Rust (`_fetch_crates_license`), PHP (`_fetch_packagist_license`), Ruby (`_fetch_rubygems_license`), C# (`_fetch_nuget_license`), and Java (`_fetch_maven_license`) - but the repo's-own-license path never reused any of that ecosystem knowledge. A Rust/PHP/Ruby/C#/Java repo with a real, explicit license field (`Cargo.toml`'s `license=`, `composer.json`'s `"license"`, a gemspec's `s.license=`, a csproj's `PackageLicenseExpression`, `pom.xml`'s `<licenses>`) fell all the way through to `"unknown"` whenever it had no separate LICENSE file - the same "one ecosystem quietly unhandled while its siblings work" shape as the Gin route-group gap fixed earlier this session (#597), on a scanner that markets full support for all 12 languages.

Confirmed by execution: each of the 5 cases returned `{"category": "unknown", "detected_from": None}` before this fix despite a real, unambiguous license field being present.

## Fix
Added the same pattern already used for `pyproject.toml`/`package.json` for each of the 5 ecosystems, reusing this file's own established lookup conventions (`Cargo.toml`/`composer.json`/`pom.xml` at repo root, `*.gemspec` via glob, `*.csproj` via rglob - matching how `vulnerabilities.py`'s own dependency parsers already locate each of these). `composer.json`'s dual/multi-license array form and a `pom.xml` without a declared XML namespace (a real, common shape for a hand-written `pom.xml`, unlike Maven Central's own served POMs) are both handled.

## Test plan
- [x] Constructed real manifest files for all 5 ecosystems and ran `detect_repo_license` directly, confirming the wrong output before the fix and correct output after (including a namespace-less `pom.xml` and a nested `.csproj`)
- [x] Added 6 regression tests
- [x] Full `src/tests/test_licenses.py`: 56/56 passing
- [x] Full `src/tests/` suite: 1783/1783 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK