### PR TITLE
fix: an embedded newline in an LLM-proposed cluster name could inject a fake node into an AIRview diagram

### DIFF
--- a/src/aletheore/wiki_diagrams.py
+++ b/src/aletheore/wiki_diagrams.py
@@ -11,7 +11,22 @@ testable and usable before naming happens.
 
 
 def _mermaid_safe_label(text: str) -> str:
-    return text.replace('"', "'")
+    # Real bug found via audit: quote-neutralization alone stops a label
+    # from breaking out of its enclosing "..." via an embedded quote, but
+    # Mermaid flowchart syntax is line-oriented - a node is
+    # `C{id}["{label}"]` on one line - and an embedded newline was never
+    # touched. Cluster names reach this function straight from an LLM call
+    # (live_wiki.py's propose_cluster_names) with no server-side
+    # sanitization beyond a truthy .strip() check on the unstripped
+    # original string, so a multi-line model response (or a deliberately
+    # crafted one) could land a second line as its own new Mermaid
+    # statement - confirmed this could inject an entirely unrelated extra
+    # node into the rendered diagram, undermining this module's own
+    # guarantee that "a diagram can never show a relationship that doesn't
+    # actually exist in the code." Collapsing newlines/carriage returns to
+    # a space keeps a multi-line model response on the label's own single
+    # line instead of letting it spill onto new Mermaid statements.
+    return text.replace('"', "'").replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
 
 
 def _file_to_cluster_map(clusters: list[dict]) -> dict[str, int]:

--- a/src/tests/test_wiki_diagrams.py
+++ b/src/tests/test_wiki_diagrams.py
@@ -64,6 +64,40 @@ def test_build_overview_diagram_escapes_quotes_in_names():
     assert "The 'Auth' layer" in diagram
 
 
+def test_build_overview_diagram_neutralizes_embedded_newlines_in_names():
+    # Real bug found via audit: _mermaid_safe_label only neutralized
+    # quotes, never touching an embedded newline. Mermaid flowchart syntax
+    # is line-oriented - a node is C{id}["{label}"] on one line - so a
+    # multi-line cluster name (cluster names come straight from an LLM
+    # call with no server-side sanitization beyond a truthy .strip()
+    # check on the unstripped original string) could land a second line
+    # as its own new Mermaid statement, injecting an entirely unrelated
+    # extra node into the rendered diagram - confirmed directly: a name of
+    # 'Auth"]\n    C99["INJECTED' produced a real extra C99 node that
+    # doesn't correspond to anything in the dependency graph, undermining
+    # this module's own guarantee that "a diagram can never show a
+    # relationship that doesn't actually exist in the code."
+    diagram = build_overview_diagram(
+        make_evidence(), cluster_names={0: 'Auth"]\n    C99["INJECTED', 1: "Database"}
+    )
+    # C99 may still appear as harmless label TEXT on C0's own line - what
+    # matters is it's not a separate node statement of its own, on its own
+    # line, the way a real injected node would be.
+    stripped_lines = [line.strip() for line in diagram.splitlines() if line.strip()]
+    assert len(stripped_lines) == 4  # header + C0 + C1 + one edge, not 5
+    assert not any(line.startswith("C99[") for line in stripped_lines)
+    node0_lines = [line for line in stripped_lines if line.startswith("C0[")]
+    assert len(node0_lines) == 1
+    assert "C99" in node0_lines[0]  # survives as harmless text, not a new statement
+
+
+def test_build_overview_diagram_neutralizes_a_bare_carriage_return_in_names():
+    diagram = build_overview_diagram(make_evidence(), cluster_names={0: "Auth\rC99[\"INJECTED", 1: "Database"})
+    stripped_lines = [line.strip() for line in diagram.splitlines() if line.strip()]
+    assert len(stripped_lines) == 4
+    assert not any(line.startswith("C99[") for line in stripped_lines)
+
+
 def test_build_subsystem_diagram_has_one_node_per_member_file():
     evidence = make_evidence()
     cluster = evidence["architecture"]["clusters"][0]


### PR DESCRIPTION
## Summary
- `_mermaid_safe_label` (`src/aletheore/wiki_diagrams.py`) only neutralized double quotes (`"` -> `'`), never touching an embedded newline. Mermaid flowchart syntax is line-oriented - a node is `C{id}["{label}"]` on one line - and cluster names reach this function straight from an LLM call (`live_wiki.py`'s `propose_cluster_names`) with no server-side sanitization beyond a truthy `.strip()` check on the unstripped original string.
- A multi-line cluster name landed its second line as its own new Mermaid statement. Confirmed directly: a name of `'Auth"]\n    C99["INJECTED'` produced a real extra `C99` node with no corresponding entry in the dependency graph, undermining this module's own docstring guarantee that "a diagram can never show a relationship that doesn't actually exist in the code." Even a benign, non-adversarial case - a model response with a short aside on a second line, plausible LLM behavior with no malicious intent - broke the diagram the same way.

## Fix
Also collapse `\r\n`, `\n`, and bare `\r` to a space in `_mermaid_safe_label`, keeping a multi-line model response on the label's own single line instead of letting it spill onto new Mermaid statements.

## Test plan
- [x] Added `test_build_overview_diagram_neutralizes_embedded_newlines_in_names` and `..._a_bare_carriage_return_in_names` to `src/tests/test_wiki_diagrams.py`
- [x] Confirmed both fail against the pre-fix code (stashed the fix, re-ran - 5 rendered lines instead of the correct 4, the extra one being the injected node) and pass post-fix
- [x] `python3 -m pytest src/tests/ -q` - 1835 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK