### PR TITLE
fix: Maven pom.xml without a declared xmlns was totally invisible to vulnerability scanning

### DIFF
--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -255,6 +255,9 @@ def _maven_child(element: ElementTree.Element, tag: str) -> ElementTree.Element 
     return element.find(tag)
 
 
+_MAVEN_POM_NAMESPACE_PREFIX = "{http://maven.apache.org/POM/4.0.0}"
+
+
 def _strip_xml_namespace_prefixes(root: ElementTree.Element) -> ElementTree.Element:
     """Removes the `{uri}` prefix ElementTree attaches to every element's
     tag when a document declares a default xmlns, so a plain, unprefixed
@@ -271,10 +274,19 @@ def _strip_xml_namespace_prefixes(root: ElementTree.Element) -> ElementTree.Elem
     from "no dependencies" - for a repo whose real pom.xml declares
     dependencies with real, potentially vulnerable versions, not a
     partial result or an error.
+
+    Scoped to exactly the Maven POM namespace, not every `{uri}` prefix in
+    the document - a pom.xml can embed foreign-namespaced elements (e.g. a
+    build plugin's own `<vendor:dependencies>` config block), and
+    stripping those too would make them indistinguishable from real Maven
+    <dependencies>/<properties> elements, producing dependency or
+    vulnerability results from content Maven itself never treats as POM
+    metadata.
     """
+    prefix_len = len(_MAVEN_POM_NAMESPACE_PREFIX)
     for element in root.iter():
-        if isinstance(element.tag, str) and element.tag.startswith("{"):
-            element.tag = element.tag.split("}", 1)[1]
+        if isinstance(element.tag, str) and element.tag.startswith(_MAVEN_POM_NAMESPACE_PREFIX):
+            element.tag = element.tag[prefix_len:]
     return root
 
 

--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -251,8 +251,31 @@ def _maven_text(element: ElementTree.Element | None) -> str | None:
     return text or None
 
 
-def _maven_child(element: ElementTree.Element, tag: str, ns: dict[str, str]) -> ElementTree.Element | None:
-    return element.find(f"m:{tag}", ns)
+def _maven_child(element: ElementTree.Element, tag: str) -> ElementTree.Element | None:
+    return element.find(tag)
+
+
+def _strip_xml_namespace_prefixes(root: ElementTree.Element) -> ElementTree.Element:
+    """Removes the `{uri}` prefix ElementTree attaches to every element's
+    tag when a document declares a default xmlns, so a plain, unprefixed
+    tag name (`dependencies/dependency`, not `m:dependencies/m:dependency`)
+    matches regardless of whether the source declared one.
+
+    Maven does not require a pom.xml to declare
+    xmlns="http://maven.apache.org/POM/4.0.0" on <project> for a build to
+    work, and a real, hand-written or legacy repo pom.xml commonly omits
+    it - unlike the POMs Maven Central itself serves (what
+    licenses.py's _fetch_maven_license reads), which always declare it.
+    Every m:-prefixed lookup below silently matched nothing against such a
+    file before this fix: _parse_maven_pins returned [] - indistinguishable
+    from "no dependencies" - for a repo whose real pom.xml declares
+    dependencies with real, potentially vulnerable versions, not a
+    partial result or an error.
+    """
+    for element in root.iter():
+        if isinstance(element.tag, str) and element.tag.startswith("{"):
+            element.tag = element.tag.split("}", 1)[1]
+    return root
 
 
 def _maven_resolve_property(version: str | None, properties: dict[str, str]) -> str | None:
@@ -325,43 +348,43 @@ def _parse_maven_pom(pom: Path, seen: set[Path]) -> list[tuple[str, str, str]]:
         root = ElementTree.fromstring(pom.read_text(encoding="utf-8", errors="ignore"))
     except ElementTree.ParseError:
         return []
-    ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+    root = _strip_xml_namespace_prefixes(root)
     properties = {
-        child.tag.rsplit("}", 1)[-1]: child.text.strip()
-        for child in root.findall("m:properties/*", ns)
+        child.tag: child.text.strip()
+        for child in root.findall("properties/*")
         if child.text and child.text.strip()
     }
     managed_versions = {}
-    management = root.find("m:dependencyManagement/m:dependencies", ns)
+    management = root.find("dependencyManagement/dependencies")
     if management is not None:
-        for dep in management.findall("m:dependency", ns):
-            group = _maven_text(_maven_child(dep, "groupId", ns))
-            artifact = _maven_text(_maven_child(dep, "artifactId", ns))
+        for dep in management.findall("dependency"):
+            group = _maven_text(_maven_child(dep, "groupId"))
+            artifact = _maven_text(_maven_child(dep, "artifactId"))
             version = _maven_resolve_property(
-                _maven_text(_maven_child(dep, "version", ns)),
+                _maven_text(_maven_child(dep, "version")),
                 properties,
             )
             if group and artifact and version:
                 managed_versions[(group, artifact)] = version
 
     pins = []
-    dependencies = root.find("m:dependencies", ns)
+    dependencies = root.find("dependencies")
     if dependencies is not None:
-        for dep in dependencies.findall("m:dependency", ns):
-            group = _maven_text(_maven_child(dep, "groupId", ns))
-            artifact = _maven_text(_maven_child(dep, "artifactId", ns))
+        for dep in dependencies.findall("dependency"):
+            group = _maven_text(_maven_child(dep, "groupId"))
+            artifact = _maven_text(_maven_child(dep, "artifactId"))
             if not group or not artifact:
                 continue
             version = _maven_resolve_property(
-                _maven_text(_maven_child(dep, "version", ns)),
+                _maven_text(_maven_child(dep, "version")),
                 properties,
             ) or managed_versions.get((group, artifact))
             if version:
                 pins.append((f"{group}:{artifact}", version, "Maven"))
 
-    modules = root.find("m:modules", ns)
+    modules = root.find("modules")
     if modules is not None:
-        for module in modules.findall("m:module", ns):
+        for module in modules.findall("module"):
             module_name = _maven_text(module)
             if not module_name:
                 continue

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -357,6 +357,37 @@ def test_parse_maven_pins_reads_direct_dependencies(tmp_path):
     assert not any(p[0] == "com.example:interpolated" for p in pins)
 
 
+def test_parse_maven_pins_reads_dependencies_from_a_pom_with_no_declared_namespace(tmp_path):
+    # Real bug found via audit: every lookup in _parse_maven_pom was
+    # namespace-prefixed against "http://maven.apache.org/POM/4.0.0", but
+    # Maven does not require a pom.xml to declare that xmlns on <project>
+    # for a build to work - a real, hand-written or legacy pom.xml commonly
+    # omits it, unlike the POMs Maven Central itself serves. Every m:-
+    # prefixed lookup silently matched nothing against such a file,
+    # returning [] - indistinguishable from "no dependencies" - for a repo
+    # whose real pom.xml declares real, potentially vulnerable dependencies.
+    from aletheore.vulnerabilities import _parse_maven_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pom.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<project>\n"
+        "  <dependencies>\n"
+        "    <dependency>\n"
+        "      <groupId>com.fasterxml.jackson.core</groupId>\n"
+        "      <artifactId>jackson-databind</artifactId>\n"
+        "      <version>2.9.8</version>\n"
+        "    </dependency>\n"
+        "  </dependencies>\n"
+        "</project>\n"
+    )
+
+    pins = _parse_maven_pins(repo)
+
+    assert ("com.fasterxml.jackson.core:jackson-databind", "2.9.8", "Maven") in pins
+
+
 def test_parse_maven_pins_empty_when_no_pom(tmp_path):
     from aletheore.vulnerabilities import _parse_maven_pins
 

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -388,6 +388,48 @@ def test_parse_maven_pins_reads_dependencies_from_a_pom_with_no_declared_namespa
     assert ("com.fasterxml.jackson.core:jackson-databind", "2.9.8", "Maven") in pins
 
 
+def test_parse_maven_pins_ignores_a_foreign_namespaced_dependencies_element(tmp_path):
+    # Flash Review finding on PR #599: the original fix stripped every
+    # "{uri}" prefix, not just Maven's own POM namespace - a real pom.xml
+    # can embed a build plugin's own foreign-namespaced config block (e.g.
+    # <vendor:dependencies>), and stripping that too made it
+    # indistinguishable from a real Maven <dependencies> element, pulling
+    # in a fabricated dependency that isn't part of the project's real
+    # Maven dependency set.
+    from aletheore.vulnerabilities import _parse_maven_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pom.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0" '
+        'xmlns:vendor="http://example.com/vendor-plugin">\n'
+        "  <dependencies>\n"
+        "    <dependency>\n"
+        "      <groupId>com.fasterxml.jackson.core</groupId>\n"
+        "      <artifactId>jackson-databind</artifactId>\n"
+        "      <version>2.9.8</version>\n"
+        "    </dependency>\n"
+        "  </dependencies>\n"
+        "  <build>\n"
+        "    <plugins>\n"
+        "      <plugin>\n"
+        "        <configuration>\n"
+        "          <vendor:dependencies>\n"
+        "            <vendor:dependency>fake:not-a-real-maven-dep:9.9.9</vendor:dependency>\n"
+        "          </vendor:dependencies>\n"
+        "        </configuration>\n"
+        "      </plugin>\n"
+        "    </plugins>\n"
+        "  </build>\n"
+        "</project>\n"
+    )
+
+    pins = _parse_maven_pins(repo)
+
+    assert pins == [("com.fasterxml.jackson.core:jackson-databind", "2.9.8", "Maven")]
+
+
 def test_parse_maven_pins_empty_when_no_pom(tmp_path):
     from aletheore.vulnerabilities import _parse_maven_pins
 


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/vulnerabilities.py` found a real, high-impact bug: `_parse_maven_pom` hardcoded `ns = {"m": "http://maven.apache.org/POM/4.0.0"}` and every lookup (properties, `dependencyManagement`, `dependencies`, `modules`) was namespace-prefixed against it. Maven does not require a `pom.xml` to declare that `xmlns` on `<project>` for a build to work - a real, hand-written or legacy `pom.xml` commonly omits it, unlike the POMs Maven Central itself serves (what `licenses.py`'s `_fetch_maven_license` reads, which is unaffected by this bug).

Confirmed by execution: a namespace-less `pom.xml` declaring a real dependency (`com.fasterxml.jackson.core:jackson-databind`) returned `[]` from `_parse_maven_pins` - indistinguishable from "no dependencies" - while the identical file with `xmlns` added returned the dependency correctly.

This wasn't a narrow edge case: every code path (direct dependencies, `dependencyManagement` version resolution, `<properties>` interpolation, multi-module `<modules>` recursion) is gated behind the same namespace assumption, so this was the function's entire output for any such repo. `check_vulnerabilities` would report zero Maven vulnerabilities for such a repo regardless of how many real, vulnerable dependencies it actually declares.

## Fix
Strip the `{uri}` prefix ElementTree attaches to every element's tag right after parsing (a well-established technique for exactly this problem), then query with plain, unprefixed tag names throughout - works uniformly whether the source document declared a default `xmlns` or not, with no behavior change for the already-working namespaced case.

## Test plan
- [x] Constructed a real namespace-less `pom.xml` and ran `_parse_maven_pins` directly, confirming `[]` before the fix and the correct dependency after
- [x] Verified the pre-existing namespaced case, properties-based version interpolation, and multi-module recursion all still work correctly after the fix
- [x] Added a regression test
- [x] Full `src/tests/test_vulnerabilities.py`: 64/64 passing
- [x] Full `src/tests/` suite: 1776/1776 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK