### PR TITLE
fix: runtime-event parsing could attribute one exception's message to a different exception's file:line

### DIFF
--- a/src/aletheore/runtime_events.py
+++ b/src/aletheore/runtime_events.py
@@ -13,19 +13,34 @@ rather than building a universal adapter for every monitoring platform.
 from urllib.parse import urlparse
 
 
-def _last_frame(exception_values: list[dict]) -> dict | None:
+def _last_frame_and_source(exception_values: list[dict]) -> tuple[dict, dict] | None:
     """The most specific frame available for the most recent exception in
-    the chain - Sentry's own convention for "where the interesting code
-    is" is the last in_app frame (deepest into the application's own
-    code, past any framework/library frames); falls back to the last
-    frame at all when nothing is marked in_app."""
+    the chain that actually HAS one, paired with the exception it came
+    from - Sentry's own convention for "where the interesting code is" is
+    the last in_app frame (deepest into the application's own code, past
+    any framework/library frames); falls back to the last frame at all
+    when nothing is marked in_app.
+
+    Real bug found via audit: this used to return only the frame, while
+    parse_sentry_event separately took exception_values[-1] (the last
+    exception in the chain, unconditionally) for the exception_type/
+    exception_value fields. When the outermost exception in a chain has
+    no stacktrace frames of its own (a real, plausible shape - a wrapped/
+    re-raised exception with no captured traceback) but an earlier cause
+    does, this walk would fall through to that earlier exception's frame
+    while the caller still paired it with the OUTER exception's message -
+    attributing one exception's message to a different exception's
+    file:line. Returning the (frame, exception) pair together means the
+    exception fields reported always describe the SAME exception the
+    frame actually came from.
+    """
     for value in reversed(exception_values):
         frames = value.get("stacktrace", {}).get("frames") or []
         in_app_frames = [f for f in frames if f.get("in_app")]
         if in_app_frames:
-            return in_app_frames[-1]
+            return in_app_frames[-1], value
         if frames:
-            return frames[-1]
+            return frames[-1], value
     return None
 
 
@@ -34,17 +49,19 @@ def parse_sentry_event(payload: dict) -> dict | None:
     - never a partially-filled result a caller might mistake for real
     data."""
     exception_values = payload.get("exception", {}).get("values") or []
-    frame = _last_frame(exception_values)
-    if frame is None or not frame.get("filename") or frame.get("lineno") is None:
+    result = _last_frame_and_source(exception_values)
+    if result is None:
+        return None
+    frame, source_exception = result
+    if not frame.get("filename") or frame.get("lineno") is None:
         return None
 
-    last_exception = exception_values[-1] if exception_values else {}
     request = payload.get("request") or {}
     url = request.get("url", "")
 
     return {
-        "exception_type": last_exception.get("type", "Error"),
-        "exception_value": last_exception.get("value", ""),
+        "exception_type": source_exception.get("type", "Error"),
+        "exception_value": source_exception.get("value", ""),
         "file": frame["filename"],
         "line": frame["lineno"],
         "function": frame.get("function"),

--- a/src/tests/test_runtime_events.py
+++ b/src/tests/test_runtime_events.py
@@ -91,6 +91,45 @@ def test_parse_sentry_event_uses_the_last_exception_when_chained():
     assert result["file"] == "outer.py"
 
 
+def test_parse_sentry_event_pairs_the_exception_message_with_its_own_frame_not_a_causes_frame():
+    # Real bug found via audit: the outermost exception in a chain can
+    # legitimately have no stacktrace frames of its own (a wrapped/
+    # re-raised exception with no captured traceback) while an earlier
+    # cause does. The frame walk correctly falls back to that earlier
+    # exception's frame, but exception_type/exception_value used to be
+    # taken from exception_values[-1] unconditionally - pairing the OUTER
+    # exception's message with the EARLIER exception's file:line, a
+    # location that has nothing to do with the message being described.
+    event = _event(
+        exception={
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": "original failure in db layer",
+                    "stacktrace": {
+                        "frames": [{"filename": "db.py", "function": "query", "lineno": 42, "in_app": True}]
+                    },
+                },
+                {
+                    "type": "RuntimeError",
+                    "value": "wrapped: something went wrong",
+                    "stacktrace": {"frames": []},
+                },
+            ]
+        }
+    )
+
+    result = parse_sentry_event(event)
+
+    # The frame is still correctly the earlier exception's - but its
+    # message must come from that SAME exception, not the frameless outer
+    # one.
+    assert result["file"] == "db.py"
+    assert result["line"] == 42
+    assert result["exception_type"] == "ValueError"
+    assert result["exception_value"] == "original failure in db layer"
+
+
 def test_parse_sentry_event_returns_none_without_a_usable_frame():
     assert parse_sentry_event({"exception": {"values": []}}) is None
     assert parse_sentry_event({}) is None


### PR DESCRIPTION
## Summary
- `_last_frame` walked `exception_values` in reverse and returned the first frame it found with content, potentially from an **earlier** exception in the chain if the **last** one had empty/missing frames. But `parse_sentry_event` separately set `last_exception = exception_values[-1]` unconditionally for `exception_type`/`exception_value`.
- When the outermost exception in a chain has no stacktrace frames (a real, plausible shape - a wrapped/re-raised exception with no captured traceback of its own) but an earlier cause does, the returned dict paired the outer exception's **message** with the earlier exception's **file:line**.

## Confirmation
```python
values = [
    {"type": "ValueError", "value": "original failure in db layer",
     "stacktrace": {"frames": [{"filename": "db.py", "lineno": 42, "in_app": True}]}},
    {"type": "RuntimeError", "value": "wrapped: something went wrong", "stacktrace": {"frames": []}},
]
parse_sentry_event({"exception": {"values": values}, "request": {...}})
# {'exception_type': 'RuntimeError', 'exception_value': 'wrapped: something went wrong',
#  'file': 'db.py', 'line': 42, ...}
```
`db.py:42` is where the `ValueError` occurred, not the `RuntimeError` being described. Per this module's own docstring, this feeds `scan_worker.jobs._attach_recent_commit_for_failure` - a real production error investigation would get a commit correlated with a location that has nothing to do with the exception message shown alongside it.

## Fix
Renamed `_last_frame` to `_last_frame_and_source` and return the `(frame, exception)` pair together, so `parse_sentry_event` always pairs a frame with the exception it actually came from rather than unconditionally using the chain's last exception for the message fields.

## Test plan
- [x] Added a regression test reproducing the exact mismatch to `src/tests/test_runtime_events.py`
- [x] Confirmed it fails against the pre-fix code (stashed the fix, re-ran - got `'RuntimeError'` instead of the expected `'ValueError'`) and passes post-fix
- [x] The existing chained-exception test (where the last exception DOES have its own frame, so frame and message already matched) still passes unchanged
- [x] `python3 -m pytest src/tests/ -q` - 1834 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK