### PR TITLE
fix: public demo crashed on a null AIR evidence section instead of degrading gracefully

### DIFF
--- a/github-app/scan_worker/demo_scan.py
+++ b/github-app/scan_worker/demo_scan.py
@@ -80,19 +80,43 @@ def _run_sandboxed_scan(repo_url: str) -> dict:
         raise DemoScanError("demo scan is temporarily unavailable - please try again shortly") from exc
 
 
-def _summarize_for_public_display(evidence: dict) -> dict:
-    repository = evidence.get("repository", {})
-    security = evidence.get("security", {})
-    architecture = evidence.get("architecture", {})
+def _dict_or_empty(value: object) -> dict:
+    return value if isinstance(value, dict) else {}
 
-    languages = repository.get("languages", [])
-    dead_code = repository.get("dead_code", {})
-    unreachable_modules = dead_code.get("unreachable_modules", [])
-    unused_dependencies = dead_code.get("unused_dependencies", [])
-    secrets_findings = security.get("secrets", {}).get("findings", [])
-    license_findings = security.get("dependency_licenses", {}).get("findings", [])
-    endpoints = repository.get("api_endpoints", {}).get("endpoints", [])
-    clusters = architecture.get("clusters", [])
+
+def _list_or_empty(value: object) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _summarize_for_public_display(evidence: dict) -> dict:
+    # Real bug this closes: evidence comes from demo_sandbox_runner over
+    # HTTP, a separate process this file has no control over - a
+    # `dict.get(key, {})`/`.get(key, [])` default only ever applies when
+    # the key is MISSING, not when it's present with an explicit JSON
+    # null (Python None). A "200 OK, JSON parses, but one AIR section
+    # serialized as null" response (a partial/degraded scan result that
+    # didn't hard-fail the way timeout/memory_limited/nonzero_exit do)
+    # crashed here with an unhandled AttributeError - 'NoneType' object
+    # has no attribute 'get' - on the very next .get() call, surfacing as
+    # a raw traceback in the RQ job instead of this file's own
+    # established clean-error pattern for every OTHER failure shape.
+    # _dict_or_empty/_list_or_empty check the value itself, not just
+    # whether the key exists, so every step below degrades to the same
+    # empty-but-valid shape regardless of which sections evidence supplies.
+    repository = _dict_or_empty(evidence.get("repository"))
+    security = _dict_or_empty(evidence.get("security"))
+    architecture = _dict_or_empty(evidence.get("architecture"))
+
+    languages = _list_or_empty(repository.get("languages"))
+    dead_code = _dict_or_empty(repository.get("dead_code"))
+    unreachable_modules = _list_or_empty(dead_code.get("unreachable_modules"))
+    unused_dependencies = _list_or_empty(dead_code.get("unused_dependencies"))
+    secrets_findings = _list_or_empty(_dict_or_empty(security.get("secrets")).get("findings"))
+    license_findings = _list_or_empty(
+        _dict_or_empty(security.get("dependency_licenses")).get("findings")
+    )
+    endpoints = _list_or_empty(_dict_or_empty(repository.get("api_endpoints")).get("endpoints"))
+    clusters = _list_or_empty(architecture.get("clusters"))
 
     return {
         "languages": [

--- a/github-app/tests/test_demo_scan.py
+++ b/github-app/tests/test_demo_scan.py
@@ -111,6 +111,37 @@ def test_summarize_handles_empty_evidence_gracefully():
     assert summary["secrets"]["finding_count"] == 0
 
 
+def test_summarize_handles_a_null_section_gracefully(tmp_path):
+    # Real bug found via audit: evidence comes from demo_sandbox_runner
+    # over HTTP, a separate process this file has no control over - a
+    # "200 OK, JSON parses, but one AIR section serialized as null"
+    # response (a partial/degraded scan result that didn't hard-fail)
+    # crashed with an unhandled AttributeError on the very next .get()
+    # call, since dict.get(key, {}) only supplies its default when the
+    # key is MISSING, not when it's present with an explicit null.
+    summary = _summarize_for_public_display(
+        {"repository": {"dead_code": None, "api_endpoints": None}, "security": None, "architecture": None}
+    )
+    assert summary["dead_code"]["unreachable_module_count"] == 0
+    assert summary["secrets"]["finding_count"] == 0
+    assert summary["dependency_licenses"]["issue_count"] == 0
+    assert summary["api_endpoints"]["count"] == 0
+    assert summary["architecture"]["cluster_count"] == 0
+
+
+def test_summarize_handles_evidence_that_is_entirely_null_sections():
+    # Every top-level section null at once, not just one - repository/
+    # security/architecture themselves must degrade the same way their
+    # own nested fields do.
+    summary = _summarize_for_public_display(
+        {"repository": None, "security": None, "architecture": None}
+    )
+    assert summary["languages"] == []
+    assert summary["dead_code"]["unreachable_module_count"] == 0
+    assert summary["secrets"]["finding_count"] == 0
+    assert summary["architecture"]["cluster_count"] == 0
+
+
 def test_summarize_notes_osv_is_held_back():
     summary = _summarize_for_public_display(_fake_evidence())
     assert "OSV" in summary["held_back"]["vulnerabilities"]


### PR DESCRIPTION
## Summary
Adversarial audit of `demo_scan.py` (the unauthenticated, public "paste a repo" website demo - a security-sensitive, internet-reachable surface) found a real crash bug.

`_summarize_for_public_display` used `dict.get(key, {})`/`.get(key, [])` defaults throughout, but those only apply when a key is **missing** - not when it's present with an explicit JSON `null`. `evidence` comes from `demo_sandbox_runner` over HTTP, a separate process this file has no control over. A "200 OK, JSON parses, but one AIR section serialized as `null`" response (a partial/degraded scan result that didn't hard-fail the way `timeout`/`memory_limited`/`nonzero_exit` already do) crashed with an unhandled `AttributeError` on the very next `.get()` call - surfacing as a raw traceback in the RQ job rather than this file's own established clean-error pattern for every other failure shape.

Confirmed by execution: `evidence["repository"]["dead_code"] = None` (or `security["secrets"] = None`, or the whole `repository`/`security`/`architecture` section itself `null`) each crashed `_summarize_for_public_display` before this fix.

## Fix
Two small type-checking helpers (`_dict_or_empty`/`_list_or_empty`) that check the value itself, not just whether the key exists, used at every `.get()` step - every section now degrades to the same empty-but-valid shape regardless of which sections a partial scan result supplies.

## Test plan
- [x] Constructed evidence dicts with `null` at every fragile point (single section, multiple sections, entire top-level sections) and confirmed the crash before the fix, graceful degradation after
- [x] Added 2 regression tests
- [x] Full `github-app/tests/test_demo_scan.py`: 15/15 passing
- [x] Full `github-app/tests/` suite: 1805 passed, 8 skipped

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK