### PR TITLE
fix: Paddle webhook crashed permanently on a null/string seat quantity

### DIFF
--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 
@@ -103,6 +104,14 @@ def _seat_item_quantity(item: dict) -> int:
     if isinstance(quantity, int):
         return quantity
     if isinstance(quantity, float):
+        # Flash Review finding: JSON's own grammar has no literal for
+        # inf/-inf/nan, but Python's json module accepts them anyway
+        # (a real, if nonstandard, shape a sender can transmit) - int()
+        # on either raises OverflowError (inf) or ValueError (nan), the
+        # exact same "crash the whole webhook handler" failure mode this
+        # function exists to close for None/string quantity.
+        if not math.isfinite(quantity):
+            return 0
         return int(quantity)
     if isinstance(quantity, str):
         try:

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -86,6 +86,32 @@ class PaddleWebhookAttributionError(RuntimeError):
     to any installation - see the installation_id is None branch below."""
 
 
+def _seat_item_quantity(item: dict) -> int:
+    """A line item's quantity, coerced to a real int - never trusts Paddle's
+    own JSON shape to guarantee an int the way `item.get("quantity", 0)`
+    implicitly did. That default only ever applies when the key is
+    MISSING, not when Paddle sends it present with an explicit null or a
+    numeric string - confirmed directly: quantity=None or quantity="3"
+    both crashed the whole webhook handler with an unhandled TypeError
+    on the sum() below, permanently stuck (Paddle keeps retrying the
+    same payload) rather than a legitimate plan/seat change ever
+    applying for that customer.
+    """
+    quantity = item.get("quantity")
+    if isinstance(quantity, bool):
+        return 0
+    if isinstance(quantity, int):
+        return quantity
+    if isinstance(quantity, float):
+        return int(quantity)
+    if isinstance(quantity, str):
+        try:
+            return int(quantity)
+        except ValueError:
+            return 0
+    return 0
+
+
 async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue=None) -> None:
     event_type = payload.get("event_type")
     if event_type == "transaction.completed":
@@ -181,7 +207,7 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     # reads `items`/`plan`, already available.
     extra_seats = (
         sum(
-            item.get("quantity", 0)
+            _seat_item_quantity(item)
             for item in items
             if (item.get("price") or {}).get("id") == EXTRA_SEAT_PRICE_ID
         )

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -731,6 +731,66 @@ async def test_subscription_updated_reconciles_extra_seats_from_items(pool):
 
 
 @pytest.mark.asyncio
+async def test_subscription_updated_with_a_null_seat_quantity_does_not_crash(pool):
+    # Real bug found via audit: item.get("quantity", 0) only supplies its
+    # default when the key is MISSING, not when Paddle sends it present
+    # with an explicit null - crashed the whole webhook handler with an
+    # unhandled TypeError, permanently stuck (Paddle keeps retrying the
+    # same payload) rather than a legitimate plan/seat change ever
+    # applying for that customer.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+        "VALUES (308, 'acme', 'air', 3)"
+    )
+    payload = {
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_308",
+            "customer_id": "ctm_test_308",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(308)},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": None},
+            ],
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_extra_seats(pool, 308) == 0
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_with_a_string_seat_quantity_reconciles_correctly(pool):
+    # Same gap as the null case above - Paddle's own real quantity field is
+    # always an int, but this must not crash on a non-int shape either.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+        "VALUES (309, 'acme', 'air', 0)"
+    )
+    payload = {
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_309",
+            "customer_id": "ctm_test_309",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(309)},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": "3"},
+            ],
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_extra_seats(pool, 309) == 3
+
+
+@pytest.mark.asyncio
 async def test_subscription_canceled_resets_extra_seats_to_zero(pool):
     fake_queue = MagicMock()
     await pool.execute(

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -791,6 +791,39 @@ async def test_subscription_updated_with_a_string_seat_quantity_reconciles_corre
 
 
 @pytest.mark.asyncio
+async def test_subscription_updated_with_a_non_finite_seat_quantity_does_not_crash(pool):
+    # Flash Review finding on the null/string-quantity fix above: the float
+    # branch called int(quantity) unconditionally, but JSON's own grammar
+    # has no literal for inf/-inf/nan - Python's json module accepts them
+    # anyway (a real, if nonstandard, shape a sender can transmit), and
+    # int() on either raises OverflowError (inf) or ValueError (nan), the
+    # exact same "crash the whole webhook handler" failure this function
+    # exists to close.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+        "VALUES (310, 'acme', 'air', 3)"
+    )
+    payload = {
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_310",
+            "customer_id": "ctm_test_310",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(310)},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": float("nan")},
+            ],
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_extra_seats(pool, 310) == 0
+
+
+@pytest.mark.asyncio
 async def test_subscription_canceled_resets_extra_seats_to_zero(pool):
     fake_queue = MagicMock()
     await pool.execute(


### PR DESCRIPTION
## Summary
Adversarial audit of `github-app/app_server/webhooks/paddle.py` (real customer billing/subscription state) found a real bug: `item.get("quantity", 0)` only supplies its default when the key is **missing**, not when Paddle sends it present with an explicit `null` or a non-int value (a numeric string, say).

Confirmed by execution against a real test DB: an extra-seat line item with `quantity=None` or `quantity="3"` both crashed `handle_paddle_webhook_event` with an unhandled `TypeError` on the `sum()` computing `extra_seats`.

## Severity
The crash happens before the DB transaction opens, so no partial writes occur (`release_webhook_delivery` + re-raise keeps this retry-safe, not data-corrupting) - but since the payload is deterministic, Paddle keeps retrying the same event and it keeps crashing the same way, so a legitimate plan/seat change for that customer never applies until someone intervenes manually.

## Fix
A small `_seat_item_quantity` helper coerces `quantity` to a real int (bool/int/float/numeric-string handled, anything else treated as 0) instead of trusting `item.get("quantity", 0)`'s default to cover every malformed shape - matching this file's own stated philosophy: never trust a single choke point.

## Test plan
- [x] Confirmed the crash before the fix and correct reconciliation after, for both `null` and string `quantity`, via `_seat_item_quantity` directly and end-to-end through `handle_paddle_webhook_event` against a real test DB
- [x] Added 2 regression tests
- [x] Full `github-app/tests/test_webhooks_paddle.py`: 59/59 passing
- [x] Full `github-app/tests/` suite: 1746 passed, 8 skipped

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK