### PR TITLE
fix: a deleted symbol's stale Live Docs description was never pruned once its module had no other work

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -4623,7 +4623,24 @@ def _module_has_uncovered_docs_work(module: dict, already_covered_names: set[str
     """
     needing = live_docs._symbols_needing_work(module, polish_existing=False)
     needing += live_docs._symbols_needing_work(module, polish_existing=True)
-    return any(s["name"] not in already_covered_names for s in needing)
+    if any(s["name"] not in already_covered_names for s in needing):
+        return True
+    # Real gap found via audit: a name in already_covered_names that no
+    # longer appears among the module's CURRENT symbols (deleted from the
+    # source since it was last documented) can never show up in `needing`
+    # above - it isn't a real symbol anymore, so _symbols_needing_work
+    # never asks about it. Without this check, a module whose remaining
+    # symbols are all already covered was judged to have zero uncovered
+    # work and skipped entirely - so _store_docs_generation_for_module
+    # (the only place anything ever prunes an orphaned docs_symbols row,
+    # via delete_docs_symbols_not_in) never ran for it, and a deleted
+    # symbol's stale AI-generated description survived indefinitely on
+    # the customer-facing Docs page. This doesn't cost an LLM call by
+    # itself - _store_docs_generation_for_module makes no LLM call when
+    # there's nothing left needing generation/polish, it just still runs
+    # the (free) prune.
+    current_names = {s["name"] for s in module["symbols"]["functions"] + module["symbols"]["classes"]}
+    return bool(already_covered_names - current_names)
 
 
 def _modules_with_uncovered_docs_work(

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -7007,6 +7007,26 @@ def test_module_has_uncovered_docs_work_false_when_nothing_needs_work_at_all():
     assert _module_has_uncovered_docs_work(module, already_covered_names=set()) is False
 
 
+def test_module_has_uncovered_docs_work_true_when_a_covered_symbol_was_deleted():
+    # Real gap found via audit: a symbol removed from the source file
+    # simply isn't in live_docs._symbols_needing_work's output anymore -
+    # it isn't a real symbol - so if every symbol still present is already
+    # covered, this used to report False even though a stale docs_symbols
+    # row for the deleted symbol exists and would never get pruned (the
+    # only place that prunes it, _store_docs_generation_for_module, only
+    # ever runs for a module this function says has work).
+    from scan_worker.jobs import _module_has_uncovered_docs_work
+
+    module = _docs_module(functions=[{"name": "keep_me", "is_public": True, "docstring": "d"}])
+
+    assert (
+        _module_has_uncovered_docs_work(module, already_covered_names={"keep_me", "deleted_fn"})
+        is True
+    )
+    # No orphan - every covered name still exists in the module - stays False.
+    assert _module_has_uncovered_docs_work(module, already_covered_names={"keep_me"}) is False
+
+
 def test_modules_with_uncovered_docs_work_filters_and_caps():
     from scan_worker.jobs import _modules_with_uncovered_docs_work
 
@@ -7032,6 +7052,25 @@ def test_modules_with_uncovered_docs_work_filters_and_caps():
     # fully-untouched files come first so a capped run can't get crowded
     # out by files that are already mostly done.
     assert paths[0] == "untouched.py"
+
+
+def test_modules_with_uncovered_docs_work_includes_a_module_with_only_an_orphaned_symbol():
+    # Same real gap as _module_has_uncovered_docs_work's own test above,
+    # exercised at this function's level: a module whose only remaining
+    # symbol is already covered, but whose covered set also names a
+    # symbol deleted from the source, must still come back - it's the
+    # only way _run_docs_build_for_modules ever reaches this module to
+    # prune the orphaned docs_symbols row.
+    from scan_worker.jobs import _modules_with_uncovered_docs_work
+
+    stale = _docs_module(
+        "stale.py", functions=[{"name": "keep_me", "is_public": True, "docstring": "d"}]
+    )
+    covered_by_module = {"stale.py": {"keep_me", "deleted_fn"}}
+
+    result = _modules_with_uncovered_docs_work([stale], covered_by_module, limit=10)
+
+    assert [m["path"] for m in result] == ["stale.py"]
 
 
 def test_modules_with_uncovered_docs_work_respects_limit():


### PR DESCRIPTION
## Summary

Real, execution-confirmed gap found via adversarial audit of `jobs.py`'s Live Docs generation internals.

`_module_has_uncovered_docs_work`/`_modules_with_uncovered_docs_work` decide whether a module gets reprocessed by checking only the module's **currently-existing** symbols (`live_docs._symbols_needing_work`) against `already_covered_names`. A symbol removed from the source file simply isn't in that "needing work" list anymore, so its stale `docs_symbols` row is invisible to this check.

Confirmed by real execution:
```
module = {"path": "a.py", "symbols": {"functions": [{"name": "keep_me", "is_public": True, "docstring": "d"}], "classes": []}}
already_covered = {"keep_me", "deleted_fn"}   # deleted_fn no longer exists in the file

_module_has_uncovered_docs_work(module, already_covered) -> False   # WRONG
```
If every symbol still present in the file is already covered, the module was judged to have zero uncovered work and dropped from the build entirely - `_store_docs_generation_for_module` (the only place `delete_docs_symbols_not_in` is ever called - confirmed via `grep`, no other cleanup path exists) never ran for it. The orphaned `deleted_fn` row in `docs_symbols` - and whatever stale description it still shows on the customer-facing Docs page / `.aletheore/docs/API.md` sync - survived indefinitely, until some unrelated, genuinely new symbol in that same file eventually triggered a real reprocessing run as a side effect. Not a contrived edge case: a repo where a file's remaining public symbols are already fully documented but one function was deleted hits this every time.

## Fix
`_module_has_uncovered_docs_work` now also treats an `already_covered_names` entry that no longer appears among the module's current symbol set as uncovered work, so the module gets reprocessed and the prune actually runs. This doesn't cost an LLM call by itself - `_store_docs_generation_for_module` already makes no LLM call when there's nothing left needing generation/polish (returns `{}` immediately per its own docstring), it just still runs the (free) `delete_docs_symbols_not_in` cleanup.

## Test plan
- [x] `test_jobs.py` (221 tests) - full pass
- [x] New regression tests confirmed to fail pre-fix, pass post-fix:
  - `test_module_has_uncovered_docs_work_true_when_a_covered_symbol_was_deleted`
  - `test_modules_with_uncovered_docs_work_includes_a_module_with_only_an_orphaned_symbol`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK

Not merging - for review only, per this session's standing audit-sweep practice.