### PR TITLE
fix: ChatOps trigger phrases matched as a bare string prefix, firing on ordinary English words

### DIFF
--- a/github-app/app_server/webhooks/issue_comment.py
+++ b/github-app/app_server/webhooks/issue_comment.py
@@ -9,6 +9,25 @@ logger = logging.getLogger(__name__)
 
 AUDIT_COMMAND = "/aletheore audit"
 
+
+def _matches_command(line: str, command: str) -> bool:
+    """True if `line` (already stripped) IS `command`, or starts with
+    `command` followed by whitespace - not a bare string-prefix check.
+
+    Real bug this closes: `line.startswith(command)` also matches an
+    ordinary English word sharing the same stem - "/aletheore auditing
+    this PR now" or "/aletheore auditorium" both satisfied the old
+    check, on a GitHub PR thread whose entire subject is reviewing/
+    auditing code, exactly the conversational context where a commenter
+    typing a sentence starting with "audit..." is a real, not
+    hypothetical, risk. Confirmed directly: both fired the real, billed,
+    AIR-tier-gated managed-audit job with no intent to trigger it.
+    """
+    if line == command:
+        return True
+    return line.startswith(command) and line[len(command) : len(command) + 1].isspace()
+
+
 # Anyone who can push to the repo can already do everything a managed audit
 # does (read the code, spend the org's own compute) - "read" or below is
 # exactly the set of people an outside PR commenter represents, which is
@@ -30,7 +49,7 @@ async def handle_issue_comment_event(payload: dict, pool, redis_url: str, queue=
         return
     comment = payload.get("comment", {})
     body = comment.get("body", "")
-    if not any(line.strip().startswith(AUDIT_COMMAND) for line in body.splitlines()):
+    if not any(_matches_command(line.strip(), AUDIT_COMMAND) for line in body.splitlines()):
         return
     if comment.get("user", {}).get("type") == "Bot":
         return

--- a/github-app/app_server/webhooks/pull_request_review_comment.py
+++ b/github-app/app_server/webhooks/pull_request_review_comment.py
@@ -10,6 +10,27 @@ logger = logging.getLogger(__name__)
 
 DISMISS_COMMAND = "/dismiss"
 
+
+def _matches_command(line: str, command: str) -> bool:
+    """True if `line` (already stripped) IS `command`, or starts with
+    `command` followed by whitespace - not a bare string-prefix check.
+
+    Real bug this closes: `line.startswith(command)` also matches an
+    ordinary English word sharing the same stem - "/dismissed this
+    already" or "/dismissing for now" both satisfied the old check, on a
+    thread whose entire subject is dismissing/discussing findings,
+    exactly the conversational context where this is a real risk.
+    Confirmed directly: both silently dismissed a real finding with no
+    intent to trigger it, and (via the identical bug in _dismiss_reason
+    below) recorded a garbled reason - "/dismissed this already"[8:]
+    slices into the middle of the word itself, producing "ed this
+    already" as the stored dismissal reason.
+    """
+    if line == command:
+        return True
+    return line.startswith(command) and line[len(command) : len(command) + 1].isspace()
+
+
 # Same reasoning as issue_comment.py's AUDIT_COMMAND gate: anyone who can
 # push to the repo can already suppress a finding by editing the code
 # around it or disabling the check entirely - write/admin is the same bar
@@ -30,7 +51,7 @@ def _dismiss_reason(body: str) -> str | None:
     used; a reply is one short comment, not a document."""
     for line in body.splitlines():
         stripped = line.strip()
-        if stripped.startswith(DISMISS_COMMAND):
+        if _matches_command(stripped, DISMISS_COMMAND):
             reason = stripped[len(DISMISS_COMMAND):].strip()
             return reason or None
     return None
@@ -61,7 +82,7 @@ async def handle_pull_request_review_comment_event(payload: dict, pool, redis_ur
     if comment.get("user", {}).get("type") == "Bot":
         return  # never act on our own resolution-edit comments or any other bot's reply
     body = comment.get("body", "")
-    if not any(line.strip().startswith(DISMISS_COMMAND) for line in body.splitlines()):
+    if not any(_matches_command(line.strip(), DISMISS_COMMAND) for line in body.splitlines()):
         return
 
     installation_id = payload["installation"]["id"]

--- a/github-app/tests/test_issue_comment_webhook.py
+++ b/github-app/tests/test_issue_comment_webhook.py
@@ -124,6 +124,24 @@ async def test_quoted_command_does_not_enqueue(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_a_word_sharing_the_command_stem_does_not_enqueue(pool, monkeypatch):
+    # Real bug found via audit: a bare string-prefix check
+    # (line.startswith(AUDIT_COMMAND)) also matches an ordinary English
+    # word sharing the same stem - on a GitHub PR thread whose entire
+    # subject is reviewing/auditing code, a commenter typing a sentence
+    # starting with "audit..." is a real, not hypothetical, risk. This
+    # used to enqueue a real, billed, AIR-tier-gated managed audit with
+    # no intent to trigger it.
+    await _seed_paid_installation(pool)
+    _mock_permission_check(monkeypatch, "write")
+    fake_queue = MagicMock()
+    await handle_issue_comment_event(
+        _payload("/aletheore auditing this PR now"), pool, "redis://unused", queue=fake_queue
+    )
+    fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_bot_command_does_not_enqueue(pool, monkeypatch):
     await _seed_paid_installation(pool)
     _mock_permission_check(monkeypatch, "write")

--- a/github-app/tests/test_pull_request_review_comment_webhook.py
+++ b/github-app/tests/test_pull_request_review_comment_webhook.py
@@ -121,6 +121,33 @@ async def test_dismiss_reply_captures_the_reason_text(pool, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_a_word_sharing_the_command_stem_does_not_record(pool, monkeypatch):
+    # Real bug found via audit: a bare string-prefix check
+    # (line.startswith(DISMISS_COMMAND)) also matches an ordinary English
+    # word sharing the same stem - "/dismissed this already" or
+    # "/dismissing for now" both silently dismissed a real finding with
+    # no intent to trigger it, on a thread whose entire subject is
+    # dismissing/discussing findings. The same bug in _dismiss_reason's
+    # slicing also produced a garbled reason ("/dismissed this
+    # already"[8:] == "ed this already") - both are fixed by the same
+    # word-boundary check.
+    await _seed_installation(pool)
+    await _seed_tracked_comment(pool)
+    _mock_permission_check(monkeypatch, "write")
+
+    await handle_pull_request_review_comment_event(
+        _payload("/dismissed this already"), pool, "redis://unused"
+    )
+
+    row = await pool.fetchrow(
+        "SELECT reason FROM dismissed_findings WHERE installation_id = $1 AND identity_key = $2",
+        111,
+        "app.py\x1f10\x1fabc123",
+    )
+    assert row is None
+
+
+@pytest.mark.asyncio
 async def test_dismiss_reply_from_a_read_only_commenter_does_not_record(pool, monkeypatch):
     await _seed_installation(pool)
     await _seed_tracked_comment(pool)


### PR DESCRIPTION
## Summary
Adversarial audit of the ChatOps webhook handlers found a real bug: both `AUDIT_COMMAND` (`/aletheore audit`) and `DISMISS_COMMAND` (`/dismiss`) were matched with a bare `line.startswith(command)` check - no word boundary.

Confirmed by execution: `"/aletheore auditing this PR now"` and `"/aletheore auditorium"` both satisfied `issue_comment.py`'s trigger check; `"/dismissed this already"` and `"/dismissing for now"` both satisfied `pull_request_review_comment.py`'s.

Neither is hypothetical: both trigger phrases are common English word stems, and the exact threads these commands live on (a PR review, a reply to a Flash Review finding comment) are already about auditing/dismissing findings - a commenter writing an ordinary sentence starting with "audit..." or "dismiss..." is a real, plausible shape, not a contrived one.

## Impact
- **`issue_comment.py`**: a write-access commenter typing something as ordinary as `"/aletheore auditing this now"` enqueues a real, billed, AIR-tier-gated managed-audit job with no intent to trigger it.
- **`pull_request_review_comment.py`**: the same shape silently dismisses a real Flash Review finding. Worse, `_dismiss_reason`'s slicing compounds it: `"/dismissed this already"[len("/dismiss"):].strip()` slices into the middle of the word itself, recording the garbled reason `"ed this already"` against the dismissal.

## Fix
A shared `_matches_command(line, command)` helper (duplicated in both files, matching their own existing pattern of duplicating small helpers like `_verify_commenter_permission_sync` rather than a new shared module) - true only for an exact match or the command followed by whitespace, not any string sharing its prefix.

## Test plan
- [x] Confirmed both false-positive triggers and the garbled-reason corruption before the fix, and correct rejection/reason after, via direct unit calls and end-to-end through the real webhook handlers against a real test DB
- [x] Confirmed legitimate command usage still works (`/aletheore audit please`, `/dismiss not relevant to this repo`)
- [x] Added 2 regression tests
- [x] Full `github-app/tests/test_issue_comment_webhook.py` + `test_pull_request_review_comment_webhook.py`: 30/30 passing
- [x] Full `github-app/tests/` suite: 1746 passed, 8 skipped

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK