### PR TITLE
fix: multi-target health checks blended into one row, hiding real outages

### DIFF
--- a/github-app/app_server/dashboard.py
+++ b/github-app/app_server/dashboard.py
@@ -49,23 +49,38 @@ STALE_ENDPOINT_WINDOW_DAYS = 30
 
 
 def find_stale_endpoints(
-    endpoints: list[dict], health_summary: dict[tuple[str, str], dict]
+    endpoints: list[dict], health_summary: dict[tuple[int | None, str, str], dict]
 ) -> list[dict]:
-    stale = []
+    # health_summary is now keyed per (target_id, method, path) - real bug
+    # found via audit: get_endpoint_health_summary_since used to blend
+    # every target checking the same endpoint into one summary, so a
+    # permanently-broken production target could be hidden behind a
+    # healthy staging target sharing its (method, path) and never get
+    # flagged here. One endpoint can now surface as stale once per target
+    # that's actually stale, each carrying its own target_id/target_label
+    # so the caller can tell which target the flag is about - the same
+    # per-target detail get_recent_endpoint_health already exposes
+    # elsewhere on this same authenticated dashboard.
+    endpoints_by_key: dict[tuple[str, str], dict] = {}
     for endpoint in endpoints:
-        key = (endpoint.get("method"), endpoint.get("path"))
-        summary = health_summary.get(key)
-        if summary is None:
+        endpoints_by_key.setdefault((endpoint.get("method"), endpoint.get("path")), endpoint)
+
+    stale = []
+    for (target_id, method, path), summary in health_summary.items():
+        endpoint = endpoints_by_key.get((method, path))
+        if endpoint is None:
             continue
         if summary["ever_reachable"] or summary["check_count"] < MIN_CHECKS_FOR_STALE_CONFIDENCE:
             continue
         stale.append(
             {
-                "method": endpoint.get("method"),
-                "path": endpoint.get("path"),
+                "method": method,
+                "path": path,
                 "file": endpoint.get("file"),
                 "line": endpoint.get("line"),
                 "check_count": summary["check_count"],
+                "target_id": target_id,
+                "target_label": summary.get("target_label"),
             }
         )
     return stale
@@ -683,13 +698,32 @@ async def get_public_health(org: str, repo: str, request: Request, response: Res
             headers={"Access-Control-Allow-Origin": "*"},
         )
 
+    # Real bug found via audit: this used to DISTINCT ON (endpoint_method,
+    # endpoint_path) alone. Two targets checking the exact same endpoint
+    # (e.g. staging and production) collapsed into whichever target
+    # happened to have the more recently checked_at row - a genuinely
+    # down production target could be silently reported as "up" whenever
+    # a healthy staging target's row landed later. latest_per_target first
+    # gets each target's own latest row (matching get_recent_endpoint_
+    # health's already-fixed shape), then the outer query orders
+    # `reachable` ascending (false sorts before true in Postgres) so a
+    # down target is always what gets surfaced for that endpoint - a real
+    # outage on any one target can never be hidden behind a healthy
+    # sibling target on this public, unauthenticated status page, without
+    # exposing which specific target it was.
     rows = await request.app.state.db_pool.fetch(
         """
+        WITH latest_per_target AS (
+            SELECT DISTINCT ON (target_id, endpoint_method, endpoint_path)
+                target_id, endpoint_method, endpoint_path, reachable, status_code, latency_ms, checked_at
+            FROM endpoint_health
+            WHERE installation_id = $1 AND repo_full_name = $2 AND checked_at >= $3
+            ORDER BY target_id, endpoint_method, endpoint_path, checked_at DESC, id DESC
+        )
         SELECT DISTINCT ON (endpoint_method, endpoint_path)
             endpoint_method, endpoint_path, reachable, status_code, latency_ms, checked_at
-        FROM endpoint_health
-        WHERE installation_id = $1 AND repo_full_name = $2 AND checked_at >= $3
-        ORDER BY endpoint_method, endpoint_path, checked_at DESC, id DESC
+        FROM latest_per_target
+        ORDER BY endpoint_method, endpoint_path, reachable ASC, checked_at DESC
         """,
         installation["installation_id"],
         repo_full_name,

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -1264,13 +1264,30 @@ async def get_endpoint_uptime_pct_since(
     # aggregate percentage rather than the raw per-check history exposed
     # on the authenticated dashboard endpoint - an unauthenticated,
     # CORS-open route shouldn't hand out granular check-by-check timing
-    # data to anyone who asks.
+    # data to anyone who asks (including which specific target is
+    # unhealthy - see the worst-case aggregation below).
+    #
+    # Real bug found via audit: this used to GROUP BY endpoint_method,
+    # endpoint_path alone. Two targets checking the exact same endpoint
+    # (e.g. staging and production) blended into one row - a production
+    # target with 0% uptime over the window, sitting next to a staging
+    # target with 100%, reported a misleading 50% instead of the real,
+    # customer-relevant fact that production has been down the whole
+    # time. Computing per-target uptime_pct first, then taking the
+    # MINIMUM across targets per endpoint, means a real outage on any one
+    # target can never be hidden behind a healthy sibling target -
+    # without exposing which target it was (still just one number per
+    # endpoint, same public-API contract as before).
     rows = await pool.fetch(
         """
-        SELECT endpoint_method, endpoint_path,
-               (count(*) FILTER (WHERE reachable))::float / count(*) AS uptime_pct
-        FROM endpoint_health
-        WHERE installation_id = $1 AND repo_full_name = $2 AND checked_at >= $3
+        SELECT endpoint_method, endpoint_path, min(uptime_pct) AS uptime_pct
+        FROM (
+            SELECT target_id, endpoint_method, endpoint_path,
+                   (count(*) FILTER (WHERE reachable))::float / count(*) AS uptime_pct
+            FROM endpoint_health
+            WHERE installation_id = $1 AND repo_full_name = $2 AND checked_at >= $3
+            GROUP BY target_id, endpoint_method, endpoint_path
+        ) per_target
         GROUP BY endpoint_method, endpoint_path
         """,
         installation_id,
@@ -1285,22 +1302,35 @@ async def get_endpoint_health_summary_since(
     installation_id: int,
     repo_full_name: str,
     since: datetime,
-) -> dict[tuple[str, str], dict]:
+) -> dict[tuple[int | None, str, str], dict]:
+    # Real bug found via audit: this used to GROUP BY endpoint_method,
+    # endpoint_path alone, so bool_or(reachable) blended every target
+    # checking the same endpoint together - a permanently-broken
+    # production target (never once reachable) was invisible to
+    # find_stale_endpoints as long as a healthy staging target shared its
+    # (method, path). Grouped per target_id instead, matching
+    # get_recent_endpoint_health's already-fixed shape - the authenticated
+    # dashboard this backs already shows a per-target breakdown via that
+    # function, so surfacing target-level staleness here too is not new
+    # exposure, just internal consistency.
     rows = await pool.fetch(
         """
-        SELECT endpoint_method, endpoint_path, bool_or(reachable) AS ever_reachable, count(*) AS check_count
-        FROM endpoint_health
-        WHERE installation_id = $1 AND repo_full_name = $2 AND checked_at >= $3
-        GROUP BY endpoint_method, endpoint_path
+        SELECT eh.target_id, t.label AS target_label, eh.endpoint_method, eh.endpoint_path,
+               bool_or(eh.reachable) AS ever_reachable, count(*) AS check_count
+        FROM endpoint_health eh
+        LEFT JOIN health_check_targets t ON t.id = eh.target_id
+        WHERE eh.installation_id = $1 AND eh.repo_full_name = $2 AND eh.checked_at >= $3
+        GROUP BY eh.target_id, t.label, eh.endpoint_method, eh.endpoint_path
         """,
         installation_id,
         repo_full_name,
         since,
     )
     return {
-        (row["endpoint_method"], row["endpoint_path"]): {
+        (row["target_id"], row["endpoint_method"], row["endpoint_path"]): {
             "ever_reachable": row["ever_reachable"],
             "check_count": row["check_count"],
+            "target_label": row["target_label"],
         }
         for row in rows
     }

--- a/github-app/tests/test_dashboard.py
+++ b/github-app/tests/test_dashboard.py
@@ -812,6 +812,105 @@ async def test_public_health_uptime_pct_excludes_checks_older_than_7_days(pool):
 
 
 @pytest.mark.asyncio
+async def test_public_health_surfaces_a_down_target_even_when_a_sibling_target_is_up(pool):
+    # Real bug found via audit: get_public_health's raw query used to
+    # DISTINCT ON (endpoint_method, endpoint_path) alone. Two targets
+    # checking the exact same endpoint (e.g. staging and production)
+    # collapsed into whichever target had the more recently checked_at
+    # row - a genuinely down production target could be silently reported
+    # as "up" whenever a healthy staging target's row happened to land
+    # later. A real outage on any one target must never be hidden behind
+    # a healthy sibling target on this public status page.
+    await upsert_installation(pool, 509, "octocat")
+    await set_public_status_enabled(pool, 509, "octocat/hello-world", True)
+    async with pool.acquire() as conn:
+        staging_id = await conn.fetchval(
+            """
+            INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url)
+            VALUES (509, 'octocat/hello-world', 'Staging', 'https://staging.example.com') RETURNING id
+            """
+        )
+        prod_id = await conn.fetchval(
+            """
+            INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url)
+            VALUES (509, 'octocat/hello-world', 'Production', 'https://prod.example.com') RETURNING id
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path,
+                 reachable, status_code, target_id, checked_at)
+            VALUES
+                (509, 'octocat/hello-world', 'GET', '/api/users', false, 500, $1, now() - interval '1 minute'),
+                (509, 'octocat/hello-world', 'GET', '/api/users', true, 200, $2, now())
+            """,
+            prod_id,
+            staging_id,
+        )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/health/octocat/hello-world")
+
+    assert response.status_code == 200
+    endpoints = {(e["method"], e["path"]): e for e in response.json()["endpoints"]}
+    assert len(endpoints) == 1
+    # Even though staging's row is the more recently checked one, the down
+    # production target must be what's surfaced publicly.
+    assert endpoints[("GET", "/api/users")]["reachable"] is False
+
+
+@pytest.mark.asyncio
+async def test_public_health_uptime_pct_is_the_worst_case_across_targets(pool):
+    # Sibling of the reachability bug above: uptime_pct_7d used to GROUP BY
+    # endpoint_method, endpoint_path alone, averaging a permanently-down
+    # production target's 0% together with a healthy staging target's
+    # 100% into a misleading 50%, instead of the real, customer-relevant
+    # fact that production has been down the whole window.
+    await upsert_installation(pool, 510, "octocat")
+    await set_public_status_enabled(pool, 510, "octocat/hello-world", True)
+    async with pool.acquire() as conn:
+        staging_id = await conn.fetchval(
+            """
+            INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url)
+            VALUES (510, 'octocat/hello-world', 'Staging', 'https://staging.example.com') RETURNING id
+            """
+        )
+        prod_id = await conn.fetchval(
+            """
+            INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url)
+            VALUES (510, 'octocat/hello-world', 'Production', 'https://prod.example.com') RETURNING id
+            """
+        )
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path,
+                 reachable, status_code, target_id, checked_at)
+            VALUES
+                (510, 'octocat/hello-world', 'GET', '/api/users', false, 500, $1, now() - interval '1 minute'),
+                (510, 'octocat/hello-world', 'GET', '/api/users', false, 500, $1, now() - interval '2 minute'),
+                (510, 'octocat/hello-world', 'GET', '/api/users', true, 200, $2, now())
+            """,
+            prod_id,
+            staging_id,
+        )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/health/octocat/hello-world")
+
+    assert response.status_code == 200
+    endpoints = {(e["method"], e["path"]): e for e in response.json()["endpoints"]}
+    # Production: 0 of 2 reachable (0.0). Staging: 1 of 1 (1.0). The
+    # reported uptime must be the worst case (0.0), never an average.
+    assert endpoints[("GET", "/api/users")]["uptime_pct_7d"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_public_health_excludes_endpoints_not_checked_recently(pool):
     # An endpoint whose most recent check is older than the staleness
     # window has either been removed from the route set or was never a
@@ -1348,6 +1447,92 @@ async def test_dashboard_health_includes_stale_endpoints(pool, monkeypatch):
             "file": "routes.py",
             "line": 5,
             "check_count": 5,
+            "target_id": None,
+            "target_label": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_health_stale_endpoints_flags_a_broken_target_even_with_a_healthy_sibling(
+    pool, monkeypatch
+):
+    # Real bug found via audit: get_endpoint_health_summary_since used to
+    # GROUP BY endpoint_method, endpoint_path alone, so bool_or(reachable)
+    # blended a permanently-broken production target together with a
+    # healthy staging target checking the same endpoint - the dead
+    # production target's "ever_reachable" came back True (from staging)
+    # and it never showed up in stale_endpoints at all.
+    await upsert_installation(pool, 511, "octocat")
+    await set_installation_plan(pool, 511, "air")
+    await insert_repo_history(
+        pool,
+        511,
+        "octocat/hello-world",
+        datetime.now(timezone.utc),
+        {
+            "aletheore_version": EVIDENCE_VERSION,
+            "repository": {
+                "api_endpoints": {
+                    "endpoints": [
+                        {
+                            "method": "GET",
+                            "path": "/api/legacy",
+                            "file": "routes.py",
+                            "line": 5,
+                            "handler": "legacy",
+                        }
+                    ]
+                }
+            },
+        },
+    )
+    async with pool.acquire() as conn:
+        staging_id = await conn.fetchval(
+            """
+            INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url)
+            VALUES (511, 'octocat/hello-world', 'Staging', 'https://staging.example.com') RETURNING id
+            """
+        )
+        prod_id = await conn.fetchval(
+            """
+            INSERT INTO health_check_targets (installation_id, repo_full_name, label, base_url)
+            VALUES (511, 'octocat/hello-world', 'Production', 'https://prod.example.com') RETURNING id
+            """
+        )
+        for _ in range(5):
+            await conn.execute(
+                """
+                INSERT INTO endpoint_health
+                    (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, target_id)
+                VALUES (511, 'octocat/hello-world', 'GET', '/api/legacy', false, $1)
+                """,
+                prod_id,
+            )
+        await conn.execute(
+            """
+            INSERT INTO endpoint_health
+                (installation_id, repo_full_name, endpoint_method, endpoint_path, reachable, target_id)
+            VALUES (511, 'octocat/hello-world', 'GET', '/api/legacy', true, $1)
+            """,
+            staging_id,
+        )
+
+    client = await _logged_in_client(pool, monkeypatch, administered_ids=[511])
+    async with client:
+        response = await client.get("/app/octocat/hello-world/health")
+
+    assert response.status_code == 200
+    stale = response.json()["stale_endpoints"]
+    assert stale == [
+        {
+            "method": "GET",
+            "path": "/api/legacy",
+            "file": "routes.py",
+            "line": 5,
+            "check_count": 5,
+            "target_id": prod_id,
+            "target_label": "Production",
         }
     ]
 

--- a/github-app/tests/test_stale_endpoints.py
+++ b/github-app/tests/test_stale_endpoints.py
@@ -8,9 +8,10 @@ def _endpoint(method="GET", path="/api/legacy", file="routes.py", line=10):
 def test_flags_endpoint_with_zero_successes_over_min_checks():
     endpoints = [_endpoint()]
     health_summary = {
-        ("GET", "/api/legacy"): {
+        (1, "GET", "/api/legacy"): {
             "ever_reachable": False,
             "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+            "target_label": "Production",
         }
     }
 
@@ -23,13 +24,17 @@ def test_flags_endpoint_with_zero_successes_over_min_checks():
             "file": "routes.py",
             "line": 10,
             "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+            "target_id": 1,
+            "target_label": "Production",
         }
     ]
 
 
 def test_does_not_flag_endpoint_that_has_ever_been_reachable():
     endpoints = [_endpoint()]
-    health_summary = {("GET", "/api/legacy"): {"ever_reachable": True, "check_count": 10}}
+    health_summary = {
+        (1, "GET", "/api/legacy"): {"ever_reachable": True, "check_count": 10, "target_label": None}
+    }
 
     assert find_stale_endpoints(endpoints, health_summary) == []
 
@@ -37,9 +42,10 @@ def test_does_not_flag_endpoint_that_has_ever_been_reachable():
 def test_does_not_flag_endpoint_below_min_check_count():
     endpoints = [_endpoint()]
     health_summary = {
-        ("GET", "/api/legacy"): {
+        (1, "GET", "/api/legacy"): {
             "ever_reachable": False,
             "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE - 1,
+            "target_label": None,
         }
     }
 
@@ -55,9 +61,10 @@ def test_does_not_flag_endpoint_with_no_health_history_at_all():
 def test_ignores_endpoints_missing_file_or_line():
     endpoints = [{"method": "GET", "path": "/api/legacy"}]
     health_summary = {
-        ("GET", "/api/legacy"): {
+        (1, "GET", "/api/legacy"): {
             "ever_reachable": False,
             "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+            "target_label": None,
         }
     }
 
@@ -70,5 +77,44 @@ def test_ignores_endpoints_missing_file_or_line():
             "file": None,
             "line": None,
             "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+            "target_id": 1,
+            "target_label": None,
+        }
+    ]
+
+
+def test_a_permanently_broken_target_is_flagged_even_when_a_sibling_target_is_healthy():
+    # Real bug found via audit: get_endpoint_health_summary_since used to
+    # GROUP BY endpoint_method, endpoint_path alone, so bool_or(reachable)
+    # blended a permanently-broken production target together with a
+    # healthy staging target checking the same endpoint - "ever_reachable"
+    # came back True (from staging), so the dead production target never
+    # got flagged here at all. Now that the summary is grouped per
+    # target_id, each target's own staleness is visible independently.
+    endpoints = [_endpoint()]
+    health_summary = {
+        (1, "GET", "/api/legacy"): {
+            "ever_reachable": False,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+            "target_label": "Production",
+        },
+        (2, "GET", "/api/legacy"): {
+            "ever_reachable": True,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+            "target_label": "Staging",
+        },
+    }
+
+    result = find_stale_endpoints(endpoints, health_summary)
+
+    assert result == [
+        {
+            "method": "GET",
+            "path": "/api/legacy",
+            "file": "routes.py",
+            "line": 10,
+            "check_count": MIN_CHECKS_FOR_STALE_CONFIDENCE,
+            "target_id": 1,
+            "target_label": "Production",
         }
     ]


### PR DESCRIPTION
## Summary
`get_recent_endpoint_health` already carries its own comment fixing this exact class ("DISTINCT ON must include target_id, not just method+path - otherwise two targets checking the exact same endpoint... collapse into a single row and one target's results silently disappear"), but three sibling query paths were never given the same fix:

1. **`dashboard.py`'s public, unauthenticated `/v1/health/{org}/{repo}` raw query** - `DISTINCT ON (endpoint_method, endpoint_path)` alone. Whichever target had the more recently `checked_at` row won; a genuinely down production target could be reported as "up" whenever a healthy staging target's row happened to land later.
2. **`db.py`'s `get_endpoint_uptime_pct_since`** - `GROUP BY endpoint_method, endpoint_path` alone. A production target down 0% the whole window, averaged with a staging target up 100%, reported a misleading 50% uptime instead of the real fact that production has been down the entire time.
3. **`db.py`'s `get_endpoint_health_summary_since`** - same `GROUP BY` gap. `bool_or(reachable)` blended a permanently-broken production target's "never once succeeded" together with a healthy staging target's history, so `find_stale_endpoints` never flagged the dead production target at all.

## Confirmation
Against the real test DB: a production target down 100% and a staging target up 100% on the same endpoint reported `{'total': 1, 'reachable': 0}` pre-fix (should be `{'total': 2, 'reachable': 1}`), 50% uptime instead of the real 0%, and zero entries in `stale_endpoints` despite production having failed every single check.

## Fix
Two strategies depending on the surface:
- The **public, unauthenticated status API** (`get_public_health`'s raw query, `get_endpoint_uptime_pct_since`) now computes per-target results first, then takes the **worst case** across targets per endpoint - a real outage on any target can never be hidden behind a healthy sibling, without exposing which specific target it was (this route deliberately never hands out granular per-target detail).
- The **authenticated dashboard** (`get_endpoint_health_summary_since`, `find_stale_endpoints`) is now grouped/keyed per `target_id`, each carrying its own `target_label` - matching `get_recent_endpoint_health`'s already-fixed shape, which this same authenticated page already exposes elsewhere.

## Test plan
- [x] Added regression tests for all three paths (public-status reachability, public-status uptime, authenticated stale-endpoints), plus updated `find_stale_endpoints`' existing test suite for its new `(target_id, method, path)`-keyed input shape
- [x] Confirmed all four new tests fail against the pre-fix code (stashed the fix, re-ran) and pass post-fix
- [x] `python3 -m pytest github-app/tests/ -q` - 1765 passed, 8 skipped

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK