### PR TITLE
fix: unvalidated layer_markers rank could silently miss violations or crash a scan

### DIFF
--- a/src/aletheore/repo_config.py
+++ b/src/aletheore/repo_config.py
@@ -57,7 +57,23 @@ def parse_repo_config(raw_text: str | None) -> dict:
 
     layer_markers = data.get("layer_markers", {})
     if isinstance(layer_markers, dict):
-        result["layer_markers"] = layer_markers
+        # Real bug found via audit: an unvalidated rank flows straight into
+        # architecture.detect_layer_violations's `from_rank < to_rank`
+        # comparison. A string rank (e.g. from a user who quoted their
+        # numbers) silently compares lexicographically instead of
+        # numerically ("2" < "10" is False), producing false negatives -
+        # a real inner-to-outer violation goes unreported with no error.
+        # Mixing a string-ranked custom marker with any of this module's
+        # own built-in int-ranked markers raises TypeError mid-comparison,
+        # crashing the whole `aletheore scan`, not just layer-violation
+        # detection. cluster_resolution two lines below is already
+        # type-checked for exactly this reason; this closes the same gap
+        # for layer_markers.
+        result["layer_markers"] = {
+            name: rank
+            for name, rank in layer_markers.items()
+            if isinstance(name, str) and isinstance(rank, int) and not isinstance(rank, bool)
+        }
 
     cluster_resolution = data.get("cluster_resolution", 1.0)
     if isinstance(cluster_resolution, (int, float)) and not isinstance(cluster_resolution, bool):

--- a/src/tests/test_repo_config.py
+++ b/src/tests/test_repo_config.py
@@ -99,6 +99,32 @@ def test_load_repo_config_still_reads_existing_keys(tmp_path: Path):
     assert config["accepted_secrets"] == [{"path": "a.py", "pattern": "x", "match_preview": "y"}]
 
 
+def test_load_repo_config_drops_a_non_int_layer_marker_rank(tmp_path: Path):
+    # Real bug found via audit: an unvalidated string rank flowed straight
+    # into architecture.detect_layer_violations's `from_rank < to_rank`
+    # comparison. "2" < "10" is False under lexicographic string
+    # comparison, so a real inner-to-outer violation went unreported with
+    # no error - and mixing a string-ranked custom marker with any
+    # built-in int-ranked marker raised a TypeError that crashed the
+    # whole scan. cluster_resolution is already type-checked for exactly
+    # this reason; layer_markers must be too.
+    (tmp_path / ".aletheore.json").write_text(
+        json.dumps({"layer_markers": {"domain": "2", "web": 10}})
+    )
+    config = load_repo_config(tmp_path)
+    assert config["layer_markers"] == {"web": 10}
+
+
+def test_load_repo_config_drops_a_bool_layer_marker_rank(tmp_path: Path):
+    # bool is a subclass of int in Python - True/False must not slip
+    # through as a rank of 1/0.
+    (tmp_path / ".aletheore.json").write_text(
+        json.dumps({"layer_markers": {"domain": True, "web": 10}})
+    )
+    config = load_repo_config(tmp_path)
+    assert config["layer_markers"] == {"web": 10}
+
+
 def test_is_ignored_no_patterns_matches_nothing():
     assert is_ignored("vendor/lib.js", []) is False
 


### PR DESCRIPTION
## Summary
- `parse_repo_config` (`src/aletheore/repo_config.py`) validated that `.aletheore.json`'s `layer_markers` value is a dict, but never validated that its entries' rank values are ints - unlike `cluster_resolution` two lines below, which is type-checked. Those unvalidated ranks flow straight into `architecture.detect_layer_violations`'s `from_rank < to_rank` comparison.
- **Silent false negative**: an all-string-ranked config (e.g. `{"domain": "2", "web": "10"}`) compares ranks lexicographically - `"2" < "10"` is `False` under string comparison - so a real inner-to-outer violation is silently never reported.
- **Crash**: mixing a custom string-ranked marker with any built-in int-ranked marker raises `TypeError: '<' not supported between instances of 'int' and 'str'` inside `detect_layer_violations`, called unconditionally during `analyze_architecture=True` (the default) - crashing the entire `aletheore scan`, not just layer-violation detection.
- Neither shape was covered by existing tests (only int ranks were ever exercised).

## Fix
Filter `layer_markers` entries to only those with an int (non-bool) rank, matching `cluster_resolution`'s existing type-check convention. A caller with an invalid rank silently loses just that one marker rather than falling back to the whole default, matching this function's own docstring contract and the same per-entry filtering `dead_code_entry_points`/`accepted_secrets`/`ignored_paths` already use.

## Test plan
- [x] Added `test_load_repo_config_drops_a_non_int_layer_marker_rank` and `test_load_repo_config_drops_a_bool_layer_marker_rank` to `src/tests/test_repo_config.py`
- [x] Confirmed both fail against the pre-fix code (stashed the fix, re-ran) and pass post-fix
- [x] `python3 -m pytest src/tests/ -q` - 1817 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK