### PR TITLE
fix: Flash Review cached findings the second-model verifier had already rejected

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -1447,12 +1447,6 @@ def review_diff(
 
     valid = _merge_semantic_findings(valid, semantic_findings)
 
-    if cache_write is not None:
-        try:
-            cache_write(diff_text, valid, model_used)
-        except Exception as exc:
-            logger.warning("flash review cache write failed (%s); continuing without cache", type(exc).__name__)
-
     kept = _validate_findings(valid, diff_text, file_contents, diff_patches)
     if on_grounding_result is not None:
         on_grounding_result({"proposed": len(valid), "kept": len(kept)})
@@ -1471,4 +1465,23 @@ def review_diff(
             model_part, diff_text, on_usage=on_verification_usage
         )
         kept = semantic_part + verified_model_part
+
+    # Real bug found via audit: this used to write `valid` (only basic
+    # structural validation) to the similarity cache BEFORE grounding
+    # (_validate_findings) and second-model verification got a chance to
+    # reject a finding. A finding the verifier explicitly determined was a
+    # false positive still got written to cache as if it were kept - and
+    # worse than the sibling read-side bugs #549/#583 already fixed, a
+    # rejected finding WITH a quotable citation would never be rechecked
+    # on any future cache hit (needs_recheck only rechecks findings
+    # lacking one), so it would be served as valid forever on any similar
+    # future diff for that installation/repo. Write the same post-
+    # verification `kept` list this function actually returns, so nothing
+    # the verifier rejected can ever enter the cache.
+    if cache_write is not None:
+        try:
+            cache_write(diff_text, kept, model_used)
+        except Exception as exc:
+            logger.warning("flash review cache write failed (%s); continuing without cache", type(exc).__name__)
+
     return kept

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -767,6 +767,49 @@ def test_review_diff_writes_to_cache_after_a_fresh_call(mock_adapter_class):
     ]
 
 
+@patch("scan_worker.model_tiers.verification_adapter")
+@patch("scan_worker.flash_review.writing_adapter_for")
+def test_review_diff_does_not_cache_a_finding_the_second_model_verifier_rejects(
+    mock_adapter_class, mock_verification_adapter
+):
+    # Real bug found via audit: cache_write used to receive `valid` -
+    # findings that had only passed basic structural validation - BEFORE
+    # grounding (_validate_findings) and second-model verification got a
+    # chance to reject a finding. A finding the verifier explicitly
+    # determined was a false positive still got written to the similarity
+    # cache as if it were kept. Worse than the sibling read-side bugs
+    # #549/#583 already fixed: a rejected finding WITH a quotable citation
+    # (like this one) would never be rechecked on any future cache hit
+    # (needs_recheck only rechecks findings lacking one), so it would be
+    # served as valid forever on any future similar diff for that
+    # installation/repo.
+    mock_adapter = MagicMock()
+    mock_adapter.simple_completion.return_value = (
+        '[{"file": "app.py", "line": 42, "issue": "hardcoded secret in \\"sk-abc123\\""}]'
+    )
+    mock_adapter_class.return_value = mock_adapter
+
+    mock_verifier = MagicMock()
+    mock_verifier.is_available.return_value = True
+    mock_verifier.simple_completion.return_value = '{"verdict": "REJECT", "reason": "already fixed"}'
+    mock_verification_adapter.return_value = mock_verifier
+
+    diff_text = "--- app.py ---\n@@ -40,1 +42,1 @@\n+key = \"sk-abc123\""
+    file_contents = {"app.py": "\n".join(f"line {i}" for i in range(1, 42)) + '\nkey = "sk-abc123"\n'}
+    written = []
+
+    findings = review_diff(
+        diff_text,
+        cache_lookup=lambda diff: None,
+        cache_write=lambda diff, findings, model_used: written.append(findings),
+        file_contents=file_contents,
+        verify_with_second_model=True,
+    )
+
+    assert findings == []
+    assert written == [[]]
+
+
 @patch("scan_worker.flash_review.writing_adapter_for")
 def test_review_diff_resolves_model_used_dynamically_when_not_passed(mock_adapter_class, monkeypatch):
     mock_adapter = MagicMock()


### PR DESCRIPTION
## Summary
- `review_diff`'s fresh-generation path wrote `valid` (only basic structural validation) to the similarity cache **before** grounding (`_validate_findings`) and the AIR-tier second-model verifier got a chance to reject a finding. A finding the verifier explicitly determined was a false positive ("already fixed", "not actually a bug") was still written to cache as if it were kept.
- This is a sibling of the exact bug class #549/#583 already fixed - but those were on the cache-**read** side; this is on the **write** side, and worse: a rejected finding **with** a quotable citation would never be rechecked on any future cache hit (`needs_recheck` only rechecks findings lacking one - see `_has_verifiable_content_citation`), so it would be served as valid **forever** on any future similar diff for that installation/repo, having already been explicitly rejected once.
- No existing test covered `cache_write`'s content when `verify_with_second_model=True` and the verifier rejects a finding - both existing `cache_write` tests never pass that flag.

## Confirmation
```python
result = review_diff(diff_text, cache_lookup=lambda d: None,
    cache_write=lambda d, findings, m: written.append(findings),
    verify_with_second_model=True, file_contents=file_contents)
# result (correct, generation-time answer): []
# written (what got cached pre-fix):
#   [{'file': 'app.py', 'line': 42, 'issue': 'hardcoded secret in "sk-abc123"', 'source': 'llm'}]
```

## Fix
Move the `cache_write` call to after the final `kept` list is computed (post-grounding, post-verification) and write `kept` instead of `valid` - the exact same list this function actually returns to the caller, so nothing the verifier rejected can ever enter the cache.

## Test plan
- [x] Added `test_review_diff_does_not_cache_a_finding_the_second_model_verifier_rejects` to `github-app/tests/test_flash_review.py`, mirroring `_verify_findings_with_second_model`'s existing REJECT-verdict test fixture shape
- [x] Confirmed it fails against the pre-fix code (stashed the fix, re-ran) and passes post-fix
- [x] `python3 -m pytest github-app/tests/test_flash_review.py -q` - 192 passed
- [x] `python3 -m pytest github-app/tests/ -q` - 1756 passed, 8 skipped

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK