### PR TITLE
fix: marketing copy had a stale price and a false model claim

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -40,7 +40,7 @@
       {
         "@type": "Offer",
         "name": "Aletheore Flash",
-        "price": "6",
+        "price": "8",
         "priceCurrency": "USD",
         "description": "Automatic PR reviews on every push, up to 800/month, one model."
       },
@@ -49,7 +49,7 @@
         "name": "Aletheore AIR",
         "price": "29.99",
         "priceCurrency": "USD",
-        "description": "Up to 3 team members. Everything in Flash plus a second-model verification pass, managed audits, and AIRview builds run on an OpenAI frontier model."
+        "description": "Up to 3 team members. Everything in Flash plus a second-model verification pass, managed audits, and AIRview builds run on DeepSeek."
       }
     ],
     "featureList": [
@@ -61,7 +61,7 @@
       "MCP server for coding agents",
       "Multi-provider AI audit reports (Claude, OpenAI, Gemini, Mistral, Grok, DeepSeek, Ollama)",
       "GitHub App: automatic PR comments and branch-protection check runs",
-      "AI-powered managed audit reports on pull requests, written by an OpenAI frontier model",
+      "AI-powered managed audit reports on pull requests, written by DeepSeek",
       "Automatic Flash reviews on every pull request push (Flash tier and up); AIR adds a second, independent model that re-checks every finding against the diff before it's shown",
       "Slack/Teams alerts on new findings",
       "Live API endpoint health monitoring across multiple targets, with a public status API",

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -86,7 +86,7 @@
           </div>
           <ul>
             <li>Everything in Flash.</li>
-            <li>Managed audits and AIRview, written by an OpenAI frontier model.</li>
+            <li>Managed audits and AIRview, written by DeepSeek.</li>
             <li>AI-generated Docs for every public symbol - grounded in source, kept current automatically, nobody has to write one. Exportable as a single Markdown file.</li>
             <li>Flash reviews get a second, independent model that re-checks every individual finding against the diff before it's ever shown to you, dropping anything that doesn't hold up. Methodology and real per-review cost on the <a href="benchmarks.html">Benchmarks page</a>.</li>
             <li>Slack / Teams alerts on new findings.</li>


### PR DESCRIPTION
## Summary
Found while scoping the PR-count promise for a possible credit-based pricing redesign (not the redesign itself, just an audit turning up two unrelated real bugs).

- `index.html`'s JSON-LD structured data listed Aletheore Flash at **"$6"** - the real price everywhere else on the site (and `PLAN_MONTHLY_PRICE_USD` in the backend) is **$8/mo**. Stale since a past price change.
- Both `index.html` and `pricing.html` claimed AIRview and managed audits are **"written by an OpenAI frontier model"** - false. Confirmed directly in code: `writing_adapter_for_airview` and `writing_adapter_for_managed_audit` both explicitly always use DeepSeek, never Luna/OpenAI, regardless of `OPENAI_API_KEY` availability.

## Fix
- JSON-LD price corrected to `"8"`.
- Both mentions corrected to "written by DeepSeek".

## Test plan
- [x] Grepped both files post-fix for `OpenAI frontier model` and `"price": "6"` - zero matches
- [x] Confirmed pricing.html's visible price card was already correct ($8) - only the JSON-LD block and the model claims were stale

Not merging - for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)