### PR TITLE
fix: build_history_summary crashed the whole History tab on one older-schema snapshot

### DIFF
--- a/src/aletheore/dashboard.py
+++ b/src/aletheore/dashboard.py
@@ -72,8 +72,23 @@ def build_history_summary(repo_path: Path) -> list[dict]:
             evidence = json.loads(snapshot_path.read_text())
         except json.JSONDecodeError:
             continue
-        result.append(
-            {
+        # Real bug found via audit: this indexed straight into
+        # evidence["security"]["dependency_vulnerabilities"]["findings"]
+        # etc. with no schema check - unlike load_evidence_file, imported
+        # into this same file specifically to guard against exactly this.
+        # An older-schema snapshot (a real, reachable shape in this exact
+        # history/ directory - see history.py's own _compute_curated_diff,
+        # which had the identical gap) raised an uncaught KeyError here,
+        # and since this loop has no per-snapshot isolation, one bad
+        # snapshot anywhere in history killed the whole summary - the
+        # History tab's only caller, api_history, has no try/except of
+        # its own, so this propagated as an unhandled 500 for the entire
+        # session, not just that one snapshot's display. Skip a snapshot
+        # missing an expected key or shaped wrong, same "treat as
+        # unavailable" contract load_evidence_file already establishes,
+        # rather than losing every other snapshot's history alongside it.
+        try:
+            entry = {
                 "scanned_at": evidence["scanned_at"],
                 "module_count": len(evidence["repository"]["modules"]),
                 "secrets_findings": len(evidence["security"]["secrets"]["findings"]),
@@ -81,7 +96,9 @@ def build_history_summary(repo_path: Path) -> list[dict]:
                     evidence["security"]["dependency_vulnerabilities"]["findings"]
                 ),
             }
-        )
+        except (KeyError, TypeError):
+            continue
+        result.append(entry)
     return result
 
 

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -128,6 +128,32 @@ def test_build_history_summary_empty_when_no_history(tmp_path):
     assert build_history_summary(repo) == []
 
 
+def test_build_history_summary_skips_an_older_schema_snapshot_instead_of_crashing(tmp_path):
+    # Real bug found via audit: this indexed straight into
+    # evidence["security"]["dependency_vulnerabilities"]["findings"] with
+    # no schema check, unlike load_evidence_file (imported into this same
+    # file specifically to guard against this class of gap). An
+    # older-schema snapshot - missing a section a newer scan always
+    # writes - raised an uncaught KeyError, and with no per-snapshot
+    # isolation, one bad snapshot anywhere in history killed the whole
+    # summary (this function's only caller, api_history, has no
+    # try/except of its own, so it propagated as an unhandled 500).
+    repo = tmp_path / "repo"
+    history_dir = repo / ".aletheore" / "history"
+    history_dir.mkdir(parents=True)
+    older_schema_snapshot = make_evidence("2026-07-15T10:00:00+00:00")
+    del older_schema_snapshot["security"]["dependency_vulnerabilities"]
+    (history_dir / "2026-07-15T10-00-00.json").write_text(json.dumps(older_schema_snapshot))
+    (history_dir / "2026-07-15T11-00-00.json").write_text(
+        json.dumps(make_evidence("2026-07-15T11:00:00+00:00"))
+    )
+
+    result = build_history_summary(repo)
+
+    assert len(result) == 1
+    assert result[0]["scanned_at"] == "2026-07-15T11:00:00+00:00"
+
+
 def test_build_graph_summary_annotates_nodes_with_cluster_id():
     evidence = {
         "repository": {


### PR DESCRIPTION
## Summary
- `build_history_summary` (`src/aletheore/dashboard.py`) read each snapshot with a bare `json.loads`, catching only `json.JSONDecodeError` - unlike `load_evidence_file` (imported into this same file specifically to fix this class of bug elsewhere in it), it never checked schema version or required-field presence before indexing `evidence["security"]["dependency_vulnerabilities"]["findings"]` etc.
- An older-schema snapshot (a real, reachable shape in this exact `history/` directory - this session's own PR #614 already established this for `history.py`'s `_compute_curated_diff`, which had the identical gap) raised an uncaught `KeyError`. This function's only caller, `api_history`, has no try/except around it, so the `KeyError` propagated out of the Starlette route handler as an unhandled 500 - and because the loop had no per-snapshot isolation, one bad snapshot anywhere in history killed the History tab's XHR for the entire session, not just that one entry's display.

## Fix
Catch `(KeyError, TypeError)` around each snapshot's summary construction and skip just that snapshot - the same "treat as unavailable" contract `load_evidence_file` already establishes for a version-incompatible or malformed file, applied per-entry here instead of per-call.

## Test plan
- [x] Added `test_build_history_summary_skips_an_older_schema_snapshot_instead_of_crashing` to `src/tests/test_dashboard.py`
- [x] Confirmed it fails against the pre-fix code with the exact `KeyError` (stashed the fix, re-ran) and passes post-fix, correctly returning only the valid snapshot
- [x] `python3 -m pytest src/tests/ -q` - 1834 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK