### PR TITLE
fix: evidence resolution misattributed commits by whole-file recency, dropped risk findings on package-name mismatch

### DIFF
--- a/src/aletheore/evidence_resolution.py
+++ b/src/aletheore/evidence_resolution.py
@@ -3,6 +3,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from aletheore.dead_code import _package_import_names
+
 CONFIDENCE_ORDER = {"unavailable": 0, "weak": 1, "inferred": 2, "exact": 3}
 CANONICAL_FIELDS = (
     "kind",
@@ -186,10 +188,65 @@ def resolve_owner(repo_path: Path, file_path: str) -> dict:
 
 
 def resolve_recent_commit(repo_path: Path, file_path: str, line: int | None = None) -> dict:
-    del line
+    """The commit that most recently touched file_path - the specific
+    LINE when one is given, via `git blame` (the real per-line
+    attribution signal), falling back to the whole file's own most
+    recent commit only when no line is given.
+
+    A prior version accepted `line` but silently discarded it (`del
+    line`), always answering with the whole file's most recent commit
+    regardless of which line a finding was actually attached to. On any
+    file with more than one contributor, a finding at a line nobody has
+    touched since it was first written still got attributed to whoever
+    most recently edited some OTHER, unrelated line in the same file -
+    confirmed directly against a real two-commit, two-author repo: a
+    finding at bar()'s own line, never touched after Alice's original
+    commit, was attributed to Bob purely because Bob's later, unrelated
+    commit happened to touch foo() elsewhere in the same file.
+
+    Falls back to the same whole-file lookup no `line` gets (rather than
+    reporting unavailable) whenever blame itself can't answer - a line
+    number past the file's real current length (stale evidence from
+    before the file shrank, or evidence describing a symbol slightly
+    differently than the file's exact current line count), an
+    uncommitted/working-tree-only line, or any other blame failure -
+    the same "a partial/degraded result beats none" preference this
+    codebase applies elsewhere (schema_map's partial-schema-over-failed-
+    scan, CI's fail-soft config loading), not silently swallowed.
+    """
+    sha_from_blame: str | None = None
+    if line is not None:
+        try:
+            blame_proc = subprocess.run(
+                ["git", "blame", "-L", f"{line},{line}", "--porcelain", "HEAD", "--", file_path],
+                cwd=repo_path,
+                check=False,
+                capture_output=True,
+                text=True,
+                errors="ignore",
+                timeout=2,
+            )
+        except (OSError, subprocess.SubprocessError):
+            blame_proc = None
+        if blame_proc is not None and blame_proc.returncode == 0 and blame_proc.stdout:
+            # porcelain's first line is "<sha> <orig-line> <final-line> [<count>]".
+            candidate = blame_proc.stdout.split(None, 1)[0]
+            # git blame's own convention for a line that exists only in
+            # the uncommitted working tree (no real commit to report yet)
+            # is an all-zero SHA - not a bug to route around, a genuine
+            # "no commit for this exact line", falls through to the
+            # whole-file lookup below same as any other blame failure.
+            if candidate and set(candidate) != {"0"}:
+                sha_from_blame = candidate
+
+    log_args = ["git", "log", "-1", "--format=%H%x1f%an%x1f%aI%x1f%s"]
+    if sha_from_blame is not None:
+        log_args.append(sha_from_blame)
+    else:
+        log_args.extend(["--", file_path])
     try:
         proc = subprocess.run(
-            ["git", "log", "-1", "--format=%H%x1f%an%x1f%aI%x1f%s", "--", file_path],
+            log_args,
             cwd=repo_path,
             check=False,
             capture_output=True,
@@ -276,7 +333,18 @@ def attach_risk_evidence(evidence: dict, resolution: dict, max_risks: int = 5) -
         evidence.get("security", {}).get("dependency_vulnerabilities", {}).get("findings", [])
     ):
         package = finding.get("package")
-        if not dependencies or package in dependencies:
+        # dependencies holds import-time names (module["imports"]) - a
+        # finding's own "package" is the real registry name
+        # (dependency_vulnerabilities/dependency_licenses both come from
+        # PyPI/npm/etc lookups against the manifest-declared package name).
+        # These two diverge for a real, common set of packages (PyYAML vs
+        # yaml, beautifulsoup4 vs bs4, Pillow vs PIL) - a bare `package in
+        # dependencies` equality check silently dropped every real match
+        # whenever they differed, the exact same PyYAML/yaml divergence
+        # dead_code.py's own PACKAGE_IMPORT_ALIASES already exists to
+        # handle for its own, structurally identical unused-dependency
+        # check - reused here rather than re-solving the same problem.
+        if not dependencies or (package and _package_import_names(package) & dependencies):
             risks.append(
                 _risk(
                     "vulnerability",
@@ -290,7 +358,7 @@ def attach_risk_evidence(evidence: dict, resolution: dict, max_risks: int = 5) -
         evidence.get("security", {}).get("dependency_licenses", {}).get("findings", [])
     ):
         package = finding.get("package")
-        if package in dependencies:
+        if package and _package_import_names(package) & dependencies:
             risks.append(
                 _risk(
                     "license",

--- a/src/tests/test_evidence_resolution.py
+++ b/src/tests/test_evidence_resolution.py
@@ -200,6 +200,61 @@ def test_resolve_recent_commit_returns_unavailable_for_non_git_repo(tmp_path):
     assert result["commit_status"] == "unavailable"
 
 
+def test_resolve_recent_commit_attributes_a_line_to_its_own_last_editor_not_the_file(tmp_path):
+    # Real bug found via audit: a prior version accepted `line` but
+    # silently discarded it (`del line`), always answering with the whole
+    # file's most recent commit - so a line nobody has touched since it
+    # was first written still got attributed to whoever most recently
+    # edited some OTHER, unrelated line in the same file.
+    repo = tmp_path
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Alice"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "alice@example.com"], cwd=repo, check=True)
+    (repo / "app.py").write_text("def foo():\n    return 1\n\ndef bar():\n    return 2\n")
+    subprocess.run(["git", "add", "app.py"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Alice adds foo and bar"], cwd=repo, check=True, capture_output=True
+    )
+    subprocess.run(["git", "config", "user.name", "Bob"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "bob@example.com"], cwd=repo, check=True)
+    (repo / "app.py").write_text("def foo():\n    return 100\n\ndef bar():\n    return 2\n")
+    subprocess.run(["git", "add", "app.py"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Bob edits foo only"], cwd=repo, check=True, capture_output=True
+    )
+
+    bar_line = resolve_recent_commit(repo, "app.py", line=5)
+    foo_line = resolve_recent_commit(repo, "app.py", line=2)
+    whole_file = resolve_recent_commit(repo, "app.py")
+
+    assert bar_line["commit"]["author"] == "Alice"
+    assert bar_line["commit"]["subject"] == "Alice adds foo and bar"
+    assert foo_line["commit"]["author"] == "Bob"
+    # Whole-file fallback (no line given) is unchanged: the most recent
+    # commit touching the file at all, regardless of which line.
+    assert whole_file["commit"]["author"] == "Bob"
+
+
+def test_resolve_recent_commit_falls_back_to_whole_file_when_the_line_is_out_of_range(tmp_path):
+    # A line number past the file's real current length (stale evidence,
+    # or evidence describing a symbol at a slightly different line than
+    # the file's exact current line count) makes `git blame -L` fail -
+    # this must degrade to the same whole-file answer `line=None` gets,
+    # not silently report the commit as unavailable.
+    repo = tmp_path
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Alice"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "alice@example.com"], cwd=repo, check=True)
+    (repo / "app.py").write_text("print('hello')\n")
+    subprocess.run(["git", "add", "app.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "add app"], cwd=repo, check=True, capture_output=True)
+
+    result = resolve_recent_commit(repo, "app.py", line=999)
+
+    assert result["commit"]["subject"] == "add app"
+    assert result["commit_status"] == "available"
+
+
 def test_attach_dependency_evidence_uses_module_imports():
     resolution = resolve_endpoint(make_evidence(), "GET", "/v1/users")
 
@@ -219,6 +274,37 @@ def test_attach_risk_evidence_attaches_matching_findings():
     assert "architecture" in categories
     assert "vulnerability" in categories
     assert result["risk_status"] == "available"
+
+
+def test_attach_risk_evidence_matches_a_finding_whose_package_name_differs_from_the_import_name():
+    # Real bug found via audit: dependencies holds import-time names
+    # (module["imports"]) but a finding's own "package" is the real
+    # registry name - these diverge for a real, common set of packages
+    # (PyYAML vs yaml, beautifulsoup4 vs bs4, Pillow vs PIL). A bare
+    # `package in dependencies` equality check silently dropped every
+    # real vulnerability/license match whenever they differed.
+    evidence = {
+        "security": {
+            "dependency_vulnerabilities": {
+                "findings": [
+                    {"package": "PyYAML", "severity": "high", "advisory_id": "CVE-2024-XXXX"}
+                ]
+            },
+            "dependency_licenses": {
+                "findings": [
+                    {"package": "beautifulsoup4", "license": "MIT", "severity": "low"}
+                ]
+            },
+        }
+    }
+    resolution = normalize_resolution(
+        kind="symbol", file="app.py", dependency=["yaml", "bs4"], confidence="exact"
+    )
+
+    result = attach_risk_evidence(evidence, resolution)
+
+    categories = {risk["category"] for risk in result["risk"]}
+    assert categories == {"vulnerability", "license"}
 
 
 def test_normalize_resolution_sets_suggestion_and_status():


### PR DESCRIPTION
## Summary
Two real bugs found via adversarial audit of `src/aletheore/evidence_resolution.py`.

**1. `resolve_recent_commit` accepted a `line` parameter but silently discarded it (`del line`)**, always answering with the whole file's most recent commit regardless of which line a finding was actually attached to. On any file with more than one contributor, a finding at a line nobody has touched since it was first written still got attributed to whoever most recently edited some *other*, unrelated line in the same file.

Confirmed against a real two-commit, two-author repo: a finding at `bar()`'s own line (never touched after Alice's original commit) was attributed to Bob purely because Bob's later, unrelated commit touched `foo()` elsewhere in the same file.

**2. `attach_risk_evidence` matched `dependency_vulnerabilities`/`dependency_licenses` findings against import-time names via a bare `package in dependencies` equality check**, but a finding's own `"package"` field is the real registry name - these diverge for a real, common set of packages (`PyYAML` vs `yaml`, `beautifulsoup4` vs `bs4`, `Pillow` vs `PIL`), the exact same divergence `dead_code.py`'s own `PACKAGE_IMPORT_ALIASES` already exists to handle for its structurally identical unused-dependency check. A real, matching CVE or license risk against the file's actual dependency was silently invisible whenever the two names differed.

## Fix
1. Use `git blame -L <line>,<line>` for real per-line attribution, falling back to the prior whole-file lookup whenever blame itself can't answer (a stale/out-of-range line, uncommitted content, or any other blame failure) rather than reporting the commit as unavailable - matches this codebase's established "a partial/degraded result beats none" preference.
2. Reuse `dead_code.py`'s `_package_import_names` instead of a bare equality check.

## Test plan
- [x] Constructed a real two-commit, two-author git repo and confirmed the wrong attribution before the fix, correct per-line attribution after
- [x] Confirmed an out-of-range line gracefully falls back to whole-file recency rather than reporting unavailable
- [x] Confirmed the PyYAML/yaml risk-matching gap before/after with a real evidence dict
- [x] Added 3 regression tests
- [x] Full `src/tests/test_evidence_resolution.py`: 24/24 passing
- [x] Full `src/tests/` suite: 1778/1778 passing
- [x] Full `github-app/tests/` suite: 1803 passed, 8 skipped (this function backs endpoint-health failure pinpointing in production)

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK