### PR TITLE
fix: concurrent CLI invocations could silently lose a saved API key

### DIFF
--- a/src/aletheore/credentials.py
+++ b/src/aletheore/credentials.py
@@ -74,6 +74,18 @@ def _load_saved_key(provider_name: str, credentials_path: Path) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _write_all(fd: int, data: bytes) -> None:
+    """os.write(fd, data) on a regular file can write fewer bytes than
+    given - the filesystem running out of space mid-write is the real,
+    if rare, case (Flash Review finding) - and the return value has to
+    be checked and looped on, or a short write leaves credentials.json
+    truncated with incomplete JSON while the call itself returns
+    normally, no exception raised."""
+    written = 0
+    while written < len(data):
+        written += os.write(fd, data[written:])
+
+
 @contextlib.contextmanager
 def _locked_rw_credentials_file(credentials_path: Path):
     """Opens credentials_path for read+write under an exclusive advisory
@@ -124,7 +136,7 @@ def _locked_rw_credentials_file(credentials_path: Path):
             yield data
             os.lseek(fd, 0, os.SEEK_SET)
             os.ftruncate(fd, 0)
-            os.write(fd, json.dumps(data, indent=2).encode())
+            _write_all(fd, json.dumps(data, indent=2).encode())
         finally:
             if sys.platform == "win32":
                 os.lseek(fd, 0, os.SEEK_SET)

--- a/src/aletheore/credentials.py
+++ b/src/aletheore/credentials.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import sys
@@ -73,51 +74,81 @@ def _load_saved_key(provider_name: str, credentials_path: Path) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-def _save_key(provider_name: str, key: str, credentials_path: Path) -> None:
+@contextlib.contextmanager
+def _locked_rw_credentials_file(credentials_path: Path):
+    """Opens credentials_path for read+write under an exclusive advisory
+    lock held for the whole read-modify-write, yielding the parsed dict -
+    whatever the caller mutates it to is what gets written back on exit.
+
+    Real bug this closes: _save_key/clear_api_key used to read the whole
+    file, modify a plain in-memory dict, then write the whole file back
+    as three independent, UNLOCKED steps. Two CLI invocations started
+    close together (a real, plausible scenario - a user with two
+    terminal tabs, or an interactive run overlapping a CI job) could both
+    read the file's original state before either wrote, so whichever
+    wrote last silently discarded the other's saved key - with no error
+    surfaced to the process whose own save call returned normally.
+    Confirmed directly: process A saves "anthropic", process B (reading
+    that same pre-A state) saves "gemini" - the file ends up holding only
+    "gemini"; "anthropic" is gone with no indication it never landed.
+
+    Platform-conditional locking (fcntl on POSIX, msvcrt on Windows)
+    matches this module's own established pattern for exactly this kind
+    of platform difference - see cli.py's O_NOFOLLOW handling, this CLI
+    ships for Windows too (claude-desktop mcp-install is a documented
+    Windows target).
+    """
     credentials_path.parent.mkdir(parents=True, exist_ok=True)
-    data = {}
-    if credentials_path.exists():
-        try:
-            loaded = json.loads(credentials_path.read_text())
-            if isinstance(loaded, dict):
-                data = loaded
-        except json.JSONDecodeError:
-            data = {}
-    data[provider_name] = key
-    _write_credentials(data, credentials_path)
-
-
-def _write_credentials(data: dict, credentials_path: Path) -> None:
-    content = json.dumps(data, indent=2)
-    # os.open's mode only applies when it creates the file - an existing
-    # file (e.g. one that pre-dates this restrictive-permissions fix, or
-    # was seeded some other way) keeps whatever permissions it already had.
-    # fchmod before writing closes that gap too: permissions are locked
-    # down before any new key content is written, whether the file is new
-    # or pre-existing, instead of write_text() then chmod() after, which
-    # left the file (and the key) briefly world/group-readable in between.
-    fd = os.open(credentials_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    # O_CREAT + fchmod before any read locks permissions down for the
+    # whole locked section, whether the file is new or pre-existing -
+    # same reasoning _write_credentials previously used to avoid ever
+    # leaving the file briefly world/group-readable.
+    fd = os.open(str(credentials_path), os.O_RDWR | os.O_CREAT, 0o600)
     try:
         os.fchmod(fd, 0o600)
-    except BaseException:
+        if sys.platform == "win32":
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            raw = os.read(fd, os.fstat(fd).st_size)
+            try:
+                loaded = json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                loaded = {}
+            data = loaded if isinstance(loaded, dict) else {}
+            yield data
+            os.lseek(fd, 0, os.SEEK_SET)
+            os.ftruncate(fd, 0)
+            os.write(fd, json.dumps(data, indent=2).encode())
+        finally:
+            if sys.platform == "win32":
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
         os.close(fd)
-        raise
-    with os.fdopen(fd, "w") as f:
-        f.write(content)
+
+
+def _save_key(provider_name: str, key: str, credentials_path: Path) -> None:
+    with _locked_rw_credentials_file(credentials_path) as data:
+        data[provider_name] = key
 
 
 def clear_api_key(provider_name: str, credentials_path: Path = DEFAULT_CREDENTIALS_PATH) -> bool:
     if not credentials_path.exists():
         return False
-    try:
-        data = json.loads(credentials_path.read_text())
-    except json.JSONDecodeError:
-        return False
-    if not isinstance(data, dict) or provider_name not in data:
-        return False
-    del data[provider_name]
-    _write_credentials(data, credentials_path)
-    return True
+    removed = False
+    with _locked_rw_credentials_file(credentials_path) as data:
+        if provider_name in data:
+            del data[provider_name]
+            removed = True
+    return removed
 
 
 def save_api_token(

--- a/src/tests/test_credentials.py
+++ b/src/tests/test_credentials.py
@@ -189,6 +189,36 @@ def test_concurrent_saves_do_not_silently_lose_each_others_keys(tmp_path):
     }
 
 
+def test_write_all_loops_through_a_short_write_instead_of_dropping_bytes(monkeypatch):
+    # Flash Review finding: os.write's return value was ignored - a write
+    # to a regular file can write fewer bytes than requested (a full
+    # filesystem is the real, if rare, case), leaving credentials.json
+    # truncated with incomplete JSON while the call itself still returns
+    # normally, no exception raised. Simulates a short write (a real fd
+    # would only write 3 of 10 bytes here) and confirms the retry loop
+    # picks up exactly where the short write left off.
+    import os as os_module
+
+    from aletheore.credentials import _write_all
+
+    data = b"0123456789"
+    written_chunks = []
+    calls = {"n": 0}
+
+    def fake_write(fd, buf):
+        calls["n"] += 1
+        chunk_len = 3 if calls["n"] == 1 else len(buf)
+        written_chunks.append(buf[:chunk_len])
+        return chunk_len
+
+    monkeypatch.setattr(os_module, "write", fake_write)
+
+    _write_all(123, data)
+
+    assert b"".join(written_chunks) == data
+    assert calls["n"] == 2  # one short write, one that finishes it
+
+
 def test_save_api_token_is_readable_via_get_api_key(monkeypatch, tmp_path):
     monkeypatch.delenv("TESTPROVIDER_API_KEY", raising=False)
     creds_path = tmp_path / "creds.json"

--- a/src/tests/test_credentials.py
+++ b/src/tests/test_credentials.py
@@ -148,6 +148,47 @@ def test_save_key_preserves_other_providers_existing_keys(monkeypatch, tmp_path)
     assert saved == {"provider_a": "sk-a", "provider_b": "sk-b"}
 
 
+def test_concurrent_saves_do_not_silently_lose_each_others_keys(tmp_path):
+    # Real bug found via audit: _save_key used to read the whole file,
+    # modify a plain in-memory dict, then write the whole file back as
+    # three independent, UNLOCKED steps. Two CLI invocations started
+    # close together (a real, plausible scenario - two terminal tabs)
+    # could both read the file's original state before either wrote, so
+    # whichever wrote last silently discarded the other's saved key -
+    # with no error surfaced to the process whose own save call returned
+    # normally.
+    import threading
+
+    from aletheore.credentials import _save_key
+
+    creds_path = tmp_path / "creds.json"
+    creds_path.write_text(json.dumps({"openai": "sk-openai-existing"}))
+
+    barrier = threading.Barrier(2)
+
+    def save_anthropic():
+        barrier.wait()
+        _save_key("anthropic", "sk-anthropic-new", creds_path)
+
+    def save_gemini():
+        barrier.wait()
+        _save_key("gemini", "sk-gemini-new", creds_path)
+
+    t1 = threading.Thread(target=save_anthropic)
+    t2 = threading.Thread(target=save_gemini)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    saved = json.loads(creds_path.read_text())
+    assert saved == {
+        "openai": "sk-openai-existing",
+        "anthropic": "sk-anthropic-new",
+        "gemini": "sk-gemini-new",
+    }
+
+
 def test_save_api_token_is_readable_via_get_api_key(monkeypatch, tmp_path):
     monkeypatch.delenv("TESTPROVIDER_API_KEY", raising=False)
     creds_path = tmp_path / "creds.json"


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/credentials.py` found a real bug: `_save_key`/`clear_api_key` each did an unlocked read-modify-write - read the whole `credentials.json`, modify a plain in-memory dict, write the whole file back, as three independent, unlocked steps.

Two CLI invocations started close together (a real, plausible scenario - a user with two terminal tabs, or an interactive run overlapping a background job) could both read the file's original state before either wrote, so whichever wrote last silently discarded the other's saved key - with no error surfaced to the process whose own save call returned normally.

Confirmed by execution: process A saves `"anthropic"`, process B (reading that same pre-A state) saves `"gemini"` concurrently - the file ends up holding only `"gemini"`; `"anthropic"` is gone with no indication it never landed.

## Fix
A single locked read+write file handle spans the whole read-modify-write, using an exclusive advisory lock held for its duration - platform-conditional (`fcntl` on POSIX, `msvcrt` on Windows), matching this codebase's own established pattern for exactly this kind of platform difference (`cli.py`'s `O_NOFOLLOW` handling - this CLI ships for Windows too). `fchmod` still locks permissions down before any read/write, same as before.

## Test plan
- [x] Constructed a real concurrent-write scenario (two threads racing on the same file) and confirmed data loss before the fix, all keys preserved after
- [x] Confirmed permissions (`0o600`), directory auto-creation, and `clear_api_key`'s "never creates a file that didn't exist" behavior are all unchanged
- [x] Added 1 regression test
- [x] Full `src/tests/test_credentials.py`: 18/18 passing
- [x] Full `src/tests/` suite: 1816/1816 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK