### PR TITLE
fix: _trim_patch_context treated git's "no newline at end of file" marker as real content, injecting a fake line into the model-facing diff

### DIFF
--- a/github-app/scan_worker/github_api.py
+++ b/github-app/scan_worker/github_api.py
@@ -97,6 +97,21 @@ def _trim_patch_context(patch: str, context_lines: int = DIFF_PROMPT_CONTEXT_LIN
                 old_lines.append(text)
             elif tag == "+":
                 new_lines.append(text)
+            elif line == r"\ No newline at end of file":
+                # Real bug found via audit: git emits this literal marker
+                # line immediately after a +/- line whenever that version
+                # of the file has no trailing newline - a real, common
+                # shape (any hunk touching the last line of such a file),
+                # not an edge case. Its tag ("\\") matched neither "-" nor
+                # "+", so it fell into the else branch below and was
+                # treated as genuine unchanged context present in BOTH
+                # file versions - injecting a fake source line into the
+                # model-facing diff and inflating the reconstructed
+                # hunk's line count to match. Skipped entirely: it
+                # carries no real content, and difflib's own hunk-header
+                # math already correctly accounts for one fewer real line
+                # once it's excluded.
+                continue
             else:
                 old_lines.append(text)
                 new_lines.append(text)

--- a/github-app/tests/test_github_api.py
+++ b/github-app/tests/test_github_api.py
@@ -500,6 +500,37 @@ def test_trim_patch_context_handles_pure_removal():
     assert trimmed == patch
 
 
+def test_trim_patch_context_drops_the_no_newline_at_end_of_file_marker():
+    # Real bug found via audit: git emits a literal "\ No newline at end
+    # of file" line immediately after a +/- line whenever that version of
+    # the file lacks a trailing newline - a real, common shape, not an
+    # edge case (any hunk touching the last line of such a file). Its own
+    # tag ("\\") matched neither "-" nor "+", so it fell into the
+    # unchanged-context branch and was treated as real content present in
+    # BOTH old and new file versions - injecting a fake source line into
+    # the model-facing trimmed diff and inflating the hunk's reported
+    # line count to match.
+    patch = (
+        "@@ -1,3 +1,3 @@\n"
+        " line1\n"
+        " line2\n"
+        "-line3_old\n"
+        r"\ No newline at end of file" + "\n"
+        "+line3_new\n"
+        r"\ No newline at end of file"
+    )
+
+    trimmed = _trim_patch_context(patch, context_lines=1)
+
+    assert r"\ No newline at end of file" not in trimmed
+    assert trimmed == (
+        "@@ -2,2 +2,2 @@\n"
+        " line2\n"
+        "-line3_old\n"
+        "+line3_new"
+    )
+
+
 def test_fetch_pr_diff_packs_smallest_patches_first_under_a_total_byte_budget():
     # Real gap: fetch_pr_diff had no total size cap at all before this -
     # every file's patch got concatenated unconditionally. Packs smallest


### PR DESCRIPTION
## Summary
- `_trim_patch_context`'s hunk-body parser used `tag = line[:1]`, branching only on `-` and `+`; anything else - including git's literal `\ No newline at end of file` marker line, which every GitHub patch emits immediately after a `+`/`-` line when that version of the file has no trailing newline - fell into the unchanged-context `else` branch and was appended to **both** `old_lines` and `new_lines` as if it were genuine content present in both file versions.
- Confirmed by execution with a real GitHub patch shape (a line changed in a file with no trailing newline - a common, unremarkable shape): the marker text was rendered as a fake unchanged source line between the removed and added lines, and the hunk's reported line counts inflated (2->4) to include it. This is the text actually sent to the LLM in the diff prompt (`fetch_pr_diff`) - the model sees a nonexistent line of "code" it could reference or let confuse its line-number reasoning.
- Per this function's own docstring, grounding/citation validation always uses the untrimmed `PRDiff.patches`, never this trimmed text, so the corruption was confined to what the model reads, not to what a finding gets validated against - but it's still real and reachable.

## Fix
Explicitly skip the `\ No newline at end of file` marker line before it can reach the tag-branching logic - it carries no real content, and difflib's own hunk-header math already correctly accounts for one fewer real line once it's excluded.

## Test plan
- [x] Added `test_trim_patch_context_drops_the_no_newline_at_end_of_file_marker` to `github-app/tests/test_github_api.py`
- [x] Confirmed it fails against the pre-fix code (stashed the fix, re-ran - hunk header came out as `@@ -2,4 +2,4 @@` instead of the correct `@@ -2,2 +2,2 @@`, with the marker text embedded as a fake context line) and passes post-fix
- [x] `python3 -m pytest github-app/tests/test_github_api.py -q` - 49 passed
- [x] `python3 -m pytest github-app/tests/ -q` - 1766 passed, 8 skipped

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK