### PR TITLE
fix: git-intel field parser silently corrupted commits with a control character in the author name

### DIFF
--- a/src/aletheore/git_intel/incremental.py
+++ b/src/aletheore/git_intel/incremental.py
@@ -49,14 +49,28 @@ MAX_CO_CHANGE_PARTNERS_TRACKED = 200
 
 # A commit header line in the streamed format below always starts with this
 # byte - real file paths never do, so it unambiguously marks "new commit"
-# without needing a second git invocation just to know where one ends.
+# without needing a second git invocation just to know where one ends. It
+# also separates the fields *within* one header line (sha/name/email/date/
+# subject) - not just between commits. Real bug found via audit: an earlier
+# version used `\x1f` (unit separator) for the intra-line field split, on the
+# assumption that a real commit would "vanishingly unlikely" contain a raw
+# control byte. That assumption is false - GIT_AUTHOR_NAME accepts arbitrary
+# bytes, and a name containing a literal `\x1f` (confirmed directly) shifted
+# every field after it: author_email silently became a fragment of the
+# author name, the commit's real date landed in the wrong field and failed
+# to parse (silently falling back to the 1970 epoch), and the subject came
+# out as the real date and subject concatenated - all with no error raised.
+# `\x00` doesn't have this problem: it's git's own record-boundary byte and
+# genuinely cannot occur inside any of these fields (not "unlikely" - a
+# commit's author/committer line and message are built from NUL-terminated
+# strings internally, so this is the same guarantee the record separator
+# below already depends on, just applied to every field instead of one).
 # `%x00` (four literal characters) is git's own pretty-format escape for a
 # NUL byte - it belongs in the --format argument. The real `\x00` byte only
 # ever appears in git's *output*, never in argv (POSIX forbids embedding a
 # raw NUL in an argv string - subprocess correctly rejects that outright).
 _RECORD_SEP_FORMAT = "%x00"
 _RECORD_SEP = "\x00"
-_FIELD_SEP = "\x1f"
 
 
 class GitLogStreamError(RuntimeError):
@@ -116,7 +130,8 @@ def stream_commit_touches(
     prefix = _scan_root_prefix(repo_path)
     args = [
         "log",
-        f"--format={_RECORD_SEP_FORMAT}%H{_FIELD_SEP}%an{_FIELD_SEP}%ae{_FIELD_SEP}%ad{_FIELD_SEP}%s",
+        f"--format={_RECORD_SEP_FORMAT}%H{_RECORD_SEP_FORMAT}%an{_RECORD_SEP_FORMAT}%ae"
+        f"{_RECORD_SEP_FORMAT}%ad{_RECORD_SEP_FORMAT}%s",
         "--date=iso-strict",
         "--name-only",
     ]
@@ -143,11 +158,11 @@ def stream_commit_touches(
             if line.startswith(_RECORD_SEP):
                 if pending_header is not None:
                     yield CommitTouch(*pending_header, files=tuple(pending_files), subject=pending_subject)
-                # maxsplit=4: a subject line containing a literal field-sep
-                # byte (vanishingly unlikely - it's a control character, not
-                # something a real commit message would contain) lands
-                # whole in the subject rather than breaking the unpack.
-                sha, name, email, date_str, pending_subject = line[1:].split(_FIELD_SEP, 4)
+                # maxsplit=4 defensively, though `\x00` cannot occur inside
+                # any of these fields (see the module-level comment on
+                # _RECORD_SEP) - a fifth split point would only ever come
+                # from something the fields themselves can never contain.
+                sha, name, email, date_str, pending_subject = line[1:].split(_RECORD_SEP, 4)
                 pending_header = (sha, name, email, parse_commit_date(date_str))
                 pending_files = []
             elif line.strip():

--- a/src/tests/test_incremental.py
+++ b/src/tests/test_incremental.py
@@ -166,6 +166,42 @@ def test_stream_commit_touches_handles_merge_commit_with_no_file_changes(tmp_pat
     assert len(touches) == 3
 
 
+def test_stream_commit_touches_survives_a_control_character_in_the_author_name(tmp_path):
+    # Real bug found via audit: the intra-line field parser used to split on
+    # `\x1f` (unit separator), on the assumption a real commit would never
+    # contain a raw control byte in that position. GIT_AUTHOR_NAME accepts
+    # arbitrary bytes though, and a name containing a literal `\x1f`
+    # (confirmed directly against the pre-fix parser) shifted every field
+    # after it: author_email became a fragment of the author name, the
+    # commit's real date landed in the wrong field and failed to parse
+    # (silently falling back to the 1970 epoch), and the subject came out as
+    # the real date and subject concatenated - all with no error raised.
+    repo = init_repo(tmp_path)
+    (repo / "a.txt").write_text("1")
+    run(repo, "add", "a.txt")
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = "Weird\x1fName"
+    env["GIT_AUTHOR_EMAIL"] = "weird@example.com"
+    env["GIT_AUTHOR_DATE"] = "2026-06-01T00:00:00+00:00"
+    env["GIT_COMMITTER_DATE"] = "2026-06-01T00:00:00+00:00"
+    subprocess.run(
+        ["git", "commit", "-m", "commit with a control character in the author name"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    touches = list(stream_commit_touches(repo, "HEAD"))
+    assert len(touches) == 1
+    touch = touches[0]
+    assert touch.author_name == "Weird\x1fName"
+    assert touch.author_email == "weird@example.com"
+    assert touch.committed_at == datetime.fromisoformat("2026-06-01T00:00:00+00:00")
+    assert touch.subject == "commit with a control character in the author name"
+    assert touch.files == ("a.txt",)
+
+
 # --- fold: pure aggregation, must be additive for incremental correctness ---
 
 


### PR DESCRIPTION
## Summary
- `stream_commit_touches()` (git-intel's incremental repo graph builder) parsed each commit's header line by splitting on `\x1f` (unit separator) between the sha/author-name/email/date/subject fields, on the assumption a real commit would "vanishingly unlikely" contain that byte in `author_name`.
- `GIT_AUTHOR_NAME` accepts arbitrary bytes though - confirmed directly against a constructed repo: a name containing a literal `\x1f` shifted every field after it. `author_email` silently became a fragment of the author name, the real commit date landed in the wrong field and failed to parse (silently falling back to the 1970 epoch), and the subject came out as the real date and subject concatenated. No error was raised; the corrupted commit just flowed into ownership/cadence/hotspot aggregates as bad data.
- Fixed by using `\x00` (the same byte already trusted as the inter-commit record separator) to delimit fields *within* a header line too - `\x00` genuinely cannot occur in any of these fields (not "unlikely" like `\x1f` - a commit's author/committer line and message are built from NUL-terminated strings internally), so this closes the gap with the same guarantee the code already relied on for record separation.

## Test plan
- [x] Added `test_stream_commit_touches_survives_a_control_character_in_the_author_name` to `src/tests/test_incremental.py`, matching the file's existing real-repo test style.
- [x] Confirmed the new test fails against the pre-fix parser (`Weird` instead of `Weird\x1fName`) and passes against the fix.
- [x] `python3 -m pytest src/tests/test_incremental.py src/tests/test_git_intel.py src/tests/test_sqlite_store.py` - 58 passed.
- [x] Full `python3 -m pytest src/tests/` - 1816 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK