### PR TITLE
fix: Regression Fence flagged additive signature changes as breaking on a comma-containing string default

### DIFF
--- a/src/aletheore/signature_diff.py
+++ b/src/aletheore/signature_diff.py
@@ -29,7 +29,15 @@ def _split_params(params: str) -> list[str]:
 
     Splits only at depth zero so a default value or generic type
     containing commas - `Callable[[str], int | None] | None = None`,
-    `dict[str, int]`, `foo=(1, 2)` - stays a single parameter.
+    `dict[str, int]`, `foo=(1, 2)` - stays a single parameter. Also
+    tracks whether we're inside a quoted string literal: a bracket
+    character or comma inside one (`sep: str = ", "`) is text, not
+    structure, and must not affect depth or trigger a split. Real bug
+    found via audit: without this, a purely additive parameter whose
+    default is a string containing a comma got torn into two bogus
+    "parameters", which made is_backward_compatible_change reject it -
+    exactly the false-positive-noise-on-a-merge-blocking-check failure
+    this module exists to prevent (see its own module docstring).
     """
     inner = params.strip()
     if inner.startswith("(") and inner.endswith(")"):
@@ -37,7 +45,22 @@ def _split_params(params: str) -> list[str]:
     parts: list[str] = []
     depth = 0
     current: list[str] = []
+    quote_char: str | None = None
+    escaped = False
     for char in inner:
+        if quote_char is not None:
+            current.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote_char:
+                quote_char = None
+            continue
+        if char in "\"'":
+            quote_char = char
+            current.append(char)
+            continue
         if char in "([{<":
             depth += 1
         elif char in ")]}>":

--- a/src/tests/test_signature_diff.py
+++ b/src/tests/test_signature_diff.py
@@ -273,6 +273,17 @@ def test_is_backward_compatible_change_accepts_added_defaults_and_variadics():
     assert is_backward_compatible_change("(a)", "(a, b=(1, 2))") is True
 
 
+def test_is_backward_compatible_change_accepts_a_string_default_containing_a_comma():
+    # Real bug found via audit: a string-literal default with a comma
+    # (`sep: str = ", "`) was torn into two bogus parameters by
+    # _split_params, which is not tracking quote state - only bracket
+    # depth. That made a purely additive change get rejected as breaking:
+    # the exact false-positive-noise-on-a-merge-blocking-check failure
+    # this module exists to prevent.
+    assert is_backward_compatible_change("(a)", '(a, sep: str = ", ")') is True
+    assert is_backward_compatible_change("(a)", "(a, sep: str = ', ')") is True
+
+
 def test_is_backward_compatible_change_rejects_anything_a_caller_can_trip_on():
     assert is_backward_compatible_change("(a)", "(a, b)") is False        # new required arg
     assert is_backward_compatible_change("(a, b)", "(a)") is False        # removed arg


### PR DESCRIPTION
## Summary
- `_split_params` (in `src/aletheore/signature_diff.py`), which splits a function's raw parameter-list text on top-level commas, tracked bracket depth (`([{<`/`)]}>`) but never quote state.
- A purely additive parameter whose default is a string literal containing a comma - e.g. `sep: str = ", "` - got torn into two bogus "parameters" mid-string, because the comma inside the quotes looked like a top-level separator.
- That corruption fed straight into `is_backward_compatible_change`, which compares parameter lists positionally: the extra bogus "parameter" broke the "everything old must still be a prefix, unchanged" check, so a genuinely safe, additive change got rejected as breaking.
- This is exactly the failure class Regression Fencing exists to prevent noise on: the module's own docstring already documents one prior real incident (PR #97) where a safe additive change posted a merge-blocking-eligible Check Run. This is a different root cause producing the identical failure mode.

## Confirmation
```python
>>> is_backward_compatible_change("(a)", '(a, sep: str = ", ")')
False   # before the fix - wrong, this is purely additive
```
Fixed by tracking quote state (single/double, with backslash-escape handling) alongside bracket depth, so a comma or bracket character inside a string literal is treated as text, not structure:
```python
>>> is_backward_compatible_change("(a)", '(a, sep: str = ", ")')
True    # after the fix
```
Also verified the fix doesn't disturb any of the shapes the existing depth-tracking already handled correctly (bracket defaults, generics, nested lists with embedded commas inside quoted strings, escaped quotes).

## Test plan
- [x] Added `test_is_backward_compatible_change_accepts_a_string_default_containing_a_comma` to `src/tests/test_signature_diff.py`, matching the existing file's style (mirrors the adjacent bracket-default test and PR #97 regression test)
- [x] `python3 -m pytest src/tests/test_signature_diff.py -q` — 18 passed
- [x] `python3 -m pytest src/tests/ -q` (full `src` suite) — 1816 passed

Not merging — for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK