### PR TITLE
fix: find_blast_radius's direct_dependents was completely unbounded

### DIFF
--- a/src/aletheore/query.py
+++ b/src/aletheore/query.py
@@ -150,6 +150,19 @@ def find_layer_violations(evidence: dict, target: str | None) -> dict:
 _BLAST_RADIUS_CONFIRM_CANDIDATES = 40
 _BLAST_RADIUS_CONFIRMED_CALLERS_SHOWN = 10
 _BLAST_RADIUS_MAX_TRANSITIVE = 50
+# Real bug found via audit: direct_dependents (evidence's own raw
+# imported_by list) was returned verbatim with no cap at all - unlike
+# transitive_dependents just below (capped, with an honest truncated
+# flag) and unlike flash_review.py's own build_blast_radius_context,
+# which this function's docstring says it mirrors - that sibling caps
+# its candidate list at MAX_BLAST_RADIUS_CANDIDATES (40) right at the
+# start. A genuinely central module (a shared utils.py/models.py) can
+# have hundreds-to-thousands of direct importers on a real repo -
+# confirmed directly: a 500-file synthetic hub returned all 500 with no
+# truncation signal, the same unbounded-MCP/CLI-result failure mode
+# already hardened twice this session for aletheore_search and
+# aletheore_ast_pattern.
+_BLAST_RADIUS_MAX_DIRECT = 50
 
 
 def find_blast_radius(
@@ -205,7 +218,13 @@ def find_blast_radius(
 
     result: dict[str, Any] = {
         "target": target,
-        "direct_dependents": direct_dependents,
+        # Truncated for DISPLAY only - the BFS above, confirmed_callers
+        # below, and blast_radius_modules further down all still use the
+        # full, untruncated direct_dependents list, so a large hub's real
+        # transitive reach and layer-violation exposure are never
+        # understated just because its own direct-importer list is long.
+        "direct_dependents": direct_dependents[:_BLAST_RADIUS_MAX_DIRECT],
+        "direct_dependents_truncated": len(direct_dependents) > _BLAST_RADIUS_MAX_DIRECT,
         "transitive_dependents": transitive_dependents,
         "transitive_dependents_truncated": truncated,
     }

--- a/src/tests/test_query.py
+++ b/src/tests/test_query.py
@@ -387,6 +387,48 @@ def test_find_blast_radius_truncates_transitive_dependents_past_the_cap(tmp_path
     assert result["transitive_dependents_truncated"] is True
 
 
+def test_find_blast_radius_truncates_direct_dependents_past_the_cap(tmp_path, monkeypatch):
+    # Real bug found via audit: direct_dependents (evidence's own raw
+    # imported_by list) was returned verbatim with no cap at all, unlike
+    # transitive_dependents just above and unlike flash_review.py's own
+    # sibling implementation this function's docstring says it mirrors -
+    # a genuinely central module (a shared utils.py) can have hundreds to
+    # thousands of direct importers on a real repo.
+    import aletheore.query as query_module
+
+    monkeypatch.setattr(query_module, "_BLAST_RADIUS_MAX_DIRECT", 1)
+
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
+
+    assert result["direct_dependents"] == ["service/handler.py"]
+    assert result["direct_dependents_truncated"] is False
+
+    monkeypatch.setattr(query_module, "_BLAST_RADIUS_MAX_DIRECT", 0)
+
+    truncated_result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
+
+    assert truncated_result["direct_dependents"] == []
+    assert truncated_result["direct_dependents_truncated"] is True
+
+
+def test_find_blast_radius_truncating_direct_dependents_does_not_shrink_transitive_reach(tmp_path, monkeypatch):
+    # The truncation above must be display-only: the BFS, confirmed_callers,
+    # and layer_violations filtering all still need the FULL direct_dependents
+    # list internally, or capping the displayed list would silently understate
+    # a real hub's true transitive reach and layer-violation exposure.
+    import aletheore.query as query_module
+
+    monkeypatch.setattr(query_module, "_BLAST_RADIUS_MAX_DIRECT", 0)
+
+    result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
+
+    assert result["direct_dependents"] == []
+    assert set(result["transitive_dependents"]) == {"api/routes.py", "web/app.py"}
+    assert result["layer_violations"] == [
+        {"from": "service/handler.py", "to": "web/app.py", "reason": "inner imports outer"}
+    ]
+
+
 def test_find_blast_radius_omits_confirmed_callers_without_a_symbol(tmp_path):
     result = find_blast_radius(_blast_radius_evidence(), tmp_path, "core/util.py")
     assert "confirmed_callers" not in result


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/query.py` found a real bug: `direct_dependents` (evidence's own raw `imported_by` list) was returned verbatim with no cap at all - unlike `transitive_dependents` right below it (capped at `_BLAST_RADIUS_MAX_TRANSITIVE=50`, with an honest `truncated` flag) and unlike `flash_review.py`'s own `build_blast_radius_context`, which this function's own docstring says it mirrors - that sibling implementation caps its candidate list at `MAX_BLAST_RADIUS_CANDIDATES` (40) right at the start.

Confirmed by execution: a synthetic 500-file hub (one shared `utils.py` imported by 500 other files) returned all 500 entries in `direct_dependents` with no truncation signal at all - a genuinely central module (a shared `utils.py`/`models.py`/config file) can easily reach this scale on a real repo. Both `aletheore_get_blast_radius` (MCP) and `aletheore query blast-radius` (CLI) were exposed to this: the same unbounded-result failure mode already hardened twice this session for `aletheore_search` and `aletheore_ast_pattern`, both real production incidents documented in this codebase's own history, not hypothetical.

## Fix
`direct_dependents` is now truncated to `_BLAST_RADIUS_MAX_DIRECT` (50, matching the transitive cap) with its own `direct_dependents_truncated` flag - display-only, though: the BFS traversal, `confirmed_callers`, and `layer_violations` filtering all still use the full, untruncated list internally, so capping the displayed list never understates a real hub's true transitive reach or layer-violation exposure.

## Test plan
- [x] Constructed a real 500-file hub and confirmed the unbounded result before the fix, correctly capped after
- [x] Confirmed the normal small-repo case is unaffected (no truncation when under the cap)
- [x] Added 2 regression tests, including one confirming truncation is display-only (transitive reach and layer violations stay complete even when direct_dependents is capped to 0)
- [x] Full `src/tests/test_query.py`: 48/48 passing
- [x] Full `src/tests/` suite: 1817/1817 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK