### PR TITLE
feat: add a durable per-feature LLM spend ledger

### DIFF
--- a/github-app/migrations/062_llm_spend_events.sql
+++ b/github-app/migrations/062_llm_spend_events.sql
@@ -1,0 +1,23 @@
+-- Durable per-event cost ledger. llm_spend itself only ever stored one
+-- blended monthly total per installation, with no feature breakdown - the
+-- only place a feature label ("flash_review", "airview_incremental", etc.)
+-- was ever attached to a cost was a log line, and logs don't survive a
+-- container restart (every deploy wipes them). Found via a real audit: a
+-- $8.29/8-day spend on one installation was completely unexplainable after
+-- the fact because nothing durable recorded which feature spent it. This
+-- table is written alongside the existing aggregate on every
+-- record_llm_spend call, so "where did the money go" is answerable from
+-- the database, not from logs that may already be gone.
+CREATE TABLE IF NOT EXISTS llm_spend_events (
+    id                BIGSERIAL PRIMARY KEY,
+    installation_id   BIGINT NOT NULL REFERENCES installations(installation_id) ON DELETE CASCADE,
+    feature           TEXT NOT NULL,
+    cost_usd          NUMERIC NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS llm_spend_events_lookup
+ON llm_spend_events (installation_id, created_at);
+
+CREATE INDEX IF NOT EXISTS llm_spend_events_feature_lookup
+ON llm_spend_events (installation_id, feature, created_at);

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -240,6 +240,24 @@ def get_llm_spend_this_month(dsn: str, installation_id: int) -> float:
             return float(row[0]) if row else 0.0
 
 
+def get_llm_spend_breakdown(dsn: str, installation_id: int, since: datetime) -> dict[str, float]:
+    """Per-feature cost breakdown for one installation since `since` - the
+    query llm_spend's own blended monthly total can never answer, and the
+    reason llm_spend_events exists (see record_llm_spend)."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT feature, SUM(cost_usd) FROM llm_spend_events
+                WHERE installation_id = %s AND created_at >= %s
+                GROUP BY feature
+                ORDER BY SUM(cost_usd) DESC
+                """,
+                (installation_id, since),
+            )
+            return {feature: float(total) for feature, total in cur.fetchall()}
+
+
 def record_llm_spend(
     dsn: str,
     installation_id: int,
@@ -273,6 +291,20 @@ def record_llm_spend(
                 (installation_id, cost_usd),
             )
             row = cur.fetchone()
+            # Durable per-feature breakdown - llm_spend above only ever
+            # keeps one blended monthly total per installation, and the
+            # logger.info below is the only other place a feature label
+            # was ever attached to a cost, which doesn't survive a
+            # container restart (every deploy wipes it). Same transaction
+            # as the aggregate update, so the two can never disagree.
+            if cost_usd > 0:
+                cur.execute(
+                    """
+                    INSERT INTO llm_spend_events (installation_id, feature, cost_usd)
+                    VALUES (%s, %s, %s)
+                    """,
+                    (installation_id, feature, cost_usd),
+                )
         conn.commit()
 
     if cost_usd > 0:

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -34,6 +34,7 @@ from scan_worker.db import (
     get_last_endpoint_health,
     get_last_reviewed_sha,
     get_latest_evidence,
+    get_llm_spend_breakdown,
     get_llm_spend_this_month,
     get_seconds_since_last_health_check,
     get_wiki_overview,
@@ -903,6 +904,47 @@ async def test_record_llm_spend_sync_warns_once_when_crossing_the_threshold(pool
     warnings = [r for r in caplog.records if "installation=301" in r.message]
     assert len(warnings) == 1
     assert "30%" in warnings[0].message
+
+
+@pytest.mark.asyncio
+async def test_record_llm_spend_writes_a_durable_per_feature_event(pool):
+    # Real gap found via audit: llm_spend only ever kept one blended monthly
+    # total per installation - the only place a feature label was ever
+    # attached to a cost was a log line, which doesn't survive a container
+    # restart. llm_spend_events is the durable fix.
+    await _insert_installation(pool, 1090, "a")
+    record_llm_spend(TEST_DATABASE_URL, 1090, 0.30, feature="flash_review")
+    record_llm_spend(TEST_DATABASE_URL, 1090, 0.20, feature="airview_incremental")
+    record_llm_spend(TEST_DATABASE_URL, 1090, 0.05, feature="flash_review")
+
+    since = datetime.now(timezone.utc) - timedelta(hours=1)
+    breakdown = get_llm_spend_breakdown(TEST_DATABASE_URL, 1090, since)
+
+    assert breakdown == {"flash_review": pytest.approx(0.35), "airview_incremental": pytest.approx(0.20)}
+
+
+@pytest.mark.asyncio
+async def test_record_llm_spend_does_not_write_an_event_for_zero_cost(pool):
+    # Matches the existing logger.info guard (cost_usd > 0) - a zero-cost
+    # cache-hit call shouldn't add a noise row to the ledger.
+    await _insert_installation(pool, 1091, "a")
+    record_llm_spend(TEST_DATABASE_URL, 1091, 0.0, feature="flash_review")
+
+    since = datetime.now(timezone.utc) - timedelta(hours=1)
+    breakdown = get_llm_spend_breakdown(TEST_DATABASE_URL, 1091, since)
+
+    assert breakdown == {}
+
+
+@pytest.mark.asyncio
+async def test_get_llm_spend_breakdown_excludes_events_before_since(pool):
+    await _insert_installation(pool, 1092, "a")
+    record_llm_spend(TEST_DATABASE_URL, 1092, 0.10, feature="flash_review")
+
+    since = datetime.now(timezone.utc) + timedelta(hours=1)  # in the future
+    breakdown = get_llm_spend_breakdown(TEST_DATABASE_URL, 1092, since)
+
+    assert breakdown == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `llm_spend` only ever kept one blended monthly total per installation - the only place a feature label (`flash_review`, `airview_incremental`, etc.) was ever attached to a cost was a log line, which doesn't survive a container restart (every deploy wipes it).
- Found via a real audit tonight: an $8.29/8-day spend on one installation was completely unexplainable after the fact, because nothing durable recorded which feature actually spent it. Only $0.19 was reconstructable from that day's still-live logs.

## Fix
- New `llm_spend_events` table: `(installation_id, feature, cost_usd, created_at)`.
- `record_llm_spend` now writes to it in the same transaction as the existing aggregate update, only when `cost_usd > 0` (matches the existing log-line guard - no noise rows for zero-cost cache hits).
- New `get_llm_spend_breakdown(dsn, installation_id, since)` reads the per-feature totals back out.

## Test plan
- [x] `test_record_llm_spend_writes_a_durable_per_feature_event` - multiple calls across two features aggregate correctly per feature
- [x] `test_record_llm_spend_does_not_write_an_event_for_zero_cost` - zero-cost calls don't add a row
- [x] `test_get_llm_spend_breakdown_excludes_events_before_since` - time-window filtering works
- [x] `python3 -m pytest github-app/tests/test_scan_worker_db.py -q` - 138 passed

Not merging - for review, per this session's standing practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)