### PR TITLE
fix: check_citations.py aborted the whole benchmark run on a non-UTF-8 file

### DIFF
--- a/benchmarks/pr-review-benchmark/scripts/check_citations.py
+++ b/benchmarks/pr-review-benchmark/scripts/check_citations.py
@@ -95,7 +95,11 @@ def verify_findings_against_checkout(findings: list[dict], checkout_dir: Path) -
             continue
         line = finding.get("line")
         if line is not None:
-            line_count = sum(1 for _ in full_path.open())
+            # errors="replace", matching _content_matches_cited_line below -
+            # a real checkout can contain files with a stray non-UTF-8 byte
+            # (a Latin-1 comment, etc.), and a strict decode here used to
+            # raise UnicodeDecodeError and abort the whole benchmark run.
+            line_count = sum(1 for _ in full_path.open(errors="replace"))
             if line < 1 or line > line_count:
                 unverified.append(finding)
                 continue

--- a/benchmarks/pr-review-benchmark/tests/test_check_citations.py
+++ b/benchmarks/pr-review-benchmark/tests/test_check_citations.py
@@ -173,3 +173,23 @@ def test_content_grounding_is_not_scored_for_a_finding_that_failed_location(tmp_
     assert result["content_verified"] == []
     assert result["content_unverified"] == []
     assert result["content_grounding_rate"] is None
+
+
+def test_verify_findings_does_not_crash_on_a_file_with_invalid_utf8_bytes(tmp_path):
+    # Real bug found via audit: line-count verification opened the cited
+    # file with a strict UTF-8 decode while the content-grounding check
+    # right after it (_content_matches_cited_line) tolerantly decodes with
+    # errors="replace". A real checkout can contain a file with a stray
+    # non-UTF-8 byte (a Latin-1 comment, a copy-pasted smart quote, etc.),
+    # and the strict decode raised UnicodeDecodeError and aborted the
+    # whole benchmark run instead of scoring that one finding.
+    checkout = tmp_path
+    (checkout / "weird.py").write_bytes(
+        b"def foo():\n    x = 1\n    y = b'\xff\xfe bad bytes'\n    return x + y\n"
+    )
+    findings = [{"file": "weird.py", "line": 3, "message": "looks fine", "severity": None}]
+
+    result = verify_findings_against_checkout(findings, checkout)
+
+    assert result["verified"] == findings
+    assert result["unverified"] == []


### PR DESCRIPTION
## Summary
- `verify_findings_against_checkout` (in `benchmarks/pr-review-benchmark/scripts/check_citations.py`) counted a cited file's lines via `full_path.open()` — a strict UTF-8 decode — but the content-grounding check it calls right after (`_content_matches_cited_line`) reads the *same file* with `read_text(errors="replace")`.
- A real checkout can legitimately contain a file with a stray non-UTF-8 byte (a Latin-1 source comment, a pasted smart quote, etc.) — not malformed input, just an ordinary real-world file. When a finding cited such a file, `line_count = sum(1 for _ in full_path.open())` raised `UnicodeDecodeError`, and nothing in the caller catches it — the whole benchmark run (which can already be mid-way through dozens of real cloned repos) died instead of scoring that one finding.
- Fixed by opening with `errors="replace"`, matching the tolerant decoding already used two lines later in the same function, so the two decodes of the same file are now consistent.

## Confirmation
Reproduced the crash by calling the real function directly against a file containing an invalid UTF-8 byte:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 31: invalid start byte
```
Verified the fix eliminates the crash and the finding is scored normally (`verified`, not `unverified`).

## Test plan
- [x] Added `test_verify_findings_does_not_crash_on_a_file_with_invalid_utf8_bytes` to `tests/test_check_citations.py`, matching the existing file's style (real bug found via audit, docstring-style comment explaining the scenario)
- [x] `python3 -m pytest tests/test_check_citations.py -q` — 13 passed
- [x] `python3 -m pytest tests/ -q` (full `benchmarks/pr-review-benchmark` suite) — 65 passed

Not merging — for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK