### PR TITLE
fix: LLM spend ledger dropped true-up spend, and clone tokens outlived a hard process kill

### DIFF
--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -264,6 +264,7 @@ def record_llm_spend(
     cost_usd: float,
     monthly_cap: float | None = None,
     feature: str = "unknown",
+    ledger_cost_usd: float | None = None,
 ) -> None:
     """monthly_cap: when given, logs a one-time warning if this call is the
     one that pushes the installation's spend this month past
@@ -277,7 +278,20 @@ def record_llm_spend(
     without this logged breakdown there is no way to later reconstruct
     which feature is actually driving an installation's spend. Every
     caller should pass a real label; "unknown" exists only so this doesn't
-    hard-fail if a future call site forgets to set it."""
+    hard-fail if a future call site forgets to set it.
+
+    ledger_cost_usd: the real total cost to attribute to `feature`, when it
+    differs from `cost_usd`. reserve_llm_spend's true-up callers pass
+    `real_cost - reserve_usd` as `cost_usd` (the aggregate delta, correct
+    for llm_spend's running total) - real found via audit: ledgering that
+    same delta into llm_spend_events silently drops the event whenever real
+    cost is at or under the reservation (delta <= 0, the common case per
+    reserve_llm_spend's own docstring), and under-reports by the reservation
+    amount otherwise, even though the delta can be a real, nonzero cost.
+    Pass the real total here so the per-feature breakdown doesn't collapse
+    to zero or under-count; omit it for a call that was never preceded by a
+    reservation (the two already coincide there: no reservation, no
+    discrepancy)."""
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -297,20 +311,21 @@ def record_llm_spend(
             # was ever attached to a cost, which doesn't survive a
             # container restart (every deploy wipes it). Same transaction
             # as the aggregate update, so the two can never disagree.
-            if cost_usd > 0:
+            ledger_amount = cost_usd if ledger_cost_usd is None else ledger_cost_usd
+            if ledger_amount > 0:
                 cur.execute(
                     """
                     INSERT INTO llm_spend_events (installation_id, feature, cost_usd)
                     VALUES (%s, %s, %s)
                     """,
-                    (installation_id, feature, cost_usd),
+                    (installation_id, feature, ledger_amount),
                 )
         conn.commit()
 
-    if cost_usd > 0:
+    if ledger_amount > 0:
         logger.info(
             "llm_spend: installation=%s feature=%s cost_usd=%.4f",
-            installation_id, feature, cost_usd,
+            installation_id, feature, ledger_amount,
         )
 
     if monthly_cap is not None and row is not None:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -372,8 +372,30 @@ def _run_git(args: list[str], **kwargs) -> None:
 
 
 def _clone_ref(url: str, ref: str, dest: Path) -> None:
+    # Scrubs the credentialed URL from dest/.git/config in a finally block
+    # right after cloning, the same reasoning and shape as
+    # _ensure_persistent_checkout's own reset: real audit found this
+    # ephemeral checkout's own docstring assumption ("deleted with the
+    # whole job_dir within minutes") only holds on a clean return or a
+    # Python exception, both of which run the caller's job-level
+    # try/finally cleanup - a hard process kill (e.g. the OOM kills this
+    # file's own _run_scan comment documents as real on large repos) skips
+    # that entirely and falls back to run_job_temp_dir_cleanup_job's
+    # periodic sweep, which only reaps a job_dir after
+    # JOB_TEMP_DIR_MAX_AGE_SECONDS (6 hours) - not "minutes". Nothing
+    # after this function ever needs to fetch against origin again (the
+    # scan that follows only runs local git/static-analysis commands), so
+    # there's no reason for the live token to still be on disk once the
+    # checkout itself is done.
     _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
-    subprocess.run(["git", "checkout", "-q", ref], cwd=dest, check=True)
+    try:
+        subprocess.run(["git", "checkout", "-q", ref], cwd=dest, check=True)
+    finally:
+        subprocess.run(
+            ["git", "remote", "set-url", "origin", _url_without_credentials(url)],
+            cwd=dest,
+            check=True,
+        )
 
 
 # Root for persistent, reused-across-scans checkouts (see
@@ -1364,13 +1386,24 @@ def run_push_scan_job(
 
 
 def _clone_pr_head(url: str, pr_number: int, dest: Path) -> None:
+    # See _clone_ref's identical scrub - this checkout still needs to
+    # fetch against the credentialed origin (the PR head isn't in the
+    # initial clone), so the scrub can only happen after that fetch, but
+    # nothing here needs it afterward either.
     _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
-    subprocess.run(
-        ["git", "fetch", "-q", "origin", f"refs/pull/{pr_number}/head"],
-        cwd=dest,
-        check=True,
-    )
-    subprocess.run(["git", "checkout", "-q", "FETCH_HEAD"], cwd=dest, check=True)
+    try:
+        subprocess.run(
+            ["git", "fetch", "-q", "origin", f"refs/pull/{pr_number}/head"],
+            cwd=dest,
+            check=True,
+        )
+        subprocess.run(["git", "checkout", "-q", "FETCH_HEAD"], cwd=dest, check=True)
+    finally:
+        subprocess.run(
+            ["git", "remote", "set-url", "origin", _url_without_credentials(url)],
+            cwd=dest,
+            check=True,
+        )
 
 
 def _git_rev_parse_head(repo_dir: Path) -> str | None:
@@ -2257,6 +2290,7 @@ def _run_flash_review(
     record_llm_spend(
         settings.database_url, installation_id, spend_accumulator["total"] - reserved_spend,
         monthly_cap=monthly_cap, feature="flash_review",
+        ledger_cost_usd=spend_accumulator["total"],
     )
 
     proposed = grounding_result.get("proposed", 0)
@@ -3956,9 +3990,15 @@ class _IncrementalSpendBudget:
             )
         cost = cost_for_usage(self.model, prompt_tokens, completion_tokens)
         delta = cost - self.next_call_reserve_usd
-        if delta == 0:
-            return
-        record_llm_spend(self.dsn, self.installation_id, delta, feature=self.feature)
+        # Always call through, even when delta == 0 (real cost landed
+        # exactly on the reservation) - the aggregate write is a genuine
+        # no-op then, but skipping the call used to also skip ledgering
+        # this call's real cost entirely (see record_llm_spend's
+        # ledger_cost_usd - the delta this reservation pattern produces is
+        # never the right amount to attribute to a feature).
+        record_llm_spend(
+            self.dsn, self.installation_id, delta, feature=self.feature, ledger_cost_usd=cost,
+        )
 
     def cap_message(self) -> str:
         return (

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -373,10 +373,10 @@ def _run_git(args: list[str], **kwargs) -> None:
 
 def _clone_ref(url: str, ref: str, dest: Path) -> None:
     # Scrubs the credentialed URL from dest/.git/config in a finally block
-    # right after cloning, the same reasoning and shape as
-    # _ensure_persistent_checkout's own reset: real audit found this
-    # ephemeral checkout's own docstring assumption ("deleted with the
-    # whole job_dir within minutes") only holds on a clean return or a
+    # covering the clone itself, the same reasoning and shape as
+    # _ensure_persistent_checkout's own fresh-clone path: real audit found
+    # this ephemeral checkout's own docstring assumption ("deleted with
+    # the whole job_dir within minutes") only holds on a clean return or a
     # Python exception, both of which run the caller's job-level
     # try/finally cleanup - a hard process kill (e.g. the OOM kills this
     # file's own _run_scan comment documents as real on large repos) skips
@@ -387,15 +387,28 @@ def _clone_ref(url: str, ref: str, dest: Path) -> None:
     # scan that follows only runs local git/static-analysis commands), so
     # there's no reason for the live token to still be on disk once the
     # checkout itself is done.
-    _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
+    #
+    # Flash Review finding on the first version of this fix: the clone
+    # call itself sat before the try, so an interruption during the clone
+    # (not just the checkout after it) skipped the scrub entirely. Real
+    # for the catchable subset of interruptions this fix already protects
+    # against elsewhere in this same file (RQ's signal-based job_timeout,
+    # not a raw OOM SIGKILL - no try/finally anywhere can run after that,
+    # regardless of placement, since the whole process is gone) - moved
+    # inside the try, mirroring _ensure_persistent_checkout's own
+    # fresh-clone path exactly, including its `.git` existence guard
+    # (clone interrupted before `git init` ever ran leaves no `.git` to
+    # run `git remote set-url` against).
     try:
+        _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
         subprocess.run(["git", "checkout", "-q", ref], cwd=dest, check=True)
     finally:
-        subprocess.run(
-            ["git", "remote", "set-url", "origin", _url_without_credentials(url)],
-            cwd=dest,
-            check=True,
-        )
+        if (dest / ".git").exists():
+            subprocess.run(
+                ["git", "remote", "set-url", "origin", _url_without_credentials(url)],
+                cwd=dest,
+                check=True,
+            )
 
 
 # Root for persistent, reused-across-scans checkouts (see
@@ -1386,12 +1399,14 @@ def run_push_scan_job(
 
 
 def _clone_pr_head(url: str, pr_number: int, dest: Path) -> None:
-    # See _clone_ref's identical scrub - this checkout still needs to
-    # fetch against the credentialed origin (the PR head isn't in the
-    # initial clone), so the scrub can only happen after that fetch, but
-    # nothing here needs it afterward either.
-    _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
+    # See _clone_ref's identical scrub (including the Flash Review finding
+    # that moved the clone itself inside the try, and why the `.git`
+    # existence guard is needed) - this checkout still needs to fetch
+    # against the credentialed origin (the PR head isn't in the initial
+    # clone), so the scrub can only happen after that fetch, but nothing
+    # here needs it afterward either.
     try:
+        _run_git(["git", "clone", "-q", "--no-checkout", url, str(dest)])
         subprocess.run(
             ["git", "fetch", "-q", "origin", f"refs/pull/{pr_number}/head"],
             cwd=dest,
@@ -1399,11 +1414,12 @@ def _clone_pr_head(url: str, pr_number: int, dest: Path) -> None:
         )
         subprocess.run(["git", "checkout", "-q", "FETCH_HEAD"], cwd=dest, check=True)
     finally:
-        subprocess.run(
-            ["git", "remote", "set-url", "origin", _url_without_credentials(url)],
-            cwd=dest,
-            check=True,
-        )
+        if (dest / ".git").exists():
+            subprocess.run(
+                ["git", "remote", "set-url", "origin", _url_without_credentials(url)],
+                cwd=dest,
+                check=True,
+            )
 
 
 def _git_rev_parse_head(repo_dir: Path) -> str | None:

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -376,6 +376,64 @@ def test_clone_ref_scrubs_the_token_even_when_checkout_fails(tmp_path, monkeypat
     assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
 
 
+def test_clone_ref_scrubs_the_token_even_when_the_clone_itself_is_interrupted(tmp_path, monkeypatch):
+    # Real Flash Review finding on the first version of this fix: the
+    # clone call sat before the try, so an interruption DURING the clone
+    # (e.g. an RQ job timeout - not a raw OOM SIGKILL, which no
+    # try/finally placement can survive regardless of where it sits)
+    # skipped the scrub entirely, even though the clone had already
+    # written the credentialed URL into .git/config by the time it was
+    # interrupted.
+    from scan_worker.jobs import _clone_ref
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            # git writes .git/config with the credentialed remote before
+            # the clone finishes populating the working tree - simulate
+            # an interruption after that point.
+            os.makedirs(os.path.join(args[-1], ".git"), exist_ok=True)
+            raise subprocess.CalledProcessError(1, args)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    dest = tmp_path / "ephemeral-clone-interrupted"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    with pytest.raises(subprocess.CalledProcessError):
+        _clone_ref(credentialed_url, "somesha", dest)
+
+    set_url_calls = [c for c in calls if c[:3] == ["git", "remote", "set-url"]]
+    assert set_url_calls, "expected the scrub to still run even though the clone itself was interrupted"
+    assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
+
+
+def test_clone_ref_does_not_attempt_a_scrub_when_the_clone_never_created_a_git_dir(tmp_path, monkeypatch):
+    # The other half: a clone interrupted before git ever created .git at
+    # all (e.g. a DNS failure) must not attempt a `git remote set-url`
+    # against a directory that has no repo in it.
+    from scan_worker.jobs import _clone_ref
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            raise subprocess.CalledProcessError(1, args)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    dest = tmp_path / "ephemeral-never-cloned"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    with pytest.raises(subprocess.CalledProcessError):
+        _clone_ref(credentialed_url, "somesha", dest)
+
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
+
+
 def test_clone_pr_head_does_not_leave_a_live_token_on_disk(tmp_path, monkeypatch):
     # Same real gap as _clone_ref above, for the PR-head clone path (used
     # by run_managed_audit_pr_job).
@@ -399,6 +457,54 @@ def test_clone_pr_head_does_not_leave_a_live_token_on_disk(tmp_path, monkeypatch
     assert set_url_calls, "expected a 'git remote set-url' call scrubbing the clone"
     assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
     assert "livetoken" not in set_url_calls[-1][-1]
+
+
+def test_clone_pr_head_scrubs_the_token_even_when_the_clone_itself_is_interrupted(tmp_path, monkeypatch):
+    # Same Flash Review finding as _clone_ref's identical test above.
+    from scan_worker.jobs import _clone_pr_head
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            os.makedirs(os.path.join(args[-1], ".git"), exist_ok=True)
+            raise subprocess.CalledProcessError(1, args)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    dest = tmp_path / "pr-head-clone-interrupted"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    with pytest.raises(subprocess.CalledProcessError):
+        _clone_pr_head(credentialed_url, 42, dest)
+
+    set_url_calls = [c for c in calls if c[:3] == ["git", "remote", "set-url"]]
+    assert set_url_calls, "expected the scrub to still run even though the clone itself was interrupted"
+    assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
+
+
+def test_clone_pr_head_does_not_attempt_a_scrub_when_the_clone_never_created_a_git_dir(
+    tmp_path, monkeypatch
+):
+    from scan_worker.jobs import _clone_pr_head
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            raise subprocess.CalledProcessError(1, args)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    dest = tmp_path / "pr-head-never-cloned"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    with pytest.raises(subprocess.CalledProcessError):
+        _clone_pr_head(credentialed_url, 42, dest)
+
+    assert [c for c in calls if c[:3] == ["git", "remote", "set-url"]] == []
 
 
 def test_incremental_spend_budget_record_usage_ledgers_the_real_cost_not_the_delta(monkeypatch):

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -310,6 +310,150 @@ def test_ensure_persistent_checkout_strips_credentials_on_reuse_path_too(tmp_pat
     assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
 
 
+def test_clone_ref_does_not_leave_a_live_token_on_disk(tmp_path, monkeypatch):
+    # Real gap found via audit: _clone_ref's own docstring assumption
+    # ("deleted with the whole job_dir within minutes" - see
+    # _ensure_persistent_checkout's docstring, which contrasts against
+    # this function by name) only holds on a clean return or a Python
+    # exception, both of which run the caller job's own try/finally
+    # job_dir cleanup. A hard process kill (this file's own _run_scan
+    # comment documents real OOM kills on large repos) skips that
+    # entirely and falls back to run_job_temp_dir_cleanup_job's periodic
+    # sweep, which only reaps a job_dir after JOB_TEMP_DIR_MAX_AGE_SECONDS
+    # (6 hours) - not "minutes". Nothing after this function ever needs to
+    # fetch against origin again, so the live token has no reason to still
+    # be on disk once the checkout is done.
+    from scan_worker.jobs import _clone_ref
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            os.makedirs(os.path.join(args[-1], ".git"), exist_ok=True)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    dest = tmp_path / "ephemeral"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    _clone_ref(credentialed_url, "somesha", dest)
+
+    set_url_calls = [c for c in calls if c[:3] == ["git", "remote", "set-url"]]
+    assert set_url_calls, "expected a 'git remote set-url' call scrubbing the clone"
+    assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
+    assert "livetoken" not in set_url_calls[-1][-1]
+
+
+def test_clone_ref_scrubs_the_token_even_when_checkout_fails(tmp_path, monkeypatch):
+    # Proves the scrub runs from a finally block, not just after a
+    # successful checkout - a failed checkout must not leave the
+    # credentialed .git/config behind for run_job_temp_dir_cleanup_job's
+    # 6-hour sweep to be the only thing standing between a live token and
+    # disk.
+    from scan_worker.jobs import _clone_ref
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            os.makedirs(os.path.join(args[-1], ".git"), exist_ok=True)
+            return subprocess.CompletedProcess(args, 0)
+        if args[:2] == ["git", "checkout"]:
+            raise subprocess.CalledProcessError(1, args)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    dest = tmp_path / "ephemeral-fail"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    with pytest.raises(subprocess.CalledProcessError):
+        _clone_ref(credentialed_url, "badsha", dest)
+
+    set_url_calls = [c for c in calls if c[:3] == ["git", "remote", "set-url"]]
+    assert set_url_calls, "expected the scrub to still run in a finally block"
+    assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
+
+
+def test_clone_pr_head_does_not_leave_a_live_token_on_disk(tmp_path, monkeypatch):
+    # Same real gap as _clone_ref above, for the PR-head clone path (used
+    # by run_managed_audit_pr_job).
+    from scan_worker.jobs import _clone_pr_head
+
+    calls = []
+
+    def fake_run(args, cwd=None, check=None):
+        calls.append(args)
+        if args[:2] == ["git", "clone"]:
+            os.makedirs(os.path.join(args[-1], ".git"), exist_ok=True)
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr("scan_worker.jobs.subprocess.run", fake_run)
+
+    dest = tmp_path / "pr-head"
+    credentialed_url = "https://x-access-token:livetoken@github.com/org/repo.git"
+    _clone_pr_head(credentialed_url, 42, dest)
+
+    set_url_calls = [c for c in calls if c[:3] == ["git", "remote", "set-url"]]
+    assert set_url_calls, "expected a 'git remote set-url' call scrubbing the clone"
+    assert set_url_calls[-1][-1] == "https://github.com/org/repo.git"
+    assert "livetoken" not in set_url_calls[-1][-1]
+
+
+def test_incremental_spend_budget_record_usage_ledgers_the_real_cost_not_the_delta(monkeypatch):
+    # Real gap found via audit: record_usage passed the true-up delta
+    # (cost - next_call_reserve_usd) as both the aggregate update AND the
+    # per-feature ledger amount - correct for the former, wrong for the
+    # latter, the same class of bug as run_flash_review_job's own
+    # dollar-cap true-up (see record_llm_spend's ledger_cost_usd).
+    from scan_worker.jobs import _IncrementalSpendBudget
+
+    calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.record_llm_spend",
+        lambda dsn, iid, delta, **k: calls.append((delta, k)),
+    )
+    monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a, **k: 0.03)
+
+    budget = _IncrementalSpendBudget(
+        "dsn", 1, "model", monthly_cap=5.0, next_call_reserve_usd=0.05, feature="airview_full_build",
+    )
+    budget.record_usage(prompt_tokens=100, completion_tokens=50)
+
+    assert len(calls) == 1
+    delta, kwargs = calls[0]
+    assert delta == pytest.approx(0.03 - 0.05)
+    assert kwargs["ledger_cost_usd"] == pytest.approx(0.03)
+    assert kwargs["feature"] == "airview_full_build"
+
+
+def test_incremental_spend_budget_record_usage_still_ledgers_when_cost_exactly_matches_reservation(
+    monkeypatch,
+):
+    # Before this fix, delta == 0 short-circuited with an early return,
+    # silently skipping the ledger event entirely even though a real,
+    # nonzero cost was spent - it just happened to equal the reservation.
+    from scan_worker.jobs import _IncrementalSpendBudget
+
+    calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.record_llm_spend",
+        lambda dsn, iid, delta, **k: calls.append((delta, k)),
+    )
+    monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a, **k: 0.05)
+
+    budget = _IncrementalSpendBudget(
+        "dsn", 1, "model", monthly_cap=5.0, next_call_reserve_usd=0.05, feature="docs_incremental",
+    )
+    budget.record_usage(prompt_tokens=100, completion_tokens=50)
+
+    assert len(calls) == 1
+    delta, kwargs = calls[0]
+    assert delta == 0
+    assert kwargs["ledger_cost_usd"] == pytest.approx(0.05)
+
+
 def test_run_pr_scan_job_uses_persistent_checkout_and_unchanged_cache_for_head(
     bare_repo_with_two_commits, monkeypatch
 ):

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -1006,6 +1006,44 @@ async def test_get_llm_spend_breakdown_excludes_events_before_since(pool):
 
 
 @pytest.mark.asyncio
+async def test_record_llm_spend_ledgers_the_real_cost_not_the_true_up_delta(pool):
+    # Real gap found via audit: reserve_llm_spend's true-up callers pass
+    # (real_cost - reserve_usd) as cost_usd - the correct delta for
+    # llm_spend's running total, but before this fix that same delta was
+    # also what got ledgered into llm_spend_events. Real cost under the
+    # reservation (the common case per reserve_llm_spend's own docstring)
+    # made the delta <= 0, so no event was written at all despite real
+    # money being spent - exactly defeating the ledger's purpose.
+    await _insert_installation(pool, 1093, "a")
+    reserve_llm_spend(TEST_DATABASE_URL, 1093, reserve_usd=0.05, monthly_cap=5.0)
+    real_cost = 0.03  # under the reservation - delta is negative
+    record_llm_spend(
+        TEST_DATABASE_URL, 1093, real_cost - 0.05, feature="flash_review", ledger_cost_usd=real_cost,
+    )
+
+    since = datetime.now(timezone.utc) - timedelta(hours=1)
+    breakdown = get_llm_spend_breakdown(TEST_DATABASE_URL, 1093, since)
+
+    assert breakdown == {"flash_review": pytest.approx(real_cost)}
+    # The aggregate total must still reflect the true-up delta, not
+    # ledger_cost_usd - the two are deliberately allowed to differ.
+    assert get_llm_spend_this_month(TEST_DATABASE_URL, 1093) == pytest.approx(real_cost)
+
+
+@pytest.mark.asyncio
+async def test_record_llm_spend_ledger_cost_usd_defaults_to_cost_usd_when_omitted(pool):
+    # Non-true-up callers (no reservation involved) never pass
+    # ledger_cost_usd - must behave exactly as before this fix.
+    await _insert_installation(pool, 1094, "a")
+    record_llm_spend(TEST_DATABASE_URL, 1094, 0.12, feature="managed_audit")
+
+    since = datetime.now(timezone.utc) - timedelta(hours=1)
+    breakdown = get_llm_spend_breakdown(TEST_DATABASE_URL, 1094, since)
+
+    assert breakdown == {"managed_audit": pytest.approx(0.12)}
+
+
+@pytest.mark.asyncio
 async def test_get_extra_seats_sync_defaults_to_zero(pool):
     await _insert_installation(pool, 301, "a")
     assert get_extra_seats(TEST_DATABASE_URL, 301) == 0


### PR DESCRIPTION
## Summary

Two real, execution-confirmed gaps found via adversarial audit of `scan_worker/db.py`'s spend-tracking cluster and `jobs.py`'s git-checkout cluster.

**1. Per-feature spend ledger silently dropped true-up spend** (`scan_worker/db.py`, `scan_worker/jobs.py`)

The new `llm_spend_events` ledger (#635) records whatever `cost_usd` it's given. That's correct for direct `record_llm_spend` calls, but `reserve_llm_spend`'s true-up callers - `run_flash_review_job`'s dollar-cap true-up and `_IncrementalSpendBudget.record_usage` (used by AIRview/Docs full builds) - pass `real_cost - reserve_usd` as that argument, since it's also the correct delta for `llm_spend`'s running total.

Confirmed by real execution against the test DB:
```
reserve_usd=0.05, real_cost=0.03 (under reservation - the common case):
  aggregate total: 0.03   <- correct
  per-feature breakdown: {}   <- WRONG, real money was spent
```
Real cost at or under the reservation made the ledger event skip entirely (the `cost_usd > 0` guard); over the reservation, only the excess was recorded. The aggregate total was always right - only the per-feature breakdown was wrong, for exactly the features (Flash Review) most likely to drive spend, defeating the ledger's whole stated purpose.

Fix: `record_llm_spend` takes an optional `ledger_cost_usd`, defaulting to `cost_usd` (non-true-up callers unaffected). Both true-up call sites now pass the real total cost through it. Also fixed `_IncrementalSpendBudget.record_usage`'s `delta == 0` early return, which used to skip the ledger event entirely on the (real, nonzero) exact-match case too.

**2. Ephemeral clone tokens could sit on disk for hours after a process kill** (`scan_worker/jobs.py`)

`_clone_ref`/`_clone_pr_head` embed a live installation token in `.git/config` and never scrub it, relying on the docstring's assumption that the checkout is "deleted with the whole job_dir within minutes" via the calling job's own `try/finally`. That holds on a clean return or a Python exception - not on a hard process kill, which this file's own `_run_scan` comment documents as a real, observed event (OOM kills on large repos). A killed worker skips straight to `run_job_temp_dir_cleanup_job`'s periodic sweep, which only reaps a `job_dir` after 6 hours.

Neither function needs the credentialed remote again after the checkout completes (confirmed: nothing downstream runs another `git fetch`/`pull` against `origin`), so both now scrub the URL the same way `_ensure_persistent_checkout` already does for its own long-lived checkout - closing the exposure window from up to 6 hours down to the few seconds the checkout itself takes, including on a failed checkout (scrub runs in a `finally`).

## Test plan
- [x] `test_scan_worker_db.py` (141 tests) - full pass
- [x] `test_jobs.py` (224 tests) - full pass
- [x] New regression tests confirmed to fail pre-fix, pass post-fix:
  - `test_record_llm_spend_ledgers_the_real_cost_not_the_true_up_delta`, `test_record_llm_spend_ledger_cost_usd_defaults_to_cost_usd_when_omitted`
  - `test_incremental_spend_budget_record_usage_ledgers_the_real_cost_not_the_delta`, `test_incremental_spend_budget_record_usage_still_ledgers_when_cost_exactly_matches_reservation`
  - `test_clone_ref_does_not_leave_a_live_token_on_disk`, `test_clone_ref_scrubs_the_token_even_when_checkout_fails`, `test_clone_pr_head_does_not_leave_a_live_token_on_disk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK

Not merging - for review only, per this session's standing audit-sweep practice.