### PR TITLE
fix: AIRview permanently blanked a file newly joining a subsystem cluster

### DIFF
--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -1027,7 +1027,28 @@ def generate_subsystems(
         prior_record = prior_records.get(str(brief["cluster_id"]))
         if prior_record is None:
             return None, None
-        skip = [f["path"] for f in brief.get("files", []) if f["path"] not in changed_set]
+        # Real bug found via audit: skip used to include every unchanged
+        # path, with no check that prior_record actually has an entry to
+        # splice back in for it. Cluster membership is recomputed from
+        # community detection each scan, so a file can join this
+        # subsystem's brief for the first time on a run where the file's
+        # own bytes didn't change (e.g. an unrelated file's edit shifted
+        # the import graph) - a real, reachable condition, not contrived.
+        # Marking that file skip told the model to omit it entirely, and
+        # _splice_prior_files has nothing to fill the resulting blank
+        # entry with (prior_record has no path for it), leaving a
+        # permanently blank role/key_symbols entry with no recovery path:
+        # the file stays skip on every future incremental run for as long
+        # as its own content stays unchanged. Only skip a path prior_record
+        # can actually splice back in.
+        prior_paths = {
+            f["path"] for f in (prior_record.get("files") or []) if isinstance(f, dict) and f.get("path")
+        }
+        skip = [
+            f["path"]
+            for f in brief.get("files", [])
+            if f["path"] not in changed_set and f["path"] in prior_paths
+        ]
         if not skip:
             return None, None
         return skip, prior_record

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -781,6 +781,63 @@ def test_generate_subsystems_incremental_only_writes_changed_files_within_a_clus
     assert by_path["auth/tokens.py"]["role"] == "Issues tokens."
 
 
+def test_generate_subsystems_does_not_skip_a_file_new_to_the_cluster_with_no_prior_entry():
+    # Real bug found via audit: skip_files used to include every unchanged
+    # path in a cluster's brief, with no check that prior_record actually
+    # has an entry to splice back in for it. Cluster membership is
+    # recomputed from community detection each scan, so a file can join a
+    # subsystem's brief for the first time on a run where the file's own
+    # bytes didn't change (e.g. an unrelated file's edit shifted the
+    # import graph) - a real, reachable condition. Marking that file skip
+    # told the model to omit it entirely, and _splice_prior_files has
+    # nothing to fill the resulting blank entry with, leaving it
+    # permanently blank on every future incremental run.
+    evidence = make_evidence()
+    evidence["repository"]["modules"].append(
+        {
+            "path": "auth/session.py",
+            "language": "python",
+            "imports": [],
+            "symbols": {"functions": [], "classes": []},
+        }
+    )
+    evidence["architecture"]["clusters"][0]["modules"].append("auth/session.py")
+    naming_adapter = _adapter(json.dumps({"0": "Authentication"}))
+    captured_payload = {}
+
+    def _respond(_system_prompt, user_prompt, cwd):
+        captured_payload.update(json.loads(user_prompt))
+        return json.dumps(
+            {
+                "description": "Handles login.",
+                "files": [
+                    {"path": "auth/login.py", "role": "New login logic.", "key_symbols": []},
+                    {"path": "auth/session.py", "role": "New session handling.", "key_symbols": []},
+                ],
+            }
+        )
+
+    writing_adapter = MagicMock()
+    writing_adapter.simple_completion.side_effect = _respond
+    # prior_records only knows about auth/tokens.py - auth/session.py is
+    # new to this cluster and has no prior entry to splice from.
+    prior_records = {
+        "0": {
+            "subsystem_id": "0",
+            "files": [{"path": "auth/tokens.py", "role": "Issues tokens.", "key_symbols": []}],
+        }
+    }
+
+    records = generate_subsystems(
+        evidence, naming_adapter, writing_adapter,
+        changed_files=["auth/login.py"], prior_records=prior_records,
+    )
+
+    assert captured_payload["skip_files"] == ["auth/tokens.py"]
+    by_path = {f["path"]: f for f in records[0]["files"]}
+    assert by_path["auth/session.py"]["role"] == "New session handling."
+
+
 def test_generate_subsystems_full_build_sends_no_skip_files_even_with_a_prior_record():
     # changed_files=None (the full-build default) must ignore prior_records
     # entirely and write every file fresh, matching today's behavior - this


### PR DESCRIPTION
## Summary
- `_skip_files_and_prior` (inside `generate_subsystems`, `github-app/scan_worker/live_wiki.py`) computed `skip_files` purely from whether a file's path was in `changed_files`, with no check that `prior_record` actually had an entry to splice back in for it.
- Cluster membership is recomputed from community detection each scan, so a file can join a subsystem's brief for the first time on a run where the file's own bytes didn't change (e.g. an unrelated file's edit shifted the import graph) - a real, reachable condition, not contrived.
- Marking that file `skip` told the model to omit it entirely from its response, and `_splice_prior_files` has nothing to fill the resulting blank entry with (`prior_record` has no path for it), leaving a **permanently blank** `role`/`key_symbols` entry with no recovery path - the file stays in `skip_files` on every future incremental run for as long as its own content stays unchanged, since the skip decision never re-examines whether `prior_record` has caught up.

## Fix
Only skip a path that `prior_record` can actually splice back in, matching `_splice_prior_files`' own `prior_by_path` construction.

## Test plan
- [x] Added `test_generate_subsystems_does_not_skip_a_file_new_to_the_cluster_with_no_prior_entry` to `github-app/tests/test_live_wiki.py`
- [x] Confirmed it fails against the pre-fix code (stashed the fix, re-ran - `auth/session.py` was wrongly included in `skip_files`) and passes post-fix
- [x] `python3 -m pytest github-app/tests/test_live_wiki.py -q` - 78 passed
- [x] `python3 -m pytest github-app/tests/ -q` - 1760 passed, 8 skipped

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK