### PR TITLE
fix: an unguarded email alert could silently skip Pushover, and Flash Review's own failure comment could fail invisibly

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1772,8 +1772,23 @@ def run_flash_review_job(
             _post_flash_review_failure_comment(
                 settings, installation_id, repo_full_name, pr_number, exc
             )
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as comment_exc:  # noqa: BLE001
+            # Real gap found via audit: this was a bare `pass` with no
+            # logging at all, unlike _try_post_failure_comment (used by
+            # run_pr_scan_job/run_managed_audit_api_job for the identical
+            # situation), which logs a warning when the failure comment
+            # itself fails to post. Flash Review was the one job whose
+            # "couldn't even tell the customer it failed" case left zero
+            # trace anywhere - an ops issue in this specific path (e.g.
+            # token expiry, a GitHub API auth failure) would be invisible
+            # until a customer complained.
+            logging.getLogger("scan_worker.jobs").warning(
+                "flash review failed to post failure comment for installation=%s repo=%s pr=%s (%s)",
+                installation_id,
+                repo_full_name,
+                pr_number,
+                comment_exc,
+            )
     finally:
         # A reservation that never became a real review (every free-tier
         # provider failed, no provider keys configured, or an unrelated
@@ -2419,14 +2434,29 @@ def _send_alerts_if_configured(installation: dict, message: dict) -> None:
     if alert_email:
         settings = get_settings()
         target_id = installation.get("target_id")
-        enqueue_transactional_email(
-            settings.redis_url,
-            dedupe_key=f"health_alert:{target_id}:{int(time.time())}",
-            template_name="health_alert",
-            template_arg=message["text"],
-            to_email=alert_email,
-            installation_id=installation.get("installation_id"),
-        )
+        # Real gap found via audit: unlike the Slack/Teams and Pushover
+        # branches, this call was unguarded - enqueue_transactional_email
+        # calls get_redis_client() then Queue(...).enqueue(...), both of
+        # which can raise (a transient Redis blip is not hypothetical).
+        # An unhandled exception here propagated out of this function
+        # entirely, skipping Pushover below even when it's configured and
+        # healthy - exactly the "one channel's failure takes down the
+        # others" bug this docstring already documents fixing for the
+        # other two channels, just not for email.
+        try:
+            enqueue_transactional_email(
+                settings.redis_url,
+                dedupe_key=f"health_alert:{target_id}:{int(time.time())}",
+                template_name="health_alert",
+                template_arg=message["text"],
+                to_email=alert_email,
+                installation_id=installation.get("installation_id"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger("scan_worker.jobs").warning(
+                "email alert failed for installation=%s (%s)",
+                installation.get("installation_id"), exc,
+            )
 
     pushover_user_key = installation.get("pushover_user_key")
     if pushover_user_key:

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3221,6 +3221,51 @@ def test_flash_review_job_posts_failure_comment_instead_of_raising(monkeypatch):
     assert "GitHub API timed out" in posted["body"]
 
 
+def test_flash_review_job_logs_when_it_cannot_even_post_the_failure_comment(monkeypatch, caplog):
+    # Real gap found via audit: this inner except was a bare `pass` with no
+    # logging at all - unlike _try_post_failure_comment (used by
+    # run_pr_scan_job/run_managed_audit_api_job for the identical
+    # situation), which logs a warning when the failure comment itself
+    # fails to post. An ops issue in this specific path (e.g. token
+    # expiry, a GitHub API auth failure) was invisible until a customer
+    # complained.
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs._evidence_by_head_sha_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+
+    def _raise_diff_fetch(*a, **k):
+        raise RuntimeError("GitHub API timed out")
+
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", _raise_diff_fetch)
+
+    def _raise_on_comment(*a, **k):
+        raise RuntimeError("installation token expired")
+
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", _raise_on_comment)
+
+    from scan_worker.jobs import run_flash_review_job
+
+    with caplog.at_level("WARNING", logger="scan_worker.jobs"):
+        run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
+
+    assert any(
+        "flash review failed to post failure comment" in record.message
+        and "installation token expired" in record.message
+        for record in caplog.records
+    )
+
+
 def test_flash_review_job_passes_referenced_symbol_context_to_review_diff(monkeypatch):
     # Real hallucination this exists to prevent: Flash Review claimed an
     # imported function needed `await`, citing "usage in admin.py", when
@@ -4118,6 +4163,50 @@ def test_send_alerts_if_configured_isolates_a_slack_failure_from_other_channels(
     )
 
     assert len(email_sent) == 1
+    assert len(pushover_sent) == 1
+
+
+def test_send_alerts_if_configured_isolates_an_email_failure_from_pushover(monkeypatch):
+    # Real bug found via audit, the same class as the Slack isolation test
+    # above but for the email branch: unlike Slack/Teams and Pushover,
+    # enqueue_transactional_email's call was unguarded -
+    # get_redis_client()/Queue(...).enqueue(...) can both raise (a
+    # transient Redis blip is not hypothetical), and that exception
+    # propagated out of this function entirely, skipping Pushover below
+    # even when it's configured and healthy.
+    from app_server.config import get_settings
+    from scan_worker.jobs import _send_alerts_if_configured
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setenv("PUSHOVER_API_TOKEN", "server-app-token")
+    get_settings.cache_clear()
+
+    slack_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_health_alert", lambda *a, **k: slack_sent.append(a)
+    )
+
+    def failing_enqueue(*a, **k):
+        raise RuntimeError("redis connection refused")
+
+    monkeypatch.setattr("scan_worker.jobs.enqueue_transactional_email", failing_enqueue)
+    pushover_sent = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.send_pushover_alert", lambda *a, **k: pushover_sent.append(a)
+    )
+
+    _send_alerts_if_configured(
+        {
+            "installation_id": 1,
+            "target_id": 900,
+            "webhook_url": "https://slack.example.com/webhook",
+            "alert_email": "ops@example.com",
+            "pushover_user_key": "u" * 30,
+        },
+        {"text": "down"},
+    )
+
+    assert len(slack_sent) == 1
     assert len(pushover_sent) == 1
 
 


### PR DESCRIPTION
## Summary

Two real, execution-confirmed gaps found via adversarial audit of `jobs.py`'s failure-comment and token-refresh cluster.

**1. `_send_alerts_if_configured`'s email branch was unguarded, defeating its own documented per-channel isolation**

The function's docstring documents an earlier fix: an unguarded exception used to skip email/Pushover entirely instead of just the failing channel, so the Slack/Teams and Pushover branches were each wrapped in `try/except`. The email branch never got the same treatment - `enqueue_transactional_email()` calls `get_redis_client()` then `Queue(...).enqueue(...)`, both of which can raise (a transient Redis blip, not a hypothetical).

Confirmed by real execution: monkeypatched `enqueue_transactional_email` to raise, called `_send_alerts_if_configured` with all three channels configured - the exception propagated out of the function entirely, and Pushover was never attempted, even though it was configured and its own send call would have succeeded.

Worse: every call site wraps the *whole per-target sweep body* in one outer try/except for loop isolation, not per-alert-call - so a transient Redis blip during the email enqueue didn't just skip Pushover for that one alert, it silently aborted the rest of that target's health-check tick until the next sweep interval.

Fix: wrapped the email branch in try/except, logging a warning on failure - the same pattern already used for Slack/Teams and Pushover.

**2. Flash Review's own failure-comment posting could fail with zero trace**

`run_flash_review_job`'s exception handler tries to post a failure comment to the PR, and swallows any error from *that* with a bare `except Exception: pass` - no logging at all. Every other job in this file (`run_pr_scan_job`, `run_managed_audit_api_job`) uses `_try_post_failure_comment` for the identical situation, which logs a warning when the failure comment itself fails to post.

Flash Review was the one job whose "couldn't even tell the customer it failed" case left zero trace anywhere - an ops issue in this specific path (token expiry, a GitHub API auth failure) was invisible until a customer complained.

Fix: logs the same way the other jobs already do, naming the installation/repo/PR and the underlying error.

## Test plan
- [x] `test_jobs.py` (221 tests) - full pass
- [x] New regression tests confirmed to fail pre-fix, pass post-fix:
  - `test_send_alerts_if_configured_isolates_an_email_failure_from_pushover`
  - `test_flash_review_job_logs_when_it_cannot_even_post_the_failure_comment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK

Not merging - for review only, per this session's standing audit-sweep practice.