### PR TITLE
fix: select_adapter crashed on a mistyped interactive answer

### DIFF
--- a/src/aletheore/report.py
+++ b/src/aletheore/report.py
@@ -35,9 +35,25 @@ def select_adapter(
         print("Available agent providers:")
         for i, name in enumerate(names, start=1):
             print(f"  {i}. {name}")
-        choice = input(f"Which one? [1-{len(names)}]: ").strip()
-        index = int(choice) - 1
-        return available[index]
+        # Real bug found via audit: a non-numeric answer raised a raw
+        # ValueError from int(), and an out-of-range number raised a raw
+        # IndexError from the list access - neither is caught by this
+        # function's only caller (cli.py only catches NoAdapterAvailableError/
+        # AmbiguousAdapterError), so a mistyped answer crashed the whole
+        # command with an unhandled traceback instead of a clean re-prompt.
+        # interactive is only ever True when the caller already confirmed
+        # sys.stdin.isatty(), so a bounded re-prompt loop here is safe - it
+        # can't hang against a closed/non-tty stdin.
+        for _ in range(5):
+            choice = input(f"Which one? [1-{len(names)}]: ").strip()
+            try:
+                index = int(choice) - 1
+                if 0 <= index < len(available):
+                    return available[index]
+            except ValueError:
+                pass
+            print(f"Not a valid choice - enter a number from 1 to {len(names)}.")
+        raise NoAdapterAvailableError("no valid selection made after multiple attempts")
 
     names = ", ".join(a.name for a in available)
     raise AmbiguousAdapterError(

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -130,6 +130,36 @@ def test_select_adapter_honors_forced_name():
     assert result is b
 
 
+def test_select_adapter_reprompts_on_non_numeric_input():
+    # Real bug found via audit: a non-numeric answer raised a raw
+    # ValueError from int(choice), uncaught by this function's only
+    # caller (cli.py only catches NoAdapterAvailableError/
+    # AmbiguousAdapterError) - a mistyped answer crashed the whole
+    # command with an unhandled traceback instead of a clean re-prompt.
+    a = make_adapter("claude", True)
+    b = make_adapter("cursor", True)
+    with patch("builtins.input", side_effect=["not a number", "2"]):
+        result = select_adapter([a, b], forced_name=None, interactive=True)
+    assert result is b
+
+
+def test_select_adapter_reprompts_on_out_of_range_choice():
+    # Same bug, the out-of-range half: an IndexError from the list access,
+    # equally uncaught by the only caller.
+    a = make_adapter("claude", True)
+    b = make_adapter("cursor", True)
+    with patch("builtins.input", side_effect=["99", "0", "1"]):
+        result = select_adapter([a, b], forced_name=None, interactive=True)
+    assert result is a
+
+
+def test_select_adapter_raises_after_repeated_invalid_input():
+    a = make_adapter("claude", True)
+    with patch("builtins.input", return_value="not a number"):
+        with pytest.raises(NoAdapterAvailableError):
+            select_adapter([a], forced_name=None, interactive=True)
+
+
 def test_build_instruction_references_manual_and_evidence():
     instruction = build_instruction(manual_dir="manual")
     assert "manual" in instruction


### PR DESCRIPTION
## Summary
- `select_adapter`'s interactive prompt did `index = int(choice) - 1; return available[index]` with no input validation. A non-numeric answer raised a raw `ValueError` from `int()`; an out-of-range number raised a raw `IndexError` from the list access. Neither is caught by this function's only caller (`cli.py` only catches `NoAdapterAvailableError`/`AmbiguousAdapterError`), so a user running `aletheore audit`/similar interactively and mistyping their choice got an unhandled Python traceback instead of a clean re-prompt.

## Fix
A bounded re-prompt loop (5 attempts) instead of failing on the first bad input - safe because `interactive` is only ever `True` when the caller already confirmed `sys.stdin.isatty()` (see `cli.py`'s call sites), so it can't hang against a closed/non-tty stdin. Uses an explicit `0 <= index < len(available)` bounds check rather than relying on `IndexError`, so `"0"` (which `int()`s to a valid negative Python index, `-1`, and would otherwise silently return the *last* adapter instead of erroring) is correctly treated as invalid input too.

## Test plan
- [x] Added three regression tests to `src/tests/test_cli.py` (where `select_adapter`'s existing test coverage already lives) - a non-numeric answer, an out-of-range answer, and exhausting all retry attempts
- [x] Confirmed the first two fail against the pre-fix code with a raw `ValueError` (stashed the fix, re-ran) and pass post-fix
- [x] `python3 -m pytest src/tests/ -q` - 1836 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK