### PR TITLE
fix: build-tool detection root-only (missed nested Dockerfiles), .env.dist convention missing

### DIFF
--- a/src/aletheore/scanner/detect.py
+++ b/src/aletheore/scanner/detect.py
@@ -147,7 +147,12 @@ K8S_KIND_MARKERS = {
 
 YAML_EXTENSIONS = (".yaml", ".yml")
 
-ENV_FILE_MARKERS = (".env.example", ".env.sample", ".env.template", "env.example")
+# .env.dist is Symfony's own canonical convention (PHP is one of the 12
+# languages this scanner otherwise fully supports) - real, common enough
+# that its absence here was a silent, whole-ecosystem blind spot, the
+# same "one ecosystem quietly unhandled while its siblings work" shape
+# already found for Gin route groups and repo license detection.
+ENV_FILE_MARKERS = (".env.example", ".env.sample", ".env.template", "env.example", ".env.dist")
 
 BUILD_TOOL_MARKERS = {
     "Dockerfile": "docker",
@@ -389,13 +394,32 @@ def detect_ai_usage(repo_path: Path) -> dict:
     }
 
 
-def detect_build_tools(repo_path: Path) -> list[dict]:
-    tools = []
-    for filename, tool_name in BUILD_TOOL_MARKERS.items():
-        marker = repo_path / filename
-        if marker.exists():
-            tools.append({"name": tool_name, "evidence": filename})
-    return tools
+def detect_build_tools(repo_path: Path, pruned_tree=None) -> list[dict]:
+    """Real bug this closes: every marker was checked only at repo_path
+    itself (repo_path / filename), never recursively - a Dockerfile living
+    in a subdirectory (services/api/Dockerfile, the ordinary layout for
+    any microservices/monorepo project rather than a fringe case) was
+    completely invisible, an internal inconsistency with
+    _detect_docker_compose_services above, which already correctly
+    searches the whole pruned tree for docker-compose.yml. Same root-only
+    gap applied identically to Makefile/webpack/vite markers.
+
+    One entry per tool name (first match in tree-walk order wins) rather
+    than one per file found - preserves the prior "existence, not a full
+    inventory" shape for repos with more than one Dockerfile.
+    """
+    if pruned_tree is None:
+        pruned_tree = _iter_pruned_tree(repo_path)
+    found: dict[str, str] = {}
+    for path, is_dir in pruned_tree:
+        if is_dir:
+            continue
+        tool_name = BUILD_TOOL_MARKERS.get(path.name)
+        if tool_name is None or tool_name in found:
+            continue
+        found[tool_name] = path.relative_to(repo_path).as_posix()
+    # See _detect_migration_directories for why this is sorted.
+    return [{"name": name, "evidence": found[name]} for name in sorted(found)]
 
 
 def detect_policy_docs(repo_path: Path) -> list[dict]:

--- a/src/tests/test_detect.py
+++ b/src/tests/test_detect.py
@@ -166,6 +166,22 @@ def test_detect_build_tools_finds_dockerfile(tmp_path):
     assert "docker" in names
 
 
+def test_detect_build_tools_finds_a_dockerfile_in_a_subdirectory(tmp_path):
+    # Real bug found via audit: every marker was checked only at repo_path
+    # itself, never recursively - a Dockerfile living in a subdirectory
+    # (services/api/Dockerfile, the ordinary layout for any microservices/
+    # monorepo project) was completely invisible, unlike
+    # _detect_docker_compose_services, which already correctly searches
+    # the whole pruned tree for docker-compose.yml.
+    repo = make_repo(tmp_path)
+    (repo / "services" / "api").mkdir(parents=True)
+    (repo / "services" / "api" / "Dockerfile").write_text("FROM python:3.11\n")
+
+    tools = detect_build_tools(repo)
+
+    assert {"name": "docker", "evidence": "services/api/Dockerfile"} in tools
+
+
 def test_detect_monorepo_detects_npm_workspaces(tmp_path):
     repo = make_repo(tmp_path)
     (repo / "package.json").write_text(
@@ -786,6 +802,21 @@ def test_detect_declared_env_vars_returns_empty_when_no_env_files(tmp_path):
     (repo / "main.py").write_text("x = 1\n")
 
     assert _detect_declared_env_vars(repo) == []
+
+
+def test_detect_declared_env_vars_reads_symfonys_env_dist_convention(tmp_path):
+    # Real bug found via audit: .env.dist is Symfony's own canonical
+    # convention (PHP is one of the 12 languages this scanner otherwise
+    # fully supports), missing from ENV_FILE_MARKERS entirely.
+    from aletheore.scanner.detect import _detect_declared_env_vars
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env.dist").write_text("DATABASE_URL=\n")
+
+    result = _detect_declared_env_vars(repo)
+
+    assert result == [{"name": "DATABASE_URL", "source": ".env.dist"}]
 
 
 def test_detect_infrastructure_combines_all_categories(tmp_path):


### PR DESCRIPTION
## Summary
Two real bugs found via adversarial audit of `src/aletheore/scanner/detect.py`.

**1. `detect_build_tools` checked every marker only at `repo_path` itself**, never recursively - a Dockerfile living in a subdirectory (`services/api/Dockerfile`, the ordinary layout for any microservices/monorepo project, not a fringe case) was completely invisible. An internal inconsistency with `_detect_docker_compose_services` in the same file, which already correctly searches the whole pruned tree for `docker-compose.yml`.

Confirmed by execution: a repo with only a nested Dockerfile reported zero build tools, while its sibling compose file one directory over was found fine.

**2. `ENV_FILE_MARKERS` never included `.env.dist`**, Symfony's own canonical convention - PHP is one of the 12 languages this scanner otherwise fully supports, and this is the same "one ecosystem quietly unhandled while its siblings work" shape already found for Gin route groups (#597) and repo license detection (#598) this session.

## Fix
`detect_build_tools` now walks the pruned tree the same way every other recursive detector in this file already does (accepting an optional `pruned_tree` for future call-site sharing), reporting one entry per tool name (first match wins) rather than one per file found - preserves the prior "existence, not a full inventory" shape for repos with more than one Dockerfile. `.env.dist` added to `ENV_FILE_MARKERS`.

## Test plan
- [x] Constructed real nested Dockerfile and `.env.dist` cases, confirmed the false negative before the fix and correct detection after
- [x] Verified the pre-existing root-level Dockerfile case still works
- [x] Added 2 regression tests
- [x] Full `src/tests/test_detect.py`: 64/64 passing
- [x] Full `src/tests/` suite: 1777/1777 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK