### PR TITLE
fix: managed-audit HTTP client leaked a connection pool on every call

### DIFF
--- a/src/aletheore/managed_audit_client.py
+++ b/src/aletheore/managed_audit_client.py
@@ -26,7 +26,15 @@ def run_managed_audit_request(
     timeout: float = 300.0,
 ) -> str:
     owns_client = http_client is None
-    client = http_client or httpx.Client(base_url=api_base_url)
+    # Flash Review finding: `http_client or httpx.Client(...)` chooses by
+    # truthiness while owns_client above checks identity against None - a
+    # caller-supplied client-like object that's falsy (unusual, but not
+    # impossible - a test double with a custom __bool__, an httpx.Client
+    # subclass overriding it) would be silently discarded here in favor
+    # of a freshly created one, while owns_client still says "not owned",
+    # so that new client is never closed. Both checks now use the same
+    # None comparison.
+    client = http_client if http_client is not None else httpx.Client(base_url=api_base_url)
     headers = {"Authorization": f"Bearer {token}"}
 
     try:

--- a/src/aletheore/managed_audit_client.py
+++ b/src/aletheore/managed_audit_client.py
@@ -25,34 +25,42 @@ def run_managed_audit_request(
     poll_interval: float = 2.0,
     timeout: float = 300.0,
 ) -> str:
+    owns_client = http_client is None
     client = http_client or httpx.Client(base_url=api_base_url)
     headers = {"Authorization": f"Bearer {token}"}
 
     try:
-        encoded_evidence = to_toon(evidence)
-    except ToonEncodingError as exc:
-        raise ManagedAuditError(f"could not encode evidence for managed audit: {exc}") from exc
+        try:
+            encoded_evidence = to_toon(evidence)
+        except ToonEncodingError as exc:
+            raise ManagedAuditError(f"could not encode evidence for managed audit: {exc}") from exc
 
-    response = client.post(
-        "/v1/managed-audit",
-        json={"evidence": encoded_evidence, "repo_full_name": repo_full_name},
-        headers=headers,
-    )
-    if response.status_code in (401, 402, 429):
-        raise ManagedAuditError(_error_detail(response))
-    response.raise_for_status()
-    job_id = response.json()["job_id"]
+        response = client.post(
+            "/v1/managed-audit",
+            json={"evidence": encoded_evidence, "repo_full_name": repo_full_name},
+            headers=headers,
+        )
+        if response.status_code in (401, 402, 429):
+            raise ManagedAuditError(_error_detail(response))
+        response.raise_for_status()
+        job_id = response.json()["job_id"]
 
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        status_response = client.get(f"/v1/managed-audit/{job_id}", headers=headers)
-        status_response.raise_for_status()
-        body = status_response.json()
-        if body["status"] == "finished":
-            return body["result"]
-        if body["status"] == "failed":
-            raise ManagedAuditError("managed audit job failed on the server")
-        if poll_interval:
-            time.sleep(poll_interval)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            status_response = client.get(f"/v1/managed-audit/{job_id}", headers=headers)
+            status_response.raise_for_status()
+            body = status_response.json()
+            if body["status"] == "finished":
+                return body["result"]
+            if body["status"] == "failed":
+                raise ManagedAuditError("managed audit job failed on the server")
+            if poll_interval:
+                time.sleep(poll_interval)
 
-    raise ManagedAuditError(f"managed audit timed out after {timeout}s waiting for job {job_id}")
+        raise ManagedAuditError(f"managed audit timed out after {timeout}s waiting for job {job_id}")
+    finally:
+        # Only close a client we created ourselves - a caller-supplied
+        # http_client is owned by the caller (e.g. reused across requests)
+        # and must outlive this call.
+        if owns_client:
+            client.close()

--- a/src/tests/test_managed_audit_client.py
+++ b/src/tests/test_managed_audit_client.py
@@ -158,6 +158,31 @@ def test_no_http_client_passed_closes_the_client_it_creates_on_error(monkeypatch
     assert created[0].is_closed is True
 
 
+def test_a_falsy_caller_supplied_http_client_is_still_used_and_never_closed():
+    # Flash Review finding: client selection used to be `http_client or
+    # httpx.Client(...)` (truthiness) while ownership was tracked via
+    # `http_client is None` (identity) - a caller-supplied client that's
+    # falsy (unusual, but real: any object can define __bool__) would be
+    # silently discarded in favor of a freshly created one, while
+    # ownership still said "not owned", so that new client leaked -
+    # never closed, and the caller's own client silently never used.
+    class FalsyClient(httpx.Client):
+        def __bool__(self) -> bool:
+            return False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(202, json={"job_id": "job-1"})
+        return httpx.Response(200, json={"status": "finished", "result": "# Report"})
+
+    client = FalsyClient(transport=httpx.MockTransport(handler), base_url="https://aletheore.com")
+    report = run_managed_audit_request({"scanned_at": "x"}, "real-token", http_client=client, poll_interval=0)
+
+    assert report == "# Report"  # proves the caller's own falsy client was really used
+    assert client.is_closed is False
+    client.close()
+
+
 def test_a_caller_supplied_http_client_is_never_closed():
     # The caller owns the lifecycle of a client it passed in explicitly
     # (e.g. one reused across several managed-audit calls) - this function

--- a/src/tests/test_managed_audit_client.py
+++ b/src/tests/test_managed_audit_client.py
@@ -108,3 +108,67 @@ def test_failed_job_raises_managed_audit_error():
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://aletheore.com")
     with pytest.raises(ManagedAuditError, match="failed"):
         run_managed_audit_request({"scanned_at": "x"}, "real-token", http_client=client, poll_interval=0)
+
+
+def test_no_http_client_passed_closes_the_client_it_creates_on_success(monkeypatch):
+    # Real bug found via audit: run_managed_audit_request created its own
+    # httpx.Client whenever a caller didn't pass one in, but never closed
+    # it on any path - both real production callers (mcp_server.py's
+    # aletheore_managed_audit tool, cli.py's `aletheore audit` command)
+    # hit this path, since neither passes http_client. In the long-running
+    # MCP server this leaked one connection pool per call.
+    created = []
+
+    class TrackingClient(httpx.Client):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, transport=httpx.MockTransport(_handler), **kwargs)
+            created.append(self)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(202, json={"job_id": "job-1"})
+        return httpx.Response(200, json={"status": "finished", "result": "# Report"})
+
+    monkeypatch.setattr("aletheore.managed_audit_client.httpx.Client", TrackingClient)
+
+    report = run_managed_audit_request({"scanned_at": "x"}, "real-token", poll_interval=0)
+
+    assert report == "# Report"
+    assert len(created) == 1
+    assert created[0].is_closed is True
+
+
+def test_no_http_client_passed_closes_the_client_it_creates_on_error(monkeypatch):
+    created = []
+
+    class TrackingClient(httpx.Client):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, transport=httpx.MockTransport(_handler), **kwargs)
+            created.append(self)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "invalid or revoked token"})
+
+    monkeypatch.setattr("aletheore.managed_audit_client.httpx.Client", TrackingClient)
+
+    with pytest.raises(ManagedAuditError):
+        run_managed_audit_request({"scanned_at": "x"}, "bad-token")
+
+    assert len(created) == 1
+    assert created[0].is_closed is True
+
+
+def test_a_caller_supplied_http_client_is_never_closed():
+    # The caller owns the lifecycle of a client it passed in explicitly
+    # (e.g. one reused across several managed-audit calls) - this function
+    # must not close it out from under the caller.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(202, json={"job_id": "job-1"})
+        return httpx.Response(200, json={"status": "finished", "result": "# Report"})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://aletheore.com")
+    run_managed_audit_request({"scanned_at": "x"}, "real-token", http_client=client, poll_interval=0)
+
+    assert client.is_closed is False
+    client.close()


### PR DESCRIPTION
## Summary
- `run_managed_audit_request` (`src/aletheore/managed_audit_client.py`) created its own `httpx.Client` whenever a caller didn't pass one in (`client = http_client or httpx.Client(base_url=api_base_url)`), but never closed it on any path - success, `ManagedAuditError`, `raise_for_status()`, or timeout. There was no `try/finally`, no context manager, no `.close()` call anywhere in the function.
- Both real production call sites - `mcp_server.py`'s `aletheore_managed_audit` MCP tool (a long-running server process) and `cli.py`'s `aletheore audit` command - call `run_managed_audit_request` with no `http_client` argument, so every real invocation hit this leaking path. Every existing test passed an explicit `http_client`, so this path had zero coverage and the leak was never caught.
- In the MCP server this accumulates one leaked connection pool (and its underlying socket) per `aletheore_managed_audit` tool call over the process's lifetime.

## Confirmation
Subclassed `httpx.Client` to track created instances and their `is_closed` state, confirmed on both the success path and the 401 error path: the client is created but never closed pre-fix.

## Fix
Track whether this function created the client itself (`owns_client`) and close it in a `finally` block only in that case - a caller-supplied `http_client` is owned by the caller (e.g. reused across several calls) and must not be closed out from under it.

## Test plan
- [x] Added `test_no_http_client_passed_closes_the_client_it_creates_on_success`, `test_no_http_client_passed_closes_the_client_it_creates_on_error`, and `test_a_caller_supplied_http_client_is_never_closed` to `src/tests/test_managed_audit_client.py`
- [x] Confirmed the first two fail against the pre-fix code (stashed the fix, re-ran - both failed with `assert False is True`) and pass post-fix
- [x] `python3 -m pytest src/tests/ -q` - 1818 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK