### PR TITLE
fix: CLI managed audit never surfaced the signed report's verification link

### DIFF
--- a/src/aletheore/managed_audit_client.py
+++ b/src/aletheore/managed_audit_client.py
@@ -59,7 +59,26 @@ def run_managed_audit_request(
             status_response.raise_for_status()
             body = status_response.json()
             if body["status"] == "finished":
-                return body["result"]
+                result = body["result"]
+                # Real bug found via audit: the server signs the report
+                # and persists a verification_token whenever signing
+                # succeeds (see jobs.py's run_managed_audit_api_job /
+                # get_managed_audit_status), but this was the only real
+                # consumer of that endpoint that never read it - the CLI
+                # user got the raw report text with no indication the
+                # report is a cryptographically signed, independently
+                # verifiable certificate, or where to verify it. The
+                # PR-comment path (run_managed_audit_pr_job) already
+                # appends the identical "[Verify this report](url)" link
+                # directly into the report text on success - matching
+                # that same convention here instead of inventing a new
+                # one, and keeping this function's return type a plain
+                # str rather than changing its public contract.
+                verification_token = body.get("verification_token")
+                if verification_token:
+                    verify_url = f"{api_base_url}/v1/audit/{verification_token}/verify"
+                    result = f"{result}\n\n[Verify this report]({verify_url})"
+                return result
             if body["status"] == "failed":
                 raise ManagedAuditError("managed audit job failed on the server")
             if poll_interval:

--- a/src/tests/test_managed_audit_client.py
+++ b/src/tests/test_managed_audit_client.py
@@ -110,6 +110,51 @@ def test_failed_job_raises_managed_audit_error():
         run_managed_audit_request({"scanned_at": "x"}, "real-token", http_client=client, poll_interval=0)
 
 
+def test_successful_request_appends_the_verify_link_when_a_verification_token_is_returned():
+    # Real bug found via audit: the server signs the report and persists
+    # a verification_token whenever signing succeeds (see jobs.py's
+    # run_managed_audit_api_job / get_managed_audit_status), but this
+    # function used to return only body["result"] - the CLI user got the
+    # raw report text with no indication the report is a cryptographically
+    # signed, independently verifiable certificate, or where to verify it.
+    # Matches the identical "[Verify this report](url)" convention the
+    # PR-comment path (run_managed_audit_pr_job) already uses on success.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(202, json={"job_id": "job-1"})
+        return httpx.Response(
+            200,
+            json={"status": "finished", "result": "# Report", "verification_token": "abc123"},
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://aletheore.com")
+    report = run_managed_audit_request(
+        {"scanned_at": "x"}, "real-token", api_base_url="https://aletheore.com",
+        http_client=client, poll_interval=0,
+    )
+
+    assert report == (
+        "# Report\n\n[Verify this report](https://aletheore.com/v1/audit/abc123/verify)"
+    )
+
+
+def test_successful_request_omits_the_verify_link_when_no_verification_token_is_returned():
+    # A failed signing (per jobs.py's own branch: `if verification_token
+    # is not None`) means the server itself never signed a certificate -
+    # nothing to link to, and no invented link should be appended.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(202, json={"job_id": "job-1"})
+        return httpx.Response(200, json={"status": "finished", "result": "# Report", "verification_token": None})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://aletheore.com")
+    report = run_managed_audit_request(
+        {"scanned_at": "x"}, "real-token", http_client=client, poll_interval=0
+    )
+
+    assert report == "# Report"
+
+
 def test_no_http_client_passed_closes_the_client_it_creates_on_success(monkeypatch):
     # Real bug found via audit: run_managed_audit_request created its own
     # httpx.Client whenever a caller didn't pass one in, but never closed


### PR DESCRIPTION
## Summary
- The server signs the report and persists a `verification_token` whenever signing succeeds (`jobs.py`'s `run_managed_audit_api_job` writes it to `job.meta`, `managed_audit_api.py`'s `get_managed_audit_status` includes it in the finished-job response), but `run_managed_audit_request` - the only real consumer of that endpoint (used by `cli.py`'s `aletheore audit` command) - did `return body["result"]` and never read `body["verification_token"]` at all. A repo-wide grep confirmed no other file anywhere reads that field from this endpoint.
- Every OTHER managed-audit surface already shows this: the PR-comment path (`run_managed_audit_pr_job`, `jobs.py`) builds and appends a `[Verify this report](verify_url)` link into the comment whenever signing succeeds. The CLI path silently dropped the one piece of information telling a user their report is a real, independently-verifiable, cryptographically signed (Ed25519) certificate - the server did the signing work, but the CLI user never saw it happened or where to verify it.

## Fix
Append the identical `[Verify this report](url)` link into the returned report text when a `verification_token` is present - matching the PR-comment path's own established convention exactly, rather than inventing a new one or changing this function's public return type (still a plain `str`, no call-site changes needed beyond this file's own tests).

## Test plan
- [x] Added two regression tests: the verify link is appended when a `verification_token` is returned, and correctly omitted when the server didn't sign (`verification_token` is `None`, e.g. after a real signing failure)
- [x] Confirmed the positive test fails against the pre-fix code (stashed the fix, re-ran) and passes post-fix
- [x] All 11 pre-existing tests pass unchanged
- [x] `python3 -m pytest src/tests/ -q` - 1842 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK