### PR TITLE
fix: get_endpoint_health_summary collapsed the same path across two repos in one installation

### DIFF
--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -1837,19 +1837,31 @@ def count_repo_scans_since(dsn: str, installation_id: int, since: datetime) -> i
 
 
 def get_endpoint_health_summary(dsn: str, installation_id: int, stale_after_seconds: int = 900) -> dict:
-    """Current live status - most-recent row per (method, path) within the
-    same 15-minute staleness window as the public status API
+    """Current live status - most-recent row per (repo, method, path) within
+    the same 15-minute staleness window as the public status API
     (dashboard.py's PUBLIC_HEALTH_STALE_AFTER), so the digest and the
     status page never disagree about what's currently "up".
+
+    Real bug found via audit: DISTINCT ON previously partitioned by
+    (endpoint_method, endpoint_path) alone, with no repo_full_name - every
+    other query in this file scopes endpoint_health by
+    (installation_id, repo_full_name, endpoint_method, endpoint_path), but
+    an installation can cover multiple repos, and two different repos
+    sharing a conventional health-check path (GET /health, say) collapsed
+    into a single row here. Whichever repo happened to have the more
+    recently checked_at row silently absorbed the other repo's endpoint
+    into the count, and the reported reachability could reflect the wrong
+    repo's status entirely - masking a real outage in one repo behind the
+    other's healthy result in the weekly digest email.
     """
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT DISTINCT ON (endpoint_method, endpoint_path) reachable
+                SELECT DISTINCT ON (repo_full_name, endpoint_method, endpoint_path) reachable
                 FROM endpoint_health
                 WHERE installation_id = %s AND checked_at >= now() - make_interval(secs => %s)
-                ORDER BY endpoint_method, endpoint_path, checked_at DESC, id DESC
+                ORDER BY repo_full_name, endpoint_method, endpoint_path, checked_at DESC, id DESC
                 """,
                 (installation_id, stale_after_seconds),
             )

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -1879,6 +1879,33 @@ async def test_get_endpoint_health_summary_excludes_stale_rows(pool):
 
 
 @pytest.mark.asyncio
+async def test_get_endpoint_health_summary_does_not_collapse_the_same_path_across_two_repos(pool):
+    # Real bug found via audit: DISTINCT ON partitioned by
+    # (endpoint_method, endpoint_path) alone, with no repo_full_name -
+    # every other query in this file scopes endpoint_health by
+    # (installation_id, repo_full_name, endpoint_method, endpoint_path),
+    # but an installation can cover multiple repos, and two repos sharing
+    # a conventional health-check path (GET /health here) collapsed into
+    # a single row, silently dropping one repo's endpoint from the count
+    # and potentially reporting the wrong repo's reachability.
+    await _insert_installation(pool, 90601, "co-multi")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, status_code, latency_ms)
+            VALUES
+                (90601, 'co-multi/repo-a', 'GET', '/health', true, 200, 5.0),
+                (90601, 'co-multi/repo-b', 'GET', '/health', false, NULL, NULL)
+            """
+        )
+
+    summary = get_endpoint_health_summary(TEST_DATABASE_URL, 90601)
+
+    assert summary == {"total": 2, "reachable": 1}
+
+
+@pytest.mark.asyncio
 async def test_list_installation_member_emails_sync_matches_async_semantics(pool):
     await _insert_installation(pool, 808, "co")
     async with pool.acquire() as conn:


### PR DESCRIPTION
## Summary
- `DISTINCT ON` in `get_endpoint_health_summary` (`github-app/scan_worker/db.py`) partitioned by `(endpoint_method, endpoint_path)` alone, with no `repo_full_name` - every other query in this file scopes `endpoint_health` by `(installation_id, repo_full_name, endpoint_method, endpoint_path)`, but an installation can cover multiple repos, and it's a realistic, common shape for two different repos to expose the same conventional health-check route (`GET /health`, `GET /api/status`, etc.).
- When that happens, whichever repo had the more recently `checked_at` row silently absorbed the other repo's endpoint into the count - the reported total undercounted, and the reachability could reflect the wrong repo's status entirely, masking a real outage in one repo behind the other repo's healthy result.
- This function is the sole data source for the weekly digest email's `endpoints_reachable`/`endpoints_total` fields (`run_weekly_digest_sweep_job`), so a customer with two repos sharing a health-check path got a wrong digest with no error surfaced. Both existing tests for this function only ever insert rows under a single `repo_full_name`, so this gap had no coverage.

## Fix
Add `repo_full_name` to the `DISTINCT ON` partition and `ORDER BY`, matching every sibling query's scoping in this file.

## Confirmation
```python
# two repos, same path, before the fix:
get_endpoint_health_summary(dsn, installation_id)
# actual: {'total': 1, 'reachable': 0}
# expected: {'total': 2, 'reachable': 1}
```

## Test plan
- [x] Added `test_get_endpoint_health_summary_does_not_collapse_the_same_path_across_two_repos` to `github-app/tests/test_scan_worker_db.py`
- [x] Confirmed it fails against the pre-fix code (stashed the fix, re-ran) and passes post-fix
- [x] `python3 -m pytest github-app/tests/ -q` - 1756 passed, 8 skipped (run in isolation)

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK