### PR TITLE
fix: OpenAI free-tier reservation could true-up against the wrong day's Redis key across UTC midnight

### DIFF
--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -59,7 +59,7 @@ def openai_free_tier_tokens_today(redis_conn) -> int:
     return int(value) if value is not None else 0
 
 
-def _reserve_openai_free_tier_budget(redis_conn) -> bool:
+def _reserve_openai_free_tier_budget(redis_conn, key: str | None = None) -> bool:
     """Atomically reserve OPENAI_FREE_TIER_RESERVATION_TOKENS against
     today's counter, right before a real OpenAI call is about to happen
     (wired as an adapter's before_llm_call - invoked fresh per real
@@ -78,8 +78,14 @@ def _reserve_openai_free_tier_budget(redis_conn) -> bool:
     is bounded by one reservation each, not unbounded; (2) an adapter that
     was merely *included* in the chain but never actually reached (an
     earlier provider succeeded first) never reserves anything, since this
-    only fires at the moment a real call is about to be attempted."""
-    key = _openai_free_tier_token_key()
+    only fires at the moment a real call is about to be attempted.
+
+    `key`: the caller may pass the exact key to reserve against (see
+    run_with_free_tier_fallback's chain-building, which captures this
+    same key for the later true-up/release call) - defaults to computing
+    a fresh one, preserving this function's own standalone behavior for
+    any other caller."""
+    key = key or _openai_free_tier_token_key()
     new_total = redis_conn.incrby(key, OPENAI_FREE_TIER_RESERVATION_TOKENS)
     if hasattr(redis_conn, "expire"):
         # 2 days: comfortably outlives the single calendar day this key is
@@ -92,13 +98,26 @@ def _reserve_openai_free_tier_budget(redis_conn) -> bool:
     return True
 
 
-def _true_up_openai_free_tier_reservation(redis_conn, real_total_tokens: int) -> None:
+def _true_up_openai_free_tier_reservation(
+    redis_conn, real_total_tokens: int, key: str | None = None
+) -> None:
     """Correct the reservation placeholder with the real prompt+completion
     total once a reserved call has actually completed - the reservation
-    was a conservative estimate, not the real usage."""
+    was a conservative estimate, not the real usage.
+
+    `key`: the exact key the matching reservation was placed against (see
+    _reserve_openai_free_tier_budget's own `key` parameter) - real bug
+    this closes: computing a fresh key here independently, rather than
+    reusing the one the reservation actually used, meant a call that
+    straddled the UTC midnight boundary between reservation and true-up
+    corrected the WRONG day's counter - permanently over-reserving the
+    day it actually ran on (bounded by the key's own 2-day TTL) and
+    leaking negative headroom into the next day's real allowance.
+    Defaults to computing a fresh key, preserving this function's own
+    standalone behavior for any other caller."""
     delta = real_total_tokens - OPENAI_FREE_TIER_RESERVATION_TOKENS
     if delta != 0:
-        redis_conn.incrby(_openai_free_tier_token_key(), delta)
+        redis_conn.incrby(key or _openai_free_tier_token_key(), delta)
 
 LUNA_MODEL = "gpt-5.6-luna"
 PRO_MODEL = "deepseek-v4-pro"
@@ -360,10 +379,30 @@ def writing_adapter_chain_for_free_tier(
         logger.info("free-tier: GEMINI_API_KEY not configured, skipping Gemini")
 
     if has_api_key("OPENAI_FREE_TIER_API_KEY", "OpenAI-FreeTier"):
+        # Captures the exact key before_llm_call reserved against, so
+        # on_usage/on_call_failed correct that SAME day's counter even if
+        # the real call straddles the UTC midnight boundary between
+        # reservation and true-up - see both functions' own docstrings
+        # for the real corruption this closes. A plain dict (not a bare
+        # local) since it's written from inside a nested closure.
+        _reserved_key: dict[str, str] = {}
+
+        def _reserve_and_capture_key() -> bool:
+            key = _openai_free_tier_token_key()
+            ok = _reserve_openai_free_tier_budget(redis_conn, key=key)
+            if ok:
+                _reserved_key["key"] = key
+            return ok
+
+        def _true_up_reserved_key(real_total_tokens: int) -> None:
+            _true_up_openai_free_tier_reservation(
+                redis_conn, real_total_tokens, key=_reserved_key.pop("key", None)
+            )
+
         def _on_openai_free_tier_usage(
             prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0
         ) -> None:
-            _true_up_openai_free_tier_reservation(redis_conn, prompt_tokens + completion_tokens)
+            _true_up_reserved_key(prompt_tokens + completion_tokens)
             if on_usage is not None:
                 on_usage(prompt_tokens, completion_tokens, cached_tokens)
 
@@ -380,7 +419,7 @@ def writing_adapter_chain_for_free_tier(
             model="gpt-5-nano",
             extra_body={"reasoning_effort": "minimal"},
             on_usage=_on_openai_free_tier_usage,
-            before_llm_call=lambda: _reserve_openai_free_tier_budget(redis_conn),
+            before_llm_call=_reserve_and_capture_key,
             # Releases the reservation before_llm_call just made when the
             # real call then fails (rate limit, auth error, timeout) -
             # on_usage never fires on a failed call, so without this the
@@ -389,7 +428,7 @@ def writing_adapter_chain_for_free_tier(
             # on_call_failed for why this can't just reuse on_usage(0, 0):
             # that would misrepresent a failed call as a completed one to
             # any other on_usage consumer.
-            on_call_failed=lambda: _true_up_openai_free_tier_reservation(redis_conn, 0),
+            on_call_failed=lambda: _true_up_reserved_key(0),
             # OpenAICompatibleAdapter's default budget_exceeded_message
             # names the monthly LLM spend cap - correct for every other
             # before_llm_call wiring (e.g. jobs.py's spend_budget.

--- a/github-app/scan_worker/model_tiers.py
+++ b/github-app/scan_worker/model_tiers.py
@@ -23,6 +23,7 @@ price entry from the start.)
 
 import logging
 import os
+import threading
 from datetime import datetime, timezone
 from typing import Callable
 
@@ -84,8 +85,12 @@ def _reserve_openai_free_tier_budget(redis_conn, key: str | None = None) -> bool
     run_with_free_tier_fallback's chain-building, which captures this
     same key for the later true-up/release call) - defaults to computing
     a fresh one, preserving this function's own standalone behavior for
-    any other caller."""
-    key = key or _openai_free_tier_token_key()
+    any other caller. Checked against None, not truthiness - Flash
+    Review finding: `key or ...` would silently discard a caller-supplied
+    empty string and reserve against a freshly computed key instead,
+    contradicting this docstring's own "the exact key to use" contract.
+    """
+    key = key if key is not None else _openai_free_tier_token_key()
     new_total = redis_conn.incrby(key, OPENAI_FREE_TIER_RESERVATION_TOKENS)
     if hasattr(redis_conn, "expire"):
         # 2 days: comfortably outlives the single calendar day this key is
@@ -114,10 +119,12 @@ def _true_up_openai_free_tier_reservation(
     day it actually ran on (bounded by the key's own 2-day TTL) and
     leaking negative headroom into the next day's real allowance.
     Defaults to computing a fresh key, preserving this function's own
-    standalone behavior for any other caller."""
+    standalone behavior for any other caller. Checked against None, not
+    truthiness, for the same reason _reserve_openai_free_tier_budget's
+    own `key` parameter is - see its docstring."""
     delta = real_total_tokens - OPENAI_FREE_TIER_RESERVATION_TOKENS
     if delta != 0:
-        redis_conn.incrby(key or _openai_free_tier_token_key(), delta)
+        redis_conn.incrby(key if key is not None else _openai_free_tier_token_key(), delta)
 
 LUNA_MODEL = "gpt-5.6-luna"
 PRO_MODEL = "deepseek-v4-pro"
@@ -383,21 +390,29 @@ def writing_adapter_chain_for_free_tier(
         # on_usage/on_call_failed correct that SAME day's counter even if
         # the real call straddles the UTC midnight boundary between
         # reservation and true-up - see both functions' own docstrings
-        # for the real corruption this closes. A plain dict (not a bare
-        # local) since it's written from inside a nested closure.
-        _reserved_key: dict[str, str] = {}
+        # for the real corruption this closes. threading.local(), not a
+        # plain dict, so a concurrent second call through this same
+        # adapter (this chain is built fresh per job today, but the
+        # adapter object itself carries no such guarantee) gets its own
+        # isolated slot instead of racing the first call's key through
+        # one shared mutable cell - Flash Review finding: a plain dict
+        # here means an overlapping second reservation overwrites the
+        # first call's key, so a usage/failure callback can true-up or
+        # release the WRONG call's Redis reservation.
+        _reserved_key_local = threading.local()
 
         def _reserve_and_capture_key() -> bool:
             key = _openai_free_tier_token_key()
             ok = _reserve_openai_free_tier_budget(redis_conn, key=key)
             if ok:
-                _reserved_key["key"] = key
+                _reserved_key_local.key = key
             return ok
 
         def _true_up_reserved_key(real_total_tokens: int) -> None:
-            _true_up_openai_free_tier_reservation(
-                redis_conn, real_total_tokens, key=_reserved_key.pop("key", None)
-            )
+            key = getattr(_reserved_key_local, "key", None)
+            if key is not None:
+                del _reserved_key_local.key
+            _true_up_openai_free_tier_reservation(redis_conn, real_total_tokens, key=key)
 
         def _on_openai_free_tier_usage(
             prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from datetime import datetime, timezone
 
 import pytest
 
@@ -456,6 +457,67 @@ def test_openai_free_tier_usage_trues_up_the_reservation_to_the_real_total(monke
 
     assert redis_conn.data[_openai_free_tier_token_key()] == 1500
     assert redis_conn.expiries[_openai_free_tier_token_key()] == 2 * 24 * 3600
+
+
+def test_openai_free_tier_true_up_corrects_the_same_day_the_reservation_used(monkeypatch):
+    # Real bug found via audit: before_llm_call and on_usage/on_call_failed
+    # each independently computed _openai_free_tier_token_key() from
+    # datetime.now(timezone.utc) at the moment they were called - not a
+    # value captured once per call. A call reserved at 23:59:59 UTC that
+    # completes at 00:00:01 UTC the next day reserved against yesterday's
+    # key but trued up against today's key, permanently over-reserving
+    # the first day and leaking negative headroom into the second day's
+    # real allowance (a brand-new day's counter starting negative means
+    # more real tokens than the cap intends can be spent before
+    # _reserve_openai_free_tier_budget starts rejecting new reservations).
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    import scan_worker.model_tiers as model_tiers_module
+
+    class _FakeDatetime(datetime):
+        _now = datetime(2026, 1, 1, 23, 59, 59, tzinfo=timezone.utc)
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls._now
+
+    monkeypatch.setattr(model_tiers_module, "datetime", _FakeDatetime)
+    redis_conn = _FakeRedis()
+    chain = writing_adapter_chain_for_free_tier(redis_conn)
+    openai_adapter = next(a for a in chain if a.name == "OpenAI-FreeTier")
+
+    assert openai_adapter._before_llm_call() is True  # reserves against 2026-01-01's key
+
+    _FakeDatetime._now = datetime(2026, 1, 2, 0, 0, 1, tzinfo=timezone.utc)
+    openai_adapter._on_usage(30_000, 20_000)  # completes just after midnight UTC
+
+    assert redis_conn.data["free_tier:openai_tokens:2026-01-01"] == 50_000
+    assert redis_conn.data.get("free_tier:openai_tokens:2026-01-02") is None
+
+
+def test_openai_free_tier_on_call_failed_releases_against_the_same_day_the_reservation_used(monkeypatch):
+    # Same real bug as the true-up test above, for the failure-release path.
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    import scan_worker.model_tiers as model_tiers_module
+
+    class _FakeDatetime(datetime):
+        _now = datetime(2026, 1, 1, 23, 59, 59, tzinfo=timezone.utc)
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls._now
+
+    monkeypatch.setattr(model_tiers_module, "datetime", _FakeDatetime)
+    redis_conn = _FakeRedis()
+    chain = writing_adapter_chain_for_free_tier(redis_conn)
+    openai_adapter = next(a for a in chain if a.name == "OpenAI-FreeTier")
+
+    assert openai_adapter._before_llm_call() is True
+
+    _FakeDatetime._now = datetime(2026, 1, 2, 0, 0, 1, tzinfo=timezone.utc)
+    openai_adapter._on_call_failed()
+
+    assert redis_conn.data["free_tier:openai_tokens:2026-01-01"] == 0
+    assert redis_conn.data.get("free_tier:openai_tokens:2026-01-02") is None
 
 
 def test_openai_free_tier_usage_still_forwards_to_the_shared_on_usage(monkeypatch):

--- a/github-app/tests/test_model_tiers.py
+++ b/github-app/tests/test_model_tiers.py
@@ -397,6 +397,36 @@ def test_openai_free_tier_reservation_arithmetic_is_correct_at_the_cap_boundary(
     assert redis_conn.data[_openai_free_tier_token_key()] == OPENAI_FREE_TIER_DAILY_TOKEN_CAP
 
 
+def test_reserve_openai_free_tier_budget_honors_an_explicit_empty_string_key(monkeypatch):
+    # Flash Review finding: `key or _openai_free_tier_token_key()` treats
+    # an explicitly-passed empty string the same as "no key given" and
+    # silently reserves against a freshly computed key instead - this
+    # function's own docstring promises "the caller may pass the exact
+    # key to reserve against", which an empty string is a legal (if
+    # unusual) instance of.
+    from scan_worker.model_tiers import OPENAI_FREE_TIER_RESERVATION_TOKENS, _reserve_openai_free_tier_budget
+
+    redis_conn = _FakeRedis()
+
+    assert _reserve_openai_free_tier_budget(redis_conn, key="") is True
+
+    assert "" in redis_conn.data
+    assert redis_conn.data[""] == OPENAI_FREE_TIER_RESERVATION_TOKENS
+
+
+def test_true_up_openai_free_tier_reservation_honors_an_explicit_empty_string_key(monkeypatch):
+    from scan_worker.model_tiers import (
+        OPENAI_FREE_TIER_RESERVATION_TOKENS,
+        _true_up_openai_free_tier_reservation,
+    )
+
+    redis_conn = _FakeRedis({"": OPENAI_FREE_TIER_RESERVATION_TOKENS})
+
+    _true_up_openai_free_tier_reservation(redis_conn, 500, key="")
+
+    assert redis_conn.data[""] == 500
+
+
 def test_openai_free_tier_reservation_is_atomic_across_real_concurrent_threads(monkeypatch):
     # The TOCTOU race this closes: two concurrent reviews both attempting
     # to reserve budget right at the cap boundary. A plain read-then-decide
@@ -518,6 +548,54 @@ def test_openai_free_tier_on_call_failed_releases_against_the_same_day_the_reser
 
     assert redis_conn.data["free_tier:openai_tokens:2026-01-01"] == 0
     assert redis_conn.data.get("free_tier:openai_tokens:2026-01-02") is None
+
+
+def test_openai_free_tier_reserved_key_is_isolated_across_concurrent_threads(monkeypatch):
+    # Flash Review finding: the reserved key used to live in one dict
+    # shared by every call through this adapter. Two real, concurrent
+    # calls whose reservations land on DIFFERENT keys (the UTC-midnight
+    # case the sequential tests above already cover one at a time) used
+    # to race: thread B's reservation could overwrite thread A's key in
+    # the shared cell before A's true-up ran, so A's true-up/release
+    # would silently correct B's key instead of its own. A Barrier forces
+    # both threads to reserve before either trues up, so this only passes
+    # if each thread's key is really isolated, not just usually not
+    # clobbered by scheduling luck.
+    monkeypatch.setattr("scan_worker.model_tiers.has_api_key", lambda *a, **k: True)
+    import scan_worker.model_tiers as model_tiers_module
+
+    # Each thread computes its own key by name, standing in for two calls
+    # whose reservations land on different real dates (this file's other
+    # UTC-boundary tests already prove the date->key mapping itself; this
+    # test is only about whether concurrent calls keep their keys apart).
+    monkeypatch.setattr(
+        model_tiers_module, "_openai_free_tier_token_key",
+        lambda: f"free_tier:openai_tokens:{threading.current_thread().name}",
+    )
+    redis_conn = _FakeRedis()
+    chain = writing_adapter_chain_for_free_tier(redis_conn)
+    openai_adapter = next(a for a in chain if a.name == "OpenAI-FreeTier")
+
+    reserve_barrier = threading.Barrier(2)
+    true_up_barrier = threading.Barrier(2)
+
+    def _run(true_up_amount: int) -> None:
+        reserve_barrier.wait()  # both threads reserve before either trues up
+        assert openai_adapter._before_llm_call() is True
+        true_up_barrier.wait()
+        openai_adapter._on_usage(true_up_amount, 0)
+
+    thread_a = threading.Thread(target=_run, args=(11_000,), name="thread-a")
+    thread_b = threading.Thread(target=_run, args=(22_000,), name="thread-b")
+    thread_a.start()
+    thread_b.start()
+    thread_a.join()
+    thread_b.join()
+
+    # Each thread's own key trued up to its own real total, not the other
+    # thread's - the exact corruption the shared-dict version risked.
+    assert redis_conn.data["free_tier:openai_tokens:thread-a"] == 11_000
+    assert redis_conn.data["free_tier:openai_tokens:thread-b"] == 22_000
 
 
 def test_openai_free_tier_usage_still_forwards_to_the_shared_on_usage(monkeypatch):


### PR DESCRIPTION
## Summary
Adversarial audit of `github-app/scan_worker/model_tiers.py` found a real bug: `_reserve_openai_free_tier_budget` (called from `before_llm_call`, right before the real API call) and `_true_up_openai_free_tier_reservation` (called from `on_usage`/`on_call_failed`, after the call completes) each independently computed `_openai_free_tier_token_key()` from `datetime.now(timezone.utc)` at the moment they were called - not a value captured once per call attempt.

A call reserved at `23:59:59` UTC that completes at `00:00:01` UTC the next day reserved against yesterday's key but trued up against today's key.

Confirmed by execution against the real adapter chain (`writing_adapter_chain_for_free_tier`'s `before_llm_call`/`on_usage`/`on_call_failed`): day1's key stayed stuck at the full 130,000-token placeholder (self-expires via its own 2-day TTL, bounded) while day2's counter started at **-80,000** - a brand-new day's free-tier allowance silently starting with extra headroom above the real `OPENAI_FREE_TIER_DAILY_TOKEN_CAP` before `_reserve_openai_free_tier_budget` starts rejecting new reservations. The same mismatch affects the failure-release path (`on_call_failed`) identically.

## Fix
The chain-building closure now captures the exact key `before_llm_call` reserved against in a small mutable cell, and passes that same key explicitly to the later true-up/release call - both `_reserve_openai_free_tier_budget` and `_true_up_openai_free_tier_reservation` gained an optional `key` parameter (defaulting to computing a fresh one, preserving their existing standalone behavior/signatures for any other caller) rather than changing their public contract.

## Test plan
- [x] Confirmed the day1/day2 corruption before the fix and correct same-day correction after, via the real adapter chain with a monkeypatched clock crossing UTC midnight between reservation and true-up
- [x] Verified the failure-release path (`on_call_failed`) is also fixed
- [x] Confirmed all existing reservation/true-up/release tests (which don't cross a day boundary) are unaffected - the `key` parameter defaults preserve their exact prior behavior
- [x] Added 2 regression tests
- [x] Full `github-app/tests/test_model_tiers.py`: 41/41 passing
- [x] Full `github-app/tests/` suite: 1746 passed, 8 skipped

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK