### PR TITLE
fix: JVM co-located test files (FooTest.kt beside Foo.kt) invisible to _is_test_path

### DIFF
--- a/src/aletheore/search_index.py
+++ b/src/aletheore/search_index.py
@@ -301,6 +301,20 @@ def _truncate_for_embedding(text: str) -> str:
     return text[:MAX_EMBEDDING_CHARS] + "\n... (truncated for embedding)"
 
 
+# JVM (Java/Kotlin) PascalCase test-suffix convention (FooTest.kt,
+# StatisticsScreenTest.kt) - the same real, confirmed shape
+# dead_code.py's own TEST_PATH_PATTERNS already excludes (see its comment
+# citing android/architecture-samples), never carried over to this
+# module's own, independently-implemented test-path check. A bare
+# _has_dotnet_test_suffix check on the filename segment can't catch this:
+# it requires the "Tests?" match at the literal end of the segment, but a
+# real filename ends in ".kt"/".kts"/".java", not "Test"/"Tests" - so a
+# co-located test file (FooTest.kt sitting beside Foo.kt, the common
+# layout for a small-to-medium JVM package with no dedicated test source
+# set) was never excluded, polluting search results with test code the
+# same way AutoMapper's .NET test projects did before the check above.
+_JVM_TEST_SUFFIX_RE = re.compile(r"(^|/)[^/]+Test\.(kt|kts|java)$")
+
 _DOTNET_TEST_SUFFIX_RE = re.compile(r"Tests?$")
 
 
@@ -354,6 +368,8 @@ def _is_test_path(module_path: str) -> bool:
     # by a preceding "."/"-"/"_" separator or a lower-to-upper case
     # transition (AutoMapper.DI.Tests, UnitTests) - not a bare suffix.
     if any(_has_dotnet_test_suffix(part) for part in raw_parts):
+        return True
+    if _JVM_TEST_SUFFIX_RE.search(module_path):
         return True
     if any(part.endswith(".test") for part in parts):
         return True

--- a/src/tests/test_search_index.py
+++ b/src/tests/test_search_index.py
@@ -2606,6 +2606,27 @@ def test_is_test_path_does_not_exclude_ordinary_words_ending_in_tests():
     assert _is_test_path("src/IntegrationTests/Foo.java")
 
 
+def test_is_test_path_excludes_jvm_colocated_test_suffix():
+    # Real bug found via audit: dead_code.py already excludes this exact
+    # shape (its own TEST_PATH_PATTERNS, citing android/architecture-
+    # samples) but the fix was never carried over to this module's own,
+    # independently-implemented test-path check. _has_dotnet_test_suffix
+    # can't catch it: it requires "Tests?" at the literal end of the path
+    # segment, but a real filename ends in ".kt"/".java", not "Test" - so
+    # a co-located test file (FooTest.kt beside Foo.kt, the ordinary
+    # layout for a JVM package with no dedicated test source set) was
+    # never excluded, polluting search results with test code.
+    assert _is_test_path("app/src/main/java/com/example/todoapp/data/DefaultTaskRepositoryTest.kt")
+    assert _is_test_path("src/main/java/com/example/FooTest.kt")
+    assert _is_test_path("app/src/test/java/com/example/BarTest.java")
+    # An ordinary word that merely ends in "test" ("Contest", "Attestation")
+    # must not be swallowed - same false-positive class the .NET fix above
+    # already guards against, for the JVM shape.
+    assert not _is_test_path("src/main/java/com/example/Contest.kt")
+    assert not _is_test_path("src/main/java/com/example/Attestation.java")
+    assert not _is_test_path("app/src/main/java/com/example/todoapp/data/DefaultTaskRepository.kt")
+
+
 def test_detect_query_language_reads_an_explicit_language_mention():
     """apache/thrift implements TBinaryProtocol in seven languages, so a question
     naming one has a single correct answer and six near-identical wrong ones."""


### PR DESCRIPTION
## Summary
Adversarial audit of `architecture.py` (which relies on `search_index.py`'s `_is_test_path` to exclude test files from clustering, per #353) found a real bug: `dead_code.py` already excludes co-located JVM test files via its own `TEST_PATH_PATTERNS` (`"(^|/)[^/]+Test\.(kt|kts|java)$"`, citing android/architecture-samples as the confirming real repo) - but that fix was never carried over to `search_index.py`'s own, independently-implemented `_is_test_path` check.

Confirmed by execution: `_has_dotnet_test_suffix` requires the `"Tests?"` match at the literal end of the path **segment**, but a real filename ends in `.kt`/`.java`, not `Test` - so `DefaultTaskRepositoryTest.kt` and a bare `FooTest.kt` (a JVM package with no dedicated test source set, the ordinary layout for a small-to-medium project) were never recognized as test paths at all. Only files sitting inside a folder literally named `test`/`androidTest` were caught.

## Impact
- A JVM repo with co-located tests would have those test files clustered as production modules by `architecture.py`'s `build_clusters` - reproducing the exact test-pollution shape #353 fixed for the general case, specifically for this one filename convention.
- Would pollute `search_index.py`'s own retrieval results with test code, the same way AutoMapper's .NET test projects did before the .NET-suffix fix this same function already carries.

## Fix
Added a JVM PascalCase test-suffix regex, matching `dead_code.py`'s existing pattern exactly. Verified it doesn't swallow an ordinary word that merely ends in "test" (`Contest.kt`, `Attestation.java`).

## Test plan
- [x] Constructed real JVM paths and ran `_is_test_path` directly, confirming the false negative before the fix and correct exclusion after
- [x] Verified no false positives on ordinary words ending in "test"
- [x] Added a regression test
- [x] Full `src/tests/test_search_index.py`: 158/158 passing
- [x] Full `src/tests/test_architecture.py`: 23/23 passing
- [x] Full `src/tests/` suite: 1776/1776 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK