### PR TITLE
fix: llm_judge.py crashed with AttributeError on a malformed judge score

### DIFF
--- a/benchmarks/pr-review-benchmark/scripts/llm_judge.py
+++ b/benchmarks/pr-review-benchmark/scripts/llm_judge.py
@@ -35,6 +35,10 @@ def parse_judge_response(response_text: str) -> dict:
         raise ValueError("judge response did not contain a JSON object")
     parsed = json.loads(response_text[start:end + 1])
     for label, score in parsed.items():
+        if not isinstance(score, dict):
+            raise ValueError(
+                f"{label}: expected an object of scores, got {type(score).__name__}: {score!r}"
+            )
         if score.get("recall") not in {"hit", "partial", "miss"}:
             raise ValueError(
                 f"{label}: recall must be hit/partial/miss, got {score.get('recall')!r}"

--- a/benchmarks/pr-review-benchmark/tests/test_llm_judge.py
+++ b/benchmarks/pr-review-benchmark/tests/test_llm_judge.py
@@ -33,6 +33,18 @@ def test_parse_judge_response_raises_when_no_json_present():
         parse_judge_response("I refuse to answer in JSON.")
 
 
+def test_parse_judge_response_rejects_a_non_object_score_value():
+    # Real bug found via audit: a judge model that misreads the requested
+    # shape and returns a list (or any other non-object) per tool used to
+    # crash with a raw AttributeError from score.get() deep inside this
+    # function's own validation loop, instead of the clean ValueError this
+    # module otherwise guarantees for malformed judge output (see the
+    # invalid-recall-value test above).
+    response_text = '{"Tool A": ["hit", "partial"]}'
+    with pytest.raises(ValueError, match="expected an object of scores"):
+        parse_judge_response(response_text)
+
+
 class _FakeMessage:
     def __init__(self, content):
         self.content = content


### PR DESCRIPTION
## Summary
- `parse_judge_response` (in `benchmarks/pr-review-benchmark/scripts/llm_judge.py`) already has explicit, tested validation for malformed judge output — an invalid `recall` value raises a clean `ValueError` ("recall must be hit/partial/miss"), covered by an existing test.
- But if the judge model returns a non-object value for a tool's score — e.g. `{"Tool A": ["hit", "partial"]}` instead of `{"Tool A": {"recall": ..., ...}}` — the very next line, `score.get("recall")`, crashes with a raw `AttributeError: 'list' object has no attribute 'get'` instead of the same clean `ValueError` the function otherwise guarantees. This is a realistic failure mode: cheaper/free-tier judge models can misread a requested JSON shape, and this benchmark's own methodology explicitly separates the judge model from the tools under test.
- Fixed with an `isinstance(score, dict)` guard that raises the same style of `ValueError` before the `.get()` call.

## Confirmation
Reproduced directly:
```python
>>> parse_judge_response('{"aletheore": ["hit", "partial"]}')
AttributeError: 'list' object has no attribute 'get'
```
Verified the fix turns this into `ValueError: aletheore: expected an object of scores, got list: ['hit', 'partial']`.

## Test plan
- [x] Added `test_parse_judge_response_rejects_a_non_object_score_value` to `tests/test_llm_judge.py`, alongside the existing invalid-recall-value test it mirrors
- [x] `python3 -m pytest tests/test_llm_judge.py -q` — 6 passed
- [x] `python3 -m pytest tests/ -q` (full `benchmarks/pr-review-benchmark` suite) — 65 passed

Not merging — for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK