### PR TITLE
fix: two symbols sharing a name in one file corrupted each other's Docs description and content_hash

### DIFF
--- a/github-app/scan_worker/live_docs.py
+++ b/github-app/scan_worker/live_docs.py
@@ -65,9 +65,30 @@ def _parse_json_object(raw: str) -> dict:
 
 def _symbols_needing_work(module: dict, polish_existing: bool) -> list[dict]:
     all_symbols = module["symbols"]["functions"] + module["symbols"]["classes"]
+
+    # A symbol name that appears more than once in this file (e.g. two
+    # functions named `foo` - a real, if unusual, shape: a conditional
+    # redefinition, or a scanner capturing both branches of an @overload
+    # pair) can't be safely round-tripped through this module's name-keyed
+    # request/response contract - the model's JSON response can only ever
+    # carry one entry per name. Real bug found via audit: this used to
+    # happily request descriptions for every colliding name anyway, and
+    # the name-keyed `hashes`/`result` dicts downstream kept whichever one
+    # wrote last, silently discarding the other symbol's real description
+    # and corrupting its content_hash-based change-detection with a
+    # sibling's hash. Excluded entirely rather than guessing which one
+    # "wins" - matches this module's own fail-closed philosophy (an
+    # unrepresentable response degrades to no AI description, not a wrong
+    # one silently attributed to the wrong symbol).
+    name_counts: dict[str, int] = {}
+    for symbol in all_symbols:
+        name_counts[symbol["name"]] = name_counts.get(symbol["name"], 0) + 1
+
     if polish_existing:
-        return [s for s in all_symbols if s.get("is_public") and s.get("docstring")]
-    return [s for s in all_symbols if s.get("is_public") and not s.get("docstring")]
+        candidates = [s for s in all_symbols if s.get("is_public") and s.get("docstring")]
+    else:
+        candidates = [s for s in all_symbols if s.get("is_public") and not s.get("docstring")]
+    return [s for s in candidates if name_counts[s["name"]] == 1]
 
 
 def _symbol_snippet(source_lines: list[str], symbol: dict) -> str:

--- a/github-app/scan_worker/live_docs.py
+++ b/github-app/scan_worker/live_docs.py
@@ -66,28 +66,41 @@ def _parse_json_object(raw: str) -> dict:
 def _symbols_needing_work(module: dict, polish_existing: bool) -> list[dict]:
     all_symbols = module["symbols"]["functions"] + module["symbols"]["classes"]
 
-    # A symbol name that appears more than once in this file (e.g. two
-    # functions named `foo` - a real, if unusual, shape: a conditional
-    # redefinition, or a scanner capturing both branches of an @overload
-    # pair) can't be safely round-tripped through this module's name-keyed
-    # request/response contract - the model's JSON response can only ever
-    # carry one entry per name. Real bug found via audit: this used to
-    # happily request descriptions for every colliding name anyway, and
-    # the name-keyed `hashes`/`result` dicts downstream kept whichever one
+    if polish_existing:
+        candidates = [s for s in all_symbols if s.get("is_public") and s.get("docstring")]
+    else:
+        candidates = [s for s in all_symbols if s.get("is_public") and not s.get("docstring")]
+
+    # A symbol name that appears more than once among candidates THIS CALL
+    # would actually request (e.g. two undocumented functions named `foo`
+    # - a real, if unusual, shape: a conditional redefinition, or a
+    # scanner capturing both branches of an @overload pair) can't be
+    # safely round-tripped through this module's name-keyed request/
+    # response contract - the model's JSON response can only ever carry
+    # one entry per name. Real bug found via audit: this used to happily
+    # request descriptions for every colliding name anyway, and the
+    # name-keyed `hashes`/`result` dicts downstream kept whichever one
     # wrote last, silently discarding the other symbol's real description
     # and corrupting its content_hash-based change-detection with a
     # sibling's hash. Excluded entirely rather than guessing which one
     # "wins" - matches this module's own fail-closed philosophy (an
     # unrepresentable response degrades to no AI description, not a wrong
     # one silently attributed to the wrong symbol).
+    #
+    # Real Flash Review finding on this same fix: counting collisions
+    # across ALL symbols (both docstring states) over-excluded a symbol
+    # that has no real collision in what THIS call's own request actually
+    # sends - two same-named symbols where one is undocumented (eligible
+    # here) and the other already documented (eligible only for the
+    # OTHER mode's call, never sent together in this call's own request)
+    # were being treated as colliding when they never would be. Scoped to
+    # `candidates` - this call's own request - fixes that false negative.
+    # generate_file_descriptions_combined, which DOES send both modes'
+    # candidates in one combined request, does its own additional
+    # cross-mode dedup below for exactly that shape.
     name_counts: dict[str, int] = {}
-    for symbol in all_symbols:
+    for symbol in candidates:
         name_counts[symbol["name"]] = name_counts.get(symbol["name"], 0) + 1
-
-    if polish_existing:
-        candidates = [s for s in all_symbols if s.get("is_public") and s.get("docstring")]
-    else:
-        candidates = [s for s in all_symbols if s.get("is_public") and not s.get("docstring")]
     return [s for s in candidates if name_counts[s["name"]] == 1]
 
 
@@ -164,6 +177,22 @@ def generate_file_descriptions_combined(
     """
     generate_symbols = _symbols_needing_work(module, polish_existing=False)
     polish_symbols = _symbols_needing_work(module, polish_existing=True)
+
+    # This call combines both modes' candidates into ONE request, unlike
+    # generate_file_descriptions' single-mode call - a name that's unique
+    # within generate_symbols and unique within polish_symbols separately
+    # (so _symbols_needing_work's own per-call dedup above lets both
+    # through) can still collide once combined here (an undocumented
+    # `foo` needing generation and a differently-documented `foo`
+    # needing polish, both real, both eligible, both about to be sent
+    # under the same name key in the same request). Excluded from BOTH
+    # lists rather than guessing which one wins - the same fail-closed
+    # reasoning as the per-call dedup, applied to what this function
+    # actually sends as one combined request.
+    cross_mode_names = {s["name"] for s in generate_symbols} & {s["name"] for s in polish_symbols}
+    if cross_mode_names:
+        generate_symbols = [s for s in generate_symbols if s["name"] not in cross_mode_names]
+        polish_symbols = [s for s in polish_symbols if s["name"] not in cross_mode_names]
 
     hashes = {
         s["name"]: _content_hash(_symbol_snippet(source_lines, s))

--- a/github-app/tests/test_live_docs.py
+++ b/github-app/tests/test_live_docs.py
@@ -135,6 +135,53 @@ def test_no_symbols_needing_work_never_calls_the_adapter():
     adapter.simple_completion.assert_not_called()
 
 
+def test_two_undocumented_symbols_sharing_a_name_are_never_requested():
+    # Real bug found via audit: two symbols sharing a name (a real, if
+    # unusual, shape - a conditional redefinition, or a scanner capturing
+    # both branches of an @overload pair) both got sent to the model under
+    # the identical name key, but the model's own name-keyed response
+    # contract can only ever carry one entry per name - whichever wrote
+    # last in the name-keyed result dict silently discarded the other's
+    # real description. Excluded from the request entirely instead: a
+    # colliding name degrades to no AI description for either symbol,
+    # never a wrong one silently attributed to the wrong symbol.
+    module = _module(
+        "a.py",
+        [
+            _symbol("foo", start_line=1, end_line=2),
+            _symbol("foo", start_line=4, end_line=5),
+        ],
+    )
+    adapter = _adapter(json.dumps({"foo": {"description": "Ambiguous - which foo?"}}))
+
+    result = generate_file_descriptions(
+        module, ["def foo():", "    return 1", "", "def foo():", "    return 2"], adapter
+    )
+
+    assert result == {}
+    adapter.simple_completion.assert_not_called()
+
+
+def test_a_colliding_name_does_not_block_an_unrelated_symbol_in_the_same_file():
+    module = _module(
+        "a.py",
+        [
+            _symbol("foo", start_line=1, end_line=2),
+            _symbol("foo", start_line=4, end_line=5),
+            _symbol("bar", start_line=7, end_line=8),
+        ],
+    )
+    adapter = _adapter(json.dumps({"bar": {"description": "Returns a constant."}}))
+
+    result = generate_file_descriptions(
+        module,
+        ["def foo():", "    return 1", "", "def foo():", "    return 2", "", "def bar():", "    return 3"],
+        adapter,
+    )
+
+    assert result == {"bar": {"description": "Returns a constant.", "mode": "generated"}}
+
+
 def test_combined_handles_generate_and_polish_symbols_in_one_call():
     # One module with both an undocumented symbol (needs generate) and an
     # already-documented one (needs polish) - the whole point of the
@@ -194,6 +241,29 @@ def test_combined_no_symbols_needing_work_never_calls_the_adapter():
     adapter = _adapter("{}")
 
     result = generate_file_descriptions_combined(module, [], adapter)
+
+    assert result == {}
+    adapter.simple_completion.assert_not_called()
+
+
+def test_combined_two_symbols_sharing_a_name_are_never_requested():
+    # Same collision class as generate_file_descriptions' own test, but
+    # for the combined generate+polish path's own separate hashes/result
+    # collapse logic - a symbol needing "generate" colliding by name with
+    # one needing "polish" is exactly as ambiguous to the name-keyed
+    # response contract as two generate-mode symbols colliding.
+    module = _module(
+        "a.py",
+        [
+            _symbol("foo", start_line=1, end_line=2),
+            _symbol("foo", start_line=4, end_line=5, docstring="Existing doc."),
+        ],
+    )
+    adapter = _adapter(json.dumps({"foo": {"description": "Ambiguous - which foo?"}}))
+
+    result = generate_file_descriptions_combined(
+        module, ["def foo():", "    return 1", "", "def foo():", "    return 2"], adapter
+    )
 
     assert result == {}
     adapter.simple_completion.assert_not_called()

--- a/github-app/tests/test_live_docs.py
+++ b/github-app/tests/test_live_docs.py
@@ -182,6 +182,31 @@ def test_a_colliding_name_does_not_block_an_unrelated_symbol_in_the_same_file():
     assert result == {"bar": {"description": "Returns a constant.", "mode": "generated"}}
 
 
+def test_a_name_shared_across_different_docstring_states_is_not_treated_as_a_collision():
+    # Real Flash Review finding on the fix above: name_counts used to be
+    # computed across ALL symbols regardless of docstring state, so an
+    # undocumented "foo" got excluded just because a DIFFERENTLY
+    # documented "foo" also existed in the file - even though
+    # generate_file_descriptions' own single-mode request only ever sends
+    # the undocumented one. There's no real name collision in what this
+    # call's own request actually contains; excluding it was a false
+    # negative, not a safety measure.
+    module = _module(
+        "a.py",
+        [
+            _symbol("foo", start_line=1, end_line=2),
+            _symbol("foo", start_line=4, end_line=5, docstring="Existing doc."),
+        ],
+    )
+    adapter = _adapter(json.dumps({"foo": {"description": "Returns 1."}}))
+
+    result = generate_file_descriptions(
+        module, ["def foo():", "    return 1", "", "def foo():", "    return 2"], adapter
+    )
+
+    assert result == {"foo": {"description": "Returns 1.", "mode": "generated"}}
+
+
 def test_combined_handles_generate_and_polish_symbols_in_one_call():
     # One module with both an undocumented symbol (needs generate) and an
     # already-documented one (needs polish) - the whole point of the


### PR DESCRIPTION
## Summary
- `generate_file_descriptions` and `generate_file_descriptions_combined` (`github-app/scan_worker/live_docs.py`) key everything (the `hashes` dict, the model's response dict, the final `result` dict) purely by symbol name, with no disambiguation by kind or position. A file with two functions of the same name (a real, valid Python shape - a conditional redefinition, or a scanner capturing both branches of an `@overload` pair) sent two separate items to the model under the identical name key, but the model's own name-keyed response contract can only ever return one entry per name.
- Confirmed by execution: a module with two `foo` functions (different source, different `start_line`/`end_line`) both got sent as distinct request items, but the name-keyed `hashes`/`result` dicts kept only whichever wrote last - the first `foo`'s real description was silently dropped with no log line, and any future `content_hash`-based change-detection check for the first `foo` would compare against the second `foo`'s hash instead of its own.

## Fix
Exclude any symbol whose name collides with another symbol in the same file from ever being requested - both symbols degrade to no AI description rather than one silently corrupting the other's stored hash, matching this module's own fail-closed philosophy. Applied in `_symbols_needing_work`, shared by both `generate_file_descriptions` and `generate_file_descriptions_combined`, so both name-keyed collapse paths are covered by the same fix.

## Test plan
- [x] Added three regression tests: two same-named undocumented symbols never requested, a colliding name doesn't block an unrelated symbol in the same file, and the combined generate+polish path's own separate collapse logic covered too
- [x] Confirmed the two collision tests fail against the pre-fix code (stashed the fix, re-ran) and pass post-fix
- [x] `python3 -m pytest github-app/tests/test_live_docs.py -q` - 20 passed
- [x] `python3 -m pytest github-app/tests/ -q` - 1764 passed, 8 skipped

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK