### PR TITLE
fix: infrastructure section of AIRview's repo-wide scanner context was the one section PR #586's unboundedness fix missed

### DIFF
--- a/github-app/scan_worker/airview_scanner_context.py
+++ b/github-app/scan_worker/airview_scanner_context.py
@@ -54,6 +54,7 @@ MAX_ENDPOINTS = 50
 MAX_VULNERABILITY_FINDINGS = 30
 MAX_DEAD_CODE_ENTRIES = 30
 MAX_ENV_VARS = 50
+MAX_INFRASTRUCTURE_SERVICES = 50
 
 
 def build_repo_context(evidence: dict) -> dict:
@@ -202,22 +203,34 @@ def _dead_code_context(dead_code: dict) -> dict | None:
 
 
 def _infrastructure_context(infrastructure: dict) -> dict | None:
-    services = [
+    # Real gap found via audit: this was the one section PR #586's
+    # unboundedness fix missed - every sibling section below got capped
+    # and sorted deterministically, but this one still flattens every
+    # docker-compose service across every compose file with no cap and no
+    # stable sort (dict/list iteration order, not guaranteed stable for
+    # identical evidence). A real monorepo with many small services
+    # (50 compose files x 20 services - not an extreme case) reproduces
+    # the same unbounded-payload-on-every-generation-call problem #586
+    # fixed everywhere else in this file.
+    services = sorted(
         service
         for entry in infrastructure.get("docker_compose_services", [])
         for service in entry.get("services", [])
-    ]
+    )
     has_k8s = bool(infrastructure.get("kubernetes_manifests"))
     has_terraform = bool(infrastructure.get("terraform_files"))
     has_helm = bool(infrastructure.get("helm_charts"))
     if not services and not (has_k8s or has_terraform or has_helm):
         return None
-    return {
-        "docker_compose_services": services,
+    result = {
+        "docker_compose_services": services[:MAX_INFRASTRUCTURE_SERVICES],
         "has_kubernetes_manifests": has_k8s,
         "has_terraform": has_terraform,
         "has_helm_charts": has_helm,
     }
+    if len(services) > MAX_INFRASTRUCTURE_SERVICES:
+        result["docker_compose_services_total_count"] = len(services)
+    return result
 
 
 def _env_vars_context(env_vars: dict) -> list[str] | None:

--- a/github-app/tests/test_airview_scanner_context.py
+++ b/github-app/tests/test_airview_scanner_context.py
@@ -10,6 +10,7 @@ from scan_worker.airview_scanner_context import (
     MAX_DEAD_CODE_ENTRIES,
     MAX_ENDPOINTS,
     MAX_ENV_VARS,
+    MAX_INFRASTRUCTURE_SERVICES,
     MAX_SCHEMA_RELATIONS,
     MAX_SCHEMA_TABLES,
     MAX_VULNERABILITY_FINDINGS,
@@ -160,7 +161,7 @@ def test_infrastructure_context_flattens_compose_services_and_flags_iac():
         "helm_charts": [],
     }}}
     infra = build_repo_context(evidence)["infrastructure"]
-    assert infra["docker_compose_services"] == ["web", "db"]
+    assert infra["docker_compose_services"] == ["db", "web"]
     assert infra["has_kubernetes_manifests"] is True
     assert infra["has_terraform"] is False
 
@@ -325,6 +326,21 @@ def test_dead_code_context_caps_deterministically_with_total_counts():
     assert dead_code["unreachable_modules"][0] == "legacy/m000.py"
     assert len(dead_code["unused_dependencies"]) == MAX_DEAD_CODE_ENTRIES
     assert dead_code["unused_dependencies_total_count"] == MAX_DEAD_CODE_ENTRIES + 5
+
+
+def test_infrastructure_context_caps_services_deterministically_with_total_count():
+    # Real bug found via audit: this was the one section PR #586's
+    # unboundedness fix missed - it never capped or deterministically
+    # sorted docker_compose_services, unlike every sibling section above.
+    evidence = {"repository": {"infrastructure": {
+        "docker_compose_services": [
+            {"services": [f"svc{i:03d}" for i in range(MAX_INFRASTRUCTURE_SERVICES + 5)]}
+        ],
+    }}}
+    infra = build_repo_context(evidence)["infrastructure"]
+    assert len(infra["docker_compose_services"]) == MAX_INFRASTRUCTURE_SERVICES
+    assert infra["docker_compose_services_total_count"] == MAX_INFRASTRUCTURE_SERVICES + 5
+    assert infra["docker_compose_services"][0] == "svc000"
 
 
 def test_env_vars_context_caps_deterministically():


### PR DESCRIPTION
## Summary
- PR #586 capped every repo-wide context section (schema tables/relations, endpoints, vulnerabilities, dead-code, env vars) after discovering they were all unbounded despite this module's own docstring promising "compact... since this rides on every single generation call in a build, not just one." `_infrastructure_context` was not touched by that fix and remained completely unbounded - `docker_compose_services` was flattened from every docker-compose file's services list with no cap, no `MAX_*` constant, and no deterministic sort (unlike every sibling section, which #586 also made sort-stable).
- Confirmed by execution against a realistic monorepo shape (50 docker-compose files, 20 services each - not an extreme case): 1000 services, ~12KB of JSON attached to every single AIRview generation call in the build. Same failure mode #586 fixed everywhere else in this file, same contradicted docstring promise - just the one section that shipped without the fix.

## Fix
Added `MAX_INFRASTRUCTURE_SERVICES` (matching the sibling `MAX_*` constants' value of 50) and capped `docker_compose_services` on a deterministic sorted prefix, with a `docker_compose_services_total_count` field when truncated - matching `dead_code`'s identical "dict already, keep the real total alongside the capped list" pattern, since `_infrastructure_context` already returns a dict.

## Test plan
- [x] Updated the existing two-service flattening test for the new sorted order
- [x] Added `test_infrastructure_context_caps_services_deterministically_with_total_count`
- [x] Confirmed the pre-fix code has no `MAX_INFRASTRUCTURE_SERVICES` constant at all (`ImportError` on the new test's import - stashed the fix, re-ran) and the fix's capping/sorting/total-count behavior passes post-fix
- [x] `python3 -m pytest github-app/tests/test_airview_scanner_context.py -q` - 28 passed
- [x] `python3 -m pytest github-app/tests/ -q` - 1766 passed, 8 skipped

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK