### PR TITLE
fix: latency_threshold_ms accepted 0/negative, causing an immediate false latency alert

### DIFF
--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -150,7 +150,15 @@ class SetDocsRepoCommitRequest(BaseModel):
 class AddHealthCheckTargetRequest(BaseModel):
     label: str = Field(min_length=1, max_length=100, pattern=_LABEL_PATTERN)
     base_url: str
-    latency_threshold_ms: int | None = None
+    # Real bug found via audit: no lower bound meant 0 or a negative
+    # number was accepted with no validation error - jobs.py's own
+    # _latency_flipped compares strictly (latency_ms > threshold_ms), so
+    # a 0 threshold fires an immediate, permanent "latency degraded"
+    # alert on the customer's very first health check regardless of how
+    # fast the target actually responds. Confirmed directly: threshold=0
+    # flagged a healthy 45ms response as exceeded, threshold=500 (or
+    # None, meaning "don't check latency at all") did not.
+    latency_threshold_ms: int | None = Field(default=None, ge=1)
 
 
 class EndpointSelectionEntry(BaseModel):

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -859,6 +859,27 @@ async def test_add_health_check_target_returns_422_for_non_integer_threshold(poo
 
 
 @pytest.mark.asyncio
+async def test_add_health_check_target_returns_422_for_a_zero_or_negative_threshold(pool, monkeypatch):
+    # Real bug found via audit: latency_threshold_ms had no lower bound -
+    # jobs.py's own _latency_flipped compares strictly (latency_ms >
+    # threshold_ms), so a 0 (or negative) threshold fires an immediate,
+    # permanent "latency degraded" alert on the customer's very first
+    # health check regardless of how fast the target actually responds.
+    client = await _logged_in_client(pool, monkeypatch, installation_id=100)
+    async with client:
+        zero_response = await client.post(
+            "/admin/octocat/hello-world/health-targets",
+            json={"label": "Production", "base_url": "https://api.example.com", "latency_threshold_ms": 0},
+        )
+        negative_response = await client.post(
+            "/admin/octocat/hello-world/health-targets",
+            json={"label": "Production", "base_url": "https://api.example.com", "latency_threshold_ms": -100},
+        )
+    assert zero_response.status_code == 422
+    assert negative_response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_add_health_check_target_enforces_plan_limit(pool, monkeypatch):
     # Pro's included limit is 5 (INCLUDED_HEALTH_CHECK_TARGETS) - filling
     # it up, then the 6th add should be rejected.


### PR DESCRIPTION
## Summary
Adversarial audit of `github-app/app_server/admin.py` found a real bug: `AddHealthCheckTargetRequest.latency_threshold_ms` had no lower-bound constraint, unlike `label` on the same model. The route validates the URL (`validate_external_https_url`) but never validated this field before persisting it.

Confirmed against the real consumer, `jobs.py`'s `_latency_flipped` (`latency_ms > threshold_ms`, strict comparison): a threshold of `0` fired an immediate "latency exceeded" alert on a perfectly healthy 45ms response, while a sane threshold (or `None`, meaning "don't check latency at all" - `_latency_flipped`'s own first line) correctly did not.

A customer who submits `0` or a negative number (a plausible typo, or an empty numeric field client-side defaulting to `0`) gets a permanent false "latency degraded" alert on their very first health check regardless of how fast the target actually responds, with no server-side guard against the mistake.

## Fix
`Field(ge=1)` on `latency_threshold_ms` - still accepts `None` (the "don't check latency" case `_latency_flipped` already handles), rejects any non-positive integer.

## Test plan
- [x] Confirmed the false alert before the fix (via `_latency_flipped` directly) and the request validation gap before/after the fix
- [x] Added 1 regression test (both `0` and a negative value rejected with 422)
- [x] Full `github-app/tests/test_admin.py`: 114/114 passing
- [x] Full `github-app/tests/` suite: 1745 passed, 8 skipped

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK