### PR TITLE
fix: embedding_client accepted NaN/Infinity/bool as a valid embedding value

### DIFF
--- a/github-app/scan_worker/embedding_client.py
+++ b/github-app/scan_worker/embedding_client.py
@@ -9,6 +9,7 @@ serves this model behind a plain /embed endpoint.
 
 import functools
 import logging
+import math
 import os
 
 import httpx
@@ -78,7 +79,19 @@ def embed_text(text: str, base_url: str | None = None, timeout_seconds: float = 
     if not isinstance(embedding, list) or not embedding:
         logger.warning("embedding response missing embedding array; treating cache as unavailable")
         return None
-    if not all(isinstance(value, int | float) for value in embedding):
+    # bool is a subclass of int in Python, and float('nan')/float('inf')
+    # are still `float` instances - a plain isinstance(value, int | float)
+    # check lets a NaN/Infinity/bare-boolean response through as a
+    # "valid" embedding, silently poisoning the similarity cache: NaN
+    # comparisons are always False and Infinity dominates a dot product
+    # under any downstream cosine-similarity/distance comparison.
+    # Python's json module accepts NaN/Infinity/-Infinity as non-standard
+    # literals by default, so a corrupted or numerically unstable
+    # response from jina-embed could plausibly include them.
+    if not all(
+        isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(value)
+        for value in embedding
+    ):
         logger.warning("embedding response contains non-numeric values; treating cache as unavailable")
         return None
     return [float(value) for value in embedding]

--- a/github-app/tests/test_embedding_client.py
+++ b/github-app/tests/test_embedding_client.py
@@ -111,6 +111,52 @@ def test_embed_text_returns_none_on_malformed_response(monkeypatch):
     assert embed_text("some evidence text") is None
 
 
+def test_embed_text_returns_none_when_response_contains_nan(monkeypatch):
+    # Real bug found via audit: `isinstance(value, int | float)` does not
+    # reject float('nan')/float('inf') - both are still `float` instances
+    # - so a NaN/Infinity-poisoned vector was silently returned as a
+    # "valid" embedding instead of hitting this function's own
+    # "treating cache as unavailable" fallback. json.loads accepts NaN/
+    # Infinity/-Infinity as non-standard literals by default, so a real
+    # corrupted or numerically unstable jina-embed response could
+    # plausibly include them.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'{"embedding": [0.1, NaN, 0.3]}')
+
+    monkeypatch.setattr(
+        "scan_worker.embedding_client._client",
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
+    )
+
+    assert embed_text("some evidence text") is None
+
+
+def test_embed_text_returns_none_when_response_contains_infinity(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b'{"embedding": [0.1, Infinity, -Infinity]}')
+
+    monkeypatch.setattr(
+        "scan_worker.embedding_client._client",
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
+    )
+
+    assert embed_text("some evidence text") is None
+
+
+def test_embed_text_returns_none_when_response_contains_a_bare_bool(monkeypatch):
+    # bool is a subclass of int in Python - a bare true/false in the
+    # embedding array must not silently pass as a numeric component.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"embedding": [0.1, True, 0.3]})
+
+    monkeypatch.setattr(
+        "scan_worker.embedding_client._client",
+        lambda base_url=None: httpx.Client(transport=httpx.MockTransport(handler), base_url="http://jina-embed:80"),
+    )
+
+    assert embed_text("some evidence text") is None
+
+
 def test_client_is_pooled_not_reconstructed_per_call():
     # Real bug this guards: _client used to build a brand-new httpx.Client
     # (and pay a fresh TCP handshake to the jina-embed sidecar) on every


### PR DESCRIPTION
## Summary
- `embed_text`'s validation `isinstance(value, int | float)` doesn't actually reject a malformed jina-embed response. `bool` is a subclass of `int` in Python, and `float('nan')`/`float('inf')` are still `float` instances - so a response containing `NaN`, `Infinity`, or a bare `true`/`false` passed this check and was returned as a "valid" embedding vector, silently poisoning the similarity cache instead of hitting this function's own "treating cache as unavailable" fallback.
- Python's `json` module accepts `NaN`/`Infinity`/`-Infinity` as non-standard literals by default, so a real corrupted or numerically unstable response from jina-embed's model could plausibly include them. A NaN/Infinity-poisoned vector stored in `packet_cache.py`/`flash_review_cache.py` would then behave unpredictably under any downstream cosine-similarity/distance comparison (NaN comparisons are always `False`, Infinity dominates a dot product), rather than being caught at the boundary where this module's own contract says it should be.

## Fix
Added an explicit `not isinstance(value, bool)` exclusion and `math.isfinite(value)` check alongside the existing type check.

## Test plan
- [x] Added `test_embed_text_returns_none_when_response_contains_nan`, `..._infinity`, and `..._a_bare_bool` to `github-app/tests/test_embedding_client.py`
- [x] Confirmed all three fail against the pre-fix code (stashed the fix, re-ran) and pass post-fix
- [x] `python3 -m pytest github-app/tests/ -q` - 1758 passed, 8 skipped (run in isolation; a first concurrent run alongside another full-suite run in progress showed unrelated cross-suite DB contamination that vanished on a clean solo run)

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK