### PR TITLE
fix: two real bugs in snapshot rotation ordering and older-schema diffing

### DIFF
--- a/src/aletheore/history.py
+++ b/src/aletheore/history.py
@@ -9,8 +9,43 @@ def _history_dir(repo_path: Path) -> Path:
     return repo_path / ".aletheore" / "history"
 
 
+def _snapshot_sort_key(path: Path) -> tuple[str, int]:
+    # Primary key is the snapshot's own real scanned_at (read from its
+    # content, not guessed from the filename) - callers are free to save
+    # snapshots out of physical order with an explicit scanned_at
+    # (test_list_snapshots_returns_chronological_order does exactly this
+    # on purpose), and that logical timestamp, not save order, is what
+    # "chronological" means here in the normal case.
+    #
+    # mtime (real filesystem write time, nanosecond resolution) is only
+    # the TIEBREAKER, for the one case scanned_at alone can't order: two
+    # snapshots saved within the same wall-clock second get a
+    # disambiguating "-N" suffix inserted before the .json extension
+    # (_save_json_with_rotation's collision loop) - real bug this closes:
+    # a plain filename-string sort put that suffixed (chronologically
+    # LATER) file BEFORE the unsuffixed one, since '-' (0x2D) sorts
+    # before '.' (0x2E) in ASCII, so "...-1.json" < "....json" lexically
+    # even though the "-1" file was saved second. _rotate then deleted
+    # the wrong (older-looking but actually newer) snapshot when rotating
+    # past the keep limit - a real, reachable scenario (two `aletheore
+    # scan` runs seconds apart, common in CI or a fast local loop), not
+    # cosmetic display-order noise: it discarded a newer scan's real
+    # evidence while keeping an older one.
+    try:
+        scanned_at = json.loads(path.read_text()).get("scanned_at", "")
+    except (OSError, json.JSONDecodeError):
+        scanned_at = ""
+    if not isinstance(scanned_at, str):
+        scanned_at = ""
+    return (scanned_at, path.stat().st_mtime_ns)
+
+
+def _sorted_snapshots(history_dir: Path) -> list[Path]:
+    return sorted(history_dir.glob("*.json"), key=_snapshot_sort_key)
+
+
 def _rotate(history_dir: Path, keep: int) -> None:
-    snapshots = sorted(history_dir.glob("*.json"))
+    snapshots = _sorted_snapshots(history_dir)
     excess = len(snapshots) - keep
     if excess <= 0:
         return
@@ -41,7 +76,7 @@ def list_snapshots(repo_path: Path) -> list[Path]:
     history_dir = _history_dir(repo_path)
     if not history_dir.exists():
         return []
-    return sorted(history_dir.glob("*.json"))
+    return _sorted_snapshots(history_dir)
 
 
 def _identity_key(finding: dict, fields: tuple[str, ...]) -> tuple:
@@ -78,8 +113,18 @@ def _compute_curated_diff(old: dict, new: dict) -> dict:
             "toggled on/off, not necessarily real changes"
         )
 
-    old_history_scanned = old["security"]["secrets"]["history_scanned_commits"] > 0
-    new_history_scanned = new["security"]["secrets"]["history_scanned_commits"] > 0
+    # .get(..., 0) rather than a direct index - real bug found via audit:
+    # history_scanned_commits was added to the secrets section after this
+    # module's original schema, so a genuinely older on-disk snapshot (a
+    # real, plausible .aletheore/history/*.json file predating this
+    # field, diffed after a CLI upgrade) crashed with KeyError instead of
+    # degrading the same way _endpoint_block already does for
+    # api_endpoints just above - this module's own established pattern
+    # for exactly this case, applied inconsistently. 0 is the correct
+    # default: "not present" and "0 commits scanned" both mean
+    # old_history_scanned/new_history_scanned should read False.
+    old_history_scanned = old["security"]["secrets"].get("history_scanned_commits", 0) > 0
+    new_history_scanned = new["security"]["secrets"].get("history_scanned_commits", 0) > 0
     if old_history_scanned != new_history_scanned:
         caveats.append(
             "git-history secret scanning state changed between scans "
@@ -112,9 +157,12 @@ def _compute_curated_diff(old: dict, new: dict) -> dict:
     )
     result["secrets"] = {"new": new_secrets, "resolved": resolved_secrets}
 
+    # Same older-schema gap as history_scanned_commits above - history_findings
+    # is absent, not just empty, in evidence that predates git-history secret
+    # scanning.
     new_history_secrets, resolved_history_secrets = _new_and_resolved(
-        old["security"]["secrets"]["history_findings"],
-        new["security"]["secrets"]["history_findings"],
+        old["security"]["secrets"].get("history_findings", []),
+        new["security"]["secrets"].get("history_findings", []),
         ("commit", "path", "pattern"),
     )
     result["history_secrets"] = {"new": new_history_secrets, "resolved": resolved_history_secrets}

--- a/src/aletheore/history.py
+++ b/src/aletheore/history.py
@@ -33,7 +33,13 @@ def _snapshot_sort_key(path: Path) -> tuple[str, int]:
     # evidence while keeping an older one.
     try:
         scanned_at = json.loads(path.read_text()).get("scanned_at", "")
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        # Flash Review finding: read_text() can raise UnicodeDecodeError
+        # for a non-UTF-8 *.json file, which this only caught OSError/
+        # JSONDecodeError for - one corrupt or unrelated non-UTF-8 file
+        # in the history directory made both snapshot listing and
+        # rotation fail entirely, a regression from the previous
+        # filename-only sort, which never inspected file contents at all.
         scanned_at = ""
     if not isinstance(scanned_at, str):
         scanned_at = ""

--- a/src/tests/test_history.py
+++ b/src/tests/test_history.py
@@ -74,6 +74,33 @@ def test_save_snapshot_handles_same_timestamp_collision_without_losing_data(tmp_
     assert len(snapshots) == 2
 
 
+def test_rotation_keeps_the_chronologically_newest_snapshot_across_a_same_second_collision(tmp_path):
+    # Real bug found via audit: two snapshots saved within the same
+    # wall-clock second get a disambiguating "-N" suffix inserted before
+    # the .json extension - a plain filename-string sort put that
+    # suffixed (chronologically LATER) file BEFORE the unsuffixed one
+    # ('-' sorts before '.' in ASCII), so rotation deleted the wrong
+    # (older-looking but actually newer) snapshot, discarding a newer
+    # scan's real evidence while keeping an older one.
+    import time
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    same_second = "2026-07-15T10:00:00.000000+00:00"
+    first = save_snapshot({**make_evidence(same_second), "marker": "first"}, repo, keep=20)
+    time.sleep(0.01)
+    second = save_snapshot({**make_evidence(same_second), "marker": "second"}, repo, keep=20)
+    time.sleep(0.01)
+    save_snapshot({**make_evidence("2026-07-15T11:00:00.000000+00:00"), "marker": "third"}, repo, keep=2)
+
+    remaining = list_snapshots(repo)
+    markers = [json.loads(p.read_text())["marker"] for p in remaining]
+    assert markers == ["second", "third"]
+    assert first.name not in {p.name for p in remaining}
+    assert second.name in {p.name for p in remaining}
+
+
 def base_evidence() -> dict:
     return {
         "repository": {
@@ -147,6 +174,27 @@ def test_compute_diff_reports_no_new_or_resolved_when_identical():
         "total_commits": 0,
     }
     assert "caveats" not in diff
+
+
+def test_compute_diff_does_not_crash_diffing_an_older_schema_snapshot():
+    # Real bug found via audit: history_scanned_commits and
+    # history_findings were added to the secrets section after this
+    # module's original schema, so a genuinely older on-disk snapshot (a
+    # real, plausible .aletheore/history/*.json file predating either
+    # field, diffed after a CLI upgrade) crashed with KeyError instead of
+    # degrading the same way _endpoint_block already does for
+    # api_endpoints - this module's own established pattern for exactly
+    # this case, applied inconsistently.
+    new = base_evidence()
+    old = base_evidence()
+    del old["security"]["secrets"]["history_scanned_commits"]
+    del old["security"]["secrets"]["history_findings"]
+
+    diff = compute_diff(old, new)
+
+    assert diff["history_secrets"] == {"new": [], "resolved": []}
+    assert "caveats" in diff
+    assert any("history" in caveat for caveat in diff["caveats"])
 
 
 def test_compute_diff_detects_a_new_secret_finding():

--- a/src/tests/test_history.py
+++ b/src/tests/test_history.py
@@ -49,6 +49,28 @@ def test_list_snapshots_returns_chronological_order(tmp_path):
     ]
 
 
+def test_list_snapshots_tolerates_a_non_utf8_file_in_the_history_dir(tmp_path):
+    # Flash Review finding: read_text() can raise UnicodeDecodeError for a
+    # non-UTF-8 *.json file, but the sort key only caught OSError and
+    # json.JSONDecodeError - one corrupt or unrelated non-UTF-8 file in
+    # the history directory made snapshot listing (and rotation, which
+    # calls the same sort) fail entirely for every real snapshot, a
+    # regression from the previous filename-only sort, which never
+    # inspected file contents at all.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    save_snapshot(make_evidence("2026-07-15T10:00:00.000000+00:00"), repo)
+    history_dir = repo / ".aletheore" / "history"
+    (history_dir / "not-real-utf8.json").write_bytes(b"\xff\xfe\x00\x01garbage")
+
+    snapshots = list_snapshots(repo)
+
+    assert len(snapshots) == 2
+    real_snapshot = next(p for p in snapshots if p.name != "not-real-utf8.json")
+    assert json.loads(real_snapshot.read_text())["scanned_at"] == "2026-07-15T10:00:00.000000+00:00"
+
+
 def test_save_snapshot_rotates_at_21st_save_keeping_the_20_newest(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
Adversarial audit of `src/aletheore/history.py` found two real bugs.

**1. Same-second snapshot collision broke rotation ordering, deleting the wrong (newer) snapshot.** Two snapshots saved within the same wall-clock second get a disambiguating `-N` suffix inserted before the `.json` extension (`_save_json_with_rotation`'s collision loop), but `_rotate`/`list_snapshots` sorted by plain filename string. `-` (0x2D) sorts before `.` (0x2E) in ASCII, so `"...-1.json" < "....json"` lexically even though the `-1` file was saved second.

Confirmed by execution: rotating past the keep limit with two same-second snapshots plus a later one deleted the chronologically-second (real newer) snapshot and kept the older one - a real, reachable scenario (two `aletheore scan` runs seconds apart, common in CI or a fast local loop), not cosmetic display-order noise.

**2. Diffing an older-schema snapshot crashed with `KeyError`.** `history_scanned_commits`/`history_findings` were added to the secrets section after this module's original schema, but `_compute_curated_diff` direct-indexed them with no fallback - unlike `_endpoint_block` right above it in the same function, which already handles a missing `api_endpoints` key from older evidence with a documented stub.

Confirmed by execution: diffing a snapshot missing either field against current-shape evidence crashed with `KeyError` - a real scenario (a user upgrades their CLI, then runs `aletheore diff` between an old and new snapshot in their own `.aletheore/history/` directory) that this module's own established pattern for exactly this case already exists to handle, just applied inconsistently.

## Fix
1. Sort snapshots by their own real `scanned_at` (read from file content, preserving the existing "sort by logical timestamp, not physical save order" contract `test_list_snapshots_returns_chronological_order` already covers), with real filesystem mtime (nanosecond resolution) as the tiebreaker only for the same-`scanned_at` collision case a filename-string sort got backwards.
2. `.get(..., default)` for both fields, matching `_endpoint_block`'s existing pattern.

## Test plan
- [x] Constructed a real same-second collision + rotation scenario, confirmed the wrong snapshot was deleted before the fix and the correct one kept after
- [x] Confirmed the pre-existing "sort by logical scanned_at, not save order" test still passes (my first attempt at this fix - a pure mtime sort - broke it; caught and corrected before committing)
- [x] Constructed an older-schema snapshot missing both fields, confirmed the crash before the fix and a clean caveat-carrying diff after
- [x] Added 2 regression tests
- [x] Full `src/tests/test_history.py`: 33/33 passing
- [x] Full `src/tests/` suite: 1817/1817 passing

Not merging per standing instructions - opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK