### PR TITLE
feat: dollar-credit pricing - backend (per-installation balance, Paddle top-ups, annual-AIR fix)

### DIFF
--- a/docs/superpowers/plans/2026-09-09-dollar-credit-pricing-backend.md
+++ b/docs/superpowers/plans/2026-09-09-dollar-credit-pricing-backend.md
@@ -1,0 +1,916 @@
+# Dollar-Credit Pricing — Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat, static `PLAN_CAP_OVERRIDE_USD` spend ceiling with a real, per-installation, purchasable dollar-credit balance ($5/mo Flash, $18/mo AIR base credit, plus never-expiring customer-purchased top-ups), enforced by the exact same atomic reservation path that exists today, just re-pointed at two new balance columns instead of one shared monthly total.
+
+**Architecture:** Two new columns on `installations` (`base_credit_remaining_usd`, `topup_credit_balance_usd`) hold the real spendable balance, drawn down base-first-then-topup by the same `reserve_llm_spend`/`release_llm_spend_reservation` atomic UPDATE pattern that already exists and is already concurrency-tested. A `current_billing_period_start` column plus one new `balance_epoch` integer let the renewal-reset and top-up-purchase paths detect real state changes idempotently, and double as the dedupe key for two new customer emails sent through the existing `enqueue_transactional_email`/`sent_emails` infrastructure — no new email plumbing needed, only two new template names.
+
+**Tech Stack:** Python, Postgres (psycopg for scan_worker's sync path, asyncpg-style `pool` for app_server's async webhook path), RQ (existing job queue), Paddle webhooks.
+
+**Spec:** `docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md`
+
+## Global Constraints
+
+- Zero real paying customers exist on Flash or AIR (confirmed via direct production DB query 2026-09-09) - this is a clean cutover, no migration path for existing balances needed.
+- The old `PLAN_CAP_OVERRIDE_USD` flat cap is retired as an enforcement mechanism entirely once this ships - not kept as an additional ceiling layered on top of the new balance.
+- Every job that currently fails open / degrades gracefully on cap-reached (never blocks, never errors loudly, never overspends) must keep doing exactly that - only the ceiling's *source* changes.
+- The existing atomic-under-concurrency guarantee on the reservation path must be preserved exactly (see `test_reserve_llm_spend_is_atomic_under_real_concurrency`, `github-app/tests/test_scan_worker_db.py`).
+- Draw-down order: base credit first, then top-up balance. Same order in reverse on release/true-up.
+- `PLAN_BASE_CREDIT_USD = {"flash": 5.00, "air": 18.00}`.
+- Extra-seat behavior must be preserved: the current cap formula is `base_cap_usd + EXTRA_SEAT_LLM_CAP_USD * extra_seats` (`monthly_cap_for_installation`, `github-app/app_server/llm_cost.py:141`) - the new base-credit reset must apply this same per-seat bonus, not just the flat plan amount.
+- Low-balance threshold: 15% of the balance immediately after the most recent event that raised it (a renewal reset or a top-up purchase) - tracked via the new `balance_epoch` column (see Task 1), not a separately-computed value.
+- **Deviation from the committed spec, found while mapping real files** (documented here per writing-plans' self-review requirement, not silently changed): the spec proposed two dedup timestamp columns (`low_balance_email_sent_at`, `exhausted_email_sent_at`). Real code inspection found `enqueue_transactional_email` / `send_transactional_email_job` (`github-app/app_server/email_queue.py`, `github-app/scan_worker/jobs.py`) already provide a working, tested dedupe mechanism keyed on an arbitrary `dedupe_key` string, backed by the real `sent_emails` table via `email_already_sent()`. Using `dedupe_key = f"credit_low_balance:{installation_id}:{balance_epoch}"` (and the equivalent for `credit_exhausted`) reuses that existing infrastructure instead of duplicating it, and the single `balance_epoch` integer does double duty as the spec's "high-water mark" tracker - one new column instead of three, no new dedup logic to write or test.
+- **Deviation from the committed spec, found while mapping real files**: the spec proposed attributing a top-up purchase via `customer_id` matching `installations.paddle_customer_id`. Real code inspection found the actual, already-in-use, already-secure mechanism for `transaction.completed` is a signed `installation_token` in `custom_data` (`unsign_checkout_installation_id`, used identically by every subscription webhook handler and the existing `_handle_transaction_completed` in `github-app/app_server/webhooks/paddle.py:357`). Use that mechanism, not customer_id matching - it's simpler (no lookup needed beyond unsigning the token) and already proven secure for exactly this "attribute a transaction to an installation" purpose.
+
+---
+
+### Task 1: Migration — balance columns, epoch, and idempotency table
+
+**Files:**
+- Create: `github-app/migrations/063_installation_credit_balance.sql`
+- Test: `github-app/tests/test_scan_worker_db.py` (migration is exercised implicitly by every test below via `conftest.py`'s auto-apply-all-migrations fixture - no dedicated migration test needed, matches existing convention for prior migrations in this repo)
+
+**Interfaces:**
+- Produces: `installations.base_credit_remaining_usd` (NUMERIC), `installations.topup_credit_balance_usd` (NUMERIC), `installations.current_billing_period_start` (TIMESTAMPTZ), `installations.balance_epoch` (INTEGER), `processed_paddle_transactions` table (id TEXT PRIMARY KEY, processed_at TIMESTAMPTZ).
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Real per-installation dollar-credit balance, replacing the flat
+-- PLAN_CAP_OVERRIDE_USD ceiling. base_credit_remaining_usd resets every
+-- billing-period renewal to PLAN_BASE_CREDIT_USD[plan] + the existing
+-- per-seat bonus; topup_credit_balance_usd is a never-expiring balance
+-- from customer-purchased credit, drawn down only after base is
+-- exhausted. balance_epoch increments on every renewal reset AND every
+-- top-up purchase - the "high-water mark" the low-balance/exhausted
+-- email dedupe keys off of, via the existing sent_emails/dedupe_key
+-- mechanism rather than new timestamp columns.
+ALTER TABLE installations
+    ADD COLUMN base_credit_remaining_usd NUMERIC NOT NULL DEFAULT 0,
+    ADD COLUMN topup_credit_balance_usd  NUMERIC NOT NULL DEFAULT 0,
+    ADD COLUMN current_billing_period_start TIMESTAMPTZ,
+    ADD COLUMN balance_epoch INTEGER NOT NULL DEFAULT 0;
+
+-- Idempotency ledger for top-up purchases - Paddle retries a
+-- transaction.completed it didn't get a 2xx for, with the same
+-- transaction id. Recording every id this handler has already applied
+-- prevents a retry from crediting the same purchase twice.
+CREATE TABLE IF NOT EXISTS processed_paddle_transactions (
+    id           TEXT PRIMARY KEY,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+- [ ] **Step 2: Run the full local test suite once to confirm the migration applies cleanly**
+
+Run: `cd github-app && python3 -m pytest tests/test_scan_worker_db.py -q`
+Expected: all existing tests still pass (new columns default to 0/NULL, nothing existing reads them yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add github-app/migrations/063_installation_credit_balance.sql
+git commit -m "feat: add per-installation dollar-credit balance columns"
+```
+
+---
+
+### Task 2: `PLAN_BASE_CREDIT_USD` and the renewal-reset amount helper
+
+**Files:**
+- Modify: `github-app/app_server/llm_cost.py`
+- Test: `github-app/tests/test_llm_cost.py` (create if it doesn't exist - check first)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `PLAN_BASE_CREDIT_USD: dict[str, float]`, `base_credit_for_plan(plan: str, extra_seats: int) -> float`.
+
+- [ ] **Step 1: Check whether a test file already exists**
+
+Run: `ls github-app/tests/test_llm_cost.py`
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+from app_server.llm_cost import base_credit_for_plan
+
+
+def test_base_credit_for_plan_flash():
+    assert base_credit_for_plan("flash", extra_seats=0) == 5.00
+
+
+def test_base_credit_for_plan_air_no_extra_seats():
+    assert base_credit_for_plan("air", extra_seats=0) == 18.00
+
+
+def test_base_credit_for_plan_air_with_extra_seats():
+    # Same per-seat bonus the old monthly_cap_for_installation used -
+    # EXTRA_SEAT_LLM_CAP_USD ($3.00) per extra seat.
+    assert base_credit_for_plan("air", extra_seats=2) == 18.00 + 2 * 3.00
+
+
+def test_base_credit_for_plan_unknown_plan_is_zero():
+    assert base_credit_for_plan("free", extra_seats=0) == 0.0
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd github-app && python3 -m pytest tests/test_llm_cost.py -v`
+Expected: FAIL with `ImportError: cannot import name 'base_credit_for_plan'`
+
+- [ ] **Step 4: Add the mapping and helper**
+
+Add near the existing `PLAN_MONTHLY_PRICE_USD` in `github-app/app_server/llm_cost.py`:
+
+```python
+# The customer-facing, advertised included credit per plan - replaces the
+# "up to 800 reviews/month" style promise with the real dollar unit the
+# system already enforces. Deliberately below PLAN_CAP_OVERRIDE_USD
+# (real enforced worst-case ceiling: $6.00 flash / $20.00 air) so there's
+# real margin between what's promised and what's technically possible,
+# same spirit as every other cap-vs-price margin already documented in
+# this file.
+PLAN_BASE_CREDIT_USD = {
+    "flash": 5.00,
+    "air": 18.00,
+}
+
+
+def base_credit_for_plan(plan: str, extra_seats: int) -> float:
+    """The base credit an installation's balance resets to on a real
+    renewal. Applies the same per-seat bonus monthly_cap_for_installation
+    already used, so a larger AIR team keeps getting proportionally more
+    credit, not the same flat amount regardless of seat count."""
+    base = PLAN_BASE_CREDIT_USD.get(plan, 0.0)
+    if base == 0.0:
+        return 0.0
+    return base + EXTRA_SEAT_LLM_CAP_USD * extra_seats
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd github-app && python3 -m pytest tests/test_llm_cost.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add github-app/app_server/llm_cost.py github-app/tests/test_llm_cost.py
+git commit -m "feat: add PLAN_BASE_CREDIT_USD and base_credit_for_plan"
+```
+
+---
+
+### Task 3: Rewrite `reserve_llm_spend`/`release_llm_spend_reservation` for the two-column balance
+
+**Files:**
+- Modify: `github-app/scan_worker/db.py:396-460` (the existing `reserve_llm_spend`/`release_llm_spend_reservation` functions - read the current implementation first, it's a real `UPDATE ... WHERE` statement, don't guess its exact SQL)
+- Test: `github-app/tests/test_scan_worker_db.py`
+
+**Interfaces:**
+- Consumes: `PLAN_BASE_CREDIT_USD`/`base_credit_for_plan` are NOT used here - this task only changes the storage/enforcement shape. The plan-aware reset happens in Task 5.
+- Produces: `reserve_llm_spend(dsn: str, installation_id: int, reserve_usd: float) -> bool` (monthly_cap parameter REMOVED - the function now reads the installation's own two balance columns directly), `release_llm_spend_reservation(dsn: str, installation_id: int, reserve_usd: float) -> None` (unchanged signature, changed internals).
+
+- [ ] **Step 1: Read the current implementation exactly as it stands**
+
+Run: `sed -n '396,460p' github-app/scan_worker/db.py`
+
+Confirm the real current SQL and parameter names before writing the replacement - do not assume the shape described above is byte-for-byte accurate to what's on disk.
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+import pytest
+from scan_worker.db import reserve_llm_spend, release_llm_spend_reservation
+
+
+@pytest.mark.asyncio
+async def test_reserve_llm_spend_draws_from_base_credit_first(pool):
+    await _insert_installation(pool, 3001, "a")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET base_credit_remaining_usd = 5.00, "
+            "topup_credit_balance_usd = 10.00 WHERE installation_id = $1",
+            3001,
+        )
+    ok = reserve_llm_spend(TEST_DATABASE_URL, 3001, 2.00)
+    assert ok is True
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+            "FROM installations WHERE installation_id = $1", 3001,
+        )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(3.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(10.00)
+
+
+@pytest.mark.asyncio
+async def test_reserve_llm_spend_spills_into_topup_when_base_insufficient(pool):
+    await _insert_installation(pool, 3002, "a")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET base_credit_remaining_usd = 1.00, "
+            "topup_credit_balance_usd = 10.00 WHERE installation_id = $1",
+            3002,
+        )
+    ok = reserve_llm_spend(TEST_DATABASE_URL, 3002, 3.00)
+    assert ok is True
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+            "FROM installations WHERE installation_id = $1", 3002,
+        )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(0.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
+
+
+@pytest.mark.asyncio
+async def test_reserve_llm_spend_rejects_when_combined_balance_insufficient(pool):
+    await _insert_installation(pool, 3003, "a")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET base_credit_remaining_usd = 1.00, "
+            "topup_credit_balance_usd = 1.00 WHERE installation_id = $1",
+            3003,
+        )
+    ok = reserve_llm_spend(TEST_DATABASE_URL, 3003, 5.00)
+    assert ok is False
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+            "FROM installations WHERE installation_id = $1", 3003,
+        )
+    # Rejected reservation must not have mutated either column.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(1.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(1.00)
+
+
+@pytest.mark.asyncio
+async def test_release_llm_spend_reservation_credits_topup_before_base(pool):
+    # Reverse of the draw-down order: a release should restore topup
+    # first if base is already at its (post-reset) ceiling - but since
+    # we don't track a ceiling here, releasing always credits back to
+    # topup first, then base, mirroring "spend base first, so give back
+    # topup first" as the simplest consistent inverse.
+    await _insert_installation(pool, 3004, "a")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET base_credit_remaining_usd = 0.00, "
+            "topup_credit_balance_usd = 8.00 WHERE installation_id = $1",
+            3004,
+        )
+    release_llm_spend_reservation(TEST_DATABASE_URL, 3004, 2.00)
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+            "FROM installations WHERE installation_id = $1", 3004,
+        )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(10.00)
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(0.00)
+
+
+def test_reserve_llm_spend_is_atomic_under_real_concurrency(pool_sync):
+    # Real, threaded concurrency test - same style as the existing test
+    # this replaces (search git history for the old single-column
+    # version if unsure of the exact threading pattern used elsewhere in
+    # this test file). Installation has exactly $10.00 combined balance;
+    # 20 threads each try to reserve $1.00 concurrently; exactly 10 must
+    # succeed, never more.
+    import threading
+
+    installation_id = 3005
+    _insert_installation_sync(installation_id, "a")
+    _set_balance_sync(installation_id, base=10.00, topup=0.00)
+
+    results = []
+    lock = threading.Lock()
+
+    def attempt():
+        ok = reserve_llm_spend(TEST_DATABASE_URL, installation_id, 1.00)
+        with lock:
+            results.append(ok)
+
+    threads = [threading.Thread(target=attempt) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert results.count(True) == 10
+```
+
+Note: `_insert_installation_sync`/`_set_balance_sync`/`pool_sync` are illustrative - use whatever this test file's existing concurrency test (`test_reserve_llm_spend_is_atomic_under_real_concurrency`, being replaced) already uses for sync DB access in a threaded test, since `reserve_llm_spend` itself is a sync function called from async test fixtures elsewhere in this file. Read that existing test's exact fixture usage before writing this one - don't invent a new pattern.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd github-app && python3 -m pytest tests/test_scan_worker_db.py -k "reserve_llm_spend or release_llm_spend" -v`
+Expected: FAIL (old signature still takes `monthly_cap`, old logic writes to `llm_spend` not the new columns)
+
+- [ ] **Step 4: Rewrite the implementation**
+
+Replace the body of both functions in `github-app/scan_worker/db.py` (keep them at their current location in the file):
+
+```python
+def reserve_llm_spend(dsn: str, installation_id: int, reserve_usd: float) -> bool:
+    """Atomically reserves reserve_usd against an installation's real
+    credit balance (base_credit_remaining_usd, drawn down first, then
+    topup_credit_balance_usd) - replaces the old flat monthly_cap
+    parameter entirely; the ceiling is now this installation's own
+    stored balance, not a constant shared by every installation on the
+    same plan. Same atomicity guarantee as before: a single UPDATE ...
+    WHERE, so two concurrent callers against the same installation can
+    never together reserve more than what's actually available."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE installations
+                SET
+                    base_credit_remaining_usd = GREATEST(base_credit_remaining_usd - %(reserve)s, 0),
+                    topup_credit_balance_usd = topup_credit_balance_usd
+                        - GREATEST(%(reserve)s - base_credit_remaining_usd, 0)
+                WHERE installation_id = %(installation_id)s
+                    AND base_credit_remaining_usd + topup_credit_balance_usd >= %(reserve)s
+                RETURNING installation_id
+                """,
+                {"reserve": reserve_usd, "installation_id": installation_id},
+            )
+            row = cur.fetchone()
+        conn.commit()
+    return row is not None
+
+
+def release_llm_spend_reservation(dsn: str, installation_id: int, reserve_usd: float) -> None:
+    """Undoes one reserve_llm_spend reservation - credits topup_credit_
+    balance_usd first, then base_credit_remaining_usd, the reverse of the
+    base-first draw-down order (spend base first, so give back topup
+    first)."""
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE installations
+                SET topup_credit_balance_usd = topup_credit_balance_usd + %(reserve)s
+                WHERE installation_id = %(installation_id)s
+                """,
+                {"reserve": reserve_usd, "installation_id": installation_id},
+            )
+        conn.commit()
+```
+
+Note on the release simplification: crediting a release entirely back to `topup_credit_balance_usd` (rather than trying to reconstruct exactly which column the original reservation drew from) is deliberate - the combined balance ends up identical either way, and tracking "this specific reservation drew $X from base and $Y from topup" would need a reservation-id ledger this design doesn't otherwise need. A release never increases what a customer can spend beyond what they already had; it only restores it faster into whichever bucket is simplest to credit.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd github-app && python3 -m pytest tests/test_scan_worker_db.py -k "reserve_llm_spend or release_llm_spend" -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add github-app/scan_worker/db.py github-app/tests/test_scan_worker_db.py
+git commit -m "feat: reserve_llm_spend/release_llm_spend_reservation use per-installation credit balance"
+```
+
+---
+
+### Task 4: True-up the balance on `record_usage`, not just the `llm_spend` accounting table
+
+**Files:**
+- Modify: `github-app/scan_worker/jobs.py` (`_IncrementalSpendBudget.record_usage`, around line 3944 - re-read the exact current line numbers before editing, this file has changed during this session)
+- Test: `github-app/tests/test_jobs.py`
+
+**Interfaces:**
+- Consumes: `reserve_llm_spend`, `release_llm_spend_reservation` (Task 3).
+- Produces: `_IncrementalSpendBudget.record_usage` now also true-ups the credit balance, not just the `llm_spend` accounting table.
+
+**Why this task exists** (found while reading the real code, not in the original spec's data-flow section): `record_usage` reserves an *estimate* (`next_call_reserve_usd`) upfront via `can_start_next_call`, then calls `record_llm_spend(dsn, installation_id, delta, ...)` to true up the *accounting* table once the real cost is known (`delta = real_cost - reserve_usd`). Under the old single-column design, `llm_spend` was both the accounting record and the enforcement source, so this true-up naturally kept both in sync. Under the new design they're separate columns - the true-up must also adjust the credit balance by `delta`, or a systematic under/over-reservation (the estimate is rarely exactly right) will let the stored balance silently drift from real spend over time.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_incremental_spend_budget_record_usage_trues_up_the_credit_balance(pool):
+    # real_cost ($0.03) exceeds the $0.01 next_call_reserve_usd that was
+    # reserved up front - the extra $0.02 must additionally be reserved
+    # from the credit balance, not just recorded in llm_spend.
+    installation_id = _insert_installation_sync(pool, "a")
+    _set_balance_sync(installation_id, base=5.00, topup=0.00)
+
+    budget = _IncrementalSpendBudget(
+        TEST_DATABASE_URL, installation_id, "deepseek-v4-flash",
+        next_call_reserve_usd=0.01, feature="airview_incremental",
+    )
+    assert budget.can_start_next_call() is True
+    # deepseek-v4-flash: $0.44/$1.32 per M in/out - sized so prompt_tokens
+    # * input_rate + completion_tokens * output_rate lands at $0.03.
+    budget.record_usage(prompt_tokens=50000, completion_tokens=10000)
+
+    remaining = _get_balance_sync(pool, installation_id)
+    assert remaining["base_credit_remaining_usd"] == pytest.approx(5.00 - 0.03, abs=0.001)
+
+
+def test_incremental_spend_budget_record_usage_refunds_when_actual_cost_is_lower(pool):
+    installation_id = _insert_installation_sync(pool, "a")
+    _set_balance_sync(installation_id, base=5.00, topup=0.00)
+
+    budget = _IncrementalSpendBudget(
+        TEST_DATABASE_URL, installation_id, "deepseek-v4-flash",
+        next_call_reserve_usd=0.10, feature="airview_incremental",
+    )
+    assert budget.can_start_next_call() is True
+    # A tiny real call - actual cost is far below the 0.10 reserved.
+    budget.record_usage(prompt_tokens=10, completion_tokens=1)
+
+    remaining = _get_balance_sync(pool, installation_id)
+    # Reserved 0.10, actual cost is a few thousandths of a cent - most of
+    # the 0.10 reservation must have been refunded back.
+    assert remaining["base_credit_remaining_usd"] > 4.95
+```
+
+Note: `_get_balance_sync`/`_set_balance_sync` are small new test helpers this task should add near the top of `test_jobs.py`, following whatever pattern `_insert_installation_sync` (if it exists) or `_insert_installation` already use in this file - read the existing helpers first.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd github-app && python3 -m pytest tests/test_jobs.py -k "record_usage_trues_up or record_usage_refunds" -v`
+Expected: FAIL (current `record_usage` only calls `record_llm_spend`, balance columns unaffected)
+
+- [ ] **Step 3: Update `record_usage`**
+
+In `github-app/scan_worker/jobs.py`, inside `_IncrementalSpendBudget.record_usage`, after the existing `cost = cost_for_usage(...)` / `delta = cost - self.next_call_reserve_usd` lines and before the existing `record_llm_spend(...)` call, add:
+
+```python
+        if delta > 0:
+            reserve_llm_spend(self.dsn, self.installation_id, delta)
+        elif delta < 0:
+            release_llm_spend_reservation(self.dsn, self.installation_id, -delta)
+```
+
+Leave the existing `if delta == 0: return` and `record_llm_spend(...)` lines exactly as they are - this task only adds the balance true-up alongside the existing accounting true-up, it doesn't change what `llm_spend`/`llm_spend_events` record.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd github-app && python3 -m pytest tests/test_jobs.py -k "record_usage_trues_up or record_usage_refunds" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add github-app/scan_worker/jobs.py github-app/tests/test_jobs.py
+git commit -m "feat: true up the credit balance (not just llm_spend accounting) on record_usage"
+```
+
+---
+
+### Task 5: Renewal reset + top-up purchase (Paddle webhook branches, `app_server`)
+
+**Files:**
+- Modify: `github-app/app_server/webhooks/paddle.py` (the `subscription.updated` branch inside `handle_paddle_webhook_event`, and `_handle_transaction_completed`)
+- Modify: `github-app/app_server/paddle_pricing.py` (new `CREDIT_TOPUP_PRICE_ID` placeholder constant - real value filled in by Task 7)
+- Modify: `github-app/app_server/db.py` (new async helper functions for the two balance mutations, matching this file's existing async pool pattern - e.g. `get_installation`)
+- Test: `github-app/tests/test_paddle_webhook.py` (check the exact existing filename first)
+
+**Interfaces:**
+- Consumes: `base_credit_for_plan` (Task 2), `CREDIT_TOPUP_PRICE_ID` (Task 7 fills in the real value; this task can proceed with a clearly-labeled placeholder Paddle price id string since the webhook logic doesn't depend on what the id actually is, only on comparing against it).
+- Produces: `reset_billing_period_credit(pool, installation_id, plan, extra_seats, period_start) -> bool` (returns whether a reset actually happened, for the email-trigger interface in Task 6), `credit_topup_purchase(pool, installation_id, amount_usd, transaction_id) -> bool` (returns whether this was a new credit, i.e. not a duplicate).
+
+- [ ] **Step 1: Find the exact current `subscription.updated` handling location**
+
+Run: `grep -n "current_billing_period" github-app/app_server/webhooks/paddle.py`
+
+Confirm whether the payload's billing-period field is already being read anywhere in this handler (it may already be parsed for a different purpose) before adding a new read.
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+import pytest
+from app_server.db import reset_billing_period_credit, credit_topup_purchase
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_period_credit_on_genuine_new_period(pool):
+    installation_id = await _insert_installation(pool, "a", plan="air")
+    changed = await reset_billing_period_credit(
+        pool, installation_id, "air", extra_seats=0,
+        period_start="2026-09-01T00:00:00Z",
+    )
+    assert changed is True
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, current_billing_period_start, balance_epoch "
+        "FROM installations WHERE installation_id = $1", installation_id,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_period_credit_is_a_noop_on_the_same_period(pool):
+    installation_id = await _insert_installation(pool, "a", plan="air")
+    await reset_billing_period_credit(
+        pool, installation_id, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z",
+    )
+    # Spend some of it down.
+    await pool.execute(
+        "UPDATE installations SET base_credit_remaining_usd = 2.00 WHERE installation_id = $1",
+        installation_id,
+    )
+    # Same period_start delivered again (a replayed or unrelated subscription.updated).
+    changed = await reset_billing_period_credit(
+        pool, installation_id, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z",
+    )
+    assert changed is False
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    # Must NOT have been reset back to 18.00 - the spent-down 2.00 survives.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(2.00)
+
+
+@pytest.mark.asyncio
+async def test_credit_topup_purchase_increments_topup_balance(pool):
+    installation_id = await _insert_installation(pool, "a", plan="flash")
+    credited = await credit_topup_purchase(pool, installation_id, 8.00, "txn_abc123")
+    assert credited is True
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd, balance_epoch FROM installations "
+        "WHERE installation_id = $1", installation_id,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_credit_topup_purchase_is_idempotent_on_replayed_transaction(pool):
+    installation_id = await _insert_installation(pool, "a", plan="flash")
+    first = await credit_topup_purchase(pool, installation_id, 8.00, "txn_abc123")
+    second = await credit_topup_purchase(pool, installation_id, 8.00, "txn_abc123")
+    assert first is True
+    assert second is False
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    # Only credited once, not twice.
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd github-app && python3 -m pytest tests/test_paddle_webhook.py -k "reset_billing_period_credit or credit_topup_purchase" -v`
+Expected: FAIL (`ImportError`)
+
+- [ ] **Step 4: Implement the two helpers in `app_server/db.py`**
+
+Add near the existing installation-mutation helpers (e.g. `add_paddle_ids_to_installation`) in `github-app/app_server/db.py`:
+
+```python
+async def reset_billing_period_credit(
+    pool, installation_id: int, plan: str, extra_seats: int, period_start: str
+) -> bool:
+    """Resets base_credit_remaining_usd to this plan's real included
+    credit (base_credit_for_plan, same per-seat bonus the old flat cap
+    used) only if period_start is genuinely new for this installation -
+    a no-op on a replayed or unrelated subscription.updated event.
+    Increments balance_epoch on a real reset, which doubles as the
+    dedupe key both new credit-notification emails key off of. Returns
+    whether a reset actually happened."""
+    from app_server.llm_cost import base_credit_for_plan
+
+    new_credit = base_credit_for_plan(plan, extra_seats)
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            UPDATE installations
+            SET base_credit_remaining_usd = $2,
+                current_billing_period_start = $3::timestamptz,
+                balance_epoch = balance_epoch + 1
+            WHERE installation_id = $1
+                AND (current_billing_period_start IS DISTINCT FROM $3::timestamptz)
+            RETURNING installation_id
+            """,
+            installation_id, new_credit, period_start,
+        )
+    return row is not None
+
+
+async def credit_topup_purchase(
+    pool, installation_id: int, amount_usd: float, transaction_id: str
+) -> bool:
+    """Credits a real, customer-purchased top-up to topup_credit_balance_
+    usd, exactly once per transaction_id even if the webhook is
+    redelivered. Returns whether this call actually credited anything
+    (False on a replay)."""
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            inserted = await conn.fetchrow(
+                "INSERT INTO processed_paddle_transactions (id) VALUES ($1) "
+                "ON CONFLICT (id) DO NOTHING RETURNING id",
+                transaction_id,
+            )
+            if inserted is None:
+                return False
+            await conn.execute(
+                "UPDATE installations SET topup_credit_balance_usd = "
+                "topup_credit_balance_usd + $2, balance_epoch = balance_epoch + 1 "
+                "WHERE installation_id = $1",
+                installation_id, amount_usd,
+            )
+    return True
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd github-app && python3 -m pytest tests/test_paddle_webhook.py -k "reset_billing_period_credit or credit_topup_purchase" -v`
+Expected: PASS
+
+- [ ] **Step 6: Wire the renewal-reset call into the real `subscription.updated` handling path**
+
+In `handle_paddle_webhook_event` (`github-app/app_server/webhooks/paddle.py`), after the existing block that resolves `plan` and confirms `installation_id` is attributed (the code around the `previous = await get_installation(pool, installation_id)` line), add a call reading `data.get("current_billing_period", {}).get("starts_at")` and, if present, calling `await reset_billing_period_credit(pool, installation_id, plan, extra_seats, period_start)` - read the surrounding function first to place this correctly relative to the existing plan-flip logic, and to find where `extra_seats` is already available in this function (it's read elsewhere for the seat add-on price item, per `_seat_item_quantity`).
+
+- [ ] **Step 7: Wire the top-up purchase into `_handle_transaction_completed`**
+
+In `_handle_transaction_completed` (`github-app/app_server/webhooks/paddle.py:357`), after the existing `installation_id = ...` / `if installation_id is None: return` block (reuse that exact same attribution logic - do not add a second lookup), add:
+
+```python
+    items = data.get("items") or []
+    topup_item = next(
+        (item for item in items if (item.get("price") or {}).get("id") == CREDIT_TOPUP_PRICE_ID),
+        None,
+    )
+    if topup_item is not None:
+        quantity = topup_item.get("quantity")
+        transaction_id = data.get("id")
+        if quantity and transaction_id:
+            await credit_topup_purchase(pool, installation_id, float(quantity), transaction_id)
+        else:
+            logger.warning(
+                "credit topup transaction.completed missing quantity or id: %s",
+                data.get("id"),
+            )
+```
+
+Place this as an early branch in the function, before or after the existing affiliate-commission logic (they're independent - a topup purchase and a referral commission on it aren't mutually exclusive, both can apply to the same transaction). Import `credit_topup_purchase` and `CREDIT_TOPUP_PRICE_ID` at the top of the file alongside the existing imports.
+
+- [ ] **Step 8: Add the placeholder price id constant**
+
+In `github-app/app_server/paddle_pricing.py`, near `EXTRA_SEAT_PRICE_ID`:
+
+```python
+# Placeholder until Task 7 creates the real Paddle price via the Paddle
+# MCP and replaces this with the real pri_... id - the webhook logic
+# only needs to compare against whatever this constant is, so the rest
+# of this task can proceed and be tested without the real price
+# existing yet.
+CREDIT_TOPUP_PRICE_ID = "pri_PLACEHOLDER_credit_topup"
+```
+
+- [ ] **Step 9: Run the full paddle webhook test suite to confirm nothing existing broke**
+
+Run: `cd github-app && python3 -m pytest tests/test_paddle_webhook.py -q`
+Expected: all pass, including every pre-existing test.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add github-app/app_server/webhooks/paddle.py github-app/app_server/paddle_pricing.py github-app/app_server/db.py github-app/tests/test_paddle_webhook.py
+git commit -m "feat: renewal credit reset and top-up purchase Paddle webhook handling"
+```
+
+---
+
+### Task 6: Low-balance / exhausted email triggers
+
+**Files:**
+- Modify: `github-app/scan_worker/jobs.py` (`_IncrementalSpendBudget.can_start_next_call` and `.record_usage`, plus the direct `reserve_llm_spend` call in the Flash Review path - re-find the exact current line number, it shifts as earlier tasks land)
+- Test: `github-app/tests/test_jobs.py`
+
+**Interfaces:**
+- Consumes: `enqueue_transactional_email` (`github-app/app_server/email_queue.py`, already exists, unchanged), `balance_epoch` (Task 1/5).
+- Produces: two new email trigger points using `template_name` values `"credit_low_balance"` and `"credit_exhausted"` - **this is the exact interface the dashboard+emails plan must match**. `template_arg` for both is a dict: `{"account_login": str, "plan": str, "base_credit_remaining_usd": float, "topup_credit_balance_usd": float}`. `dedupe_key` is `f"credit_low_balance:{installation_id}:{balance_epoch}"` / `f"credit_exhausted:{installation_id}:{balance_epoch}"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_reserve_llm_spend_low_balance_triggers_email_enqueue(pool, monkeypatch):
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **kw: enqueued.append((a, kw)),
+    )
+    installation_id = _insert_installation_sync(pool, "a", plan="flash")
+    # balance_epoch=1, high-water-mark implied 5.00 (base_credit_for_plan
+    # flash) - 15% of 5.00 is 0.75, so leaving 0.70 remaining crosses it.
+    _set_balance_sync(installation_id, base=0.70, topup=0.00, balance_epoch=1)
+
+    result = reserve_llm_spend_with_email_hooks(
+        TEST_DATABASE_URL, installation_id, reserve_usd=0.10, feature="flash_review",
+    )
+
+    assert result is True
+    assert len(enqueued) == 1
+    _, kwargs = enqueued[0]
+    assert kwargs["template_name"] == "credit_low_balance"
+    assert kwargs["dedupe_key"] == f"credit_low_balance:{installation_id}:1"
+
+
+def test_reserve_llm_spend_rejection_triggers_exhausted_email(pool, monkeypatch):
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **kw: enqueued.append((a, kw)),
+    )
+    installation_id = _insert_installation_sync(pool, "a", plan="flash")
+    _set_balance_sync(installation_id, base=0.01, topup=0.00, balance_epoch=1)
+
+    result = reserve_llm_spend_with_email_hooks(
+        TEST_DATABASE_URL, installation_id, reserve_usd=5.00, feature="flash_review",
+    )
+
+    assert result is False
+    assert len(enqueued) == 1
+    _, kwargs = enqueued[0]
+    assert kwargs["template_name"] == "credit_exhausted"
+    assert kwargs["dedupe_key"] == f"credit_exhausted:{installation_id}:1"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd github-app && python3 -m pytest tests/test_jobs.py -k "low_balance_triggers or rejection_triggers" -v`
+Expected: FAIL (`reserve_llm_spend_with_email_hooks` doesn't exist yet)
+
+- [ ] **Step 3: Implement the wrapper in `jobs.py`**
+
+Add near `_IncrementalSpendBudget` in `github-app/scan_worker/jobs.py`:
+
+```python
+LOW_BALANCE_WARNING_FRACTION = 0.15
+
+
+def reserve_llm_spend_with_email_hooks(
+    dsn: str, installation_id: int, reserve_usd: float, feature: str
+) -> bool:
+    """Wraps reserve_llm_spend with the two customer-facing email
+    triggers - reused by both the Flash Review direct-reservation path
+    and _IncrementalSpendBudget.can_start_next_call, so both surfaces
+    get identical notification behavior instead of two hand-rolled
+    copies."""
+    row = get_installation_row(dsn, installation_id)
+    if row is None:
+        return reserve_llm_spend(dsn, installation_id, reserve_usd)
+
+    before_total = float(row["base_credit_remaining_usd"]) + float(row["topup_credit_balance_usd"])
+    ok = reserve_llm_spend(dsn, installation_id, reserve_usd)
+
+    if not ok:
+        enqueue_transactional_email(
+            redis_url=get_settings().redis_url,
+            dedupe_key=f"credit_exhausted:{installation_id}:{row['balance_epoch']}",
+            template_name="credit_exhausted",
+            template_arg={
+                "account_login": row["account_login"],
+                "plan": row["plan"],
+                "base_credit_remaining_usd": float(row["base_credit_remaining_usd"]),
+                "topup_credit_balance_usd": float(row["topup_credit_balance_usd"]),
+            },
+            to_email=row["alert_email"],
+            installation_id=installation_id,
+        )
+        return False
+
+    after_row = get_installation_row(dsn, installation_id)
+    after_total = float(after_row["base_credit_remaining_usd"]) + float(after_row["topup_credit_balance_usd"])
+    # This installation's own high-water mark is whatever the combined
+    # balance was immediately after its most recent renewal reset or
+    # top-up (both of those set balance_epoch and, transitively, the
+    # totals this check compares against) - approximated here as
+    # before_total when no reservation has yet been made this epoch.
+    # A precise high-water-mark value isn't separately stored (see the
+    # spec's resolved-questions note); using before_total on the FIRST
+    # reservation of an epoch is exact, and is a conservative
+    # (slightly-early) trigger on later reservations within the same
+    # epoch, which is the safe direction to be wrong in for a warning.
+    threshold = before_total * LOW_BALANCE_WARNING_FRACTION
+    if after_total <= threshold and before_total > threshold:
+        enqueue_transactional_email(
+            redis_url=get_settings().redis_url,
+            dedupe_key=f"credit_low_balance:{installation_id}:{after_row['balance_epoch']}",
+            template_name="credit_low_balance",
+            template_arg={
+                "account_login": after_row["account_login"],
+                "plan": after_row["plan"],
+                "base_credit_remaining_usd": float(after_row["base_credit_remaining_usd"]),
+                "topup_credit_balance_usd": float(after_row["topup_credit_balance_usd"]),
+            },
+            to_email=after_row["alert_email"],
+            installation_id=installation_id,
+        )
+    return True
+```
+
+Note: this task assumes `get_installation_row` (scan_worker's sync installation reader) already returns `account_login`, `plan`, `alert_email`, `balance_epoch` as dict-accessible keys - confirm the exact real column set this function returns before writing the implementation; add `balance_epoch` to its SELECT if it isn't already included (it's a new column from Task 1, existing SELECT statements won't pick it up automatically).
+
+- [ ] **Step 4: Replace direct `reserve_llm_spend` calls with the wrapper**
+
+In `github-app/scan_worker/jobs.py`, replace the Flash Review path's direct call (`if not reserve_llm_spend(settings.database_url, installation_id, reserved_spend, monthly_cap):`, found at the line identified during Task 3's Step 1 re-read) with `reserve_llm_spend_with_email_hooks(settings.database_url, installation_id, reserved_spend, feature="flash_review")`, and `_IncrementalSpendBudget.can_start_next_call` (Task 3 area) to call `reserve_llm_spend_with_email_hooks(self.dsn, self.installation_id, self.next_call_reserve_usd, self.feature)` instead of `reserve_llm_spend` directly.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd github-app && python3 -m pytest tests/test_jobs.py -k "low_balance_triggers or rejection_triggers" -v`
+Expected: PASS
+
+- [ ] **Step 6: Run the full jobs test suite**
+
+Run: `cd github-app && python3 -m pytest tests/test_jobs.py -q`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add github-app/scan_worker/jobs.py github-app/tests/test_jobs.py
+git commit -m "feat: low-balance and exhausted email triggers on credit reservation"
+```
+
+---
+
+### Task 7: Retire the flat-cap call sites; create the real Paddle top-up price
+
+**Files:**
+- Modify: `github-app/scan_worker/jobs.py` (every remaining `_llm_spend_cap_reached` call site and every `_IncrementalSpendBudget(...)` constructor call - Task 6's grep already found the real list: lines ~2813/2818, ~4276/4288, ~4452/4467, ~4788/4801, ~4935/4949, plus the two Flash Review sites at ~1526/1558 and ~1637/1656; re-grep at the start of this task since every prior task shifts line numbers)
+- Modify: `github-app/app_server/admin.py:549` (`monthly_cap_for_installation(base_cap_for_plan(...))` display)
+- Modify: `github-app/app_server/paddle_pricing.py` (replace the Task 5 placeholder with the real price id)
+- Delete: nothing yet - `PLAN_CAP_OVERRIDE_USD`, `base_cap_for_plan`, `monthly_cap_for_installation`, `_llm_spend_cap_reached` become dead code once every call site is updated; leave them in place with a comment noting they're superseded, rather than deleting in this pass (deleting is a separate, easy follow-up once this is confirmed working in production - not worth the risk of also needing to touch every test that still references them in the same change that's rewiring the actual enforcement).
+- Test: `github-app/tests/test_jobs.py`, `github-app/tests/test_admin.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-6.
+- Produces: nothing new - this task is pure call-site migration.
+
+- [ ] **Step 1: Get the real, current, complete list of call sites**
+
+Run: `grep -n "reserve_llm_spend\|release_llm_spend_reservation\|_llm_spend_cap_reached\|base_cap_for_plan\|monthly_cap_for_installation\|_IncrementalSpendBudget(" github-app/scan_worker/jobs.py github-app/app_server/admin.py`
+
+Use this real, current output as the task list for the remaining steps - do not reuse the line numbers written elsewhere in this plan, they're illustrative only and will have shifted.
+
+- [ ] **Step 2: For each `_llm_spend_cap_reached` call site, replace with a direct balance read**
+
+`_llm_spend_cap_reached(dsn, installation_id, plan)` currently returns `(cap_reached: bool, monthly_cap: float)`. Replace each call with a check against the installation's real combined balance:
+
+```python
+row = get_installation_row(dsn, installation_id)
+combined_balance = float(row["base_credit_remaining_usd"]) + float(row["topup_credit_balance_usd"])
+cap_reached = combined_balance <= 0
+```
+
+Every downstream use of the old `monthly_cap` return value in these call sites was for a log/status message (e.g. `f"monthly spend cap reached (${monthly_cap:.2f})"`) - replace with `f"credit balance exhausted (${combined_balance:.2f} remaining)"`, matching the new framing.
+
+- [ ] **Step 3: For each `_IncrementalSpendBudget(...)` constructor, drop the `monthly_cap` argument**
+
+`_IncrementalSpendBudget.__init__` (Task 6 area) still takes a `monthly_cap` parameter left over from before Task 3's rewrite - remove it from the constructor signature and from every call site found in Step 1 (each currently passes `monthly_cap=monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)` or similar - delete that argument and the now-unused local `monthly_cap`/`extra_seats` computation at each site, unless `extra_seats` is used for something else nearby, which Step 1's grep output will show).
+
+Also remove `_IncrementalSpendBudget.cap_message()`'s reference to `self.monthly_cap` (now removed) - replace with a message reading from the installation's real current balance at the point it's called, same pattern as Step 2.
+
+- [ ] **Step 4: Update the Flash Review direct-reservation sites**
+
+The two sites at `monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)` feeding into `reserve_llm_spend_with_email_hooks` (already updated in Task 6) - remove the now-unused `monthly_cap` computation entirely, since `reserve_llm_spend_with_email_hooks` no longer takes it.
+
+- [ ] **Step 5: Update `admin.py`'s cap display**
+
+At the `llm_spend_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)` line, replace with a read of the installation's real `base_credit_remaining_usd + topup_credit_balance_usd`, matching whatever this admin view currently does with the old `llm_spend_cap` value (read the surrounding code before changing what gets displayed, since this may be an internal-only debug view, not the customer-facing dashboard the other agent's plan owns).
+
+- [ ] **Step 6: Run the full backend test suite**
+
+Run: `cd github-app && python3 -m pytest tests/test_jobs.py tests/test_admin.py tests/test_scan_worker_db.py tests/test_paddle_webhook.py tests/test_llm_cost.py -q`
+Expected: all pass. Fix any test that still asserts against the old `monthly_cap`-based behavior - these are real, expected breaks from the call-site migration, not new bugs; update their assertions to match the new balance-based behavior rather than deleting them.
+
+- [ ] **Step 7: Create the real Paddle top-up price via the Paddle MCP**
+
+Use the Paddle MCP tools available in this session to create a real, live product/price: one-time (not recurring), $1.00 USD unit price, quantity-adjustable at checkout, matching how `EXTRA_SEAT_PRICE_ID` and the flash/air plan prices were created (per `paddle_pricing.py`'s own history comments - search MCP tools first to confirm the exact method name before calling, per this repo's own Paddle MCP usage convention).
+
+Replace the `CREDIT_TOPUP_PRICE_ID = "pri_PLACEHOLDER_credit_topup"` placeholder in `github-app/app_server/paddle_pricing.py` with the real returned price id, and update the comment to match the pattern already used for `EXTRA_SEAT_PRICE_ID`'s own history note (what it is, when it was created, that it's real and chargeable).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add github-app/scan_worker/jobs.py github-app/app_server/admin.py github-app/app_server/paddle_pricing.py github-app/tests/
+git commit -m "feat: retire flat-cap call sites in favor of per-installation credit balance; create real top-up Paddle price"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Migration (base/topup/period/epoch columns, idempotency table) — Task 1. ✓
+- `PLAN_BASE_CREDIT_USD`, extra-seat-aware reset amount — Task 2. ✓
+- `reserve_llm_spend`/`release_llm_spend_reservation` rewritten, base-first draw-down, concurrency-safe — Task 3. ✓
+- Real-cost true-up (found via code reading, not explicit in spec's data-flow section, but required for correctness) — Task 4. ✓
+- Renewal reset (idempotent, scoped to genuine period changes) — Task 5. ✓
+- Top-up purchase (real attribution mechanism, idempotent) — Task 5. ✓
+- Low-balance / exhausted emails, precise interface for the other plan — Task 6. ✓
+- Every existing call site migrated off the flat cap; real Paddle price created — Task 7. ✓
+- Old cap retired as *enforcement* (Global Constraints) — Task 7 removes every enforcement call site; the old constants/functions are deliberately left in place as dead code rather than deleted, noted explicitly in Task 7's Files section as a deliberate scope decision, not an oversight.
+
+**Placeholder scan:** `CREDIT_TOPUP_PRICE_ID`'s placeholder value (Task 5, Step 8) is intentional and explicitly resolved by Task 7, Step 7 later in the same plan - not a forgotten TBD.
+
+**Type consistency:** `reserve_llm_spend(dsn, installation_id, reserve_usd)` (Task 3's new signature) is used identically in Task 4, Task 6, and Task 7 - no task calls it with the old `monthly_cap` fourth argument. `reserve_llm_spend_with_email_hooks` (Task 6) matches this same three-argument-plus-feature shape everywhere it's introduced and consumed.

--- a/docs/superpowers/plans/2026-09-09-dollar-credit-pricing-dashboard.md
+++ b/docs/superpowers/plans/2026-09-09-dollar-credit-pricing-dashboard.md
@@ -1,0 +1,317 @@
+# Dollar-Credit Pricing — Dashboard + Emails Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the customer a real, honest view of the dollar-credit balance the backend now enforces (base credit remaining + top-up balance), a way to buy more, and two new transactional emails when that balance gets low or runs out - the customer-facing half of the redesign that makes the new promise legible instead of opaque.
+
+**Architecture:** A new, dedicated "Usage" section on the dashboard settings page (broken out from the existing mixed settings block, not folded into it - the current inline "AI usage this month" line is being replaced, not extended), fed by extending the existing `admin.py` settings API response with the two new balance fields. "Buy more credit" is a plain amount input that redirects to Paddle checkout for the real one-time credit price. The two new emails are two new render functions registered in the existing `_EMAIL_TEMPLATES` dispatch dict - no new email infrastructure, since `enqueue_transactional_email`/`send_transactional_email_job` already exist and already handle delivery, dedup, and retry.
+
+**Tech Stack:** Python (FastAPI backend serving hand-built HTML/JS, no frontend framework - `app_server/frontend.py` is server-rendered strings), Paddle Checkout (client-side overlay, matching the existing subscribe/buy-seat buttons already on this page).
+
+**Spec:** `docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md`
+
+## Global Constraints
+
+- Zero real paying customers exist on Flash or AIR (confirmed via direct production DB query 2026-09-09) - no need to handle a customer who has an old-style "reviews used this month" mental model to migrate away from.
+- The credit balance display must be a genuinely separate "Usage" (or "Billing") section, not folded into the existing mixed settings block that currently also covers seats, API tokens, and health check targets - a real product decision made this session, not a suggestion.
+- **This plan depends on the backend plan** (`docs/superpowers/plans/2026-09-09-dollar-credit-pricing-backend.md`) for two things specifically: the `installations` columns it adds (`base_credit_remaining_usd`, `topup_credit_balance_usd`), and the exact email-trigger interface its Task 6 defines. Do not start Task 3 (emails) or Task 2's balance-reading half until those columns exist - check with the other agent or `git log`/`git pull` on the shared branch before starting if timing is unclear.
+- **Exact interface this plan must match** (defined by the backend plan, not renegotiable without updating both plans): two `template_name` values, `"credit_low_balance"` and `"credit_exhausted"`, each called with `template_arg` as a dict shaped `{"account_login": str, "plan": str, "base_credit_remaining_usd": float, "topup_credit_balance_usd": float}`. Both entries must be registered in `_EMAIL_TEMPLATES` (`github-app/scan_worker/jobs.py`).
+- `CREDIT_TOPUP_PRICE_ID` (`github-app/app_server/paddle_pricing.py`) is a $1.00/unit, one-time, quantity-billed Paddle price - the backend plan creates the real price id. The checkout call this plan writes sets `quantity` from the customer's chosen dollar amount ($5 minimum, no maximum).
+
+---
+
+### Task 1: Extend the settings API response with the real balance
+
+**Files:**
+- Modify: `github-app/app_server/admin.py:540-568` (the settings endpoint that currently returns `llm_spend_cap` - read the full function first, it's shown in context below but re-read the live file since line numbers shift)
+- Test: `github-app/tests/test_admin.py`
+
+**Interfaces:**
+- Consumes: `installations.base_credit_remaining_usd`, `installations.topup_credit_balance_usd` (from the backend plan's Task 1 migration - these must exist before this task can pass its tests).
+- Produces: the settings API response gains `"base_credit_remaining_usd": float` and `"topup_credit_balance_usd": float` keys.
+
+- [ ] **Step 1: Confirm the installation dict already carries the new columns**
+
+Run: `grep -n "async def get_installation" github-app/app_server/db.py`
+
+Read that function - if it does `SELECT *` or explicitly names columns, confirm the two new columns come through automatically (a `SELECT *` picks up new columns with no code change; an explicit column list needs the two new names added). If it's an explicit list, add `base_credit_remaining_usd` and `topup_credit_balance_usd` to it as part of this task before writing the test below.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_response_includes_credit_balance(async_client, pool):
+    installation_id = await _insert_installation(pool, "acme", plan="flash")
+    await pool.execute(
+        "UPDATE installations SET base_credit_remaining_usd = 3.50, "
+        "topup_credit_balance_usd = 12.00 WHERE installation_id = $1",
+        installation_id,
+    )
+    response = await async_client.get(f"/api/admin/acme/settings")  # match this repo's real route path
+    assert response.status_code == 200
+    data = response.json()
+    assert data["base_credit_remaining_usd"] == pytest.approx(3.50)
+    assert data["topup_credit_balance_usd"] == pytest.approx(12.00)
+```
+
+Note: confirm the real route path and auth/session setup this test needs by reading an existing passing test in `test_admin.py` for the same settings endpoint first (e.g. whatever test currently covers `llm_spend_cap`) and copy its exact fixture/auth pattern - don't guess the route or the client fixture name.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd github-app && python3 -m pytest tests/test_admin.py -k "credit_balance" -v`
+Expected: FAIL (`KeyError` or missing keys in the response)
+
+- [ ] **Step 4: Add the two fields to the settings response**
+
+In the same function that currently sets `"llm_spend_cap": llm_spend_cap` (`github-app/app_server/admin.py`), add:
+
+```python
+        "base_credit_remaining_usd": float(installation["base_credit_remaining_usd"]),
+        "topup_credit_balance_usd": float(installation["topup_credit_balance_usd"]),
+```
+
+Leave the existing `llm_spend_month_to_date`/`llm_spend_cap`/`flash_reviews_month_to_date` keys in place for this task - Task 2 replaces how the frontend *displays* usage, but removing these keys is a separate decision (they may still be useful as a secondary "spend so far" stat even once the primary display is the credit balance); don't delete them speculatively.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd github-app && python3 -m pytest tests/test_admin.py -k "credit_balance" -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add github-app/app_server/admin.py github-app/tests/test_admin.py
+git commit -m "feat: expose credit balance in the settings API response"
+```
+
+---
+
+### Task 2: New "Usage" dashboard section — balance display + buy-more flow
+
+**Files:**
+- Modify: `github-app/app_server/frontend.py` (the settings page JS around the existing `llmSpend`/`llmCap`/`usageHtml` block, ~line 2327-2340 - re-find the exact current lines, this file is a hotspot and shifts often; also wherever the settings page's section HTML gets assembled/inserted, to add a new section rather than editing the existing one in place)
+
+**Interfaces:**
+- Consumes: `base_credit_remaining_usd`, `topup_credit_balance_usd` from the settings API (Task 1). `CREDIT_TOPUP_PRICE_ID` from the backend plan (for the checkout call).
+- Produces: a new, visually separate "Usage" (or "Billing") section on the dashboard settings page.
+
+- [ ] **Step 1: Read the existing settings-page assembly to find where sections are composed**
+
+Run: `sed -n '2280,2420p' github-app/app_server/frontend.py`
+
+Confirm how `usageHtml` (and its sibling `seatBillingHtml`) get inserted into the final page - whether they're concatenated into one big settings block or already rendered as separate `<div class="settings-block">` cards side by side (the earlier read showed `usageHtml` as its own `.settings-block` div already, which is a good sign - it may only need to be pulled out of whatever combined container currently groups it with unrelated settings, into its own top-level section with its own heading).
+
+- [ ] **Step 2: Replace the existing `usageHtml` block with a full "Usage" section**
+
+Replace the current `usageHtml` construction (the `'<div class="settings-block">' + '<div class="settings-block-label">AI usage this month</div>' + ...` block) with:
+
+```javascript
+  const baseCredit = data.base_credit_remaining_usd || 0;
+  const topupCredit = data.topup_credit_balance_usd || 0;
+  const combinedCredit = baseCredit + topupCredit;
+  const usageHtml =
+    '<section class="settings-section" id="usage-section">' +
+      '<h2>Usage</h2>' +
+      '<div class="settings-block">' +
+        '<div class="settings-block-label">Credit balance</div>' +
+        '<div class="settings-block-hint">$' + baseCredit.toFixed(2) + ' included this month' +
+          (topupCredit > 0 ? ' + $' + topupCredit.toFixed(2) + ' purchased (never expires)' : '') +
+        '</div>' +
+        '<div class="settings-block-hint">$' + combinedCredit.toFixed(2) + ' total available for AI reviews and builds</div>' +
+        '<div class="form-row" style="margin-top: 10px;">' +
+          '<input type="number" id="topup-amount" min="5" step="1" value="10" style="width: 80px;">' +
+          '<button class="btn" onclick="buyCredit()" style="margin-left: 6px;">Buy more credit</button>' +
+        '</div>' +
+        '<div id="topup-status" class="settings-block-hint"></div>' +
+      '</div>' +
+    '</section>';
+```
+
+Keep this as its own top-level `<section>`, inserted as a sibling of the existing settings sections (not nested inside the block that also covers seats/tokens/health targets) - matches the "separate section" decision. Find the real insertion point in the surrounding page-assembly code (Step 1's read) and place it there, rather than assuming it slots in at the exact same spot the old `usageHtml` did if that spot is inside a combined container.
+
+- [ ] **Step 3: Write the `buyCredit()` checkout function**
+
+Add near the existing `buySeat()`/`openBillingPortal()` functions in the same file (read one of them first for the exact Paddle Checkout call pattern already used here - don't invent a new one):
+
+```javascript
+function buyCredit() {
+  const amount = parseInt(document.getElementById('topup-amount').value, 10);
+  const statusEl = document.getElementById('topup-status');
+  if (!amount || amount < 5) {
+    statusEl.textContent = 'Minimum purchase is $5.';
+    return;
+  }
+  statusEl.textContent = 'Opening checkout...';
+  Paddle.Checkout.open({
+    items: [{ priceId: window._creditTopupPriceId, quantity: amount }],
+    customData: { installation_token: window._installationToken },
+  });
+}
+```
+
+Confirm the exact real global variable names this page already uses for the signed installation token and any existing Paddle price id constants exposed to the frontend (Step 1's read of the existing `buySeat()`/subscribe buttons will show the real pattern - `window._installationToken`/`window._creditTopupPriceId` above are illustrative, match whatever's actually there).
+
+- [ ] **Step 4: Expose `CREDIT_TOPUP_PRICE_ID` to the frontend**
+
+Find where existing price ids (e.g. the extra-seat price) get passed from the server-rendered page into a `window._...` JS global, and add `CREDIT_TOPUP_PRICE_ID` the same way - this constant lives in `app_server/paddle_pricing.py` on the backend plan's side; import and use it, don't hardcode a duplicate string here.
+
+- [ ] **Step 5: Manual verification in the browser**
+
+This is server-rendered HTML/JS with no test harness for visual layout - use the preview tooling to actually load the dashboard settings page for a real installation, confirm the "Usage" section renders as a distinct section (not merged into the seats/tokens block), the two balance numbers display correctly, and clicking "Buy more credit" with a real test amount opens the Paddle Checkout overlay (a sandbox/test transaction, not a real charge - use Paddle's sandbox mode per this repo's existing `paddle:sandbox-testing` conventions if available, don't complete a real purchase against production Paddle).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add github-app/app_server/frontend.py
+git commit -m "feat: dedicated Usage section on the dashboard with credit balance and buy-more flow"
+```
+
+---
+
+### Task 3: Two new email templates
+
+**Files:**
+- Modify: `github-app/app_server/email_templates.py` (add two new render functions, following the exact shape of the existing `payment_failed_email`/`subscription_canceled_email` functions - read both first)
+- Modify: `github-app/scan_worker/jobs.py` (`_EMAIL_TEMPLATES` dict, register the two new template names)
+- Test: `github-app/tests/test_email_templates.py` (check the exact existing filename)
+
+**Interfaces:**
+- Consumes: the exact `template_arg` shape the backend plan's Task 6 defines: `{"account_login": str, "plan": str, "base_credit_remaining_usd": float, "topup_credit_balance_usd": float}`.
+- Produces: `credit_low_balance_email(account_login: str, plan: str, base_credit_remaining_usd: float, topup_credit_balance_usd: float) -> dict`, `credit_exhausted_email(...)` (same signature) - both returning the existing `{"subject": str, "html": str, "text": str}` shape every other template in this file returns.
+
+- [ ] **Step 1: Read the existing template shape and helpers**
+
+Run: `sed -n '158,204p' github-app/app_server/email_templates.py`
+
+Confirm the exact real signature/return shape of `payment_failed_email`, and the existing `_shell`/`_button`/`_plan_display_name` helpers this file already provides - the two new templates should use them, not duplicate HTML boilerplate.
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+from app_server.email_templates import credit_low_balance_email, credit_exhausted_email
+
+
+def test_credit_low_balance_email_mentions_both_balances():
+    message = credit_low_balance_email(
+        account_login="acme", plan="flash",
+        base_credit_remaining_usd=0.70, topup_credit_balance_usd=0.00,
+    )
+    assert "subject" in message and "html" in message and "text" in message
+    assert "0.70" in message["text"]
+    assert "acme" in message["text"]
+
+
+def test_credit_exhausted_email_mentions_buying_more():
+    message = credit_exhausted_email(
+        account_login="acme", plan="air",
+        base_credit_remaining_usd=0.00, topup_credit_balance_usd=0.00,
+    )
+    assert "subject" in message and "html" in message and "text" in message
+    # Must give the customer an actual next step, not just "you're out."
+    assert "credit" in message["text"].lower()
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd github-app && python3 -m pytest tests/test_email_templates.py -k "credit_low_balance or credit_exhausted" -v`
+Expected: FAIL (`ImportError`)
+
+- [ ] **Step 4: Write the two templates**
+
+```python
+def credit_low_balance_email(
+    account_login: str, plan: str, base_credit_remaining_usd: float, topup_credit_balance_usd: float
+) -> dict:
+    plan_name = _plan_display_name(plan)
+    combined = base_credit_remaining_usd + topup_credit_balance_usd
+    subject = f"Your Aletheore {plan_name} credit is running low"
+    preheader = f"${combined:.2f} remaining this cycle."
+    text = (
+        f"Hi {account_login},\n\n"
+        f"Your Aletheore {plan_name} plan has ${combined:.2f} of AI credit left "
+        "this billing cycle (${base_credit_remaining_usd:.2f} included, "
+        f"${topup_credit_balance_usd:.2f} from purchased top-ups). "
+        "Once it runs out, automatic PR reviews and other AI-powered features "
+        "will pause until your next renewal or you buy more.\n\n"
+        "Buy more credit any time from your dashboard - it never expires."
+    )
+    html = _shell(
+        preheader,
+        f"<p>Your Aletheore {plan_name} plan has <strong>${combined:.2f}</strong> of AI credit "
+        "left this billing cycle.</p>"
+        f"<p>${base_credit_remaining_usd:.2f} included, ${topup_credit_balance_usd:.2f} from "
+        "purchased top-ups.</p>"
+        "<p>Once it runs out, automatic PR reviews and other AI-powered features will pause "
+        "until your next renewal or you buy more.</p>"
+        + _button("Buy more credit", "https://app.aletheore.com/"),
+    )
+    return {"subject": subject, "html": html, "text": text}
+
+
+def credit_exhausted_email(
+    account_login: str, plan: str, base_credit_remaining_usd: float, topup_credit_balance_usd: float
+) -> dict:
+    plan_name = _plan_display_name(plan)
+    subject = f"Your Aletheore {plan_name} credit has run out"
+    preheader = "AI-powered features are paused until you buy more credit or your plan renews."
+    text = (
+        f"Hi {account_login},\n\n"
+        f"Your Aletheore {plan_name} plan has run out of AI credit for this billing cycle. "
+        "Automatic PR reviews and other AI-powered features are paused - deterministic "
+        "scanning and everything in Community continues to work normally.\n\n"
+        "Buy more credit any time to resume immediately, or wait for your next renewal "
+        "when your included credit refreshes."
+    )
+    html = _shell(
+        preheader,
+        f"<p>Your Aletheore {plan_name} plan has run out of AI credit for this billing cycle.</p>"
+        "<p>Automatic PR reviews and other AI-powered features are paused - deterministic "
+        "scanning and everything in Community continues to work normally.</p>"
+        + _button("Buy more credit", "https://app.aletheore.com/"),
+    )
+    return {"subject": subject, "html": html, "text": text}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd github-app && python3 -m pytest tests/test_email_templates.py -k "credit_low_balance or credit_exhausted" -v`
+Expected: PASS
+
+- [ ] **Step 6: Register both in `_EMAIL_TEMPLATES`**
+
+In `github-app/scan_worker/jobs.py`, add to the existing `_EMAIL_TEMPLATES` dict:
+
+```python
+    "credit_low_balance": credit_low_balance_email,
+    "credit_exhausted": credit_exhausted_email,
+```
+
+Add the corresponding import at the top of the file alongside the existing `email_templates` imports.
+
+- [ ] **Step 7: Run the full email-related test suite**
+
+Run: `cd github-app && python3 -m pytest tests/test_email_templates.py tests/test_jobs.py -k "email" -q`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add github-app/app_server/email_templates.py github-app/scan_worker/jobs.py github-app/tests/test_email_templates.py
+git commit -m "feat: credit_low_balance and credit_exhausted email templates"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Balance display, distinct "Usage" section (per this session's explicit steer, not the spec's original wording) — Task 2. ✓
+- "Buy more credit" flow, customer-chosen amount, $5 minimum — Task 2. ✓
+- Two new email templates, exact interface match with the backend plan — Task 3. ✓
+- Settings API extended to carry the real balance — Task 1. ✓
+
+**Placeholder scan:** none - every code block is real, runnable code, not a description.
+
+**Type consistency:** `credit_low_balance_email`/`credit_exhausted_email`'s parameter names (`account_login`, `plan`, `base_credit_remaining_usd`, `topup_credit_balance_usd`) match the backend plan's Task 6 `template_arg` dict keys exactly - this was checked against the other plan's file, not assumed.
+
+**Cross-plan dependency, stated plainly:** this plan cannot fully pass its own tests until the backend plan's Task 1 (migration) has landed - Task 1 here reads columns that plan creates. Coordinate on that ordering before starting either plan's Task 1 in parallel.

--- a/docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md
+++ b/docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md
@@ -294,13 +294,13 @@ New Paddle plumbing - no equivalent exists today.
   both re-arm after the next renewal.
 - Release-on-failure correctly reverses a reservation's base/top-up split.
 
-## Open Questions
+## Resolved Questions
 
-1. **Low-balance threshold**: proposed 15% of that cycle's starting combined
-   total (base + top-up at the moment of the last renewal or top-up
-   purchase, whichever is more recent) - needs explicit confirmation before
-   implementation, since "15% of what" has more than one reasonable reading
-   once top-ups are in play.
-
-(Top-up amount is resolved, not open - see Decision 1a: customer-chosen
-quantity against one $1/unit price, $5 minimum, not a fixed pack menu.)
+1. **Low-balance threshold: 15%, confirmed.** Defined as 15% of a rolling
+   high-water mark - the combined balance (base + top-up) immediately after
+   the most recent event that raised it (a renewal reset or a top-up
+   purchase, whichever happened most recently). `low_balance_email_sent_at`
+   dedupes within that window; a later top-up purchase establishes a new,
+   higher high-water mark and re-arms the check against the new 15%.
+2. **Top-up amount: resolved, not open** - see Decision 1a. Customer-chosen
+   quantity against one $1/unit price, $5 minimum, not a fixed pack menu.

--- a/docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md
+++ b/docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md
@@ -1,0 +1,293 @@
+# Dollar-Credit Pricing Design
+
+## Problem
+
+Aletheore's marketing currently promises fixed review counts - "up to 800/month"
+for Flash Review on the Flash tier ($8/mo), with no explicit AIRview/Docs number
+for AIR ($29.99/mo). These counts are *derived estimates* on top of a real,
+already-enforced dollar cap (`PLAN_CAP_OVERRIDE_USD = {"flash": 6.00, "air":
+20.00}` in `github-app/app_server/llm_cost.py`), using assumptions about average
+tokens-per-review that don't hold for every repo. A customer with an unusually
+large or complex repo could hit the real $ cap well before reaching their
+"promised" review count - the promise and the enforcement mechanism are two
+different things that can silently disagree.
+
+Real measured costs (from a same-night benchmark comparing gpt-5.6-luna against
+a candidate cheaper model on the same 24-case corpus) confirm the $ cap is the
+right unit to promise: Luna costs ~$0.0049/review, so $5 of credit buys
+~1,000 reviews - *more* generous than the current "800/month" claim, not less.
+
+## Goal
+
+Replace the review-count promise with a real, transparent dollar-credit balance
+the customer can see, spend down, top up, and get notified about - matching the
+mechanism the system already enforces instead of a derived estimate layered on
+top of it.
+
+- Flash: **$5/mo** included credit (plan price unchanged, $8/mo)
+- AIR: **$18/mo** included credit (plan price unchanged, $29.99/mo)
+- Both numbers leave real margin under Paddle's cut and the real enforced
+  ceiling, and were checked against real per-review/per-build costs, not
+  picked arbitrarily.
+
+## Non-goals
+
+- Migrating existing subscribers to a new balance mid-cycle - not needed.
+  Confirmed via direct production DB query (2026-09-09): zero Flash-tier
+  installations exist, and the only two AIR installations are the project's
+  own dogfooding accounts. There is no real subscriber whose expectations
+  this change could violate.
+- Refunds or prorating a cancelled subscription's remaining balance.
+- Changing what AIRview/Docs/Flash Review/managed audits actually cost to run.
+- Annual billing for credit packs (packs are one-time purchases regardless of
+  the underlying subscription's billing interval).
+
+## Current State (what this replaces)
+
+- `PLAN_CAP_OVERRIDE_USD` (`github-app/app_server/llm_cost.py`): a flat,
+  static $ ceiling per *plan*, identical for every installation on that plan.
+  Not per-customer, no concept of a balance, no concept of purchasing more.
+- `reserve_llm_spend(dsn, installation_id, reserve_usd, monthly_cap) -> bool`
+  and `release_llm_spend_reservation` (`github-app/scan_worker/db.py`): the
+  real, atomically-safe enforcement path. Every real LLM call site (Flash
+  Review, AIRview incremental/full build, Docs incremental/full build,
+  managed audits) reserves budget here *before* calling the model, and
+  releases it if the call ultimately isn't made. Already has a real
+  concurrency test (`test_reserve_llm_spend_is_atomic_under_real_concurrency`)
+  proving two simultaneous reservations against the same installation can
+  never together exceed the cap.
+- `llm_spend` / `llm_spend_events` (`github-app/scan_worker/db.py`): pure
+  *accounting* - what was actually spent, this month, and (as of the
+  just-added `llm_spend_events` ledger) broken down by feature. This is a
+  record of the past. It is not touched by this design except to keep
+  writing to it exactly as it does today - accounting and balance-tracking
+  are separate concerns.
+- `installations` table already carries billing-derived numeric state
+  directly as columns (`extra_seats`, `max_api_tokens`), and Paddle identity
+  (`paddle_subscription_id`, `paddle_customer_id`). This design follows that
+  existing pattern rather than introducing a new table for a 1:1 relationship.
+- `github-app/app_server/webhooks/paddle.py` currently handles
+  `subscription.created` and `subscription.updated` only. There is no
+  handling today for a one-time (non-subscription) Paddle purchase.
+
+## Decisions (from brainstorming)
+
+1. **Top-up credit packs are one-time purchases, never expire.** Not a
+   recurring line item (unlike the existing extra-seat pattern). Matches
+   RepoWise's own "$5 packs, never expire" framing, confirmed with the user.
+2. **The plan's base included credit resets every renewal**, independent of
+   any top-up balance. It does not accumulate across cycles - unused base
+   credit at the end of a cycle is gone, same as the current review-count
+   promise implicitly worked (a customer never carried over unused reviews).
+3. **Draw-down order: base credit first, then top-up balance.** A customer
+   only spends from their purchased top-up once the month's included credit
+   is exhausted.
+4. **The old flat plan cap is retired as an enforcement mechanism, not kept
+   as a ceiling on top of the new balance.** Once a customer buys top-up
+   credit, their real spendable ceiling for that cycle is
+   `base_credit_remaining + topup_credit_balance`, which can exceed the old
+   $6/$20 figures by design - that's the entire point of selling top-ups.
+   There is no separate "still capped at the old number even after buying
+   more" behavior.
+5. **Exhaustion still fails open, never overspends** - same philosophy as
+   today (a job degrades gracefully, e.g. `set_wiki_build_status(...,
+   "failed", ...)`, rather than blocking or erroring loudly). What changes is
+   *visibility*: real customer-facing signals now exist where before there
+   was only an internal log line.
+6. **Two customer-facing emails**, both new:
+   - **Low-balance warning**, fired once per cycle when remaining balance
+     (base + top-up combined) crosses a threshold (proposed: 15% of that
+     cycle's starting total remaining - see Open Question 1).
+   - **Exhausted**, fired when a real reservation attempt is *rejected* for
+     insufficient balance - not a raw `== 0` check. "Exhausted" means the
+     next real call's expected cost no longer fits in what's left, which is
+     exactly what a rejected `reserve_llm_spend` call already detects.
+7. **Dashboard balance display + "buy more" flow ship in the same pass**,
+   not deferred - the customer needs to be able to see the number being
+   promised, or the whole redesign is less honest than the thing it replaces.
+
+## Architecture
+
+Two new columns on `installations`, atomically updated by the same reservation
+path that already exists, plus one new billing-period marker column so the
+renewal reset can be applied idempotently.
+
+```
+installations
+  ...
+  base_credit_remaining_usd     NUMERIC NOT NULL DEFAULT 0
+  topup_credit_balance_usd      NUMERIC NOT NULL DEFAULT 0
+  current_billing_period_start  TIMESTAMPTZ
+  low_balance_email_sent_at     TIMESTAMPTZ   -- dedup, cleared on renewal
+  exhausted_email_sent_at       TIMESTAMPTZ   -- dedup, cleared on renewal
+```
+
+Two dedup timestamp columns (rather than a single "which emails have I sent"
+flag) so a customer who tops up mid-cycle after going low can still get a
+fresh exhausted email later in the same cycle if they run out again - each
+email type dedupes independently, both reset together on the next renewal.
+
+### Why two stored columns instead of one, or instead of a live ledger sum
+
+Covered in the brainstorming approaches comparison; recorded here for anyone
+picking this spec up cold:
+
+- **One combined column** can't distinguish "this leftover $2 came from base
+  credit (must reset)" from "this leftover $2 came from a top-up (must
+  persist)" at renewal time without tracking the split anyway - it either
+  silently breaks the reset rule or collapses back into two numbers.
+- **A live-summed ledger balance** (summing `llm_spend_events` and a new
+  purchases table on every check) loses the atomic-under-concurrency
+  guarantee the current system already has and is already tested for. Two
+  simultaneous reservations could both read the same sum before either
+  commits. Keep the ledger for audit/history (it already exists via PR #635's
+  `llm_spend_events`); don't make it the hot enforcement path.
+
+### Data flow: a real LLM call (unchanged shape, changed cap source)
+
+1. A job (Flash Review, AIRview incremental update, etc.) is about to make a
+   real LLM call.
+2. It calls the reservation function with the installation's real remaining
+   balance as the ceiling, instead of `base_cap_for_plan(plan)`'s flat
+   constant.
+3. On success: the reservation amount is deducted from
+   `base_credit_remaining_usd` first; if that's insufficient, the remainder
+   is deducted from `topup_credit_balance_usd`. Both updates happen inside
+   the same atomic `UPDATE ... WHERE` the current `reserve_llm_spend` already
+   uses, extended to two columns instead of one - single query, single
+   transaction, same concurrency guarantee.
+4. On success, check whether this reservation crossed the low-balance
+   threshold (compare pre/post remaining total against the threshold) and
+   whether `low_balance_email_sent_at` is unset for this cycle; if both,
+   enqueue the low-balance email and stamp the timestamp.
+5. On failure (would exceed remaining balance): same degrade-gracefully path
+   every caller already has today (skip the job, log/set a failed status).
+   Additionally, if `exhausted_email_sent_at` is unset for this cycle,
+   enqueue the exhausted email and stamp the timestamp.
+6. `record_llm_spend`/`llm_spend_events` continue to run exactly as today,
+   unchanged - this design only changes what the *ceiling* is, not what gets
+   recorded about what actually happened.
+
+### Data flow: renewal (base credit reset)
+
+Paddle's `subscription.updated` fires for many things unrelated to renewal
+(seat changes, payment method updates) and webhooks are not ordered or
+guaranteed-exactly-once - both real, documented Paddle behaviors. The reset
+must therefore be scoped to genuine cycle boundaries and safe to process more
+than once.
+
+1. On `subscription.updated`, read `current_billing_period.starts_at` from
+   the payload.
+2. If it differs from the installation's stored `current_billing_period_start`
+   (a real new cycle, not some other kind of update):
+   - Reset `base_credit_remaining_usd` to the plan's base amount
+     (`PLAN_BASE_CREDIT_USD = {"flash": 5.00, "air": 18.00}`, a new mapping
+     alongside the existing `PLAN_MONTHLY_PRICE_USD`).
+   - Leave `topup_credit_balance_usd` untouched - it never resets.
+   - Clear both `low_balance_email_sent_at` and `exhausted_email_sent_at`.
+   - Update the stored `current_billing_period_start` to the new value.
+3. If it matches what's already stored, this is some other kind of
+   `subscription.updated` (a seat change, etc.) - do nothing to the balance.
+   Idempotent by construction: replaying the same renewal event twice is a
+   no-op the second time, since the stored period start already matches.
+
+### Data flow: a top-up purchase
+
+New Paddle plumbing - no equivalent exists today.
+
+1. Customer buys a credit pack (a new, real, one-time Paddle price - not a
+   subscription line item) from the dashboard's "buy more" flow.
+2. Paddle sends `transaction.completed` for that one-time purchase. The
+   webhook handler (new branch in `webhooks/paddle.py`) verifies the
+   signature (existing mechanism, unchanged), resolves the price ID against
+   a new `CREDIT_PACK_PRICE_TO_AMOUNT_USD` mapping (parallel to the existing
+   `PADDLE_PRICE_TO_PLAN`), and attributes the purchase to an installation
+   via `customer_id` matching `installations.paddle_customer_id` - the same
+   attribution pattern subscription webhooks already use
+   (`PaddleWebhookAttributionError` on a miss).
+3. Atomically increments `topup_credit_balance_usd` by the pack's dollar
+   amount.
+4. Idempotency: Paddle retries a webhook it didn't get a 2xx for, with the
+   *same* `transaction.id`. A `processed_paddle_transactions` table (id
+   primary key) recording every transaction ID this handler has already
+   applied prevents a retry from crediting the same purchase twice - the
+   same shape as `paddle:webhooks`' documented idempotency-ledger pattern for
+   side effects that aren't naturally idempotent via UPSERT.
+
+## Components
+
+**Backend (this session, primary implementer: this agent):**
+- Migration: new `installations` columns + `processed_paddle_transactions`
+  table.
+- `PLAN_BASE_CREDIT_USD` mapping (`llm_cost.py`).
+- `CREDIT_PACK_PRICE_TO_AMOUNT_USD` mapping (`paddle_pricing.py`), plus
+  whatever real Paddle price IDs get created for the packs (start simple:
+  $5/$10/$20 packs).
+- Rewrite `reserve_llm_spend`/`release_llm_spend_reservation` (`db.py`) to
+  read/write the two balance columns on `installations` instead of the
+  single `llm_spend` monthly total, base-first draw-down.
+- New `webhooks/paddle.py` branch for `transaction.completed` on a credit
+  pack price, with the idempotency ledger.
+- New `webhooks/paddle.py` renewal-reset branch on `subscription.updated`,
+  scoped by `current_billing_period_start` comparison.
+- Email-trigger hooks at the two points identified in the data flow above,
+  reusing the existing job-side email/alert dispatch pattern this codebase
+  already has for Slack/Teams alerts.
+- Every existing call site of the old flat-cap check
+  (`_llm_spend_cap_reached`, the various `reserve_llm_spend` calls in
+  `jobs.py` for Flash Review, AIRview, Docs, managed audits) updated to the
+  new per-installation signature.
+
+**Dashboard + emails (this session, other agent):**
+- Balance display component (`app_server/frontend.py`): current
+  `base_credit_remaining_usd` + `topup_credit_balance_usd`, clearly
+  distinguishing "included this month" from "purchased, never expires."
+- "Buy more credit" flow: pack selection UI wired to Paddle checkout for the
+  new one-time prices.
+- Email templates/copy for the two new notifications (low-balance,
+  exhausted), triggered by the backend hooks above - this agent owns the
+  content and rendering, not the trigger logic.
+
+## Error handling
+
+- **Unattributed top-up purchase** (a `transaction.completed` whose
+  `customer_id` matches no installation): same `PaddleWebhookAttributionError`
+  path the subscription webhooks already use - logged, non-2xx response so
+  Paddle retries (the real fix is usually a timing issue - `pending_subscription_claims`
+  hasn't resolved yet - and retrying recovers automatically).
+- **Duplicate transaction delivery**: caught by the idempotency ledger before
+  any balance mutation happens - a replay is a no-op, not a double-credit.
+- **Renewal event processed twice**: idempotent by construction via the
+  billing-period-start comparison - no separate ledger needed for this one.
+- **A job's reservation is released** (call ultimately wasn't made): credits
+  the exact amount back to whichever column(s) it was drawn from, same
+  base-first/top-up-second bookkeeping in reverse.
+
+## Testing
+
+- Renewal reset only fires on a genuine new billing period, not on an
+  unrelated `subscription.updated` (e.g. a seat-count change) - and is a
+  no-op if the same renewal event is delivered twice.
+- Draw-down order: a reservation that only partially fits in remaining base
+  credit correctly spills the remainder into top-up balance, in one atomic
+  update.
+- Concurrency: two simultaneous reservations against the same installation's
+  combined balance can never together exceed what's actually available -
+  same style of test as the existing `test_reserve_llm_spend_is_atomic_under_real_concurrency`.
+- Top-up webhook: a replayed `transaction.completed` (same transaction ID)
+  credits the balance exactly once.
+- Email dedup: the low-balance email fires once per cycle, not on every
+  reservation after the threshold is crossed; same for the exhausted email;
+  both re-arm after the next renewal.
+- Release-on-failure correctly reverses a reservation's base/top-up split.
+
+## Open Questions
+
+1. **Low-balance threshold**: proposed 15% of that cycle's starting combined
+   total (base + top-up at the moment of the last renewal or top-up
+   purchase, whichever is more recent) - needs explicit confirmation before
+   implementation, since "15% of what" has more than one reasonable reading
+   once top-ups are in play.
+2. **Credit pack sizes**: proposed $5/$10/$20 as a starting point - easy to
+   change later since it's just new Paddle price IDs, not a structural
+   decision, so not blocking implementation start.

--- a/docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md
+++ b/docs/superpowers/specs/2026-09-09-dollar-credit-pricing-design.md
@@ -39,7 +39,7 @@ top of it.
   this change could violate.
 - Refunds or prorating a cancelled subscription's remaining balance.
 - Changing what AIRview/Docs/Flash Review/managed audits actually cost to run.
-- Annual billing for credit packs (packs are one-time purchases regardless of
+- Annual billing for top-up credit (it's a one-time purchase regardless of
   the underlying subscription's billing interval).
 
 ## Current State (what this replaces)
@@ -72,9 +72,18 @@ top of it.
 
 ## Decisions (from brainstorming)
 
-1. **Top-up credit packs are one-time purchases, never expire.** Not a
-   recurring line item (unlike the existing extra-seat pattern). Matches
-   RepoWise's own "$5 packs, never expire" framing, confirmed with the user.
+1. **Top-up credit is a one-time purchase, never expires.** Not a recurring
+   line item (unlike the existing extra-seat pattern). Matches RepoWise's own
+   "packs, never expire" framing, confirmed with the user.
+1a. **The amount is customer-chosen, not a fixed menu of packs.** One credit
+   price at $1/unit, billed by quantity - the customer picks the quantity at
+   checkout (quantity 8 = $8 of credit). This reuses the exact "billed by
+   quantity against one price" mechanism `EXTRA_SEAT_PRICE_ID` already uses
+   in this codebase, just as a one-time transaction instead of a recurring
+   subscription line item, rather than requiring a customer to pick from a
+   predefined set of pack sizes. A $5 minimum purchase applies so Paddle's
+   fixed per-transaction processing fee doesn't eat a disproportionate share
+   of a very small purchase; no maximum.
 2. **The plan's base included credit resets every renewal**, independent of
    any top-up balance. It does not accumulate across cycles - unused base
    credit at the end of a cycle is gone, same as the current review-count
@@ -195,17 +204,20 @@ than once.
 
 New Paddle plumbing - no equivalent exists today.
 
-1. Customer buys a credit pack (a new, real, one-time Paddle price - not a
-   subscription line item) from the dashboard's "buy more" flow.
+1. Customer picks a dollar amount ($5 minimum) in the dashboard's "buy more"
+   flow, which sets the quantity on a single one-time Paddle price
+   (`CREDIT_TOPUP_PRICE_ID`, $1/unit) at checkout - not a subscription line
+   item, and not a predefined pack.
 2. Paddle sends `transaction.completed` for that one-time purchase. The
    webhook handler (new branch in `webhooks/paddle.py`) verifies the
-   signature (existing mechanism, unchanged), resolves the price ID against
-   a new `CREDIT_PACK_PRICE_TO_AMOUNT_USD` mapping (parallel to the existing
-   `PADDLE_PRICE_TO_PLAN`), and attributes the purchase to an installation
-   via `customer_id` matching `installations.paddle_customer_id` - the same
+   signature (existing mechanism, unchanged), confirms the price ID matches
+   `CREDIT_TOPUP_PRICE_ID`, reads the real purchased amount from the
+   transaction's quantity/total (not a lookup table, since the amount is
+   customer-chosen), and attributes the purchase to an installation via
+   `customer_id` matching `installations.paddle_customer_id` - the same
    attribution pattern subscription webhooks already use
    (`PaddleWebhookAttributionError` on a miss).
-3. Atomically increments `topup_credit_balance_usd` by the pack's dollar
+3. Atomically increments `topup_credit_balance_usd` by the purchased
    amount.
 4. Idempotency: Paddle retries a webhook it didn't get a 2xx for, with the
    *same* `transaction.id`. A `processed_paddle_transactions` table (id
@@ -220,14 +232,14 @@ New Paddle plumbing - no equivalent exists today.
 - Migration: new `installations` columns + `processed_paddle_transactions`
   table.
 - `PLAN_BASE_CREDIT_USD` mapping (`llm_cost.py`).
-- `CREDIT_PACK_PRICE_TO_AMOUNT_USD` mapping (`paddle_pricing.py`), plus
-  whatever real Paddle price IDs get created for the packs (start simple:
-  $5/$10/$20 packs).
+- `CREDIT_TOPUP_PRICE_ID` (`paddle_pricing.py`): one real Paddle price,
+  $1/unit, billed by customer-chosen quantity - the real price ID gets
+  created live via the Paddle MCP, same as `EXTRA_SEAT_PRICE_ID`'s history.
 - Rewrite `reserve_llm_spend`/`release_llm_spend_reservation` (`db.py`) to
   read/write the two balance columns on `installations` instead of the
   single `llm_spend` monthly total, base-first draw-down.
-- New `webhooks/paddle.py` branch for `transaction.completed` on a credit
-  pack price, with the idempotency ledger.
+- New `webhooks/paddle.py` branch for `transaction.completed` on
+  `CREDIT_TOPUP_PRICE_ID`, with the idempotency ledger.
 - New `webhooks/paddle.py` renewal-reset branch on `subscription.updated`,
   scoped by `current_billing_period_start` comparison.
 - Email-trigger hooks at the two points identified in the data flow above,
@@ -242,8 +254,9 @@ New Paddle plumbing - no equivalent exists today.
 - Balance display component (`app_server/frontend.py`): current
   `base_credit_remaining_usd` + `topup_credit_balance_usd`, clearly
   distinguishing "included this month" from "purchased, never expires."
-- "Buy more credit" flow: pack selection UI wired to Paddle checkout for the
-  new one-time prices.
+- "Buy more credit" flow: an amount input ($5 minimum) wired to Paddle
+  checkout against `CREDIT_TOPUP_PRICE_ID` with quantity set from that
+  amount.
 - Email templates/copy for the two new notifications (low-balance,
   exhausted), triggered by the backend hooks above - this agent owns the
   content and rendering, not the trigger logic.
@@ -288,6 +301,6 @@ New Paddle plumbing - no equivalent exists today.
    purchase, whichever is more recent) - needs explicit confirmation before
    implementation, since "15% of what" has more than one reasonable reading
    once top-ups are in play.
-2. **Credit pack sizes**: proposed $5/$10/$20 as a starting point - easy to
-   change later since it's just new Paddle price IDs, not a structural
-   decision, so not blocking implementation start.
+
+(Top-up amount is resolved, not open - see Decision 1a: customer-chosen
+quantity against one $1/unit price, $5 minimum, not a fixed pack menu.)

--- a/github-app/app_server/admin.py
+++ b/github-app/app_server/admin.py
@@ -71,7 +71,7 @@ from app_server.db import (
     set_webhook_url,
     update_session_tokens,
 )
-from app_server.llm_cost import EXTRA_SEAT_PRICE_USD, base_cap_for_plan, monthly_cap_for_installation
+from app_server.llm_cost import EXTRA_SEAT_PRICE_USD
 from app_server.paddle_client import PaddleAPIError
 from app_server.paddle_client import create_discount as create_paddle_discount
 from app_server.paddle_client import create_portal_session
@@ -546,7 +546,14 @@ async def admin_page(org: str, repo: str, request: Request):
     health_target_limit = INCLUDED_HEALTH_CHECK_TARGETS.get(installation["plan"], DEFAULT_HEALTH_CHECK_TARGET_LIMIT)
     llm_spend_month_to_date = await get_llm_spend_this_month(pool, installation_id)
     flash_reviews_month_to_date = await get_flash_review_count_this_month(pool, installation_id)
-    llm_spend_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
+    # Real per-installation credit balance (base + top-up), not the old
+    # flat monthly_cap_for_installation(base_cap_for_plan(...)) ceiling -
+    # see reserve_llm_spend/PLAN_BASE_CREDIT_USD (Task 7 of the
+    # dollar-credit-pricing plan, 2026-09-09). "llm_spend_cap" is kept as
+    # the response key so this doesn't also require an API-shape change.
+    llm_spend_cap = float(installation["base_credit_remaining_usd"]) + float(
+        installation["topup_credit_balance_usd"]
+    )
     public_status_enabled = await get_public_status_enabled(pool, installation_id, repo_full_name)
     return {
         "installation": installation,

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -68,7 +68,8 @@ async def get_installation(pool: asyncpg.Pool, installation_id: int) -> dict | N
         SELECT installation_id, account_login, plan, webhook_url, alert_email,
                pushover_user_key, max_api_tokens, health_check_base_url,
                health_check_latency_threshold_ms, paddle_subscription_id,
-               paddle_customer_id, llm_suggestions_enabled
+               paddle_customer_id, llm_suggestions_enabled,
+               base_credit_remaining_usd, topup_credit_balance_usd
         FROM installations
         WHERE installation_id = $1
         """,

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -194,10 +194,12 @@ async def add_paddle_ids_to_installation(
 async def reset_billing_period_credit(
     pool: asyncpg.Pool, installation_id: int, plan: str, extra_seats: int, period_start: str
 ) -> bool:
-    """Resets base_credit_remaining_usd to this plan's real included
-    credit (base_credit_for_plan, same per-seat bonus the old flat cap
-    used) only if period_start is genuinely new for this installation -
-    a no-op on a replayed or unrelated subscription.updated event.
+    """Resets base_credit_remaining_usd - and base_credit_allotment_usd,
+    this billing period's ceiling, to the same value - to this plan's
+    real included credit (base_credit_for_plan, same per-seat bonus the
+    old flat cap used) only if period_start is genuinely new for this
+    installation; a no-op on a replayed or unrelated subscription.updated
+    event.
     Increments balance_epoch on a real reset, which doubles as the
     dedupe key both new credit-notification emails key off of. Returns
     whether a reset actually happened.
@@ -220,6 +222,7 @@ async def reset_billing_period_credit(
         """
         UPDATE installations
         SET base_credit_remaining_usd = $2,
+            base_credit_allotment_usd = $2,
             current_billing_period_start = $3,
             balance_epoch = balance_epoch + 1
         WHERE installation_id = $1
@@ -232,10 +235,11 @@ async def reset_billing_period_credit(
 
 
 async def credit_extra_seat_purchase(
-    pool: asyncpg.Pool, installation_id: int, added_seats: int
+    pool: asyncpg.Pool, installation_id: int, added_seats: int, plan: str, extra_seats: int
 ) -> None:
     """Credits the per-seat LLM bonus for seats bought MID-CYCLE, when
-    reset_billing_period_credit cannot.
+    reset_billing_period_credit cannot - clamped at what the CURRENT seat
+    count actually entitles the installation to.
 
     The per-seat bonus is folded into base_credit_for_plan, which only ever
     gets applied by a real renewal reset - and a seat purchase fires
@@ -253,14 +257,32 @@ async def credit_extra_seat_purchase(
 
     balance_epoch is incremented, matching credit_topup_purchase: the
     balance just went UP, so a low-balance warning already sent for the old
-    epoch must not suppress a later one for the new, larger allotment."""
+    epoch must not suppress a later one for the new, larger allotment.
+
+    `plan` and `extra_seats` are the installation's CURRENT (post-purchase)
+    values, and base_credit_for_plan(plan, extra_seats) is therefore the
+    ceiling this installation is actually entitled to right now. Clamping
+    the credit at that ceiling - rather than adding the bonus
+    unconditionally - is what closes a self-service farming ratchet: seat
+    removal doesn't call this function and doesn't debit anything, so an
+    unclamped `+=` let a customer remove and re-add the same seat over and
+    over within one billing cycle, stacking a fresh EXTRA_SEAT_LLM_CAP_USD
+    bonus every round-trip. With the clamp, no number of remove/re-add
+    cycles can push the balance past what the current seat count pays for.
+    base_credit_allotment_usd is set to the same ceiling, keeping the
+    "release credits base first, capped at the allotment" invariant in
+    scan_worker/db.py's release_llm_spend_reservation true for the rest of
+    this billing period."""
     if added_seats <= 0:
         return
+    ceiling = base_credit_for_plan(plan, extra_seats)
     await pool.execute(
-        "UPDATE installations SET base_credit_remaining_usd = "
-        "base_credit_remaining_usd + $2, balance_epoch = balance_epoch + 1 "
+        "UPDATE installations SET "
+        "base_credit_remaining_usd = LEAST(base_credit_remaining_usd + $2, $3), "
+        "base_credit_allotment_usd = $3, "
+        "balance_epoch = balance_epoch + 1 "
         "WHERE installation_id = $1",
-        installation_id, EXTRA_SEAT_LLM_CAP_USD * added_seats,
+        installation_id, EXTRA_SEAT_LLM_CAP_USD * added_seats, ceiling,
     )
 
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import asyncpg
 
@@ -192,7 +192,12 @@ async def add_paddle_ids_to_installation(
 
 
 async def reset_billing_period_credit(
-    pool: asyncpg.Pool, installation_id: int, plan: str, extra_seats: int, period_start: str
+    pool: asyncpg.Pool,
+    installation_id: int,
+    plan: str,
+    extra_seats: int,
+    period_start: str,
+    is_annual: bool,
 ) -> bool:
     """Resets base_credit_remaining_usd - and base_credit_allotment_usd,
     this billing period's ceiling, to the same value - to this plan's
@@ -209,7 +214,28 @@ async def reset_billing_period_credit(
     an existing `pool.acquire()`/`conn.transaction()` block (the same
     pattern claim_free_to_paid_plan and friends already use) so this
     reset commits atomically with that block's plan/extra_seats/Paddle-id
-    writes instead of as an independent standalone call."""
+    writes instead of as an independent standalone call.
+
+    is_annual controls next_monthly_credit_reset_at: set to one month past
+    this reset for an annual subscriber (see
+    run_monthly_credit_reset_sweep_job in scan_worker/jobs.py, which
+    resets base credit again every time that date arrives, independent of
+    Paddle's own once-a-year billing period), or cleared to NULL for a
+    monthly subscriber (whose base credit is already correctly refreshed
+    every month by THIS function alone, so the synthetic sweep must never
+    also touch them - both firing in the same month would double-credit).
+
+    That first synthetic due date is period_start + 30 days rather than a
+    true calendar month: python-dateutil's relativedelta would express
+    "+ 1 month" exactly, but dateutil is not a dependency of this service
+    (it appears in requirements.lock.txt only transitively, via croniter,
+    and nothing in app_server/scan_worker imports it) and this fix is not
+    worth adding one for. The tradeoff is small and bounded: only the
+    FIRST interval of each year is 30 days - the sweep itself advances by
+    a real `interval '1 month'` from its own previous due date afterwards
+    - and the real annual renewal re-synchronizes this column from
+    period_start every year, so the slight calendar drift can never
+    accumulate beyond one billing year."""
     new_credit = base_credit_for_plan(plan, extra_seats)
     # Paddle sends ISO 8601 with a trailing "Z" (e.g.
     # "2026-09-01T00:00:00Z") - same format webhooks/paddle.py already
@@ -218,18 +244,20 @@ async def reset_billing_period_credit(
     # a real datetime, not a string, even with an explicit ::timestamptz
     # cast in the query.
     period_start_dt = datetime.fromisoformat(period_start)
+    next_monthly_reset = period_start_dt + timedelta(days=30) if is_annual else None
     row = await pool.fetchrow(
         """
         UPDATE installations
         SET base_credit_remaining_usd = $2,
             base_credit_allotment_usd = $2,
             current_billing_period_start = $3,
+            next_monthly_credit_reset_at = $4,
             balance_epoch = balance_epoch + 1
         WHERE installation_id = $1
             AND (current_billing_period_start IS DISTINCT FROM $3)
         RETURNING installation_id
         """,
-        installation_id, new_credit, period_start_dt,
+        installation_id, new_credit, period_start_dt, next_monthly_reset,
     )
     return row is not None
 

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -194,7 +194,14 @@ async def reset_billing_period_credit(
     a no-op on a replayed or unrelated subscription.updated event.
     Increments balance_epoch on a real reset, which doubles as the
     dedupe key both new credit-notification emails key off of. Returns
-    whether a reset actually happened."""
+    whether a reset actually happened.
+
+    Despite the parameter name/type, `pool` only needs to support
+    `.fetchrow()` - webhooks/paddle.py passes an open `conn` acquired from
+    an existing `pool.acquire()`/`conn.transaction()` block (the same
+    pattern claim_free_to_paid_plan and friends already use) so this
+    reset commits atomically with that block's plan/extra_seats/Paddle-id
+    writes instead of as an independent standalone call."""
     new_credit = base_credit_for_plan(plan, extra_seats)
     # Paddle sends ISO 8601 with a trailing "Z" (e.g.
     # "2026-09-01T00:00:00Z") - same format webhooks/paddle.py already

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -6,7 +6,12 @@ import asyncpg
 
 from aletheore.evidence import is_evidence_version_compatible
 from app_server.evidence_limits import check_evidence_size
-from app_server.llm_cost import WARN_FRACTION_OF_CAP, base_credit_for_plan, crossed_spend_warning_threshold
+from app_server.llm_cost import (
+    EXTRA_SEAT_LLM_CAP_USD,
+    WARN_FRACTION_OF_CAP,
+    base_credit_for_plan,
+    crossed_spend_warning_threshold,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +229,39 @@ async def reset_billing_period_credit(
         installation_id, new_credit, period_start_dt,
     )
     return row is not None
+
+
+async def credit_extra_seat_purchase(
+    pool: asyncpg.Pool, installation_id: int, added_seats: int
+) -> None:
+    """Credits the per-seat LLM bonus for seats bought MID-CYCLE, when
+    reset_billing_period_credit cannot.
+
+    The per-seat bonus is folded into base_credit_for_plan, which only ever
+    gets applied by a real renewal reset - and a seat purchase fires
+    subscription.updated with the SAME current_billing_period.starts_at, so
+    that reset is a deliberate no-op. Before this, a customer paid
+    EXTRA_SEAT_PRICE_USD ($6.99) for a seat and got $0 of extra credit until
+    their next renewal, up to a month later; the old flat cap recomputed
+    itself live from get_extra_seats at every enforcement call site, so
+    raising the ceiling used to be immediate.
+
+    Same `pool`-only-needs-`.execute()` contract reset_billing_period_credit
+    documents: webhooks/paddle.py passes the open `conn` from the
+    subscription handler's transaction so this commits atomically with that
+    block's plan/extra_seats/Paddle-id writes, rather than as a split write.
+
+    balance_epoch is incremented, matching credit_topup_purchase: the
+    balance just went UP, so a low-balance warning already sent for the old
+    epoch must not suppress a later one for the new, larger allotment."""
+    if added_seats <= 0:
+        return
+    await pool.execute(
+        "UPDATE installations SET base_credit_remaining_usd = "
+        "base_credit_remaining_usd + $2, balance_epoch = balance_epoch + 1 "
+        "WHERE installation_id = $1",
+        installation_id, EXTRA_SEAT_LLM_CAP_USD * added_seats,
+    )
 
 
 async def credit_topup_purchase(

--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -6,7 +6,7 @@ import asyncpg
 
 from aletheore.evidence import is_evidence_version_compatible
 from app_server.evidence_limits import check_evidence_size
-from app_server.llm_cost import WARN_FRACTION_OF_CAP, crossed_spend_warning_threshold
+from app_server.llm_cost import WARN_FRACTION_OF_CAP, base_credit_for_plan, crossed_spend_warning_threshold
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +183,64 @@ async def add_paddle_ids_to_installation(
         paddle_subscription_id,
         paddle_customer_id,
     )
+
+
+async def reset_billing_period_credit(
+    pool: asyncpg.Pool, installation_id: int, plan: str, extra_seats: int, period_start: str
+) -> bool:
+    """Resets base_credit_remaining_usd to this plan's real included
+    credit (base_credit_for_plan, same per-seat bonus the old flat cap
+    used) only if period_start is genuinely new for this installation -
+    a no-op on a replayed or unrelated subscription.updated event.
+    Increments balance_epoch on a real reset, which doubles as the
+    dedupe key both new credit-notification emails key off of. Returns
+    whether a reset actually happened."""
+    new_credit = base_credit_for_plan(plan, extra_seats)
+    # Paddle sends ISO 8601 with a trailing "Z" (e.g.
+    # "2026-09-01T00:00:00Z") - same format webhooks/paddle.py already
+    # parses for billed_at via datetime.fromisoformat (Python 3.11+
+    # accepts the "Z" suffix directly). asyncpg's timestamptz codec needs
+    # a real datetime, not a string, even with an explicit ::timestamptz
+    # cast in the query.
+    period_start_dt = datetime.fromisoformat(period_start)
+    row = await pool.fetchrow(
+        """
+        UPDATE installations
+        SET base_credit_remaining_usd = $2,
+            current_billing_period_start = $3,
+            balance_epoch = balance_epoch + 1
+        WHERE installation_id = $1
+            AND (current_billing_period_start IS DISTINCT FROM $3)
+        RETURNING installation_id
+        """,
+        installation_id, new_credit, period_start_dt,
+    )
+    return row is not None
+
+
+async def credit_topup_purchase(
+    pool: asyncpg.Pool, installation_id: int, amount_usd: float, transaction_id: str
+) -> bool:
+    """Credits a real, customer-purchased top-up to topup_credit_balance_
+    usd, exactly once per transaction_id even if the webhook is
+    redelivered. Returns whether this call actually credited anything
+    (False on a replay)."""
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            inserted = await conn.fetchrow(
+                "INSERT INTO processed_paddle_transactions (id) VALUES ($1) "
+                "ON CONFLICT (id) DO NOTHING RETURNING id",
+                transaction_id,
+            )
+            if inserted is None:
+                return False
+            await conn.execute(
+                "UPDATE installations SET topup_credit_balance_usd = "
+                "topup_credit_balance_usd + $2, balance_epoch = balance_epoch + 1 "
+                "WHERE installation_id = $1",
+                installation_id, amount_usd,
+            )
+    return True
 
 
 async def list_installations_for_ids(pool: asyncpg.Pool, installation_ids: list[int]) -> list[dict]:

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -2331,14 +2331,23 @@ async function loadSettings() {{
   // is the first place a customer actually sees what their AI review
   // usage is costing/producing, previously invisible to them.
   const llmSpend = data.llm_spend_month_to_date || 0;
-  const llmCap = data.llm_spend_cap || 0;
+  // Despite the key name, this is now the installation's REMAINING credit
+  // balance, not a fixed cap - admin.py keeps the old "llm_spend_cap" key
+  // only to avoid a lockstep API/JS rename (see its own comment). So it
+  // shrinks as llmSpend grows: rendering "$X of $Y spend cap used (Z%)"
+  // divided a rising number by a falling one, which made both the sentence
+  // and the percentage nonsense (at exhaustion: "$4.98 of $0.00 spend cap
+  // used (0%)"). Stated as two independent facts instead, with no
+  // percentage-of-a-shrinking-denominator. A proper redesign of this panel
+  // belongs to the parallel dashboard plan; this is the minimum change that
+  // stops it asserting something false in the meantime.
+  const llmCreditRemaining = data.llm_spend_cap || 0;
   const flashReviews = data.flash_reviews_month_to_date || 0;
-  const spendPct = llmCap > 0 ? Math.min(100, Math.round((llmSpend / llmCap) * 100)) : 0;
   const usageHtml =
     '<div class="settings-block">' +
       '<div class="settings-block-label">AI usage this month</div>' +
       '<div class="settings-block-hint">' + flashReviews + ' automated PR review' + (flashReviews === 1 ? '' : 's') + '</div>' +
-      '<div class="settings-block-hint">$' + llmSpend.toFixed(2) + ' of $' + llmCap.toFixed(2) + ' spend cap used (' + spendPct + '%)</div>' +
+      '<div class="settings-block-hint">$' + llmSpend.toFixed(2) + ' spent this month, $' + llmCreditRemaining.toFixed(2) + ' credit remaining</div>' +
     '</div>';
 
   const seatBillingHtml = window._hasActiveSubscription

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -111,6 +111,17 @@ def base_credit_for_plan(plan: str, extra_seats: int) -> float:
 # real single-digit dollars, not fractions of a cent) needs real headroom
 # to make meaningful progress per catch-up cycle instead of the old cap
 # forcing an artificially small per-sweep batch just to stay under it.
+# SUPERSEDED as of Task 7 of the dollar-credit-pricing plan (2026-09-09):
+# no remaining call site in scan_worker/jobs.py or app_server/admin.py
+# reads PLAN_CAP_OVERRIDE_USD, base_cap_for_plan, or
+# monthly_cap_for_installation (below) any more - real enforcement is now
+# each installation's own real balance (installations.base_credit_
+# remaining_usd + topup_credit_balance_usd, see PLAN_BASE_CREDIT_USD/
+# base_credit_for_plan above and reserve_llm_spend in scan_worker/db.py).
+# Left in place, not deleted, so that pass stayed a pure call-site
+# migration - deleting these (and updating every test that still
+# references them) is a separate, lower-risk follow-up once the balance-
+# based enforcement is confirmed working in production.
 PLAN_CAP_OVERRIDE_USD = {
     "flash": 6.00,
     "air": 20.00,

--- a/github-app/app_server/llm_cost.py
+++ b/github-app/app_server/llm_cost.py
@@ -53,6 +53,29 @@ PLAN_MONTHLY_PRICE_USD = {
     "flash": 8.00,
 }
 
+# The customer-facing, advertised included credit per plan - replaces the
+# "up to 800 reviews/month" style promise with the real dollar unit the
+# system already enforces. Deliberately below PLAN_CAP_OVERRIDE_USD
+# (real enforced worst-case ceiling: $6.00 flash / $20.00 air) so there's
+# real margin between what's promised and what's technically possible,
+# same spirit as every other cap-vs-price margin already documented in
+# this file.
+PLAN_BASE_CREDIT_USD = {
+    "flash": 5.00,
+    "air": 18.00,
+}
+
+
+def base_credit_for_plan(plan: str, extra_seats: int) -> float:
+    """The base credit an installation's balance resets to on a real
+    renewal. Applies the same per-seat bonus monthly_cap_for_installation
+    already used, so a larger AIR team keeps getting proportionally more
+    credit, not the same flat amount regardless of seat count."""
+    base = PLAN_BASE_CREDIT_USD.get(plan, 0.0)
+    if base == 0.0:
+        return 0.0
+    return base + EXTRA_SEAT_LLM_CAP_USD * extra_seats
+
 # flash's real spend cap is a deliberately looser fraction of its price
 # than the shared 50% default below (75%, $6 of $8 - raised from $5 on
 # 2026-09-07 alongside github_api.MAX_CONTEXT_FILE_BYTES's 80KB->100KB

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -14,6 +14,13 @@
 # bundle into the base $29.99/mo price.
 EXTRA_SEAT_PRICE_ID = "pri_01m123rwvvtgbm6bmmxcbav4hh"
 
+# Placeholder until Task 7 creates the real Paddle price via the Paddle
+# MCP and replaces this with the real pri_... id - the webhook logic
+# only needs to compare against whatever this constant is, so the rest
+# of this task can proceed and be tested without the real price
+# existing yet.
+CREDIT_TOPUP_PRICE_ID = "pri_PLACEHOLDER_credit_topup"
+
 # The flash plan's real Paddle product (pro_01m1754jf8nkvhrn3sbaj9rmyq,
 # "Aletheore Flash") and its one price - monthly only, no annual yet,
 # matching what was actually validated (real cost/recall data checked

--- a/github-app/app_server/paddle_pricing.py
+++ b/github-app/app_server/paddle_pricing.py
@@ -14,12 +14,11 @@
 # bundle into the base $29.99/mo price.
 EXTRA_SEAT_PRICE_ID = "pri_01m123rwvvtgbm6bmmxcbav4hh"
 
-# Placeholder until Task 7 creates the real Paddle price via the Paddle
-# MCP and replaces this with the real pri_... id - the webhook logic
-# only needs to compare against whatever this constant is, so the rest
-# of this task can proceed and be tested without the real price
-# existing yet.
-CREDIT_TOPUP_PRICE_ID = "pri_PLACEHOLDER_credit_topup"
+# Credit top-up - $1.00 USD/unit, one-time (not a subscription), customer-
+# chosen quantity (5-1000, i.e. $5-$1000 per purchase). Created live via
+# the Paddle MCP, real and chargeable as of 2026-09-09. Product:
+# pro_01m23jw9evjvn00a6gs276ynrw ("Aletheore Credit Top-up").
+CREDIT_TOPUP_PRICE_ID = "pri_01m23jw9qbsnm4zmv28bfebx4t"
 
 # The flash plan's real Paddle product (pro_01m1754jf8nkvhrn3sbaj9rmyq,
 # "Aletheore Flash") and its one price - monthly only, no annual yet,

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -13,9 +13,11 @@ from app_server.db import (
     claim_webhook_delivery,
     claim_free_to_paid_plan,
     claim_paid_setup,
+    credit_topup_purchase,
     get_installation,
     list_installation_member_emails,
     release_webhook_delivery,
+    reset_billing_period_credit,
     set_extra_seats,
     set_installation_plan,
     set_paid_installation_plan,
@@ -23,7 +25,7 @@ from app_server.db import (
 from app_server.email_queue import enqueue_transactional_email
 from app_server.error_alerts import send_error_alert
 from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
-from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID, resolve_plan_for_price_id
+from app_server.paddle_pricing import CREDIT_TOPUP_PRICE_ID, EXTRA_SEAT_PRICE_ID, resolve_plan_for_price_id
 from app_server.paddle_webhook_verify import verify_paddle_signature
 
 paddle_webhook_router = APIRouter()
@@ -224,6 +226,20 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
         else 0
     )
 
+    # A genuine billing-period renewal resets base_credit_remaining_usd to
+    # the plan's real included credit (see db.py's reset_billing_period_
+    # credit) - gated on plan != "free" the same way extra_seats above is,
+    # since current_billing_period is only meaningful for an active paid
+    # subscription: a cancellation or a past_due card decline already
+    # resolves plan to "free" above and shouldn't reset anything. Also a
+    # no-op (reset_billing_period_credit itself checks this) when
+    # current_billing_period.starts_at hasn't actually changed - a replayed
+    # or unrelated subscription.updated for the same period must not wipe
+    # out credit the installation has already spent down.
+    period_start = (data.get("current_billing_period") or {}).get("starts_at")
+    if plan != "free" and period_start:
+        await reset_billing_period_credit(pool, installation_id, plan, extra_seats, period_start)
+
     # One transaction, not three independent writes: a crash between any two
     # of these previously left the installation on the new plan with stale
     # extra_seats, or upgraded with no Paddle IDs recorded - a state that
@@ -380,6 +396,28 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
     )
     if installation_id is None:
         return
+
+    # A customer-purchased credit top-up, independent of the affiliate-
+    # commission logic below - both can apply to the same transaction (a
+    # referred installation buying a top-up owes its referrer commission
+    # AND gets credited), so this must run before the referral early-return
+    # just below, not after it - the overwhelming majority of transactions
+    # have no referral on file at all and would otherwise never reach this.
+    items = data.get("items") or []
+    topup_item = next(
+        (item for item in items if (item.get("price") or {}).get("id") == CREDIT_TOPUP_PRICE_ID),
+        None,
+    )
+    if topup_item is not None:
+        quantity = topup_item.get("quantity")
+        transaction_id = data.get("id")
+        if quantity and transaction_id:
+            await credit_topup_purchase(pool, installation_id, float(quantity), transaction_id)
+        else:
+            logger.warning(
+                "credit topup transaction.completed missing quantity or id: %s",
+                data.get("id"),
+            )
 
     referral = await get_referral(pool, installation_id)
     if referral is None:

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -448,24 +448,32 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
         None,
     )
     if topup_item is not None:
-        # TODO(before CREDIT_TOPUP_PRICE_ID becomes a real, chargeable Paddle
-        # price): credit the amount Paddle actually COLLECTED, not the line
-        # item's quantity. float(quantity) below silently ignores any
-        # discount and assumes exactly $1 of credit per unit - the referral
-        # path further down already reads the real figure from
-        # details.totals.total (in minor units), and this must do the same.
-        # Deliberately not fixed here: with CREDIT_TOPUP_PRICE_ID still a
-        # placeholder that no real transaction can match, this whole branch
-        # is inert, and the correct per-unit/total semantics can only be
-        # settled against the real price once it exists. Fix it in the same
-        # change that creates that price.
-        quantity = topup_item.get("quantity")
+        # Credit the amount Paddle actually COLLECTED for this transaction,
+        # not the line item's quantity - quantity assumes exactly $1 of
+        # credit per unit and silently ignores any discount. A top-up
+        # transaction never bundles a top-up with any other line item (see
+        # the buyCredit() comment below), so details.totals.total - Paddle's
+        # collected amount net of discount, in the currency's minor unit, as
+        # a string - IS the real dollar amount collected for this top-up.
+        # Same parsing pattern as the referral commission calculation below.
         transaction_id = data.get("id")
-        if quantity and transaction_id:
-            await credit_topup_purchase(pool, installation_id, float(quantity), transaction_id)
+        total_raw = ((data.get("details") or {}).get("totals") or {}).get("total")
+        if transaction_id and total_raw is not None:
+            try:
+                total_minor_units = Decimal(str(total_raw))
+            except InvalidOperation:
+                logger.warning(
+                    "credit topup transaction.completed has an unparseable total: %s",
+                    data.get("id"),
+                )
+            else:
+                amount_usd = (total_minor_units / Decimal(100)).quantize(
+                    Decimal("0.01"), rounding=ROUND_HALF_UP
+                )
+                await credit_topup_purchase(pool, installation_id, float(amount_usd), transaction_id)
         else:
             logger.warning(
-                "credit topup transaction.completed missing quantity or id: %s",
+                "credit topup transaction.completed missing total or id: %s",
                 data.get("id"),
             )
         # Credit top-ups are pass-through LLM spend with near-zero margin -

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -448,6 +448,17 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
         None,
     )
     if topup_item is not None:
+        # TODO(before CREDIT_TOPUP_PRICE_ID becomes a real, chargeable Paddle
+        # price): credit the amount Paddle actually COLLECTED, not the line
+        # item's quantity. float(quantity) below silently ignores any
+        # discount and assumes exactly $1 of credit per unit - the referral
+        # path further down already reads the real figure from
+        # details.totals.total (in minor units), and this must do the same.
+        # Deliberately not fixed here: with CREDIT_TOPUP_PRICE_ID still a
+        # placeholder that no real transaction can match, this whole branch
+        # is inert, and the correct per-unit/total semantics can only be
+        # settled against the real price once it exists. Fix it in the same
+        # change that creates that price.
         quantity = topup_item.get("quantity")
         transaction_id = data.get("id")
         if quantity and transaction_id:

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -381,9 +381,12 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
 
 async def _handle_transaction_completed(data: dict, pool) -> None:
     """Records an affiliate commission for one completed transaction, if
-    and only if the paying installation has a referral on file. Every other
-    (unreferred) transaction.completed event - the overwhelming majority -
-    is a fast no-op after the referral lookup.
+    and only if the paying installation has a referral on file AND the
+    transaction is not a credit top-up purchase (see the early return
+    below - top-ups are pass-through LLM spend with no margin to pay a
+    commission from). Every other (unreferred, or top-up) transaction.completed
+    event - the overwhelming majority - is a fast no-op after the relevant
+    check.
 
     15% of `details.totals.total`, Paddle's collected amount net of that
     transaction's own discount, in the currency's minor unit (cents) as a
@@ -406,12 +409,11 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
     if installation_id is None:
         return
 
-    # A customer-purchased credit top-up, independent of the affiliate-
-    # commission logic below - both can apply to the same transaction (a
-    # referred installation buying a top-up owes its referrer commission
-    # AND gets credited), so this must run before the referral early-return
-    # just below, not after it - the overwhelming majority of transactions
-    # have no referral on file at all and would otherwise never reach this.
+    # A customer-purchased credit top-up. This still needs to run before the
+    # referral lookup below (rather than after an early return on "no
+    # referral"), because a referred installation's top-up must still be
+    # credited even though - see the early return at the end of this block -
+    # it is deliberately excluded from earning its referrer any commission.
     items = data.get("items") or []
     topup_item = next(
         (item for item in items if (item.get("price") or {}).get("id") == CREDIT_TOPUP_PRICE_ID),
@@ -427,6 +429,19 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
                 "credit topup transaction.completed missing quantity or id: %s",
                 data.get("id"),
             )
+        # Credit top-ups are pass-through LLM spend with near-zero margin -
+        # paying 15% affiliate commission on them (as the code below would,
+        # unconditionally, on the full transaction total) is a real loss with
+        # no offsetting revenue to pay it from, unlike commission on a genuine
+        # subscription/seat sale. Deliberately conservative: skip commission
+        # for the WHOLE transaction if it contains a top-up item at all,
+        # rather than trying to parse Paddle's per-line-item totals to
+        # subtract just the top-up portion (this codebase has never parsed
+        # per-item totals, only the transaction-level total) - the current
+        # buyCredit() checkout flow is a standalone purchase action that
+        # never bundles a top-up with a subscription/seat item in the same
+        # transaction, so this has no practical downside today.
+        return
 
     referral = await get_referral(pool, installation_id)
     if referral is None:

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -288,7 +288,7 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
             # it would double-count.
             if plan != "free" and not reset_happened and extra_seats > previous_extra_seats:
                 await credit_extra_seat_purchase(
-                    conn, installation_id, extra_seats - previous_extra_seats
+                    conn, installation_id, extra_seats - previous_extra_seats, plan, extra_seats
                 )
 
             if plan != "free":

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -13,7 +13,9 @@ from app_server.db import (
     claim_webhook_delivery,
     claim_free_to_paid_plan,
     claim_paid_setup,
+    credit_extra_seat_purchase,
     credit_topup_purchase,
+    get_extra_seats,
     get_installation,
     list_installation_member_emails,
     release_webhook_delivery,
@@ -257,11 +259,37 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     # together means a crash here now looks identical to never having
     # started, from any later retry's point of view - no partial state to
     # reason about, whether the retry is immediate or 15 minutes later.
+    #
+    # Seats bought MID-CYCLE need their credit applied here, because the
+    # reset above cannot do it: a seat purchase fires subscription.updated
+    # with the SAME current_billing_period.starts_at, so
+    # reset_billing_period_credit is a deliberate no-op and the per-seat
+    # bonus baked into base_credit_for_plan never lands until the next real
+    # renewal. Before this, a customer paid $6.99 for a seat and got $0 of
+    # extra credit for up to a month (the old flat cap recomputed itself
+    # live from get_extra_seats at every enforcement call site, so the
+    # ceiling used to rise immediately). Read BEFORE set_extra_seats below
+    # overwrites it, and applied inside the same transaction for the same
+    # split-write reason documented on that block.
+    previous_extra_seats = await get_extra_seats(pool, installation_id) if plan != "free" else 0
+
     transitioned_to_paid = False
     async with pool.acquire() as conn:
         async with conn.transaction():
+            reset_happened = False
             if plan != "free" and period_start:
-                await reset_billing_period_credit(conn, installation_id, plan, extra_seats, period_start)
+                reset_happened = await reset_billing_period_credit(
+                    conn, installation_id, plan, extra_seats, period_start
+                )
+
+            # Only when the renewal reset did NOT fire - a real reset already
+            # sets the balance to base_credit_for_plan(plan, extra_seats),
+            # which includes the new seat count, so crediting again on top of
+            # it would double-count.
+            if plan != "free" and not reset_happened and extra_seats > previous_extra_seats:
+                await credit_extra_seat_purchase(
+                    conn, installation_id, extra_seats - previous_extra_seats
+                )
 
             if plan != "free":
                 transitioned_to_paid = await claim_free_to_paid_plan(conn, installation_id, plan)

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -235,15 +235,21 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     # no-op (reset_billing_period_credit itself checks this) when
     # current_billing_period.starts_at hasn't actually changed - a replayed
     # or unrelated subscription.updated for the same period must not wipe
-    # out credit the installation has already spent down.
+    # out credit the installation has already spent down. Folded into the
+    # same transaction as the plan/extra_seats/Paddle-id writes below
+    # (rather than run as its own standalone call first) so a crash between
+    # this reset and that block can't leave base_credit_remaining_usd and
+    # current_billing_period_start pointed at the new period while plan/
+    # extra_seats/Paddle IDs stay stale - the same split-write hazard
+    # documented on that block below, and reset_billing_period_credit only
+    # ever calls .fetchrow() on what it's given, so passing it the open
+    # `conn` from that transaction instead of `pool` works unchanged.
     period_start = (data.get("current_billing_period") or {}).get("starts_at")
-    if plan != "free" and period_start:
-        await reset_billing_period_credit(pool, installation_id, plan, extra_seats, period_start)
 
-    # One transaction, not three independent writes: a crash between any two
-    # of these previously left the installation on the new plan with stale
-    # extra_seats, or upgraded with no Paddle IDs recorded - a state that
-    # persisted until a Paddle retry happened to land outside
+    # One transaction, not three (now four) independent writes: a crash
+    # between any two of these previously left the installation on the new
+    # plan with stale extra_seats, or upgraded with no Paddle IDs recorded -
+    # a state that persisted until a Paddle retry happened to land outside
     # claim_webhook_delivery's 15-minute reclaim window (see
     # docs/audits/Claude_Audit.md finding 11; confirmed live by injecting a
     # crash between add_paddle_ids_to_installation and set_extra_seats - the
@@ -254,6 +260,9 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     transitioned_to_paid = False
     async with pool.acquire() as conn:
         async with conn.transaction():
+            if plan != "free" and period_start:
+                await reset_billing_period_credit(conn, installation_id, plan, extra_seats, period_start)
+
             if plan != "free":
                 transitioned_to_paid = await claim_free_to_paid_plan(conn, installation_id, plan)
                 if not transitioned_to_paid:

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -27,7 +27,12 @@ from app_server.db import (
 from app_server.email_queue import enqueue_transactional_email
 from app_server.error_alerts import send_error_alert
 from app_server.paddle_ip_allowlist import client_ip_from_forwarded_for, is_known_paddle_ip
-from app_server.paddle_pricing import CREDIT_TOPUP_PRICE_ID, EXTRA_SEAT_PRICE_ID, resolve_plan_for_price_id
+from app_server.paddle_pricing import (
+    CREDIT_TOPUP_PRICE_ID,
+    EXTRA_SEAT_PRICE_ID,
+    PLAN_INTERVAL_TO_PRICE_ID,
+    resolve_plan_for_price_id,
+)
 from app_server.paddle_webhook_verify import verify_paddle_signature
 
 paddle_webhook_router = APIRouter()
@@ -177,15 +182,20 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     if data.get("status") in _ACTIVE_SUBSCRIPTION_STATUSES:
         # The base plan price is whichever item resolves to a known plan -
         # not necessarily items[0], since the extra-seat add-on can be
-        # either item once seats are involved.
-        plan = next(
+        # either item once seats are involved. The matched price ID itself
+        # is kept, not just the plan name it resolves to: a plan has both a
+        # monthly and (for AIR) an annual price, and only the price ID says
+        # which of the two this subscription is actually billed on - needed
+        # for is_annual below.
+        matched_price_id = next(
             (
-                resolved
+                (item.get("price") or {}).get("id")
                 for item in items
-                if (resolved := resolve_plan_for_price_id((item.get("price") or {}).get("id")))
+                if resolve_plan_for_price_id((item.get("price") or {}).get("id"))
             ),
             None,
         )
+        plan = resolve_plan_for_price_id(matched_price_id) if matched_price_id else None
         if not plan:
             logger.warning(
                 "%s has an active status but no resolvable plan price id in items", event_type
@@ -193,6 +203,7 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
             return
     else:
         plan = "free"
+        matched_price_id = None
 
     previous = await get_installation(pool, installation_id)
     previous_plan = previous["plan"] if previous is not None else "free"
@@ -248,6 +259,20 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
     # `conn` from that transaction instead of `pool` works unchanged.
     period_start = (data.get("current_billing_period") or {}).get("starts_at")
 
+    # An ANNUAL subscriber's current_billing_period.starts_at only advances
+    # once a YEAR, so the reset above - the only thing that ever refreshes
+    # base credit - would hand them 1/12th of the $18/month AIR allotment
+    # that is meant to be monthly regardless of how the customer pays.
+    # Flagging the annual price here is what lets reset_billing_period_
+    # credit arm next_monthly_credit_reset_at, the synthetic monthly clock
+    # scan_worker/jobs.py's run_monthly_credit_reset_sweep_job fires off.
+    # Compared against the price ID rather than any interval field in the
+    # payload: PLAN_INTERVAL_TO_PRICE_ID is this codebase's own source of
+    # truth for which price means which interval (the same map the checkout
+    # page builds from), so a plan with no annual price at all - "flash"
+    # today - resolves to None and can never be mistaken for annual.
+    is_annual = plan != "free" and matched_price_id == PLAN_INTERVAL_TO_PRICE_ID.get((plan, "year"))
+
     # One transaction, not three (now four) independent writes: a crash
     # between any two of these previously left the installation on the new
     # plan with stale extra_seats, or upgraded with no Paddle IDs recorded -
@@ -279,7 +304,7 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
             reset_happened = False
             if plan != "free" and period_start:
                 reset_happened = await reset_billing_period_credit(
-                    conn, installation_id, plan, extra_seats, period_start
+                    conn, installation_id, plan, extra_seats, period_start, is_annual
                 )
 
             # Only when the renewal reset did NOT fire - a real reset already

--- a/github-app/migrations/063_installation_credit_balance.sql
+++ b/github-app/migrations/063_installation_credit_balance.sql
@@ -1,0 +1,22 @@
+-- Real per-installation dollar-credit balance, replacing the flat
+-- PLAN_CAP_OVERRIDE_USD ceiling. base_credit_remaining_usd resets every
+-- billing-period renewal to PLAN_BASE_CREDIT_USD[plan] + the existing
+-- per-seat bonus; topup_credit_balance_usd is a never-expiring balance
+-- from customer-purchased credit, drawn down only after base is
+-- exhausted. balance_epoch increments on every renewal reset AND every
+-- top-up purchase - the "high-water mark" the low-balance/exhausted
+-- email dedupe keys off of, via the existing sent_emails/dedupe_key
+-- mechanism rather than new timestamp columns.
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS base_credit_remaining_usd NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS topup_credit_balance_usd  NUMERIC NOT NULL DEFAULT 0;
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS current_billing_period_start TIMESTAMPTZ;
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS balance_epoch INTEGER NOT NULL DEFAULT 0;
+
+-- Idempotency ledger for top-up purchases - Paddle retries a
+-- transaction.completed it didn't get a 2xx for, with the same
+-- transaction id. Recording every id this handler has already applied
+-- prevents a retry from crediting the same purchase twice.
+CREATE TABLE IF NOT EXISTS processed_paddle_transactions (
+    id           TEXT PRIMARY KEY,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/github-app/migrations/063_installation_credit_balance.sql
+++ b/github-app/migrations/063_installation_credit_balance.sql
@@ -20,3 +20,37 @@ CREATE TABLE IF NOT EXISTS processed_paddle_transactions (
     id           TEXT PRIMARY KEY,
     processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+-- Backfill for installations that already existed when this migration
+-- runs. Both credit columns default to 0, and the ONLY thing that ever
+-- raises base_credit_remaining_usd is a Paddle subscription.updated
+-- carrying a genuinely NEW current_billing_period.starts_at (see
+-- reset_billing_period_credit in app_server/db.py). Without this,
+-- every existing paid installation lands at a $0 balance on deploy and
+-- is locked out of every AI feature until its next renewal webhook -
+-- up to a full month, including this project's own live dogfooding
+-- installations.
+--
+-- Amounts mirror app_server/llm_cost.py exactly: PLAN_BASE_CREDIT_USD
+-- ({"flash": 5.00, "air": 18.00}) plus EXTRA_SEAT_LLM_CAP_USD (3.00)
+-- per extra seat - i.e. base_credit_for_plan(plan, extra_seats),
+-- computed inline here because a migration can't call Python.
+-- extra_seats is a real column on installations (see get_extra_seats /
+-- set_extra_seats in app_server/db.py and scan_worker/db.py), so the
+-- seat bonus needs no join or subquery.
+--
+-- Guarded on "never been through a real renewal reset yet"
+-- (current_billing_period_start IS NULL, which is true for exactly the
+-- pre-existing population this migration is adding the column to) and
+-- on a still-untouched zero balance, so a re-execution of this file
+-- against an already-migrated database (see scripts/migrate.py's note
+-- on docker-entrypoint-initdb.d) can never double-credit anyone.
+UPDATE installations
+SET base_credit_remaining_usd = CASE plan
+        WHEN 'flash' THEN 5.00
+        WHEN 'air' THEN 18.00
+        ELSE 0
+    END + 3.00 * COALESCE(extra_seats, 0)
+WHERE plan IN ('flash', 'air')
+    AND current_billing_period_start IS NULL
+    AND base_credit_remaining_usd = 0;

--- a/github-app/migrations/064_base_credit_allotment.sql
+++ b/github-app/migrations/064_base_credit_allotment.sql
@@ -1,0 +1,27 @@
+-- Tracks each installation's current billing-period base allotment,
+-- separately from base_credit_remaining_usd (which draws down as
+-- credit is spent). release_llm_spend_reservation needs this to know
+-- how much "room" exists in base before a true-up release should spill
+-- into topup_credit_balance_usd - without it, every release credited
+-- 100% to the never-expiring topup bucket, so a customer's monthly
+-- use-it-or-lose-it allotment never actually reset, it just kept
+-- accumulating into permanent credit. Set alongside
+-- base_credit_remaining_usd everywhere that column is set: a renewal
+-- reset (reset_billing_period_credit) and a mid-cycle seat purchase
+-- (credit_extra_seat_purchase).
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS base_credit_allotment_usd NUMERIC NOT NULL DEFAULT 0;
+
+-- Same backfill population and guard as 063's base_credit_remaining_usd
+-- backfill (pre-existing paid installations that have never been
+-- through a real renewal reset yet), targeting this new column instead
+-- so release_llm_spend_reservation has a correct ceiling for them
+-- immediately, not just after their next renewal.
+UPDATE installations
+SET base_credit_allotment_usd = CASE plan
+        WHEN 'flash' THEN 5.00
+        WHEN 'air' THEN 18.00
+        ELSE 0
+    END + 3.00 * COALESCE(extra_seats, 0)
+WHERE plan IN ('flash', 'air')
+    AND current_billing_period_start IS NULL
+    AND base_credit_allotment_usd = 0;

--- a/github-app/migrations/065_annual_air_monthly_credit_reset.sql
+++ b/github-app/migrations/065_annual_air_monthly_credit_reset.sql
@@ -1,0 +1,28 @@
+-- Only an ANNUAL subscriber needs this: base_credit_remaining_usd/
+-- base_credit_allotment_usd otherwise only reset via
+-- reset_billing_period_credit, gated on Paddle's current_billing_period.
+-- starts_at genuinely changing - which for an annual subscription only
+-- happens once a year, so an annual AIR customer's intended MONTHLY $18
+-- allotment (see PLAN_BASE_CREDIT_USD in app_server/llm_cost.py) would
+-- otherwise land once for the whole year instead of 12 times. NULL for
+-- every monthly subscriber and every non-air/free installation - the
+-- scheduled sweep (scan_worker/jobs.py's run_monthly_credit_reset_sweep_job)
+-- only ever looks at rows where this is NOT NULL and due.
+ALTER TABLE installations ADD COLUMN IF NOT EXISTS next_monthly_credit_reset_at TIMESTAMPTZ;
+
+-- No backfill, unlike 063/064: there are zero live annual subscribers to
+-- backfill (("air", "year") in app_server/paddle_pricing.py's
+-- PLAN_INTERVAL_TO_PRICE_ID is a brand new price), and the webhook handler
+-- populates this column for every annual subscriber on their next real
+-- subscription.updated anyway - the same "correct from here forward"
+-- guarantee base_credit_allotment_usd relied on for fresh resets.
+
+-- The sweep's due-list query is WHERE next_monthly_credit_reset_at IS NOT
+-- NULL AND next_monthly_credit_reset_at <= now(), run on every ~3-minute
+-- scheduler tick. A partial index keyed on that same column, holding only
+-- the handful of annual subscribers (every other row is NULL and excluded
+-- from the index entirely), keeps that tick a cheap index scan rather than
+-- a full installations sequential scan forever.
+CREATE INDEX IF NOT EXISTS installations_next_monthly_credit_reset_at
+    ON installations (next_monthly_credit_reset_at)
+    WHERE next_monthly_credit_reset_at IS NOT NULL;

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -393,40 +393,29 @@ def release_flash_review_count_reservation(dsn: str, installation_id: int) -> No
         conn.commit()
 
 
-def reserve_llm_spend(dsn: str, installation_id: int, reserve_usd: float, monthly_cap: float) -> bool:
-    """Same atomic reserve-before-spend pattern as
-    reserve_flash_review_count, for the dollar cap - reserves a
-    conservative flat estimate (see jobs.py's FLASH_REVIEW_SPEND_RESERVE_USD)
-    up front, since the real cost of a Flash Review isn't known until the
-    LLM call and grounding pass complete. record_llm_spend's own additive
-    upsert then trues the reservation up to the real cost afterward (pass
-    `real_cost - reserve_usd` as the delta - negative if the real cost came
-    in under the reservation, which is the common case).
-
-    Note: on the very first reservation of a new month (no llm_spend row
-    yet for this installation), the ON CONFLICT...WHERE clause only gates
-    the UPDATE branch, not the INSERT branch, so that first reservation
-    always succeeds regardless of monthly_cap. This matches the pre-existing
-    check-then-act behavior, which also couldn't reject a single review
-    whose cost alone would exceed the cap - not a new gap, and not reachable
-    in practice since reserve_usd is always small relative to any real
-    monthly_cap.
-
-    Returns True (and reserves) if under cap, False (no reservation) if
-    already at/over it. Call release_llm_spend_reservation if the review
-    then never actually runs."""
+def reserve_llm_spend(dsn: str, installation_id: int, reserve_usd: float) -> bool:
+    """Atomically reserves reserve_usd against an installation's real
+    credit balance (base_credit_remaining_usd, drawn down first, then
+    topup_credit_balance_usd) - replaces the old flat monthly_cap
+    parameter entirely; the ceiling is now this installation's own
+    stored balance, not a constant shared by every installation on the
+    same plan. Same atomicity guarantee as before: a single UPDATE ...
+    WHERE, so two concurrent callers against the same installation can
+    never together reserve more than what's actually available."""
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                INSERT INTO llm_spend (installation_id, month, total_cost_usd)
-                VALUES (%s, date_trunc('month', now())::date, %s)
-                ON CONFLICT (installation_id, month) DO UPDATE
-                SET total_cost_usd = llm_spend.total_cost_usd + %s
-                WHERE llm_spend.total_cost_usd + %s <= %s
-                RETURNING total_cost_usd
+                UPDATE installations
+                SET
+                    base_credit_remaining_usd = GREATEST(base_credit_remaining_usd - %(reserve)s, 0),
+                    topup_credit_balance_usd = topup_credit_balance_usd
+                        - GREATEST(%(reserve)s - base_credit_remaining_usd, 0)
+                WHERE installation_id = %(installation_id)s
+                    AND base_credit_remaining_usd + topup_credit_balance_usd >= %(reserve)s
+                RETURNING installation_id
                 """,
-                (installation_id, reserve_usd, reserve_usd, reserve_usd, monthly_cap),
+                {"reserve": reserve_usd, "installation_id": installation_id},
             )
             row = cur.fetchone()
         conn.commit()
@@ -434,17 +423,19 @@ def reserve_llm_spend(dsn: str, installation_id: int, reserve_usd: float, monthl
 
 
 def release_llm_spend_reservation(dsn: str, installation_id: int, reserve_usd: float) -> None:
-    """Undoes one reserve_llm_spend reservation for a review that was
-    charged against the cap but never actually ran."""
+    """Undoes one reserve_llm_spend reservation - credits topup_credit_
+    balance_usd first, then base_credit_remaining_usd, the reverse of the
+    base-first draw-down order (spend base first, so give back topup
+    first)."""
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                UPDATE llm_spend
-                SET total_cost_usd = GREATEST(total_cost_usd - %s, 0)
-                WHERE installation_id = %s AND month = date_trunc('month', now())::date
+                UPDATE installations
+                SET topup_credit_balance_usd = topup_credit_balance_usd + %(reserve)s
+                WHERE installation_id = %(installation_id)s
                 """,
-                (reserve_usd, installation_id),
+                {"reserve": reserve_usd, "installation_id": installation_id},
             )
         conn.commit()
 

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -494,6 +494,83 @@ def get_extra_seats(dsn: str, installation_id: int) -> int:
             return row[0] if row else 0
 
 
+def list_installations_due_for_monthly_credit_reset(dsn: str) -> list[int]:
+    """Installations whose synthetic monthly credit clock has come due -
+    the due list for run_monthly_credit_reset_sweep_job in jobs.py.
+
+    next_monthly_credit_reset_at is non-NULL for ANNUAL subscribers only
+    (set by app_server/db.py's reset_billing_period_credit, migration
+    065): their Paddle current_billing_period only advances once a year,
+    so the webhook-driven reset alone would credit their monthly
+    allotment once for the whole year. The IS NOT NULL half of this
+    filter is load-bearing, not just an optimisation - a monthly
+    subscriber is already refreshed correctly by that webhook reset, and
+    the sweep firing for them too would double-credit them every month.
+    """
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+            cur.execute(
+                """
+                SELECT installation_id FROM installations
+                WHERE next_monthly_credit_reset_at IS NOT NULL
+                    AND next_monthly_credit_reset_at <= now()
+                """
+            )
+            return [row[0] for row in cur.fetchall()]
+
+
+def apply_monthly_credit_reset(dsn: str, installation_id: int, new_credit: float) -> None:
+    """One synthetic monthly reset for an annual subscriber: the same
+    write reset_billing_period_credit performs on a real Paddle renewal,
+    minus current_billing_period_start (which still belongs to Paddle's
+    own once-a-year period and must not be faked forward).
+
+    Two deliberate choices here:
+
+    (a) next_monthly_credit_reset_at advances by one month past ITS OWN
+    PREVIOUS VALUE, not past now(). The scheduler ticks about every three
+    minutes and the sweep runs behind whatever else is on the "scans"
+    queue, so a due date is always caught some minutes - occasionally
+    hours - late. Anchoring the next date on now() would bake each of
+    those delays into the schedule permanently, walking the reset day
+    later and later through the year; anchoring it on the previous due
+    date keeps it fixed to the calendar no matter how late any individual
+    tick lands.
+
+    (b) balance_epoch is incremented, exactly as a real renewal reset
+    does. That is the actual reset mechanism for the low-balance/
+    exhausted credit emails - they are deduped through sent_emails on
+    f"credit_low_balance:{installation_id}:{balance_epoch}" (see
+    reserve_llm_spend_with_email_hooks in jobs.py), there are no
+    per-installation "email sent" timestamp columns to clear. Without the
+    increment, a customer warned in month three would never be warned
+    again for the rest of the year, because every later month would reuse
+    that month's dedupe key.
+
+    Idempotent per due date rather than per call: the WHERE clause
+    re-checks that the row is still actually due, so a second sweep in
+    the same tick window (or a retried RQ job) finds the date already
+    advanced past now() and changes nothing.
+    """
+    with get_db_pool(dsn).connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE installations
+                SET base_credit_remaining_usd = %(new_credit)s,
+                    base_credit_allotment_usd = %(new_credit)s,
+                    next_monthly_credit_reset_at =
+                        next_monthly_credit_reset_at + interval '1 month',
+                    balance_epoch = balance_epoch + 1
+                WHERE installation_id = %(installation_id)s
+                    AND next_monthly_credit_reset_at IS NOT NULL
+                    AND next_monthly_credit_reset_at <= now()
+                """,
+                {"new_credit": new_credit, "installation_id": installation_id},
+            )
+        conn.commit()
+
+
 @contextmanager
 def installation_spend_lock(dsn: str, installation_id: int):
     # A single scan-worker process handles jobs sequentially today, so the

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -696,7 +696,8 @@ def get_installation(dsn: str, installation_id: int) -> dict | None:
                 """
                 SELECT installation_id, account_login, plan, webhook_url, alert_email,
                        pushover_user_key, health_check_base_url,
-                       health_check_latency_threshold_ms, llm_suggestions_enabled
+                       health_check_latency_threshold_ms, llm_suggestions_enabled,
+                       base_credit_remaining_usd, topup_credit_balance_usd, balance_epoch
                 FROM installations
                 WHERE installation_id = %s
                 """,

--- a/github-app/scan_worker/db.py
+++ b/github-app/scan_worker/db.py
@@ -423,16 +423,27 @@ def reserve_llm_spend(dsn: str, installation_id: int, reserve_usd: float) -> boo
 
 
 def release_llm_spend_reservation(dsn: str, installation_id: int, reserve_usd: float) -> None:
-    """Undoes one reserve_llm_spend reservation - credits topup_credit_
-    balance_usd first, then base_credit_remaining_usd, the reverse of the
-    base-first draw-down order (spend base first, so give back topup
-    first)."""
+    """Undoes one reserve_llm_spend reservation - credits base_credit_
+    remaining_usd first, capped at this installation's stored
+    base_credit_allotment_usd (this billing period's real ceiling), and
+    spills only the remainder into topup_credit_balance_usd. Capping at
+    the allotment is what makes base credit actually reset every
+    renewal instead of permanently leaking into the never-expiring
+    topup bucket on every partial release."""
     with get_db_pool(dsn).connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
                 UPDATE installations
-                SET topup_credit_balance_usd = topup_credit_balance_usd + %(reserve)s
+                SET
+                    base_credit_remaining_usd = LEAST(
+                        base_credit_remaining_usd + %(reserve)s, base_credit_allotment_usd
+                    ),
+                    topup_credit_balance_usd = topup_credit_balance_usd
+                        + GREATEST(
+                            %(reserve)s - GREATEST(base_credit_allotment_usd - base_credit_remaining_usd, 0),
+                            0
+                        )
                 WHERE installation_id = %(installation_id)s
                 """,
                 {"reserve": reserve_usd, "installation_id": installation_id},

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -59,6 +59,7 @@ from app_server.url_validation import UnsafeURLError, validate_and_pin_https_url
 from aletheore.docs_reference import build_api_reference
 from scan_worker import live_docs, live_wiki
 from scan_worker.db import (
+    apply_monthly_credit_reset,
     check_and_reserve_flash_review_attempt,
     check_and_reserve_managed_audit,
     check_and_reserve_monthly_repo_scan_slot,
@@ -99,6 +100,7 @@ from scan_worker.db import (
     list_docs_symbols,
     list_health_check_targets_all,
     list_installation_member_emails,
+    list_installations_due_for_monthly_credit_reset,
     list_paid_installations_due_for_digest,
     list_paid_repos_due_for_docs_catchup,
     list_paid_repos_due_for_wiki_catchup,
@@ -3917,6 +3919,63 @@ def run_weekly_digest_sweep_job() -> None:
             # per-target isolation.
             logger.warning(
                 "weekly digest sweep failed for installation=%s", installation_id, exc_info=True
+            )
+
+
+@log_job
+def run_monthly_credit_reset_sweep_job() -> None:
+    """Gives ANNUAL subscribers the monthly credit allotment they pay for.
+
+    Runs on "scans" (see scheduler.py), same placement as the weekly
+    digest sweep - a due date caught minutes or hours late is harmless
+    here, so this doesn't need "email" queue urgency.
+
+    base_credit_remaining_usd is otherwise only ever refreshed by
+    app_server/db.py's reset_billing_period_credit, which fires when
+    Paddle's current_billing_period.starts_at genuinely changes. For a
+    monthly subscriber that is once a month, which is exactly right. For
+    an ANNUAL AIR subscriber it is once a YEAR - so the $18/month
+    allotment (PLAN_BASE_CREDIT_USD), which is monthly regardless of how
+    the customer chooses to pay, landed once for the whole year: 1/12th of
+    what they bought. This sweep is the synthetic monthly clock that fixes
+    that, driven by next_monthly_credit_reset_at (migration 065) rather
+    than by Paddle's own billing period.
+
+    Only annual subscribers are ever touched: that column is NULL for
+    every monthly subscriber and every free installation, and both the due
+    query and the UPDATE require it to be non-NULL. A monthly subscriber
+    must never appear here - their real renewal reset plus a synthetic one
+    in the same month would double-credit them.
+
+    The allotment is recomputed from the installation's CURRENT plan and
+    seat count via base_credit_for_plan, not carried over from
+    base_credit_allotment_usd: a seat bought mid-year has to be reflected
+    in every later month's reset, exactly as it would be at a real
+    renewal.
+    """
+    dsn = get_settings().database_url
+    logger = logging.getLogger("scan_worker.jobs")
+
+    for installation_id in list_installations_due_for_monthly_credit_reset(dsn):
+        try:
+            installation = get_installation_row(dsn, installation_id)
+            if installation is None:
+                continue
+
+            new_credit = base_credit_for_plan(
+                installation["plan"], get_extra_seats(dsn, installation_id)
+            )
+            apply_monthly_credit_reset(dsn, installation_id, new_credit)
+        except Exception:  # noqa: BLE001
+            # One installation's bad data (a missing row, a query hiccup)
+            # must not deny every other annual customer due this tick the
+            # credit they paid for - matches the weekly digest sweep's own
+            # per-installation isolation. The next tick retries it, since
+            # nothing advanced its due date.
+            logger.warning(
+                "monthly credit reset sweep failed for installation=%s",
+                installation_id,
+                exc_info=True,
             )
 
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -42,7 +42,12 @@ from app_server.dismissed_findings import filter_dismissed, finding_identity_key
 from app_server.error_alerts import send_error_alert
 from app_server.github_auth import generate_app_jwt, get_installation_token
 from app_server.http_client import get_github_api_client
-from app_server.llm_cost import base_cap_for_plan, cost_for_usage, monthly_cap_for_installation
+from app_server.llm_cost import (
+    base_cap_for_plan,
+    base_credit_for_plan,
+    cost_for_usage,
+    monthly_cap_for_installation,
+)
 from app_server.logging_config import log_job
 from app_server.redis_client import get_redis_client
 from app_server.rate_limit import (
@@ -3929,7 +3934,8 @@ def reserve_llm_spend_with_email_hooks(
     existing tests as a minimal {"plan": ...} dict (no account_login/
     alert_email/balance_epoch/credit columns) for tests that predate this
     email feature and don't care about it - this wrapper must not KeyError
-    for any of those.
+    for any of those. get_extra_seats (used for the low-balance threshold
+    below) is mocked in the same tests for the same reason.
 
     The enqueue_transactional_email call itself is wrapped in try/except,
     same reasoning _send_alerts_if_configured already documents for its
@@ -3955,17 +3961,29 @@ def reserve_llm_spend_with_email_hooks(
     after_total = float(after_row.get("base_credit_remaining_usd", 0)) + float(
         after_row.get("topup_credit_balance_usd", 0)
     )
-    # This installation's own high-water mark is whatever the combined
-    # balance was immediately after its most recent renewal reset or
-    # top-up (both of those set balance_epoch and, transitively, the
-    # totals this check compares against) - approximated here as
-    # before_total when no reservation has yet been made this epoch. A
-    # precise high-water-mark value isn't separately stored; using
-    # before_total on the FIRST reservation of an epoch is exact, and is
-    # a conservative (slightly-late-to-fire, since a later reservation's
-    # before_total is already lower than the true high-water mark)
-    # trigger on later reservations within the same epoch.
-    threshold = before_total * LOW_BALANCE_WARNING_FRACTION
+    # Compared against the plan's real base allotment, NOT against
+    # before_total. before_total was a high-water-mark approximation, and
+    # since after_total is always exactly before_total - reserve_usd, that
+    # version could only ever fire when a SINGLE reservation consumed >=85%
+    # of whatever was left. For AIRview/Docs, whose reservations are
+    # $0.001-$0.10, that means it essentially never fired until the balance
+    # was already gone - the "low balance" and "exhausted" emails arrived
+    # together, with zero advance warning, which is the opposite of what a
+    # low-balance warning is for.
+    #
+    # base_credit_for_plan is the known, real, current allotment for this
+    # plan and seat count, recomputed per call (cheap - one small indexed
+    # read for extra_seats). Against a fixed reference the edge-trigger
+    # works as intended: it fires exactly once, on whichever reservation
+    # takes the combined balance across 15% of the allotment, regardless of
+    # how small that reservation is. A precise "balance at last reset/top-up"
+    # high-water mark isn't stored anywhere, and adding a column for it is a
+    # larger change than this; the plan allotment is the right reference
+    # anyway, since that IS what a renewal resets the balance to.
+    plan_allotment = base_credit_for_plan(
+        row.get("plan", ""), get_extra_seats(dsn, installation_id)
+    )
+    threshold = plan_allotment * LOW_BALANCE_WARNING_FRACTION
     if after_total <= threshold and before_total > threshold:
         _enqueue_credit_balance_email("credit_low_balance", installation_id, after_row)
     return True

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -3990,6 +3990,20 @@ def reserve_llm_spend_with_email_hooks(
 
 
 def _enqueue_credit_balance_email(template_name: str, installation_id: int, row: dict) -> None:
+    # alert_email is nullable and opt-in, so most installations have none -
+    # there is no address to deliver to, and enqueuing with to_email=None
+    # only puts a job on the queue for the sender to reject. Guarded the
+    # same way the pre-existing health-alert enqueue in
+    # _send_alerts_if_configured already guards it. Logged at debug, not
+    # warning: this is the common, expected state, not a fault.
+    alert_email = row.get("alert_email")
+    if not alert_email:
+        logging.getLogger("scan_worker.jobs").debug(
+            "%s email skipped for installation=%s - no alert_email configured",
+            template_name, installation_id,
+        )
+        return
+
     dedupe_key = f"{template_name}:{installation_id}:{row.get('balance_epoch', 0)}"
     try:
         enqueue_transactional_email(
@@ -4002,7 +4016,7 @@ def _enqueue_credit_balance_email(template_name: str, installation_id: int, row:
                 "base_credit_remaining_usd": float(row.get("base_credit_remaining_usd", 0)),
                 "topup_credit_balance_usd": float(row.get("topup_credit_balance_usd", 0)),
             },
-            to_email=row.get("alert_email"),
+            to_email=alert_email,
             installation_id=installation_id,
         )
     except Exception:  # noqa: BLE001

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1522,25 +1522,29 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                 f"{cooldown_seconds // 3600} hours. Try again later."
             )
         else:
-            extra_seats = get_extra_seats(settings.database_url, installation_id)
-            monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
             # No lock: this is a fast-fail hint (skip straight to a clear PR
-            # comment when the cap is obviously already blown), not the
-            # enforcement itself - real enforcement is spend_budget.
+            # comment when the balance is obviously already exhausted), not
+            # the enforcement itself - real enforcement is spend_budget.
             # can_start_next_call() below, reserving atomically against the
             # live total before every real LLM call this (possibly
             # multi-call) audit makes. Same discipline as
             # run_managed_audit_api_job - a stale read here has no
             # financial-integrity consequence, just a possibly-later-than-
             # ideal rejection.
-            current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
-            cap_reached = current_spend >= monthly_cap
+            balance_row = get_installation_row(settings.database_url, installation_id)
+            combined_balance = (
+                float(balance_row.get("base_credit_remaining_usd", 0))
+                + float(balance_row.get("topup_credit_balance_usd", 0))
+                if balance_row is not None else 0.0
+            )
+            cap_reached = combined_balance <= 0
 
             if cap_reached:
                 body = (
                     f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
-                    f"Monthly spend cap reached for this installation (${monthly_cap:.2f}). "
-                    "Resumes next month, or email support@aletheore.com to raise the limit sooner."
+                    f"Credit balance exhausted for this installation (${combined_balance:.2f} "
+                    "remaining). Resumes next billing period, or email support@aletheore.com "
+                    "to top up sooner."
                 )
             else:
                 # run_managed_audit can make several sequential LLM calls and
@@ -1559,7 +1563,6 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                     settings.database_url,
                     installation_id,
                     MANAGED_AUDIT_MODEL,
-                    monthly_cap,
                     feature="managed_audit",
                 )
                 report_text = run_managed_audit(
@@ -1620,7 +1623,6 @@ def run_managed_audit_api_job(
 ) -> str:
     settings = get_settings()
     installation = get_installation_row(settings.database_url, installation_id)
-    plan = installation["plan"] if installation is not None else "free"
     # Read off the row already fetched rather than a second query. Defaults to
     # on for a missing row or an older row, matching the column default - a
     # lookup miss must not silently change what a customer's report contains.
@@ -1628,17 +1630,19 @@ def run_managed_audit_api_job(
         installation.get("llm_suggestions_enabled", True) if installation is not None else True
     )
     # No lock: this is a fast-fail hint (skip the setup work below if the
-    # cap is obviously already blown), not the enforcement itself - real
-    # enforcement is each _IncrementalSpendBudget.can_start_next_call()
+    # balance is obviously already exhausted), not the enforcement itself -
+    # real enforcement is each _IncrementalSpendBudget.can_start_next_call()
     # reserving atomically against the live total, so a stale read here has
     # no financial-integrity consequence, just a possibly-later-than-ideal
     # rejection.
-    extra_seats = get_extra_seats(settings.database_url, installation_id)
-    monthly_cap = monthly_cap_for_installation(base_cap_for_plan(plan), extra_seats)
-    current_spend = get_llm_spend_this_month(settings.database_url, installation_id)
-    if current_spend >= monthly_cap:
+    combined_balance = (
+        float(installation.get("base_credit_remaining_usd", 0))
+        + float(installation.get("topup_credit_balance_usd", 0))
+        if installation is not None else 0.0
+    )
+    if combined_balance <= 0:
         raise RuntimeError(
-            f"monthly spend cap reached for this installation (${monthly_cap:.2f})"
+            f"credit balance exhausted for this installation (${combined_balance:.2f} remaining)"
         )
     # run_managed_audit can make several sequential LLM calls (see
     # _IncrementalSpendBudget) and has been observed to take minutes -
@@ -1657,7 +1661,6 @@ def run_managed_audit_api_job(
             settings.database_url,
             installation_id,
             MANAGED_AUDIT_MODEL,
-            monthly_cap,
             feature="managed_audit",
         )
 
@@ -1734,13 +1737,7 @@ def run_flash_review_job(
             settings.database_url, installation_id, MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH
         ):
             return
-        monthly_cap = 0.0  # no dollar cap for free tier
     else:
-        # Reads only, no lock needed - extra_seats/monthly_cap are inputs to
-        # this request's own reservation below, not shared mutable state
-        # that itself needs cross-process atomicity.
-        extra_seats = get_extra_seats(settings.database_url, installation_id)
-        monthly_cap = monthly_cap_for_installation(base_cap_for_plan(installation["plan"]), extra_seats)
         # flash's own real, separately-validated cap (800), not AIR's 500 -
         # see MAX_FLASH_TIER_FLASH_REVIEWS_PER_MONTH. Any other non-free
         # plan value falls back to the AIR cap, matching this codebase's
@@ -1765,7 +1762,7 @@ def run_flash_review_job(
     review_ran = False
     try:
         review_ran = _run_flash_review(
-            settings, installation_id, repo_full_name, pr_number, base_sha, head_sha, monthly_cap,
+            settings, installation_id, repo_full_name, pr_number, base_sha, head_sha,
             reserved_spend, is_free_tier=is_free_tier,
             verify_with_second_model=(installation["plan"] == "air"),
         )
@@ -1925,7 +1922,6 @@ def _run_flash_review(
     pr_number: int,
     base_sha: str,
     head_sha: str,
-    monthly_cap: float,
     reserved_spend: float,
     *,
     is_free_tier: bool = False,
@@ -2258,7 +2254,7 @@ def _run_flash_review(
     # illusion of atomicity, not because either write needed one on its own.
     record_llm_spend(
         settings.database_url, installation_id, spend_accumulator["total"] - reserved_spend,
-        monthly_cap=monthly_cap, feature="flash_review",
+        feature="flash_review",
     )
 
     proposed = grounding_result.get("proposed", 0)
@@ -2812,13 +2808,17 @@ def _fix_suggestion_attachment(
         installation = get_installation_row(dsn, installation_id)
         plan = installation["plan"] if installation is not None else "free"
 
-        cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-        if cap_reached:
+        combined_balance = (
+            float(installation.get("base_credit_remaining_usd", 0))
+            + float(installation.get("topup_credit_balance_usd", 0))
+            if installation is not None else 0.0
+        )
+        if combined_balance <= 0:
             return None
 
         fix_suggestion_model = model_for_plan(plan)
         spend_budget = _IncrementalSpendBudget(
-            dsn, installation_id, fix_suggestion_model, monthly_cap, feature="health_fix_suggestion"
+            dsn, installation_id, fix_suggestion_model, feature="health_fix_suggestion"
         )
         if not spend_budget.can_start_next_call():
             return None
@@ -3865,7 +3865,16 @@ def run_weekly_digest_sweep_job() -> None:
 
 
 def _llm_spend_cap_reached(dsn: str, installation_id: int, plan: str) -> tuple[bool, float]:
-    """(cap_reached, monthly_cap) - a plain read, no lock required. For
+    """SUPERSEDED as of Task 7 of the dollar-credit-pricing plan
+    (2026-09-09): every real call site below now checks this
+    installation's own combined credit balance (base_credit_remaining_usd
+    + topup_credit_balance_usd via get_installation_row) directly instead
+    of calling this. Left in place, not deleted, so that pass stayed a
+    pure call-site migration - deletion is a separate, lower-risk
+    follow-up once the balance-based enforcement is confirmed working in
+    production.
+
+    (cap_reached, monthly_cap) - a plain read, no lock required. For
     every caller, real enforcement is an _IncrementalSpendBudget's
     can_start_next_call() reserving atomically per call (see
     _fix_suggestion_attachment for the single-call shape, AIRview/Docs
@@ -4017,21 +4026,12 @@ class _IncrementalSpendBudget:
         dsn: str,
         installation_id: int,
         model: str,
-        monthly_cap: float | None = None,
         next_call_reserve_usd: float = DEFAULT_LLM_NEXT_CALL_RESERVE_USD,
         feature: str = "unknown",
     ) -> None:
-        # monthly_cap is no longer used to gate reservations (see
-        # can_start_next_call below - reserve_llm_spend now reads this
-        # installation's own real credit balance instead of a flat cap
-        # passed in per call, Task 3 of the dollar-credit-pricing plan).
-        # Kept as an optional constructor arg, still populated by every
-        # real caller and still used by cap_message()'s display text below,
-        # purely so this doesn't force an unrelated call-site rewrite here.
         self.dsn = dsn
         self.installation_id = installation_id
         self.model = model
-        self.monthly_cap = monthly_cap
         self.next_call_reserve_usd = next_call_reserve_usd
         self.feature = feature
 
@@ -4069,8 +4069,18 @@ class _IncrementalSpendBudget:
         record_llm_spend(self.dsn, self.installation_id, delta, feature=self.feature)
 
     def cap_message(self) -> str:
+        # Reads the real current balance at the point can_start_next_call()
+        # just refused a reservation, rather than a value captured once at
+        # construction time (there is no flat monthly_cap left to display -
+        # see reserve_llm_spend/PLAN_BASE_CREDIT_USD in scan_worker/db.py
+        # and app_server/llm_cost.py).
+        row = get_installation_row(self.dsn, self.installation_id)
+        combined_balance = (
+            float(row.get("base_credit_remaining_usd", 0)) + float(row.get("topup_credit_balance_usd", 0))
+            if row is not None else 0.0
+        )
         return (
-            f"monthly spend cap reached (${self.monthly_cap:.2f}); "
+            f"credit balance exhausted (${combined_balance:.2f} remaining); "
             "stopped before starting the next LLM call"
         )
 
@@ -4370,7 +4380,6 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
         return
 
     installation = get_installation_row(dsn, installation_id)
-    plan = installation["plan"] if installation is not None else "free"
     # No longer plan-dependent - see _live_wiki_full_build_writing_adapter.
     model_used = live_wiki.FLASH_MODEL
 
@@ -4381,20 +4390,25 @@ def run_live_wiki_full_build_job(installation_id: int, repo_full_name: str) -> N
     # how many clusters get batched into one call (see live_wiki.py's
     # _run_batched_with_retry) - a per-cluster loop check here couldn't do
     # that cleanly the way Docs' per-module loop check can.
-    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-    if cap_reached:
+    combined_balance = (
+        float(installation.get("base_credit_remaining_usd", 0))
+        + float(installation.get("topup_credit_balance_usd", 0))
+        if installation is not None else 0.0
+    )
+    if combined_balance <= 0:
         logging.getLogger("scan_worker.jobs").info(
-            "live wiki full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
-            installation_id, repo_full_name, monthly_cap,
+            "live wiki full build skipped for installation=%s repo=%s - "
+            "credit balance exhausted ($%.2f remaining)",
+            installation_id, repo_full_name, combined_balance,
         )
         set_wiki_build_status(
             dsn, installation_id, repo_full_name, "failed",
-            f"monthly spend cap reached (${monthly_cap:.2f})",
+            f"credit balance exhausted (${combined_balance:.2f} remaining)",
         )
         return
 
     spend_budget = _IncrementalSpendBudget(
-        dsn, installation_id, model_used, monthly_cap,
+        dsn, installation_id, model_used,
         next_call_reserve_usd=WIKI_FULL_BUILD_LLM_RESERVE_USD, feature="airview_full_build",
     )
 
@@ -4554,26 +4568,28 @@ def _maybe_update_live_wiki(
         return
 
     dsn = settings.database_url
-    plan = installation["plan"]
     # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring
     # and run_live_wiki_full_build_job's identical comment above.
-    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-    if cap_reached:
+    combined_balance = (
+        float(installation.get("base_credit_remaining_usd", 0))
+        + float(installation.get("topup_credit_balance_usd", 0))
+    )
+    if combined_balance <= 0:
         logging.getLogger("scan_worker.jobs").info(
             "live wiki incremental update skipped for installation=%s repo=%s - "
-            "monthly spend cap reached (${%.2f})",
-            installation_id, repo_full_name, monthly_cap,
+            "credit balance exhausted ($%.2f remaining)",
+            installation_id, repo_full_name, combined_balance,
         )
         set_wiki_build_status(
             dsn, installation_id, repo_full_name, "failed",
-            f"monthly spend cap reached (${monthly_cap:.2f})",
+            f"credit balance exhausted (${combined_balance:.2f} remaining)",
         )
         return
 
     # No longer dynamic - see _live_wiki_update_writing_adapter.
     update_model = live_wiki.UPDATE_MODEL
     spend_budget = _IncrementalSpendBudget(
-        dsn, installation_id, update_model, monthly_cap, feature="airview_incremental"
+        dsn, installation_id, update_model, feature="airview_incremental"
     )
 
     try:
@@ -4892,22 +4908,30 @@ def run_live_docs_full_build_job(installation_id: int, repo_full_name: str) -> N
 
     # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring;
     # real enforcement is its can_start_next_call() reserving atomically per
-    # call below.
-    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-    if cap_reached:
+    # call below. Re-read fresh rather than reusing the `installation` row
+    # fetched above - a real GitHub round-trip (_github_client_and_token)
+    # happened in between.
+    balance_row = get_installation_row(dsn, installation_id)
+    combined_balance = (
+        float(balance_row.get("base_credit_remaining_usd", 0))
+        + float(balance_row.get("topup_credit_balance_usd", 0))
+        if balance_row is not None else 0.0
+    )
+    if combined_balance <= 0:
         logging.getLogger("scan_worker.jobs").info(
-            "live docs full build skipped for installation=%s repo=%s - monthly spend cap reached (${%.2f})",
-            installation_id, repo_full_name, monthly_cap,
+            "live docs full build skipped for installation=%s repo=%s - "
+            "credit balance exhausted ($%.2f remaining)",
+            installation_id, repo_full_name, combined_balance,
         )
         set_docs_build_status(
             dsn, installation_id, repo_full_name, "failed",
-            f"monthly spend cap reached (${monthly_cap:.2f})",
+            f"credit balance exhausted (${combined_balance:.2f} remaining)",
         )
         return
 
     full_build_model = model_for_plan(plan)
     spend_budget = _IncrementalSpendBudget(
-        dsn, installation_id, full_build_model, monthly_cap,
+        dsn, installation_id, full_build_model,
         next_call_reserve_usd=DOCS_FULL_BUILD_LLM_RESERVE_USD, feature="docs_full_build",
     )
 
@@ -5033,29 +5057,35 @@ def _maybe_update_live_docs(
     client, token = client_and_token
 
     dsn = settings.database_url
-    plan = installation["plan"]
     # Fast-fail hint only, no lock - see _IncrementalSpendBudget's docstring;
     # real enforcement is its can_start_next_call() reserving atomically per
     # call below. This closes the actual gap: two concurrent jobs spending
     # against the same installation (e.g. this incremental update racing a
     # Flash Review or a full build) no longer share one stale current_spend
-    # snapshot that neither can see the other invalidate mid-run.
-    cap_reached, monthly_cap = _llm_spend_cap_reached(dsn, installation_id, plan)
-    if cap_reached:
+    # snapshot that neither can see the other invalidate mid-run. Re-read
+    # fresh rather than reusing the `installation` row fetched above - a
+    # real GitHub round-trip (_github_client_and_token) happened in between.
+    balance_row = get_installation_row(dsn, installation_id)
+    combined_balance = (
+        float(balance_row.get("base_credit_remaining_usd", 0))
+        + float(balance_row.get("topup_credit_balance_usd", 0))
+        if balance_row is not None else 0.0
+    )
+    if combined_balance <= 0:
         logging.getLogger("scan_worker.jobs").info(
             "live docs incremental update skipped for installation=%s repo=%s - "
-            "monthly spend cap reached (${%.2f})",
-            installation_id, repo_full_name, monthly_cap,
+            "credit balance exhausted ($%.2f remaining)",
+            installation_id, repo_full_name, combined_balance,
         )
         set_docs_build_status(
             dsn, installation_id, repo_full_name, "failed",
-            f"monthly spend cap reached (${monthly_cap:.2f})",
+            f"credit balance exhausted (${combined_balance:.2f} remaining)",
         )
         return
 
     update_model = resolve_model(live_docs.FLASH_MODEL)
     spend_budget = _IncrementalSpendBudget(
-        dsn, installation_id, update_model, monthly_cap,
+        dsn, installation_id, update_model,
         feature="docs_incremental",
     )
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -2252,8 +2252,22 @@ def _run_flash_review(
     # record_llm_spend's own UPSERT is already atomic per call, and it was
     # only ever paired with the (now-removed) count increment for the
     # illusion of atomicity, not because either write needed one on its own.
+    #
+    # True up the real credit balance too, not just the llm_spend accounting
+    # table below - exactly the same reasoning (and the same primitives) as
+    # _IncrementalSpendBudget.record_usage. run_flash_review_job reserved a
+    # flat FLASH_REVIEW_SPEND_RESERVE_USD ($0.50) estimate; a real review
+    # costs a fraction of a cent of that, so without this the balance drops
+    # by the flat reserve per review instead of the real cost - a $5.00
+    # flash base credit would buy ~10 reviews rather than the ~1,000 the
+    # pricing is justified by.
+    delta = spend_accumulator["total"] - reserved_spend
+    if delta > 0:
+        reserve_llm_spend(settings.database_url, installation_id, delta)
+    elif delta < 0:
+        release_llm_spend_reservation(settings.database_url, installation_id, -delta)
     record_llm_spend(
-        settings.database_url, installation_id, spend_accumulator["total"] - reserved_spend,
+        settings.database_url, installation_id, delta,
         feature="flash_review",
     )
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -4146,7 +4146,23 @@ class _IncrementalSpendBudget:
         # or given back to (delta < 0) this installation's stored balance,
         # or the balance silently drifts from real spend over many calls.
         if delta > 0:
-            reserve_llm_spend(self.dsn, self.installation_id, delta)
+            if not reserve_llm_spend(self.dsn, self.installation_id, delta):
+                # reserve_llm_spend no-ops (mutates nothing) when the
+                # combined balance can't cover the full overage. The LLM
+                # call already happened and its real cost is sunk - leaving
+                # the balance untouched would overstate what the
+                # installation actually has left, the exact invariant this
+                # whole mechanism exists to protect. Best-effort recovery:
+                # drain whatever is still there down to zero, same
+                # fetch-then-reserve pattern the Flash Review call site
+                # uses for its own near-zero tail.
+                row = get_installation_row(self.dsn, self.installation_id)
+                if row is not None:
+                    remaining = float(row.get("base_credit_remaining_usd", 0)) + float(
+                        row.get("topup_credit_balance_usd", 0)
+                    )
+                    if remaining > 0:
+                        reserve_llm_spend(self.dsn, self.installation_id, remaining)
         elif delta < 0:
             release_llm_spend_reservation(self.dsn, self.installation_id, -delta)
         record_llm_spend(self.dsn, self.installation_id, delta, feature=self.feature)

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -3926,10 +3926,17 @@ class _IncrementalSpendBudget:
         dsn: str,
         installation_id: int,
         model: str,
-        monthly_cap: float,
+        monthly_cap: float | None = None,
         next_call_reserve_usd: float = DEFAULT_LLM_NEXT_CALL_RESERVE_USD,
         feature: str = "unknown",
     ) -> None:
+        # monthly_cap is no longer used to gate reservations (see
+        # can_start_next_call below - reserve_llm_spend now reads this
+        # installation's own real credit balance instead of a flat cap
+        # passed in per call, Task 3 of the dollar-credit-pricing plan).
+        # Kept as an optional constructor arg, still populated by every
+        # real caller and still used by cap_message()'s display text below,
+        # purely so this doesn't force an unrelated call-site rewrite here.
         self.dsn = dsn
         self.installation_id = installation_id
         self.model = model
@@ -3938,9 +3945,7 @@ class _IncrementalSpendBudget:
         self.feature = feature
 
     def can_start_next_call(self) -> bool:
-        return reserve_llm_spend(
-            self.dsn, self.installation_id, self.next_call_reserve_usd, self.monthly_cap
-        )
+        return reserve_llm_spend(self.dsn, self.installation_id, self.next_call_reserve_usd)
 
     def record_usage(
         self, prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0
@@ -3958,6 +3963,16 @@ class _IncrementalSpendBudget:
         delta = cost - self.next_call_reserve_usd
         if delta == 0:
             return
+        # True up the real credit balance too, not just the llm_spend
+        # accounting table below - can_start_next_call() only reserved an
+        # ESTIMATE (next_call_reserve_usd); now that the real cost is
+        # known, the difference must be additionally drawn from (delta > 0)
+        # or given back to (delta < 0) this installation's stored balance,
+        # or the balance silently drifts from real spend over many calls.
+        if delta > 0:
+            reserve_llm_spend(self.dsn, self.installation_id, delta)
+        elif delta < 0:
+            release_llm_spend_reservation(self.dsn, self.installation_id, -delta)
         record_llm_spend(self.dsn, self.installation_id, delta, feature=self.feature)
 
     def cap_message(self) -> str:

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1757,7 +1757,28 @@ def run_flash_review_job(
             settings.database_url, installation_id, review_count_cap
         ):
             return
+        # reserve_llm_spend rejects the WHOLE reservation when the combined
+        # balance is below the requested amount (its `>= %(reserve)s` WHERE
+        # clause - deliberately untouched, that atomicity is what stops two
+        # concurrent reviews from together overdrawing). Now that the
+        # success path trues the reservation up to the real cost
+        # (~$0.007 for a typical review), a flat $0.50 request would make
+        # Flash Review go silent for any balance in the $0-$0.50 tail even
+        # though the review costs a fraction of a cent - a stranded
+        # balance, not a spent one. Reserving no more than what's actually
+        # there fixes it at the call site: the full flat amount whenever
+        # the balance comfortably covers it, only the remainder in that
+        # near-zero tail. A zero/unknown balance still requests the full
+        # amount, so the reservation is rejected and the exhausted-email
+        # path fires exactly as before.
+        # Read off the installation row already fetched above, not a second
+        # query.
+        combined_balance = float(installation.get("base_credit_remaining_usd", 0)) + float(
+            installation.get("topup_credit_balance_usd", 0)
+        )
         reserved_spend = FLASH_REVIEW_SPEND_RESERVE_USD
+        if 0 < combined_balance < reserved_spend:
+            reserved_spend = combined_balance
         if not reserve_llm_spend_with_email_hooks(
             settings.database_url, installation_id, reserved_spend, feature="flash_review"
         ):
@@ -3801,6 +3822,22 @@ def send_transactional_email_job(
     if not settings.resend_api_key:
         logger.warning(
             "RESEND_API_KEY not configured, skipping email", extra={"dedupe_key": dedupe_key}
+        )
+        return
+
+    # The credit-balance emails (credit_low_balance / credit_exhausted) are
+    # enqueued by reserve_llm_spend_with_email_hooks on this branch, but
+    # their templates land on the parallel dashboard/emails branch - so
+    # depending on merge order this worker can legitimately be asked for a
+    # template it doesn't have yet. Unguarded, that KeyError becomes an RQ
+    # failed job plus an error alert for every low-balance event. Skipping
+    # with a warning doesn't close that gap (the other branch's templates
+    # do), it just keeps this branch independently deployable.
+    if template_name not in _EMAIL_TEMPLATES:
+        logger.warning(
+            "no email template registered for %s (installation_id=%s) - skipping",
+            template_name,
+            installation_id,
         )
         return
 

--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1756,7 +1756,9 @@ def run_flash_review_job(
         ):
             return
         reserved_spend = FLASH_REVIEW_SPEND_RESERVE_USD
-        if not reserve_llm_spend(settings.database_url, installation_id, reserved_spend, monthly_cap):
+        if not reserve_llm_spend_with_email_hooks(
+            settings.database_url, installation_id, reserved_spend, feature="flash_review"
+        ):
             release_flash_review_count_reservation(settings.database_url, installation_id)
             return
 
@@ -3880,6 +3882,95 @@ def _llm_spend_cap_reached(dsn: str, installation_id: int, plan: str) -> tuple[b
     return current_spend >= monthly_cap, monthly_cap
 
 
+LOW_BALANCE_WARNING_FRACTION = 0.15
+
+
+def reserve_llm_spend_with_email_hooks(
+    dsn: str, installation_id: int, reserve_usd: float, feature: str
+) -> bool:
+    """Wraps reserve_llm_spend with the two customer-facing email triggers -
+    reused by both the Flash Review direct-reservation path and
+    _IncrementalSpendBudget.can_start_next_call, so both surfaces get
+    identical notification behavior instead of two hand-rolled copies.
+
+    Interface contract (must match exactly - a separate, parallel plan
+    builds the dashboard + email templates against this): template_name
+    is "credit_low_balance" or "credit_exhausted"; template_arg is
+    {"account_login": str, "plan": str, "base_credit_remaining_usd":
+    float, "topup_credit_balance_usd": float}; dedupe_key is
+    f"credit_low_balance:{installation_id}:{balance_epoch}" /
+    f"credit_exhausted:{installation_id}:{balance_epoch}".
+
+    Row field access below uses dict.get(...) with defaults rather than
+    row[...]: get_installation_row is mocked throughout this file's
+    existing tests as a minimal {"plan": ...} dict (no account_login/
+    alert_email/balance_epoch/credit columns) for tests that predate this
+    email feature and don't care about it - this wrapper must not KeyError
+    for any of those.
+
+    The enqueue_transactional_email call itself is wrapped in try/except,
+    same reasoning _send_alerts_if_configured already documents for its
+    own channels: a failed/unreachable notification send is a real,
+    independent failure mode (network/Redis) that must never take down
+    the actual spend-reservation result this function returns to its
+    caller - that result gates whether an LLM call is allowed to proceed.
+    """
+    row = get_installation_row(dsn, installation_id)
+    if row is None:
+        return reserve_llm_spend(dsn, installation_id, reserve_usd)
+
+    before_total = float(row.get("base_credit_remaining_usd", 0)) + float(
+        row.get("topup_credit_balance_usd", 0)
+    )
+    ok = reserve_llm_spend(dsn, installation_id, reserve_usd)
+
+    if not ok:
+        _enqueue_credit_balance_email("credit_exhausted", installation_id, row)
+        return False
+
+    after_row = get_installation_row(dsn, installation_id) or row
+    after_total = float(after_row.get("base_credit_remaining_usd", 0)) + float(
+        after_row.get("topup_credit_balance_usd", 0)
+    )
+    # This installation's own high-water mark is whatever the combined
+    # balance was immediately after its most recent renewal reset or
+    # top-up (both of those set balance_epoch and, transitively, the
+    # totals this check compares against) - approximated here as
+    # before_total when no reservation has yet been made this epoch. A
+    # precise high-water-mark value isn't separately stored; using
+    # before_total on the FIRST reservation of an epoch is exact, and is
+    # a conservative (slightly-late-to-fire, since a later reservation's
+    # before_total is already lower than the true high-water mark)
+    # trigger on later reservations within the same epoch.
+    threshold = before_total * LOW_BALANCE_WARNING_FRACTION
+    if after_total <= threshold and before_total > threshold:
+        _enqueue_credit_balance_email("credit_low_balance", installation_id, after_row)
+    return True
+
+
+def _enqueue_credit_balance_email(template_name: str, installation_id: int, row: dict) -> None:
+    dedupe_key = f"{template_name}:{installation_id}:{row.get('balance_epoch', 0)}"
+    try:
+        enqueue_transactional_email(
+            redis_url=get_settings().redis_url,
+            dedupe_key=dedupe_key,
+            template_name=template_name,
+            template_arg={
+                "account_login": row.get("account_login", ""),
+                "plan": row.get("plan", ""),
+                "base_credit_remaining_usd": float(row.get("base_credit_remaining_usd", 0)),
+                "topup_credit_balance_usd": float(row.get("topup_credit_balance_usd", 0)),
+            },
+            to_email=row.get("alert_email"),
+            installation_id=installation_id,
+        )
+    except Exception:  # noqa: BLE001
+        logging.getLogger("scan_worker.jobs").warning(
+            "%s email enqueue failed for installation=%s", template_name, installation_id,
+            exc_info=True,
+        )
+
+
 class _IncrementalSpendBudget:
     """Gates a job that makes several sequential LLM calls (managed audits,
     AIRview/Docs full builds) against the monthly dollar cap.
@@ -3945,7 +4036,9 @@ class _IncrementalSpendBudget:
         self.feature = feature
 
     def can_start_next_call(self) -> bool:
-        return reserve_llm_spend(self.dsn, self.installation_id, self.next_call_reserve_usd)
+        return reserve_llm_spend_with_email_hooks(
+            self.dsn, self.installation_id, self.next_call_reserve_usd, self.feature
+        )
 
     def record_usage(
         self, prompt_tokens: int, completion_tokens: int, cached_tokens: int = 0

--- a/github-app/scan_worker/scheduler.py
+++ b/github-app/scan_worker/scheduler.py
@@ -55,6 +55,13 @@ WIKI_CATCHUP_SWEEP_JOB_TIMEOUT_SECONDS = 1800
 # the actual Resend calls happen there, not in this job, so this stays
 # bounded even if many installations are due the same tick.
 WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS = 300
+# Same bounded shape as ENDPOINT_HEALTH_CLEANUP_JOB_TIMEOUT_SECONDS, hence
+# the same 60s: one indexed query over installations_next_monthly_credit_
+# reset_at (migration 065's partial index, which only contains the handful
+# of annual subscribers at all) plus, for the rare installation actually
+# due, a couple of single-row reads and one single-row UPDATE. Most ticks
+# find nothing due and do no work beyond that one query.
+MONTHLY_CREDIT_RESET_JOB_TIMEOUT_SECONDS = 60
 # A single max(checked_at) query plus, on the rare stale tick, one email -
 # nothing here can run long.
 HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS = 60
@@ -121,6 +128,10 @@ def run_forever(
         scans_queue.enqueue(
             "scan_worker.jobs.run_weekly_digest_sweep_job",
             job_timeout=WEEKLY_DIGEST_SWEEP_JOB_TIMEOUT_SECONDS,
+        )
+        scans_queue.enqueue(
+            "scan_worker.jobs.run_monthly_credit_reset_sweep_job",
+            job_timeout=MONTHLY_CREDIT_RESET_JOB_TIMEOUT_SECONDS,
         )
         # Deliberately on "scans" (scan-worker), not "health" (health-worker)
         # - the whole point is that this keeps running, and alerting, even

--- a/github-app/tests/conftest.py
+++ b/github-app/tests/conftest.py
@@ -48,9 +48,18 @@ async def pool():
         # one test into the next. affiliate_referrals/affiliate_commissions
         # need no separate entry: both DO have an installations FK with ON
         # DELETE CASCADE, so truncating installations already clears them.
+        # processed_paddle_transactions is listed explicitly for the same
+        # reason as webhook_deliveries above: it has no FK to installations
+        # (a transaction_id is a Paddle identifier, not an installation
+        # one), so the CASCADE from truncating installations never reaches
+        # it - without this it would leak rows across tests/runs, and
+        # test_credit_topup_purchase_is_idempotent_on_replayed_transaction
+        # relies on a clean slate to tell a genuine first credit from a
+        # stale row left by a previous run.
         await conn.execute(
             "TRUNCATE installations, sessions, cli_telemetry_events, "
-            "github_user_emails, sent_emails, data_deletion_log, webhook_deliveries, affiliates CASCADE"
+            "github_user_emails, sent_emails, data_deletion_log, webhook_deliveries, affiliates, "
+            "processed_paddle_transactions CASCADE"
         )
     yield p
     await p.close()

--- a/github-app/tests/test_admin.py
+++ b/github-app/tests/test_admin.py
@@ -342,6 +342,19 @@ async def test_admin_page_surfaces_llm_spend_and_flash_review_usage(pool, monkey
         100,
         7,
     )
+    # llm_spend_cap now reflects the real per-installation credit balance
+    # (base_credit_remaining_usd + topup_credit_balance_usd), not the old
+    # flat monthly_cap_for_installation(base_cap_for_plan(...)) ceiling -
+    # both columns default to 0 on a fresh installation row, so this needs
+    # a real balance set explicitly (Task 7 of the dollar-credit-pricing
+    # plan, 2026-09-09).
+    await pool.execute(
+        "UPDATE installations SET base_credit_remaining_usd = $2, "
+        "topup_credit_balance_usd = $3 WHERE installation_id = $1",
+        100,
+        15.00,
+        2.50,
+    )
 
     async with client:
         response = await client.get("/admin/octocat/hello-world")
@@ -350,7 +363,7 @@ async def test_admin_page_surfaces_llm_spend_and_flash_review_usage(pool, monkey
     body = response.json()
     assert body["llm_spend_month_to_date"] == 4.20
     assert body["flash_reviews_month_to_date"] == 7
-    assert body["llm_spend_cap"] > 0
+    assert body["llm_spend_cap"] == 17.50
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -289,7 +289,22 @@ def _patch_fix_suggestion_spend_gate(monkeypatch, plan: str = "air") -> None:
     # below still gets its cap-reached behavior from get_llm_spend_this_month,
     # since _llm_spend_cap_reached's fast-fail hint runs before reserve_llm_spend
     # is ever attempted.
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": plan})
+    # Task 7 of the dollar-credit-pricing plan made _fix_suggestion_
+    # attachment compute this installation's combined credit balance
+    # straight off this row (base_credit_remaining_usd +
+    # topup_credit_balance_usd, both via .get(key, 0)) and refuse the LLM
+    # call when it's zero. A bare {"plan": plan} therefore reads as a $0
+    # balance and silently short-circuits every test using this helper -
+    # give it a real positive balance, matching the ~20 equivalent mocks
+    # already fixed the same way in test_jobs.py.
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {
+            "plan": plan,
+            "base_credit_remaining_usd": 10.0,
+            "topup_credit_balance_usd": 0.0,
+        },
+    )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
@@ -312,7 +327,18 @@ def test_fix_suggestion_attachment_returns_none_when_file_content_unavailable(mo
 def test_fix_suggestion_attachment_skips_the_llm_call_when_spend_cap_reached(monkeypatch):
     monkeypatch.setattr("scan_worker.jobs.get_settings", lambda: FakeHealthSettings())
     _patch_fix_suggestion_spend_gate(monkeypatch)
-    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 999.0)
+    # An exhausted balance is what blocks the call now, not a
+    # get_llm_spend_this_month total over a flat cap (Task 7 of the
+    # dollar-credit-pricing plan retired that comparison entirely) - this
+    # overrides the helper's own healthy-balance row above.
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {
+            "plan": "air",
+            "base_credit_remaining_usd": 0.0,
+            "topup_credit_balance_usd": 0.0,
+        },
+    )
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "jwt")
     monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "token")
     llm_called = []

--- a/github-app/tests/test_correlation.py
+++ b/github-app/tests/test_correlation.py
@@ -285,10 +285,11 @@ def _patch_fix_suggestion_spend_gate(monkeypatch, plan: str = "air") -> None:
     # replacing the old check-under-one-lock/record-under-another-lock
     # shape - see before_launch_fixes.md finding #2) - default it to
     # succeed so these tests exercise the same happy path they did before
-    # that migration; test_fix_suggestion_attachment_skips_the_llm_call_when_spend_cap_reached
-    # below still gets its cap-reached behavior from get_llm_spend_this_month,
-    # since _llm_spend_cap_reached's fast-fail hint runs before reserve_llm_spend
-    # is ever attempted.
+    # that migration. test_fix_suggestion_attachment_skips_the_llm_call_when_spend_cap_reached
+    # below gets its blocked behavior from a zeroed credit balance on the
+    # installation row, NOT from get_llm_spend_this_month: Task 7 removed
+    # the _llm_spend_cap_reached fast-fail hint from this call site
+    # entirely.
     # Task 7 of the dollar-credit-pricing plan made _fix_suggestion_
     # attachment compute this installation's combined credit balance
     # straight off this row (base_credit_remaining_usd +
@@ -306,7 +307,6 @@ def _patch_fix_suggestion_spend_gate(monkeypatch, plan: str = "air") -> None:
         },
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
-    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
     monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1454,10 +1454,8 @@ async def test_reserve_llm_spend_low_balance_triggers_email_enqueue(pool, monkey
     )
     installation_id = 9300
     # balance_epoch=1, starting balance 5.00 - the real base_credit_for_plan
-    # ("flash") value, i.e. this row is at the start of its epoch, so
-    # before_total genuinely IS this epoch's high-water mark (matches
-    # reserve_llm_spend_with_email_hooks's own "before_total on the FIRST
-    # reservation of an epoch is exact" reasoning - see its docstring).
+    # ("flash", 0) value, which is also the reference the threshold is
+    # computed against (see reserve_llm_spend_with_email_hooks).
     # 15% of 5.00 is 0.75; reserving 4.30 leaves 0.70, crossing it.
     await _insert_installation(
         pool, installation_id, "a", plan="flash",
@@ -1479,6 +1477,85 @@ async def test_reserve_llm_spend_low_balance_triggers_email_enqueue(pool, monkey
         "base_credit_remaining_usd": pytest.approx(0.70),
         "topup_credit_balance_usd": pytest.approx(0.00),
     }
+
+
+@pytest.mark.asyncio
+async def test_low_balance_email_fires_on_a_small_reservation_crossing_the_threshold(
+    pool, monkeypatch
+):
+    # I1 of the final-review fix wave: the threshold used to be
+    # before_total * LOW_BALANCE_WARNING_FRACTION. Since after_total is
+    # always exactly before_total - reserve_usd, that could only ever fire
+    # when a SINGLE reservation ate >=85% of the remaining balance - so for
+    # AIRview/Docs' $0.001-$0.10 reservations it never fired until the
+    # balance was already gone, and the low-balance and exhausted emails
+    # arrived together. The threshold is now a fixed fraction of the plan's
+    # real base allotment (base_credit_for_plan), so a small reservation
+    # that happens to cross it triggers the warning.
+    #
+    # flash allotment: 5.00, so the threshold is 0.75. Starting at 0.80 and
+    # reserving a tiny 0.10 leaves 0.70 - a real crossing. Under the old
+    # before_total approximation the threshold here would have been
+    # 0.80 * 0.15 = 0.12, and 0.70 > 0.12, so no email would have been sent.
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **kw: enqueued.append((a, kw)),
+    )
+    installation_id = 9302
+    await _insert_installation(
+        pool, installation_id, "a", plan="flash",
+        base_credit_remaining_usd=0.80, topup_credit_balance_usd=0.00, balance_epoch=3,
+    )
+
+    result = reserve_llm_spend_with_email_hooks(
+        TEST_DATABASE_URL, installation_id, reserve_usd=0.10, feature="airview_full_build",
+    )
+
+    assert result is True
+    assert len(enqueued) == 1
+    _, kwargs = enqueued[0]
+    assert kwargs["template_name"] == "credit_low_balance"
+    assert kwargs["dedupe_key"] == f"credit_low_balance:{installation_id}:3"
+
+    # Edge-triggered, not level-triggered: a second small reservation once
+    # already under the threshold must not enqueue a second warning. (The
+    # sent_emails/dedupe_key mechanism would also suppress a duplicate
+    # downstream, but this check is about the trigger itself.)
+    assert (
+        reserve_llm_spend_with_email_hooks(
+            TEST_DATABASE_URL, installation_id, reserve_usd=0.10, feature="airview_full_build",
+        )
+        is True
+    )
+    assert len(enqueued) == 1
+
+
+@pytest.mark.asyncio
+async def test_low_balance_threshold_scales_with_purchased_extra_seats(pool, monkeypatch):
+    # The reference is base_credit_for_plan(plan, extra_seats), not the bare
+    # plan constant - an AIR team with 2 extra seats has an 18.00 + 2*3.00 =
+    # 24.00 allotment, so its 15% threshold is 3.60, not 2.70.
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **kw: enqueued.append((a, kw)),
+    )
+    installation_id = 9303
+    await _insert_installation(
+        pool, installation_id, "a", plan="air", extra_seats=2,
+        base_credit_remaining_usd=3.70, topup_credit_balance_usd=0.00, balance_epoch=1,
+    )
+
+    # 3.70 -> 3.55 crosses 3.60 (the seat-inclusive threshold) but not 2.70
+    # (what the threshold would be if extra_seats were ignored).
+    result = reserve_llm_spend_with_email_hooks(
+        TEST_DATABASE_URL, installation_id, reserve_usd=0.15, feature="airview_full_build",
+    )
+
+    assert result is True
+    assert len(enqueued) == 1
+    assert enqueued[0][1]["template_name"] == "credit_low_balance"
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -11,6 +11,7 @@ from scan_worker.jobs import (
     LIVE_DOCS_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
     LIVE_WIKI_INCREMENTAL_UPDATE_JOB_TIMEOUT_SECONDS,
     MAX_FREE_TIER_FLASH_REVIEWS_PER_MONTH,
+    reserve_llm_spend_with_email_hooks,
     run_pr_scan_job,
 )
 
@@ -1426,6 +1427,72 @@ async def test_incremental_spend_budget_record_usage_refunds_when_actual_cost_is
     assert combined > 4.95
 
 
+@pytest.mark.asyncio
+async def test_reserve_llm_spend_low_balance_triggers_email_enqueue(pool, monkeypatch):
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **kw: enqueued.append((a, kw)),
+    )
+    installation_id = 9300
+    # balance_epoch=1, starting balance 5.00 - the real base_credit_for_plan
+    # ("flash") value, i.e. this row is at the start of its epoch, so
+    # before_total genuinely IS this epoch's high-water mark (matches
+    # reserve_llm_spend_with_email_hooks's own "before_total on the FIRST
+    # reservation of an epoch is exact" reasoning - see its docstring).
+    # 15% of 5.00 is 0.75; reserving 4.30 leaves 0.70, crossing it.
+    await _insert_installation(
+        pool, installation_id, "a", plan="flash",
+        base_credit_remaining_usd=5.00, topup_credit_balance_usd=0.00, balance_epoch=1,
+    )
+
+    result = reserve_llm_spend_with_email_hooks(
+        TEST_DATABASE_URL, installation_id, reserve_usd=4.30, feature="flash_review",
+    )
+
+    assert result is True
+    assert len(enqueued) == 1
+    _, kwargs = enqueued[0]
+    assert kwargs["template_name"] == "credit_low_balance"
+    assert kwargs["dedupe_key"] == f"credit_low_balance:{installation_id}:1"
+    assert kwargs["template_arg"] == {
+        "account_login": "a",
+        "plan": "flash",
+        "base_credit_remaining_usd": pytest.approx(0.70),
+        "topup_credit_balance_usd": pytest.approx(0.00),
+    }
+
+
+@pytest.mark.asyncio
+async def test_reserve_llm_spend_rejection_triggers_exhausted_email(pool, monkeypatch):
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **kw: enqueued.append((a, kw)),
+    )
+    installation_id = 9301
+    await _insert_installation(
+        pool, installation_id, "a", plan="flash",
+        base_credit_remaining_usd=0.01, topup_credit_balance_usd=0.00, balance_epoch=1,
+    )
+
+    result = reserve_llm_spend_with_email_hooks(
+        TEST_DATABASE_URL, installation_id, reserve_usd=5.00, feature="flash_review",
+    )
+
+    assert result is False
+    assert len(enqueued) == 1
+    _, kwargs = enqueued[0]
+    assert kwargs["template_name"] == "credit_exhausted"
+    assert kwargs["dedupe_key"] == f"credit_exhausted:{installation_id}:1"
+    assert kwargs["template_arg"] == {
+        "account_login": "a",
+        "plan": "flash",
+        "base_credit_remaining_usd": pytest.approx(0.01),
+        "topup_credit_balance_usd": pytest.approx(0.00),
+    }
+
+
 def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
@@ -2822,7 +2889,11 @@ def test_flash_review_job_reserves_the_cap_before_running_the_review(monkeypatch
         call_order.append("reserve_count")
         return True
 
-    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+    def _reserve_llm_spend(dsn, iid, reserve_usd):
+        # reserve_llm_spend no longer takes monthly_cap (Task 3/4 of the
+        # dollar-credit-pricing plan) - the run_flash_review_job call site
+        # now goes through reserve_llm_spend_with_email_hooks (Task 6),
+        # which calls this bare 3-arg reserve_llm_spend.
         call_order.append("reserve_spend")
         return True
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1218,8 +1218,11 @@ def test_maybe_create_regression_fence_check_run_skips_free_plan(monkeypatch):
 
 
 def test_managed_audit_api_job_returns_report_text(monkeypatch):
+    # Real balance needed so the upfront fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject this run.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -1249,8 +1252,11 @@ def test_managed_audit_api_job_releases_lock_during_audit(monkeypatch):
         finally:
             lock_state["held"] = False
 
+    # Real balance needed so the upfront fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject this run.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _tracking_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -1275,8 +1281,11 @@ def test_managed_audit_api_job_releases_lock_during_audit(monkeypatch):
 
 
 def test_managed_audit_api_job_signs_and_persists_the_report(monkeypatch):
+    # Real balance needed so the upfront fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject this run.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -1312,8 +1321,11 @@ def test_managed_audit_api_job_signs_and_persists_the_report(monkeypatch):
 
 
 def test_managed_audit_api_job_still_returns_report_when_signing_fails(monkeypatch):
+    # Real balance needed so the upfront fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject this run.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
@@ -1339,6 +1351,12 @@ def test_managed_audit_api_job_still_returns_report_when_signing_fails(monkeypat
 
 
 def test_managed_audit_api_job_raises_when_spend_cap_reached(monkeypatch):
+    # No base_credit_remaining_usd/topup_credit_balance_usd in this mock -
+    # defaults to a $0 combined balance (Task 7 of the dollar-credit-
+    # pricing plan replaced the old flat monthly_cap check with a direct
+    # read of the installation's real balance), so the upfront fast-fail
+    # check below is exercised the same way get_llm_spend_this_month=999
+    # used to force it under the old mechanism.
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
@@ -1352,7 +1370,7 @@ def test_managed_audit_api_job_raises_when_spend_cap_reached(monkeypatch):
     )
     from scan_worker.jobs import run_managed_audit_api_job
 
-    with pytest.raises(Exception, match="spend cap"):
+    with pytest.raises(Exception, match="credit balance exhausted"):
         run_managed_audit_api_job(
             installation_id=100,
             evidence={"scanned_at": "2026-01-01"},
@@ -1494,8 +1512,13 @@ async def test_reserve_llm_spend_rejection_triggers_exhausted_email(pool, monkey
 
 
 def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeypatch):
+    # Real balance needed so the upfront fast-fail check (installation's
+    # own combined credit balance, Task 7 of the dollar-credit-pricing
+    # plan) doesn't itself reject before this test's own mocked
+    # reserve_llm_spend/record_llm_spend budget-stop logic ever runs.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
@@ -1585,8 +1608,12 @@ def test_managed_audit_pr_job_clones_pr_head_runs_audit_and_replies(monkeypatch,
     )
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    # Real balance needed so the fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan re-reads get_installation_row fresh at
+    # that point) doesn't itself reject this run.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
@@ -1671,8 +1698,14 @@ def test_managed_audit_pr_job_records_each_call_and_stops_mid_run_when_cap_reach
         return evidence_path
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    # Real balance needed so the fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject this run - the
+    # actual budget-stop-mid-run behavior below is still driven entirely
+    # by the mocked reserve_llm_spend/record_llm_spend pair against
+    # MONTHLY_CAP, unaffected by this row's real balance fields.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs.managed_audit_definitely_still_cooling_down", lambda *a, **k: False)
@@ -1758,8 +1791,12 @@ def test_managed_audit_pr_job_persists_and_signs_the_report(monkeypatch, tmp_pat
     )
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    # Real balance needed so the fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan re-reads get_installation_row fresh at
+    # that point) doesn't itself reject this run.
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
@@ -1895,7 +1932,10 @@ def test_managed_audit_pr_job_still_posts_report_when_signing_fails(monkeypatch,
     )
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
+    )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
@@ -1983,7 +2023,13 @@ def test_managed_audit_pr_job_skips_llm_call_when_spend_cap_reached(monkeypatch,
     run_managed_audit_pr_job(1, "octocat/hello-world", 42)
 
     assert llm_called == []
-    assert "spend cap" in posted["body"].lower()
+    # No base_credit_remaining_usd/topup_credit_balance_usd in this mock -
+    # defaults to a $0 combined balance (Task 7 of the dollar-credit-
+    # pricing plan replaced the old flat monthly_cap check with a direct
+    # balance read), so the fast-fail check is exercised the same way
+    # get_llm_spend_this_month=999 used to force it under the old
+    # mechanism.
+    assert "credit balance exhausted" in posted["body"].lower()
     assert posted["marker"] == AUDIT_COMMENT_MARKER
 
 
@@ -5608,7 +5654,7 @@ def test_maybe_update_live_wiki_generates_and_stores_for_affected_clusters(monke
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     fake_record = {
@@ -5650,7 +5696,7 @@ def test_maybe_update_live_wiki_fetches_and_threads_prior_records_through(monkey
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     stored_prior = [{"subsystem_id": "0", "files": [{"path": "auth/login.py", "role": "Old.", "key_symbols": []}]}]
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: stored_prior)
 
@@ -5676,7 +5722,7 @@ def test_maybe_update_live_wiki_records_failure_status_on_exception(monkeypatch)
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     def _boom(*a, **k):
@@ -5720,7 +5766,12 @@ def test_maybe_update_live_wiki_skips_llm_call_when_spend_cap_reached(monkeypatc
 
     assert llm_called == []
     assert status_calls[0][0] == "failed"
-    assert "spend cap" in status_calls[0][1]
+    # No base_credit_remaining_usd/topup_credit_balance_usd in this mock -
+    # defaults to a $0 combined balance (Task 7 of the dollar-credit-
+    # pricing plan), so the fast-fail check is exercised the same way
+    # get_llm_spend_this_month=999 used to force it under the old
+    # mechanism.
+    assert "credit balance exhausted" in status_calls[0][1]
 
 
 def test_maybe_update_live_wiki_reserves_spend_atomically_against_concurrent_pushes(monkeypatch):
@@ -5736,7 +5787,16 @@ def test_maybe_update_live_wiki_reserves_spend_atomically_against_concurrent_pus
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    # Real balance needed so the fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject both threads before
+    # the race below is even exercised - the actual atomic-reservation
+    # race is still driven entirely by the mocked reserve_llm_spend/
+    # get_llm_spend_this_month pair and the barrier below, unaffected by
+    # this row's real balance fields.
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
+    )
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs._store_wiki_generation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: (lambda path: None))
@@ -6512,7 +6572,8 @@ def test_run_live_wiki_full_build_job_generates_and_stores(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
     monkeypatch.setattr(
-        "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
     )
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
@@ -6554,7 +6615,7 @@ def test_run_live_wiki_full_build_job_records_failed_status_on_error(monkeypatch
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     def _raise(*a, **k):
@@ -6605,7 +6666,12 @@ def test_run_live_wiki_full_build_job_skips_llm_call_when_spend_cap_reached(monk
 
     assert llm_called == []
     assert build_status_calls[0][0] == "failed"
-    assert "spend cap" in build_status_calls[0][1]
+    # No base_credit_remaining_usd/topup_credit_balance_usd in this mock -
+    # defaults to a $0 combined balance (Task 7 of the dollar-credit-
+    # pricing plan), so the fast-fail check is exercised the same way
+    # get_llm_spend_this_month=999 used to force it under the old
+    # mechanism.
+    assert "credit balance exhausted" in build_status_calls[0][1]
 
 
 def test_run_live_wiki_full_build_job_reserves_spend_atomically_against_concurrent_repos(monkeypatch):
@@ -6629,7 +6695,16 @@ def test_run_live_wiki_full_build_job_reserves_spend_atomically_against_concurre
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    # Real balance needed so the fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject both threads before
+    # the race below is even exercised - the actual atomic-reservation
+    # race is still driven entirely by the mocked reserve_llm_spend/
+    # get_llm_spend_this_month pair and the barrier below, unaffected by
+    # this row's real balance fields.
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
+    )
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     monkeypatch.setattr("scan_worker.jobs._store_wiki_subsystem_records", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs._regenerate_wiki_overview", lambda *a, **k: None)
@@ -6762,7 +6837,7 @@ def test_run_live_wiki_full_build_job_passes_fetch_line_count_through(monkeypatc
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _wiki_evidence())
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     sentinel = lambda path: 42  # noqa: E731
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
@@ -6846,7 +6921,7 @@ def test_run_live_wiki_full_build_job_only_requests_uncovered_clusters(monkeypat
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     evidence = _multi_cluster_wiki_evidence([0, 1, 2])
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: evidence)
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr(
         "scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [{"subsystem_id": "0"}]
     )
@@ -6893,7 +6968,7 @@ def test_run_live_wiki_full_build_job_persists_each_chunk_before_the_next_one_st
     cluster_ids = list(range(120))
     evidence = _multi_cluster_wiki_evidence(cluster_ids)
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: evidence)
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     monkeypatch.setattr(
         "scan_worker.jobs.live_wiki.generate_subsystems",
@@ -6943,7 +7018,7 @@ def test_run_live_wiki_full_build_job_keeps_earlier_chunks_persisted_when_a_late
     cluster_ids = list(range(120))
     evidence = _multi_cluster_wiki_evidence(cluster_ids)
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: evidence)
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
 
     call_count = {"n": 0}
@@ -7073,7 +7148,7 @@ def test_maybe_update_live_wiki_passes_fetch_line_count_through(monkeypatch):
     from scan_worker.jobs import _maybe_update_live_wiki
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_wiki_subsystems", lambda *a, **k: [])
     sentinel = lambda path: 42  # noqa: E731
     monkeypatch.setattr("scan_worker.jobs._real_line_count_fetcher", lambda *a, **k: sentinel)
@@ -7379,7 +7454,12 @@ def test_run_live_docs_full_build_job_skips_llm_call_when_spend_cap_reached(monk
 
     assert adapter_calls == []
     assert status_calls[0][0] == "failed"
-    assert "spend cap" in status_calls[0][1]
+    # No base_credit_remaining_usd/topup_credit_balance_usd in this mock -
+    # defaults to a $0 combined balance (Task 7 of the dollar-credit-
+    # pricing plan), so the fast-fail check is exercised the same way
+    # get_llm_spend_this_month=999 used to force it under the old
+    # mechanism.
+    assert "credit balance exhausted" in status_calls[0][1]
 
 
 def test_run_live_docs_full_build_job_survives_one_module_failing(monkeypatch):
@@ -7392,7 +7472,7 @@ def test_run_live_docs_full_build_job_survives_one_module_failing(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.get_latest_evidence", lambda *a, **k: _docs_evidence([bad, good])
     )
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_docs_symbols", lambda *a, **k: [])
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
@@ -7440,7 +7520,16 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
         for i in range(3)
     ]
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _docs_evidence(modules))
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    # Real balance needed so the fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan re-reads get_installation_row fresh, and
+    # cap_message() below also reads it) doesn't itself reject this run -
+    # the actual budget-stop-mid-run behavior is still driven entirely by
+    # the mocked reserve_llm_spend/record_llm_spend pair against
+    # MONTHLY_CAP, unaffected by this row's real balance fields.
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
+    )
     monkeypatch.setattr("scan_worker.jobs.list_docs_symbols", lambda *a, **k: [])
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
@@ -7510,7 +7599,10 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
     assert recorded_deltas == [pytest.approx(-0.04)]
     assert status_calls[0][0] == "ready"
     assert "1/3 files processed" in status_calls[0][1]
-    assert "spend cap" in status_calls[0][1]
+    # cap_message() now reads the real (mocked, $10 combined) balance
+    # rather than referencing a flat monthly_cap (Task 7 of the
+    # dollar-credit-pricing plan).
+    assert "credit balance exhausted" in status_calls[0][1]
 
 
 def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(monkeypatch):
@@ -7520,7 +7612,7 @@ def test_run_live_docs_full_build_job_reports_failed_when_every_module_fails(mon
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     module = _docs_module(functions=[{"name": "f", "is_public": True, "docstring": None}])
     monkeypatch.setattr("scan_worker.jobs.get_latest_evidence", lambda *a, **k: _docs_evidence([module]))
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr("scan_worker.jobs.list_docs_symbols", lambda *a, **k: [])
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
@@ -7612,7 +7704,12 @@ def test_maybe_update_live_docs_skips_llm_call_when_spend_cap_reached(monkeypatc
 
     assert adapter_calls == []
     assert status_calls[0][0] == "failed"
-    assert "spend cap" in status_calls[0][1]
+    # No base_credit_remaining_usd/topup_credit_balance_usd in this mock -
+    # defaults to a $0 combined balance (Task 7 of the dollar-credit-
+    # pricing plan), so the fast-fail check is exercised the same way
+    # get_llm_spend_this_month=999 used to force it under the old
+    # mechanism.
+    assert "credit balance exhausted" in status_calls[0][1]
 
 
 def test_maybe_update_live_docs_survives_one_module_failing(monkeypatch):
@@ -7620,7 +7717,7 @@ def test_maybe_update_live_docs_survives_one_module_failing(monkeypatch):
     from scan_worker.jobs import _maybe_update_live_docs
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
@@ -7655,7 +7752,7 @@ def test_maybe_update_live_docs_excludes_test_files_from_changed_modules(monkeyp
     from scan_worker.jobs import _maybe_update_live_docs
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0})
     monkeypatch.setattr(
         "scan_worker.jobs._github_client_and_token", lambda *a, **k: (object(), "tok")
     )
@@ -7806,7 +7903,16 @@ def test_fix_suggestion_attachment_reserves_spend_atomically_against_concurrent_
             },
         )(),
     )
-    monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
+    # Real balance needed so the fast-fail check (Task 7 of the
+    # dollar-credit-pricing plan) doesn't itself reject both threads before
+    # the race below is even exercised - the actual atomic-reservation
+    # race is still driven entirely by the mocked reserve_llm_spend/
+    # get_llm_spend_this_month pair and the barrier below, unaffected by
+    # this row's real balance fields.
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 10.0, "topup_credit_balance_usd": 0.0},
+    )
     monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
     monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "fake-token")

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -711,6 +711,99 @@ def test_run_flash_review_cache_cleanup_job_removes_only_old_rows(monkeypatch):
     assert deleted == [("dsn", FLASH_REVIEW_CACHE_RETENTION_DAYS)]
 
 
+def _patch_monthly_credit_reset_deps(monkeypatch, due, installations, applied):
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_settings",
+        lambda: type("Settings", (), {"database_url": "dsn"})(),
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.list_installations_due_for_monthly_credit_reset", lambda dsn: list(due)
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row", lambda dsn, iid: installations.get(iid)
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda dsn, iid: 0)
+    monkeypatch.setattr(
+        "scan_worker.jobs.apply_monthly_credit_reset",
+        lambda dsn, iid, new_credit: applied.append((iid, new_credit)),
+    )
+
+
+def test_run_monthly_credit_reset_sweep_job_credits_each_due_installation(monkeypatch):
+    from scan_worker.jobs import run_monthly_credit_reset_sweep_job
+
+    applied = []
+    _patch_monthly_credit_reset_deps(
+        monkeypatch, due=[1, 2], installations={1: {"plan": "air"}, 2: {"plan": "flash"}}, applied=applied
+    )
+
+    run_monthly_credit_reset_sweep_job()
+
+    # base_credit_for_plan for the installation's CURRENT plan, exactly what
+    # a real renewal reset would have credited.
+    assert applied == [(1, 18.00), (2, 5.00)]
+
+
+def test_run_monthly_credit_reset_sweep_job_uses_the_current_seat_count(monkeypatch):
+    from scan_worker.jobs import run_monthly_credit_reset_sweep_job
+
+    applied = []
+    _patch_monthly_credit_reset_deps(
+        monkeypatch, due=[1], installations={1: {"plan": "air"}}, applied=applied
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda dsn, iid: 2)
+
+    run_monthly_credit_reset_sweep_job()
+
+    # A seat bought mid-year has to be reflected in every later month's
+    # reset, not just at the next real annual renewal.
+    assert applied == [(1, 18.00 + 2 * 3.00)]
+
+
+def test_run_monthly_credit_reset_sweep_job_does_nothing_when_nothing_is_due(monkeypatch):
+    from scan_worker.jobs import run_monthly_credit_reset_sweep_job
+
+    applied = []
+    _patch_monthly_credit_reset_deps(monkeypatch, due=[], installations={}, applied=applied)
+
+    run_monthly_credit_reset_sweep_job()
+
+    assert applied == []
+
+
+def test_run_monthly_credit_reset_sweep_job_skips_a_missing_installation(monkeypatch):
+    from scan_worker.jobs import run_monthly_credit_reset_sweep_job
+
+    applied = []
+    _patch_monthly_credit_reset_deps(monkeypatch, due=[1], installations={}, applied=applied)
+
+    run_monthly_credit_reset_sweep_job()  # must not raise
+
+    assert applied == []
+
+
+def test_run_monthly_credit_reset_sweep_job_isolates_one_failing_installation(monkeypatch):
+    from scan_worker.jobs import run_monthly_credit_reset_sweep_job
+
+    applied = []
+    _patch_monthly_credit_reset_deps(
+        monkeypatch, due=[1, 2], installations={2: {"plan": "air"}}, applied=applied
+    )
+
+    def _get_installation(dsn, iid):
+        if iid == 1:
+            raise RuntimeError("boom")
+        return {"plan": "air"}
+
+    monkeypatch.setattr("scan_worker.jobs.get_installation_row", _get_installation)
+
+    run_monthly_credit_reset_sweep_job()
+
+    # Installation 1 blowing up must not deny installation 2 the credit it
+    # paid for - same per-installation isolation as the weekly digest sweep.
+    assert applied == [(2, 18.00)]
+
+
 def test_clone_failure_posts_failure_comment_and_cleans_up(monkeypatch):
     import scan_worker.jobs as jobs_module
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1422,7 +1422,10 @@ async def test_incremental_spend_budget_record_usage_refunds_when_actual_cost_is
 
     installation_id = 9102
     await _insert_installation(
-        pool, installation_id, "a", base_credit_remaining_usd=5.00, topup_credit_balance_usd=0.00
+        pool, installation_id, "a",
+        base_credit_allotment_usd=5.00,
+        base_credit_remaining_usd=5.00,
+        topup_credit_balance_usd=0.00,
     )
 
     budget = _IncrementalSpendBudget(
@@ -1435,14 +1438,17 @@ async def test_incremental_spend_budget_record_usage_refunds_when_actual_cost_is
 
     remaining = await _get_balance(pool, installation_id)
     # Reserved 0.10, actual cost is a few thousandths of a cent - most of
-    # the 0.10 reservation must be given back. release_llm_spend_reservation
-    # always credits topup_credit_balance_usd, never base_credit_remaining_usd
-    # (see its docstring/implementation in scan_worker/db.py - a known,
-    # deliberate Task 3 simplification, not something this task changes), so
-    # this checks the COMBINED balance rather than assuming which column
-    # absorbs the refund.
+    # the 0.10 reservation must be given back, and it must go back to the
+    # column it came OUT of: base_credit_remaining_usd, up to (never past)
+    # base_credit_allotment_usd. Crediting it to topup_credit_balance_usd
+    # instead - as release_llm_spend_reservation used to do unconditionally -
+    # kept the combined total right while quietly converting monthly,
+    # use-it-or-lose-it base credit into never-expiring purchased credit on
+    # every single call, so this asserts the split, not just the total.
     combined = float(remaining["base_credit_remaining_usd"]) + float(remaining["topup_credit_balance_usd"])
     assert combined > 4.95
+    assert float(remaining["topup_credit_balance_usd"]) == pytest.approx(0.00)
+    assert float(remaining["base_credit_remaining_usd"]) == pytest.approx(combined)
 
 
 @pytest.mark.asyncio
@@ -1638,6 +1644,7 @@ async def test_flash_review_trues_up_the_credit_balance_to_the_real_cost(pool, m
     installation_id = 9400
     await _insert_installation(
         pool, installation_id, "a", plan="flash",
+        base_credit_allotment_usd=5.00,
         base_credit_remaining_usd=5.00, topup_credit_balance_usd=0.00, balance_epoch=1,
     )
 
@@ -1704,6 +1711,120 @@ async def test_flash_review_trues_up_the_credit_balance_to_the_real_cost(pool, m
     # The whole point: the balance must be down by the REAL ~$0.007 cost,
     # not by the flat $0.50 reserve.
     assert combined == pytest.approx(5.00 - real_cost, abs=1e-6)
+    # And every cent of it must still be BASE credit. The reservation came
+    # out of base, so the true-up's $0.493 give-back belongs back in base
+    # (capped at base_credit_allotment_usd, which is where it started) -
+    # crediting it to topup_credit_balance_usd, as release_llm_spend_
+    # reservation used to do unconditionally, kept this combined total
+    # correct while permanently migrating ~$0.49 of monthly use-it-or-lose-it
+    # credit into the never-expiring purchased-credit bucket on EVERY
+    # review. Over a month of reviews that bucket grows without bound and
+    # the "resets every renewal" allotment never actually resets.
+    assert float(remaining["base_credit_remaining_usd"]) == pytest.approx(
+        5.00 - real_cost, abs=1e-6
+    )
+    assert float(remaining["topup_credit_balance_usd"]) == pytest.approx(0.00)
+
+
+@pytest.mark.asyncio
+async def test_flash_review_reserves_only_what_is_left_when_the_balance_is_below_the_flat_reserve(
+    pool, monkeypatch
+):
+    # reserve_llm_spend is all-or-nothing by design: its
+    # `>= %(reserve)s` WHERE clause is what makes two concurrent reviews
+    # unable to together overdraw one installation, so it must NOT be
+    # weakened. But that means a flat $0.50 request is refused outright for
+    # any balance in the $0-$0.50 tail - and now that the success path trues
+    # the reservation up to the real cost (~$0.007), a customer with $0.30
+    # left would see Flash Review go silent while still holding ~40 reviews'
+    # worth of real credit. Stranded, not spent.
+    #
+    # Fixed at the call site: reserve no more than what's actually there.
+    installation_id = 9401
+    await _insert_installation(
+        pool, installation_id, "a", plan="flash",
+        base_credit_allotment_usd=5.00,
+        base_credit_remaining_usd=0.30, topup_credit_balance_usd=0.00, balance_epoch=1,
+    )
+
+    # Records what run_flash_review_job actually asked to reserve, while
+    # still letting the REAL reservation happen against the real row - a
+    # fully-mocked reserve would prove nothing about whether the DB accepts
+    # it.
+    from scan_worker.jobs import reserve_llm_spend_with_email_hooks as _real_hooks
+
+    requested = []
+
+    def _spy_hooks(dsn, iid, reserve_usd, feature):
+        requested.append(reserve_usd)
+        return _real_hooks(dsn, iid, reserve_usd, feature)
+
+    monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend_with_email_hooks", _spy_hooks)
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setattr("scan_worker.jobs.resolve_model", lambda *a, **k: "deepseek-v4-flash")
+    monkeypatch.setattr("scan_worker.jobs._evidence_by_head_sha_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+    monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: None)
+
+    def _fake_review_diff(diff_text, file_context="", **kwargs):
+        kwargs["on_usage"](10000, 2000)
+        return []
+
+    monkeypatch.setattr("scan_worker.jobs.review_diff", _fake_review_diff)
+    monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    released_count = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.release_flash_review_count_reservation",
+        lambda *a, **k: released_count.append(True),
+    )
+    reviewed = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: reviewed.append(True)
+    )
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
+
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(installation_id, "octocat/hello-world", 42, "aaa", "bbb")
+
+    # $0.30, not the flat $0.50 - and the review really ran rather than
+    # being refused and having its count reservation handed back.
+    assert requested == [pytest.approx(0.30)]
+    assert reviewed == [True]
+    assert released_count == []
+
+    real_cost = 10000 * 0.44 / 1e6 + 2000 * 1.32 / 1e6
+    remaining = await _get_balance(pool, installation_id)
+    # The smaller reservation is trued up exactly like the full one: the
+    # balance ends down by the real cost only.
+    assert float(remaining["base_credit_remaining_usd"]) == pytest.approx(
+        0.30 - real_cost, abs=1e-6
+    )
+    assert float(remaining["topup_credit_balance_usd"]) == pytest.approx(0.00)
 
 
 def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeypatch):

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1417,6 +1417,41 @@ async def test_incremental_spend_budget_record_usage_trues_up_the_credit_balance
 
 
 @pytest.mark.asyncio
+async def test_incremental_spend_budget_record_usage_drains_balance_when_true_up_reservation_fails(pool):
+    # reserve_llm_spend no-ops (mutates nothing, returns False) when the
+    # combined balance can't cover the requested amount - the true-up call
+    # in record_usage used to ignore that return value, so a real cost
+    # that exceeded the up-front reservation AND exceeded the installation's
+    # remaining balance left the balance untouched (overstating what's left)
+    # while record_llm_spend logged the full overage into the accounting
+    # table anyway. This installation has only $0.02 left, far less than
+    # the ~$0.0352 real cost of this call (see the sibling true-up test for
+    # the exact rate math) - the true-up reservation of the ~$0.0252
+    # overage (delta = 0.0352 - 0.01) must fail, and the fix must drain the
+    # remaining $0.02 to exactly zero rather than leave it at $0.02.
+    from scan_worker.jobs import _IncrementalSpendBudget
+
+    installation_id = 9103
+    await _insert_installation(
+        pool, installation_id, "a",
+        base_credit_allotment_usd=0.02,
+        base_credit_remaining_usd=0.02,
+        topup_credit_balance_usd=0.00,
+    )
+
+    budget = _IncrementalSpendBudget(
+        TEST_DATABASE_URL, installation_id, "deepseek-v4-flash",
+        next_call_reserve_usd=0.01, feature="airview_incremental",
+    )
+    assert budget.can_start_next_call() is True
+    budget.record_usage(prompt_tokens=50000, completion_tokens=10000)
+
+    remaining = await _get_balance(pool, installation_id)
+    assert float(remaining["base_credit_remaining_usd"]) == pytest.approx(0.00)
+    assert float(remaining["topup_credit_balance_usd"]) == pytest.approx(0.00)
+
+
+@pytest.mark.asyncio
 async def test_incremental_spend_budget_record_usage_refunds_when_actual_cost_is_lower(pool):
     from scan_worker.jobs import _IncrementalSpendBudget
 

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -82,6 +82,27 @@ def _patch_no_spend_cap(monkeypatch) -> None:
     monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
 
 
+async def _insert_installation(pool, installation_id: int, account_login: str, **values) -> None:
+    # Same shape as test_scan_worker_db.py's own _insert_installation - kept
+    # identical rather than inventing a second convention in this file.
+    columns = ["installation_id", "account_login", *values.keys()]
+    params = [installation_id, account_login, *values.values()]
+    placeholders = ", ".join(f"${i}" for i in range(1, len(params) + 1))
+    await pool.execute(
+        f"INSERT INTO installations ({', '.join(columns)}) VALUES ({placeholders})",
+        *params,
+    )
+
+
+async def _get_balance(pool, installation_id: int) -> dict:
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    return dict(row)
+
+
 class _FakeCodeGraphStore:
     """Stands in for scan_worker.code_graph_store.CodeGraphStore so
     _sync_code_graph's wiring can be tested without a real database - the
@@ -1339,13 +1360,80 @@ def test_managed_audit_api_job_raises_when_spend_cap_reached(monkeypatch):
     assert llm_called == []
 
 
+@pytest.mark.asyncio
+async def test_incremental_spend_budget_record_usage_trues_up_the_credit_balance(pool):
+    # real_cost exceeds the $0.01 next_call_reserve_usd reserved up front -
+    # the extra must additionally be reserved from the credit balance, not
+    # just recorded in llm_spend (Task 4: without this, the stored balance
+    # silently drifts from real spend over many calls).
+    #
+    # deepseek-v4-flash rates (MODEL_RATES_PER_MILLION_USD in
+    # app_server/llm_cost.py): $0.44/M input, $1.32/M output. For
+    # prompt_tokens=50000, completion_tokens=10000:
+    #   50000 * 0.44 / 1e6 = 0.022
+    #   10000 * 1.32 / 1e6 = 0.0132
+    #   total = 0.0352
+    # Verified against the real cost_for_usage/MODEL_RATES_PER_MILLION_USD
+    # constants rather than assumed - this does NOT land on $0.03 exactly.
+    # No integer (prompt_tokens, completion_tokens) pair can: output's rate
+    # is exactly 3x input's (1.32 = 3 * 0.44), so cost is always an integer
+    # multiple of 0.44/1e6, and 0.03 * 1e6 / 0.44 = 68181.81... is not an
+    # integer - $0.03 is simply unreachable with this model's real rates.
+    from scan_worker.jobs import _IncrementalSpendBudget
+
+    installation_id = 9101
+    await _insert_installation(
+        pool, installation_id, "a", base_credit_remaining_usd=5.00, topup_credit_balance_usd=0.00
+    )
+
+    budget = _IncrementalSpendBudget(
+        TEST_DATABASE_URL, installation_id, "deepseek-v4-flash",
+        next_call_reserve_usd=0.01, feature="airview_incremental",
+    )
+    assert budget.can_start_next_call() is True
+    budget.record_usage(prompt_tokens=50000, completion_tokens=10000)
+
+    remaining = await _get_balance(pool, installation_id)
+    assert float(remaining["base_credit_remaining_usd"]) == pytest.approx(5.00 - 0.0352, abs=0.001)
+
+
+@pytest.mark.asyncio
+async def test_incremental_spend_budget_record_usage_refunds_when_actual_cost_is_lower(pool):
+    from scan_worker.jobs import _IncrementalSpendBudget
+
+    installation_id = 9102
+    await _insert_installation(
+        pool, installation_id, "a", base_credit_remaining_usd=5.00, topup_credit_balance_usd=0.00
+    )
+
+    budget = _IncrementalSpendBudget(
+        TEST_DATABASE_URL, installation_id, "deepseek-v4-flash",
+        next_call_reserve_usd=0.10, feature="airview_incremental",
+    )
+    assert budget.can_start_next_call() is True
+    # A tiny real call - actual cost is far below the 0.10 reserved.
+    budget.record_usage(prompt_tokens=10, completion_tokens=1)
+
+    remaining = await _get_balance(pool, installation_id)
+    # Reserved 0.10, actual cost is a few thousandths of a cent - most of
+    # the 0.10 reservation must be given back. release_llm_spend_reservation
+    # always credits topup_credit_balance_usd, never base_credit_remaining_usd
+    # (see its docstring/implementation in scan_worker/db.py - a known,
+    # deliberate Task 3 simplification, not something this task changes), so
+    # this checks the COMBINED balance rather than assuming which column
+    # absorbs the refund.
+    combined = float(remaining["base_credit_remaining_usd"]) + float(remaining["topup_credit_balance_usd"])
+    assert combined > 4.95
+
+
 def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeypatch):
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
     )
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
-    monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: 0.0012)
+    MONTHLY_CAP = 0.0012
+    monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: MONTHLY_CAP)
     monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a, **k: 0.0006)
     # In-memory stand-in for the real atomic reserve_llm_spend/record_llm_spend
     # pair, sharing running-total state the same way the real DB row does -
@@ -1356,8 +1444,12 @@ def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeyp
     spend_state = {"total": 0.0}
     recorded_deltas = []
 
-    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
-        if spend_state["total"] + reserve_usd <= monthly_cap:
+    def _reserve_llm_spend(dsn, iid, reserve_usd):
+        # reserve_llm_spend no longer takes monthly_cap (Task 3/4 of the
+        # dollar-credit-pricing plan) - MONTHLY_CAP is captured via closure
+        # instead, same value the monthly_cap_for_installation mock above
+        # feeds into the real (untouched) upstream call site.
+        if spend_state["total"] + reserve_usd <= MONTHLY_CAP:
             spend_state["total"] += reserve_usd
             return True
         return False
@@ -1368,6 +1460,13 @@ def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeyp
 
     monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
+    # record_usage's new true-up (Task 4) additionally calls
+    # release_llm_spend_reservation for this test's negative delta - a
+    # no-op here keeps spend_state's semantics exactly as before this task
+    # (only reserve_llm_spend/record_llm_spend drive the cap-check total
+    # this test exercises; the real credit-balance columns this call would
+    # otherwise touch have their own dedicated real-DB tests).
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.insert_audit_report", lambda *a, **k: None)
 
@@ -1518,7 +1617,8 @@ def test_managed_audit_pr_job_records_each_call_and_stops_mid_run_when_cap_reach
     monkeypatch.setattr("scan_worker.jobs.get_github_api_client", lambda: object())
     monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
     monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
-    monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: 0.0012)
+    MONTHLY_CAP = 0.0012
+    monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: MONTHLY_CAP)
     monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a, **k: 0.0006)
     monkeypatch.setattr("scan_worker.jobs._sign_and_persist_audit_report", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
@@ -1529,8 +1629,8 @@ def test_managed_audit_pr_job_records_each_call_and_stops_mid_run_when_cap_reach
     spend_state = {"total": 0.0}
     recorded_deltas = []
 
-    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
-        if spend_state["total"] + reserve_usd <= monthly_cap:
+    def _reserve_llm_spend(dsn, iid, reserve_usd):
+        if spend_state["total"] + reserve_usd <= MONTHLY_CAP:
             spend_state["total"] += reserve_usd
             return True
         return False
@@ -1541,6 +1641,9 @@ def test_managed_audit_pr_job_records_each_call_and_stops_mid_run_when_cap_reach
 
     monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
+    # See test_managed_audit_api_job_records_each_call_and_exposes_budget_stop
+    # for why this must be a no-op rather than touching spend_state.
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
 
     budget_checks = []
 
@@ -5583,9 +5686,9 @@ def test_maybe_update_live_wiki_reserves_spend_atomically_against_concurrent_pus
         cap_check_barrier.wait(timeout=5)
         return value
 
-    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+    def _reserve_llm_spend(dsn, iid, reserve_usd):
         with state_lock:
-            if spend_state["total"] + reserve_usd <= monthly_cap:
+            if spend_state["total"] + reserve_usd <= DEFAULT_LLM_NEXT_CALL_RESERVE_USD:
                 spend_state["total"] += reserve_usd
                 return True
             return False
@@ -6486,9 +6589,9 @@ def test_run_live_wiki_full_build_job_reserves_spend_atomically_against_concurre
         cap_check_barrier.wait(timeout=5)
         return value
 
-    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+    def _reserve_llm_spend(dsn, iid, reserve_usd):
         with state_lock:
-            if spend_state["total"] + reserve_usd <= monthly_cap:
+            if spend_state["total"] + reserve_usd <= WIKI_FULL_BUILD_LLM_RESERVE_USD:
                 spend_state["total"] += reserve_usd
                 return True
             return False
@@ -7280,7 +7383,8 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
     # reserve amount: one reservation fits (0.10 <= 0.12), a real cost
     # below the reserve (0.06) reduces the running total afterward, then
     # a second reservation (0.06 + 0.10 = 0.16) no longer fits.
-    monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: 0.12)
+    MONTHLY_CAP = 0.12
+    monkeypatch.setattr("scan_worker.jobs.monthly_cap_for_installation", lambda *a, **k: MONTHLY_CAP)
     monkeypatch.setattr("scan_worker.jobs.cost_for_usage", lambda *a, **k: 0.06)
     monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: "source")
 
@@ -7306,8 +7410,8 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
     spend_state = {"total": 0.0}
     recorded_deltas = []
 
-    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
-        if spend_state["total"] + reserve_usd <= monthly_cap:
+    def _reserve_llm_spend(dsn, iid, reserve_usd):
+        if spend_state["total"] + reserve_usd <= MONTHLY_CAP:
             spend_state["total"] += reserve_usd
             return True
         return False
@@ -7318,6 +7422,10 @@ def test_run_live_docs_full_build_job_stops_midway_at_remaining_spend_budget(mon
 
     monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", _record_llm_spend)
+    # See test_managed_audit_api_job_records_each_call_and_exposes_budget_stop
+    # for why record_usage's new true-up call for this test's negative
+    # delta must be a no-op here rather than touching spend_state.
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     status_calls = []
     monkeypatch.setattr(
         "scan_worker.jobs.set_docs_build_status",
@@ -7667,9 +7775,9 @@ def test_fix_suggestion_attachment_reserves_spend_atomically_against_concurrent_
         cap_check_barrier.wait(timeout=5)
         return value
 
-    def _reserve_llm_spend(dsn, iid, reserve_usd, monthly_cap):
+    def _reserve_llm_spend(dsn, iid, reserve_usd):
         with state_lock:
-            if spend_state["total"] + reserve_usd <= monthly_cap:
+            if spend_state["total"] + reserve_usd <= DEFAULT_LLM_NEXT_CALL_RESERVE_USD:
                 spend_state["total"] += reserve_usd
                 return True
             return False

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -3145,6 +3145,10 @@ def test_flash_review_job_reserves_the_cap_before_running_the_review(monkeypatch
     monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", _reserve_flash_review_count)
     monkeypatch.setattr("scan_worker.jobs.reserve_llm_spend", _reserve_llm_spend)
     monkeypatch.setattr("scan_worker.jobs.review_diff", _review_diff)
+    # The post-review true-up gives back the unused part of the flat $0.50
+    # reservation (review_diff is mocked, so the real cost is $0) - a real DB
+    # write this order-only test doesn't otherwise need.
+    monkeypatch.setattr("scan_worker.jobs.release_llm_spend_reservation", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
@@ -3226,7 +3230,14 @@ def test_flash_review_job_releases_reservation_when_the_review_never_runs(monkey
 
 
 def test_flash_review_job_does_not_release_reservation_after_a_successful_review(monkeypatch):
-    released = {"count": False, "spend": False}
+    # "Does not release" means the finally block must not hand the WHOLE
+    # FLASH_REVIEW_SPEND_RESERVE_USD back for a review that really ran.
+    # _run_flash_review's success path does now call
+    # release_llm_spend_reservation, but only for the UNUSED portion of that
+    # flat reserve (the true-up to real cost - see
+    # test_flash_review_trues_up_the_credit_balance_to_the_real_cost), so
+    # this records amounts rather than a bare bool and distinguishes the two.
+    released = {"count": False, "spend": []}
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr("scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"})
@@ -3243,7 +3254,7 @@ def test_flash_review_job_does_not_release_reservation_after_a_successful_review
     )
     monkeypatch.setattr(
         "scan_worker.jobs.release_llm_spend_reservation",
-        lambda *a, **k: released.__setitem__("spend", True),
+        lambda dsn, iid, amount: released["spend"].append(amount),
     )
     monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
     monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
@@ -3251,10 +3262,16 @@ def test_flash_review_job_does_not_release_reservation_after_a_successful_review
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
     monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
     monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
-    monkeypatch.setattr(
-        "scan_worker.jobs.review_diff",
-        lambda diff_text, file_context="", **kwargs: [{"file": "app.py", "line": 1, "issue": "x", "source": "llm"}],
-    )
+    monkeypatch.setattr("scan_worker.jobs.resolve_model", lambda *a, **k: "deepseek-v4-flash")
+
+    def _review_diff_with_usage(diff_text, file_context="", **kwargs):
+        # Real token usage, so the true-up's give-back (0.50 - real cost) is
+        # distinguishable from a full-reservation release. deepseek-v4-flash:
+        # 10000 * 0.44/1e6 + 2000 * 1.32/1e6 = 0.00704.
+        kwargs["on_usage"](10000, 2000)
+        return [{"file": "app.py", "line": 1, "issue": "x", "source": "llm"}]
+
+    monkeypatch.setattr("scan_worker.jobs.review_diff", _review_diff_with_usage)
     monkeypatch.setattr("scan_worker.jobs.record_llm_spend", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
     monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
@@ -3277,7 +3294,15 @@ def test_flash_review_job_does_not_release_reservation_after_a_successful_review
     )
     run_flash_review_job(1, "octocat/hello-world", 42, "aaa", "bbb")
 
-    assert released == {"count": False, "spend": False}
+    assert released["count"] is False
+    # Exactly one release, and it is the true-up's partial give-back - NOT
+    # the full FLASH_REVIEW_SPEND_RESERVE_USD the finally block would return
+    # for a review that never ran.
+    real_cost = 10000 * 0.44 / 1e6 + 2000 * 1.32 / 1e6
+    assert released["spend"] == [
+        pytest.approx(FLASH_REVIEW_SPEND_RESERVE_USD - real_cost)
+    ]
+    assert released["spend"][0] < FLASH_REVIEW_SPEND_RESERVE_USD
 
 
 def test_flash_review_job_posts_grounding_note_when_some_findings_are_dropped(monkeypatch):

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1511,6 +1511,98 @@ async def test_reserve_llm_spend_rejection_triggers_exhausted_email(pool, monkey
     }
 
 
+@pytest.mark.asyncio
+async def test_flash_review_trues_up_the_credit_balance_to_the_real_cost(pool, monkeypatch):
+    # C1 of the final-review fix wave: run_flash_review_job reserves a flat
+    # FLASH_REVIEW_SPEND_RESERVE_USD ($0.50) per review, but a real review
+    # costs a fraction of a cent. Before the fix, _run_flash_review only
+    # trued up the llm_spend ACCOUNTING table and never the real credit
+    # balance columns, so every successful review consumed $0.50 of a $5.00
+    # base credit - ~10 reviews per month instead of the ~1,000 the pricing
+    # is justified by.
+    #
+    # Deliberately runs against the real Postgres pool with the real
+    # reserve_llm_spend/release_llm_spend_reservation (mocking them, as the
+    # other flash-review tests in this file do, is exactly what let this
+    # bug through - a mocked reserve can't show a balance drifting).
+    #
+    # deepseek-v4-flash rates (MODEL_RATES_PER_MILLION_USD in
+    # app_server/llm_cost.py): $0.44/M input, $1.32/M output. For
+    # prompt_tokens=10000, completion_tokens=2000:
+    #   10000 * 0.44 / 1e6 = 0.0044
+    #    2000 * 1.32 / 1e6 = 0.00264
+    #   real cost           = 0.00704
+    installation_id = 9400
+    await _insert_installation(
+        pool, installation_id, "a", plan="flash",
+        base_credit_remaining_usd=5.00, topup_credit_balance_usd=0.00, balance_epoch=1,
+    )
+
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setattr("scan_worker.jobs.resolve_model", lambda *a, **k: "deepseek-v4-flash")
+    monkeypatch.setattr("scan_worker.jobs._evidence_by_head_sha_or_none", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs._latest_evidence_or_none", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_flash_review_attempt", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_count_this_month", lambda *a, **k: 0)
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs._token_sync", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    monkeypatch.setattr("scan_worker.jobs.installation_spend_lock", _noop_spend_lock)
+    monkeypatch.setattr("scan_worker.jobs.get_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_diff", lambda *a, **k: "--- app.py ---\n+bug")
+    monkeypatch.setattr("scan_worker.jobs.fetch_pr_changed_files", lambda *a, **k: ["app.py"])
+    monkeypatch.setattr("scan_worker.jobs.fetch_review_file_context", lambda *a, **k: ("", {}))
+    monkeypatch.setattr("scan_worker.jobs.fetch_file_content", lambda *a, **k: None)
+
+    def _fake_review_diff(diff_text, file_context="", **kwargs):
+        # The real adapter chain reports token usage through on_usage - this
+        # is what fills spend_accumulator with the REAL cost the true-up
+        # below has to reconcile against the flat $0.50 reservation.
+        kwargs["on_usage"](10000, 2000)
+        return []
+
+    monkeypatch.setattr("scan_worker.jobs.review_diff", _fake_review_diff)
+    recorded_spend = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.record_llm_spend",
+        lambda dsn, iid, cost, **kwargs: recorded_spend.append(cost),
+    )
+    monkeypatch.setattr("scan_worker.jobs.reserve_flash_review_count", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "scan_worker.jobs.release_flash_review_count_reservation", lambda *a, **k: None
+    )
+    monkeypatch.setattr("scan_worker.jobs.set_last_reviewed_sha", lambda *a, **k: None)
+    monkeypatch.setattr("scan_worker.jobs.upsert_pr_comment", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_dismissed_identity_keys",
+        lambda *a, **k: {"flash_review_llm": set(), "flash_review_semantic": set()},
+    )
+    monkeypatch.setattr("scan_worker.jobs.get_flash_review_finding_comments", lambda *a, **k: {})
+    monkeypatch.setattr(
+        "scan_worker.jobs.mark_flash_review_finding_comment_resolved", lambda *a, **k: False
+    )
+
+    from scan_worker.jobs import run_flash_review_job
+
+    run_flash_review_job(installation_id, "octocat/hello-world", 42, "aaa", "bbb")
+
+    real_cost = 10000 * 0.44 / 1e6 + 2000 * 1.32 / 1e6
+    assert recorded_spend == [pytest.approx(real_cost - FLASH_REVIEW_SPEND_RESERVE_USD)]
+
+    remaining = await _get_balance(pool, installation_id)
+    combined = float(remaining["base_credit_remaining_usd"]) + float(
+        remaining["topup_credit_balance_usd"]
+    )
+    # The whole point: the balance must be down by the REAL ~$0.007 cost,
+    # not by the flat $0.50 reserve.
+    assert combined == pytest.approx(5.00 - real_cost, abs=1e-6)
+
+
 def test_managed_audit_api_job_records_each_call_and_exposes_budget_stop(monkeypatch):
     # Real balance needed so the upfront fast-fail check (installation's
     # own combined credit balance, Task 7 of the dollar-credit-pricing

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -1458,7 +1458,7 @@ async def test_reserve_llm_spend_low_balance_triggers_email_enqueue(pool, monkey
     # computed against (see reserve_llm_spend_with_email_hooks).
     # 15% of 5.00 is 0.75; reserving 4.30 leaves 0.70, crossing it.
     await _insert_installation(
-        pool, installation_id, "a", plan="flash",
+        pool, installation_id, "a", plan="flash", alert_email="ops@example.com",
         base_credit_remaining_usd=5.00, topup_credit_balance_usd=0.00, balance_epoch=1,
     )
 
@@ -1504,7 +1504,7 @@ async def test_low_balance_email_fires_on_a_small_reservation_crossing_the_thres
     )
     installation_id = 9302
     await _insert_installation(
-        pool, installation_id, "a", plan="flash",
+        pool, installation_id, "a", plan="flash", alert_email="ops@example.com",
         base_credit_remaining_usd=0.80, topup_credit_balance_usd=0.00, balance_epoch=3,
     )
 
@@ -1543,7 +1543,7 @@ async def test_low_balance_threshold_scales_with_purchased_extra_seats(pool, mon
     )
     installation_id = 9303
     await _insert_installation(
-        pool, installation_id, "a", plan="air", extra_seats=2,
+        pool, installation_id, "a", plan="air", extra_seats=2, alert_email="ops@example.com",
         base_credit_remaining_usd=3.70, topup_credit_balance_usd=0.00, balance_epoch=1,
     )
 
@@ -1567,7 +1567,7 @@ async def test_reserve_llm_spend_rejection_triggers_exhausted_email(pool, monkey
     )
     installation_id = 9301
     await _insert_installation(
-        pool, installation_id, "a", plan="flash",
+        pool, installation_id, "a", plan="flash", alert_email="ops@example.com",
         base_credit_remaining_usd=0.01, topup_credit_balance_usd=0.00, balance_epoch=1,
     )
 
@@ -1586,6 +1586,32 @@ async def test_reserve_llm_spend_rejection_triggers_exhausted_email(pool, monkey
         "base_credit_remaining_usd": pytest.approx(0.01),
         "topup_credit_balance_usd": pytest.approx(0.00),
     }
+
+
+@pytest.mark.asyncio
+async def test_credit_balance_email_is_skipped_when_no_alert_email_is_configured(pool, monkeypatch):
+    # alert_email is nullable and opt-in - most installations have none, so
+    # enqueuing with to_email=None only queues a job the sender must reject.
+    # Guarded the same way the pre-existing health-alert enqueue is.
+    enqueued = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.enqueue_transactional_email",
+        lambda *a, **kw: enqueued.append((a, kw)),
+    )
+    installation_id = 9304
+    await _insert_installation(
+        pool, installation_id, "a", plan="flash",
+        base_credit_remaining_usd=0.01, topup_credit_balance_usd=0.00, balance_epoch=1,
+    )
+
+    # Would otherwise enqueue "credit_exhausted" - the reservation is far
+    # larger than the balance.
+    result = reserve_llm_spend_with_email_hooks(
+        TEST_DATABASE_URL, installation_id, reserve_usd=5.00, feature="flash_review",
+    )
+
+    assert result is False
+    assert enqueued == []
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_llm_cost.py
+++ b/github-app/tests/test_llm_cost.py
@@ -6,6 +6,7 @@ from app_server import llm_cost
 from app_server.llm_cost import (
     WARN_FRACTION_OF_CAP,
     base_cap_for_plan,
+    base_credit_for_plan,
     cost_for_usage,
     crossed_spend_warning_threshold,
     monthly_cap_for_installation,
@@ -142,3 +143,21 @@ def test_crossed_spend_warning_threshold_never_fires_for_a_zero_cap():
     """A zero cap means no plan matched (base_cap_for_plan's default) - not
     a real installation to warn about."""
     assert crossed_spend_warning_threshold(0.0, 100.0, 0.0) is False
+
+
+def test_base_credit_for_plan_flash():
+    assert base_credit_for_plan("flash", extra_seats=0) == 5.00
+
+
+def test_base_credit_for_plan_air_no_extra_seats():
+    assert base_credit_for_plan("air", extra_seats=0) == 18.00
+
+
+def test_base_credit_for_plan_air_with_extra_seats():
+    # Same per-seat bonus the old monthly_cap_for_installation used -
+    # EXTRA_SEAT_LLM_CAP_USD ($3.00) per extra seat.
+    assert base_credit_for_plan("air", extra_seats=2) == 18.00 + 2 * 3.00
+
+
+def test_base_credit_for_plan_unknown_plan_is_zero():
+    assert base_credit_for_plan("free", extra_seats=0) == 0.0

--- a/github-app/tests/test_migrate.py
+++ b/github-app/tests/test_migrate.py
@@ -259,6 +259,61 @@ def test_migrations_063_and_064_agree_on_every_backfilled_installation(fresh_dat
     ]
 
 
+def test_migration_065_adds_a_nullable_monthly_credit_reset_column(fresh_database):
+    """Structural only, deliberately with no backfill (065's own comment
+    explains why: zero live annual subscribers to backfill, and the webhook
+    handler arms the column for every one of them going forward).
+
+    NULL is the load-bearing default, not just an absence of data: it is
+    what excludes every monthly subscriber and every free installation from
+    run_monthly_credit_reset_sweep_job's due list. A NOT NULL column with a
+    now()-ish default here would make the sweep credit the entire customer
+    base every month.
+    """
+    run_migrations(fresh_database)
+
+    with psycopg.connect(fresh_database) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT data_type, is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_name = 'installations'
+                    AND column_name = 'next_monthly_credit_reset_at'
+                """
+            )
+            column = cur.fetchone()
+
+        assert column is not None
+        assert column[0] == "timestamp with time zone"
+        assert column[1] == "YES"
+        assert column[2] is None
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO installations (installation_id, account_login, plan) "
+                "VALUES (1, 'fresh-co', 'air')"
+            )
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT next_monthly_credit_reset_at FROM installations WHERE installation_id = 1"
+            )
+            assert cur.fetchone()[0] is None
+
+        # The sweep's due query runs on every ~3-minute scheduler tick, so
+        # it must be an index scan over the handful of annual subscribers,
+        # not a growing sequential scan of installations.
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT indexname FROM pg_indexes WHERE tablename = 'installations'"
+            )
+            indexes = {row[0] for row in cur.fetchall()}
+
+    assert "installations_next_monthly_credit_reset_at" in indexes
+
+
 def test_concurrent_migrate_runs_do_not_collide(tmp_path):
     """Two processes running migrate.py against the same database at once -
     the shape of starting a second app-server replica, or a restart

--- a/github-app/tests/test_migrate.py
+++ b/github-app/tests/test_migrate.py
@@ -157,6 +157,108 @@ def test_migration_063_backfills_existing_paid_installations_credit(fresh_databa
         assert again == balances
 
 
+def test_migration_064_backfills_existing_paid_installations_allotment(fresh_database):
+    """base_credit_allotment_usd is the ceiling release_llm_spend_reservation
+    caps a true-up refill at, and like 063's balance column the only things
+    that ever set it are a renewal reset and a mid-cycle seat purchase. Left
+    at its 0 default for the pre-existing paid population, every release
+    would spill 100% into the never-expiring topup bucket (the exact bug
+    this column exists to fix) until their next renewal, up to a month away.
+
+    Same fixture population and re-execution check as
+    test_migration_063_backfills_existing_paid_installations_credit, and the
+    values must match 063's exactly: the allotment IS what the balance is
+    reset to.
+    """
+    run_migrations(fresh_database)
+    backfill_sql = (MIGRATIONS_DIR / "064_base_credit_allotment.sql").read_text()
+
+    with psycopg.connect(fresh_database) as conn:
+        with conn.cursor() as cur:
+            cur.executemany(
+                "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+                "VALUES (%s, %s, %s, %s)",
+                [
+                    (1, "solo-flash", "flash", 0),
+                    (2, "solo-air", "air", 0),
+                    (3, "team-air", "air", 2),
+                    (4, "freeloader", "free", 0),
+                ],
+            )
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(backfill_sql)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT installation_id, base_credit_allotment_usd FROM installations "
+                "ORDER BY installation_id"
+            )
+            allotments = {row[0]: float(row[1]) for row in cur.fetchall()}
+
+        # base_credit_for_plan(plan, extra_seats) - identical to the values
+        # 063's backfill puts in base_credit_remaining_usd.
+        assert allotments == {1: 5.00, 2: 18.00, 3: 18.00 + 2 * 3.00, 4: 0.00}
+
+        with conn.cursor() as cur:
+            cur.execute(backfill_sql)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT installation_id, base_credit_allotment_usd FROM installations "
+                "ORDER BY installation_id"
+            )
+            again = {row[0]: float(row[1]) for row in cur.fetchall()}
+
+        assert again == allotments
+
+
+def test_migrations_063_and_064_agree_on_every_backfilled_installation(fresh_database):
+    """The whole point of the new column: base_credit_allotment_usd must be
+    the ceiling base_credit_remaining_usd was backfilled TO, not some
+    independently-computed number. A drift between the two CASE expressions
+    would silently either strand credit (allotment too low - a release
+    would clamp the balance DOWN) or reopen the leak (allotment too high).
+    Asserted on the real migration runner rather than by re-reading the two
+    files, so a copy-paste divergence in either one fails here.
+    """
+    run_migrations(fresh_database)
+
+    with psycopg.connect(fresh_database) as conn:
+        with conn.cursor() as cur:
+            cur.executemany(
+                "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+                "VALUES (%s, %s, %s, %s)",
+                [
+                    (1, "solo-flash", "flash", 0),
+                    (2, "team-air", "air", 3),
+                    (3, "freeloader", "free", 0),
+                ],
+            )
+        conn.commit()
+
+        for name in ("063_installation_credit_balance.sql", "064_base_credit_allotment.sql"):
+            with conn.cursor() as cur:
+                cur.execute((MIGRATIONS_DIR / name).read_text())
+            conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT installation_id, base_credit_remaining_usd, base_credit_allotment_usd "
+                "FROM installations ORDER BY installation_id"
+            )
+            rows = cur.fetchall()
+
+    assert [(r[0], float(r[1]), float(r[2])) for r in rows] == [
+        (1, 5.00, 5.00),
+        (2, 18.00 + 3 * 3.00, 18.00 + 3 * 3.00),
+        (3, 0.00, 0.00),
+    ]
+
+
 def test_concurrent_migrate_runs_do_not_collide(tmp_path):
     """Two processes running migrate.py against the same database at once -
     the shape of starting a second app-server replica, or a restart

--- a/github-app/tests/test_migrate.py
+++ b/github-app/tests/test_migrate.py
@@ -99,6 +99,64 @@ def test_run_migrations_backfills_schema_migrations_for_already_bootstrapped_db(
     assert second == []
 
 
+def test_migration_063_backfills_existing_paid_installations_credit(fresh_database):
+    """063's credit columns default to 0, and the only thing that ever raises
+    base_credit_remaining_usd is a Paddle renewal webhook carrying a NEW
+    billing-period start - so without the backfill every installation that
+    already existed at deploy time sits at $0 and is locked out of every AI
+    feature until its next renewal, up to a full month away.
+
+    Re-executes 063's own file text against rows that look exactly like that
+    pre-migration population (zero balance, no billing period recorded yet).
+    """
+    run_migrations(fresh_database)
+    backfill_sql = (MIGRATIONS_DIR / "063_installation_credit_balance.sql").read_text()
+
+    with psycopg.connect(fresh_database) as conn:
+        with conn.cursor() as cur:
+            cur.executemany(
+                "INSERT INTO installations (installation_id, account_login, plan, extra_seats) "
+                "VALUES (%s, %s, %s, %s)",
+                [
+                    (1, "solo-flash", "flash", 0),
+                    (2, "solo-air", "air", 0),
+                    (3, "team-air", "air", 2),
+                    (4, "freeloader", "free", 0),
+                ],
+            )
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(backfill_sql)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT installation_id, base_credit_remaining_usd FROM installations "
+                "ORDER BY installation_id"
+            )
+            balances = {row[0]: float(row[1]) for row in cur.fetchall()}
+
+        # PLAN_BASE_CREDIT_USD + EXTRA_SEAT_LLM_CAP_USD per extra seat
+        # (app_server/llm_cost.py's base_credit_for_plan).
+        assert balances == {1: 5.00, 2: 18.00, 3: 18.00 + 2 * 3.00, 4: 0.00}
+
+        # Re-executing the file (the docker-entrypoint-initdb.d + migrate.py
+        # overlap scripts/migrate.py documents) must not double-credit.
+        with conn.cursor() as cur:
+            cur.execute(backfill_sql)
+        conn.commit()
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT installation_id, base_credit_remaining_usd FROM installations "
+                "ORDER BY installation_id"
+            )
+            again = {row[0]: float(row[1]) for row in cur.fetchall()}
+
+        assert again == balances
+
+
 def test_concurrent_migrate_runs_do_not_collide(tmp_path):
     """Two processes running migrate.py against the same database at once -
     the shape of starting a second app-server replica, or a restart

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -11,6 +11,8 @@ from aletheore.evidence import EVIDENCE_VERSION
 from app_server.db import hide_repo
 from app_server.evidence_limits import EvidenceTooLargeError, MAX_EVIDENCE_BYTES
 from scan_worker.db import (
+    apply_monthly_credit_reset,
+    list_installations_due_for_monthly_credit_reset,
     check_and_reserve_flash_review_attempt,
     check_and_reserve_managed_audit,
     managed_audit_definitely_still_cooling_down,
@@ -2421,3 +2423,153 @@ async def test_insert_repo_history_without_head_sha_does_not_tag_the_stored_evid
 
     evidence = get_latest_evidence(TEST_DATABASE_URL, 826, "a/repo1")
     assert "_scan_head_sha" not in evidence
+
+
+# --- Synthetic monthly credit reset for annual subscribers (migration 065) ---
+
+
+@pytest.mark.asyncio
+async def test_monthly_credit_reset_due_list_only_includes_armed_and_due_rows(pool):
+    # 830: an annual subscriber whose synthetic due date has arrived.
+    await _insert_installation(pool, 830, "annual-due", plan="air")
+    # 831: an annual subscriber whose due date is still in the future.
+    await _insert_installation(pool, 831, "annual-not-yet", plan="air")
+    # 832: a MONTHLY subscriber - NULL clock. Their base credit is already
+    # refreshed every month by the Paddle-driven reset, so the sweep picking
+    # them up would double-credit them; this is the case the IS NOT NULL half
+    # of the query exists for.
+    await _insert_installation(pool, 832, "monthly", plan="air")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET next_monthly_credit_reset_at = now() - interval '1 hour' "
+            "WHERE installation_id = $1",
+            830,
+        )
+        await conn.execute(
+            "UPDATE installations SET next_monthly_credit_reset_at = now() + interval '5 days' "
+            "WHERE installation_id = $1",
+            831,
+        )
+
+    due = list_installations_due_for_monthly_credit_reset(TEST_DATABASE_URL)
+
+    assert 830 in due
+    assert 831 not in due
+    assert 832 not in due
+
+
+@pytest.mark.asyncio
+async def test_apply_monthly_credit_reset_advances_the_due_date_without_drift(pool):
+    # The next due date must be one month past ITS OWN PREVIOUS VALUE, not
+    # one month past now(). A sweep tick always lands somewhat late (the
+    # scheduler ticks every ~3 minutes and this job queues behind whatever
+    # else is on "scans"), and anchoring on now() would bake every one of
+    # those delays permanently into the schedule, walking the reset day later
+    # and later through the year.
+    await _insert_installation(pool, 833, "annual-co", plan="air", base_credit_remaining_usd=1.25)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET next_monthly_credit_reset_at = $2 WHERE installation_id = $1",
+            833,
+            datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+
+    apply_monthly_credit_reset(TEST_DATABASE_URL, 833, 18.00)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, base_credit_allotment_usd, balance_epoch, "
+        "next_monthly_credit_reset_at FROM installations WHERE installation_id = $1",
+        833,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(18.00)
+    # Exactly 2026-10-01, the old due date + 1 month - NOT now() + 1 month,
+    # which would have been over a year out from this fixed old date.
+    assert row["next_monthly_credit_reset_at"] == datetime(2026, 10, 1, tzinfo=timezone.utc)
+    # The dedupe key for the low-balance/exhausted credit emails is
+    # f"credit_low_balance:{installation_id}:{balance_epoch}" - without this
+    # bump, a customer warned once would never be warned again all year.
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_monthly_credit_reset_leaves_paddles_own_billing_period_alone(pool):
+    # current_billing_period_start belongs to Paddle's real once-a-year
+    # period. If the synthetic sweep faked it forward, the next genuine
+    # annual renewal webhook would look like a replay to
+    # reset_billing_period_credit and be skipped entirely.
+    await _insert_installation(pool, 834, "annual-co", plan="air")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET next_monthly_credit_reset_at = now() - interval '1 minute', "
+            "current_billing_period_start = $2 WHERE installation_id = $1",
+            834,
+            datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+
+    apply_monthly_credit_reset(TEST_DATABASE_URL, 834, 18.00)
+
+    row = await pool.fetchrow(
+        "SELECT current_billing_period_start FROM installations WHERE installation_id = $1", 834
+    )
+    assert row["current_billing_period_start"] == datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_apply_monthly_credit_reset_run_twice_back_to_back_only_fires_once(pool):
+    # Two sweeps in the same tick window (or a retried RQ job): the first
+    # advances the due date a month into the future, so the second finds the
+    # row no longer due and must not credit a second allotment on top.
+    await _insert_installation(pool, 835, "annual-co", plan="air")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET next_monthly_credit_reset_at = now() - interval '1 minute' "
+            "WHERE installation_id = $1",
+            835,
+        )
+
+    apply_monthly_credit_reset(TEST_DATABASE_URL, 835, 18.00)
+    after_first = await pool.fetchrow(
+        "SELECT next_monthly_credit_reset_at, balance_epoch FROM installations "
+        "WHERE installation_id = $1",
+        835,
+    )
+    # The row is no longer in the due list at all after one firing.
+    assert 835 not in list_installations_due_for_monthly_credit_reset(TEST_DATABASE_URL)
+
+    # Spend it down, then sweep again immediately.
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE installations SET base_credit_remaining_usd = 4.00 WHERE installation_id = $1",
+            835,
+        )
+    apply_monthly_credit_reset(TEST_DATABASE_URL, 835, 18.00)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, balance_epoch, next_monthly_credit_reset_at "
+        "FROM installations WHERE installation_id = $1",
+        835,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(4.00)
+    assert row["balance_epoch"] == after_first["balance_epoch"]
+    assert row["next_monthly_credit_reset_at"] == after_first["next_monthly_credit_reset_at"]
+
+
+@pytest.mark.asyncio
+async def test_apply_monthly_credit_reset_never_touches_a_monthly_subscriber(pool):
+    # Belt and braces on the invariant that matters most for money: even
+    # called directly with a monthly subscriber's id (NULL clock), the write
+    # must be a no-op. Their real Paddle renewal is the only thing allowed to
+    # reset their credit.
+    await _insert_installation(pool, 836, "monthly-co", plan="air", base_credit_remaining_usd=2.00)
+
+    apply_monthly_credit_reset(TEST_DATABASE_URL, 836, 18.00)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, balance_epoch, next_monthly_credit_reset_at "
+        "FROM installations WHERE installation_id = $1",
+        836,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(2.00)
+    assert row["balance_epoch"] == 0
+    assert row["next_monthly_credit_reset_at"] is None

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -1167,12 +1167,16 @@ async def test_reserve_llm_spend_succeeds_when_reserve_exactly_equals_combined_b
 
 
 @pytest.mark.asyncio
-async def test_release_llm_spend_reservation_credits_topup_before_base(pool):
-    # A release always credits back to topup_credit_balance_usd first,
-    # mirroring "spend base first, so give back topup first" - the
-    # simplest consistent inverse of the base-first draw-down order.
+async def test_release_llm_spend_reservation_spills_to_topup_when_base_is_at_its_allotment(pool):
+    # No room in base (it is already sitting at this billing period's full
+    # allotment - i.e. the reservation being released must have been paid
+    # for out of topup), so the whole release goes back to topup. This is
+    # the ONLY shape in which a release should touch topup at all.
     await _insert_installation(
-        pool, 408, "a", base_credit_remaining_usd=0.00, topup_credit_balance_usd=8.00
+        pool, 408, "a",
+        base_credit_allotment_usd=5.00,
+        base_credit_remaining_usd=5.00,
+        topup_credit_balance_usd=8.00,
     )
     release_llm_spend_reservation(TEST_DATABASE_URL, 408, 2.00)
     row = await pool.fetchrow(
@@ -1181,7 +1185,59 @@ async def test_release_llm_spend_reservation_credits_topup_before_base(pool):
         408,
     )
     assert float(row["topup_credit_balance_usd"]) == pytest.approx(10.00)
-    assert float(row["base_credit_remaining_usd"]) == pytest.approx(0.00)
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(5.00)
+
+
+@pytest.mark.asyncio
+async def test_release_llm_spend_reservation_refills_base_without_exceeding_the_allotment(pool):
+    # The bug this cap exists for: releasing the unused part of a flat
+    # reservation used to credit 100% to topup_credit_balance_usd, which
+    # NEVER expires - so on every Flash Review (real cost ~$0.007 against a
+    # $0.50 flat reserve) ~$0.49 of the monthly, use-it-or-lose-it base
+    # allotment permanently migrated into the never-expiring bucket, and a
+    # customer's spendable balance grew without bound instead of resetting
+    # each renewal.
+    #
+    # $0.50 was drawn out of a $5.00 allotment, so there is exactly $0.50 of
+    # room: releasing $0.50 must land base back at exactly its allotment
+    # with nothing at all spilling into topup.
+    await _insert_installation(
+        pool, 411, "a",
+        base_credit_allotment_usd=5.00,
+        base_credit_remaining_usd=4.50,
+        topup_credit_balance_usd=2.00,
+    )
+    release_llm_spend_reservation(TEST_DATABASE_URL, 411, 0.50)
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        411,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(5.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(2.00)
+
+
+@pytest.mark.asyncio
+async def test_release_llm_spend_reservation_spills_only_the_overflow_into_topup(pool):
+    # Same $0.50 of room, but $0.80 released - which can only happen when
+    # the reservation itself was partly funded from topup (base ran out
+    # mid-reservation, see reserve_llm_spend's spill-over). Base refills to
+    # its ceiling and exactly the $0.30 that base has no room for goes
+    # back where it came from.
+    await _insert_installation(
+        pool, 412, "a",
+        base_credit_allotment_usd=5.00,
+        base_credit_remaining_usd=4.50,
+        topup_credit_balance_usd=2.00,
+    )
+    release_llm_spend_reservation(TEST_DATABASE_URL, 412, 0.80)
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        412,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(5.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(2.30)
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -1091,50 +1091,98 @@ async def test_reserve_flash_review_count_is_atomic_under_real_concurrency(pool)
 
 
 @pytest.mark.asyncio
-async def test_reserve_llm_spend_allows_up_to_cap_then_blocks(pool):
-    await _insert_installation(pool, 405, "a")
-    first = reserve_llm_spend(TEST_DATABASE_URL, 405, reserve_usd=0.5, monthly_cap=1.0)
-    second = reserve_llm_spend(TEST_DATABASE_URL, 405, reserve_usd=0.5, monthly_cap=1.0)
-    third = reserve_llm_spend(TEST_DATABASE_URL, 405, reserve_usd=0.5, monthly_cap=1.0)
-    assert (first, second, third) == (True, True, False)
-    assert get_llm_spend_this_month(TEST_DATABASE_URL, 405) == pytest.approx(1.0)
+async def test_reserve_llm_spend_draws_from_base_credit_first(pool):
+    await _insert_installation(
+        pool, 405, "a", base_credit_remaining_usd=5.00, topup_credit_balance_usd=10.00
+    )
+    ok = reserve_llm_spend(TEST_DATABASE_URL, 405, 2.00)
+    assert ok is True
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        405,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(3.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(10.00)
 
 
 @pytest.mark.asyncio
-async def test_release_llm_spend_reservation_gives_back_the_reserved_amount(pool):
-    await _insert_installation(pool, 406, "a")
-    reserve_llm_spend(TEST_DATABASE_URL, 406, reserve_usd=0.5, monthly_cap=1.0)
-    release_llm_spend_reservation(TEST_DATABASE_URL, 406, reserve_usd=0.5)
-    assert get_llm_spend_this_month(TEST_DATABASE_URL, 406) == pytest.approx(0.0)
+async def test_reserve_llm_spend_spills_into_topup_when_base_insufficient(pool):
+    await _insert_installation(
+        pool, 406, "a", base_credit_remaining_usd=1.00, topup_credit_balance_usd=10.00
+    )
+    ok = reserve_llm_spend(TEST_DATABASE_URL, 406, 3.00)
+    assert ok is True
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        406,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(0.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
 
 
 @pytest.mark.asyncio
-async def test_release_llm_spend_reservation_never_goes_negative(pool):
-    await _insert_installation(pool, 407, "a")
-    release_llm_spend_reservation(TEST_DATABASE_URL, 407, reserve_usd=0.5)
-    assert get_llm_spend_this_month(TEST_DATABASE_URL, 407) == pytest.approx(0.0)
+async def test_reserve_llm_spend_rejects_when_combined_balance_insufficient(pool):
+    await _insert_installation(
+        pool, 407, "a", base_credit_remaining_usd=1.00, topup_credit_balance_usd=1.00
+    )
+    ok = reserve_llm_spend(TEST_DATABASE_URL, 407, 5.00)
+    assert ok is False
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        407,
+    )
+    # Rejected reservation must not have mutated either column.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(1.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(1.00)
+
+
+@pytest.mark.asyncio
+async def test_release_llm_spend_reservation_credits_topup_before_base(pool):
+    # A release always credits back to topup_credit_balance_usd first,
+    # mirroring "spend base first, so give back topup first" - the
+    # simplest consistent inverse of the base-first draw-down order.
+    await _insert_installation(
+        pool, 408, "a", base_credit_remaining_usd=0.00, topup_credit_balance_usd=8.00
+    )
+    release_llm_spend_reservation(TEST_DATABASE_URL, 408, 2.00)
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        408,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(10.00)
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(0.00)
 
 
 @pytest.mark.asyncio
 async def test_reserve_llm_spend_is_atomic_under_real_concurrency(pool):
     import concurrent.futures
 
-    await _insert_installation(pool, 408, "a")
-    reserve_usd = 0.5
-    cap = 5.0
-    max_successes = 10  # cap / reserve_usd
-    attempts = 30
+    await _insert_installation(
+        pool, 409, "a", base_credit_remaining_usd=10.00, topup_credit_balance_usd=0.00
+    )
+    reserve_usd = 1.00
+    max_successes = 10  # combined $10.00 balance / $1.00 per reservation
+    attempts = 20
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=attempts) as pool_exec:
         results = list(
             pool_exec.map(
-                lambda _: reserve_llm_spend(TEST_DATABASE_URL, 408, reserve_usd, cap),
+                lambda _: reserve_llm_spend(TEST_DATABASE_URL, 409, reserve_usd),
                 range(attempts),
             )
         )
 
     assert sum(results) == max_successes
-    assert get_llm_spend_this_month(TEST_DATABASE_URL, 408) == pytest.approx(max_successes * reserve_usd)
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        409,
+    )
+    assert float(row["base_credit_remaining_usd"]) + float(row["topup_credit_balance_usd"]) == pytest.approx(0.00)
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_scan_worker_db.py
+++ b/github-app/tests/test_scan_worker_db.py
@@ -1140,6 +1140,33 @@ async def test_reserve_llm_spend_rejects_when_combined_balance_insufficient(pool
 
 
 @pytest.mark.asyncio
+async def test_reserve_llm_spend_succeeds_when_reserve_exactly_equals_combined_balance(pool):
+    # The boundary the WHERE clause's `>=` is supposed to admit: spending
+    # the balance down to exactly nothing must succeed (not be rejected as
+    # if it were an overdraft), and must leave BOTH columns at 0 rather than
+    # driving topup_credit_balance_usd negative.
+    #
+    # pytest.approx, matching this file's convention throughout: the columns
+    # are NUMERIC but reserve_llm_spend's parameters bind as double
+    # precision, so the arithmetic is not guaranteed exact-decimal.
+    await _insert_installation(
+        pool, 410, "a", base_credit_remaining_usd=1.25, topup_credit_balance_usd=0.75
+    )
+    ok = reserve_llm_spend(TEST_DATABASE_URL, 410, 2.00)
+    assert ok is True
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, topup_credit_balance_usd "
+        "FROM installations WHERE installation_id = $1",
+        410,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(0.00)
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(0.00)
+
+    # And one more cent is now genuinely refused.
+    assert reserve_llm_spend(TEST_DATABASE_URL, 410, 0.01) is False
+
+
+@pytest.mark.asyncio
 async def test_release_llm_spend_reservation_credits_topup_before_base(pool):
     # A release always credits back to topup_credit_balance_usd first,
     # mirroring "spend base first, so give back topup first" - the

--- a/github-app/tests/test_scheduler.py
+++ b/github-app/tests/test_scheduler.py
@@ -9,6 +9,7 @@ from scan_worker.scheduler import (
     HEALTH_SWEEP_JOB_TIMEOUT_SECONDS,
     HEALTH_SWEEP_STALENESS_CHECK_JOB_TIMEOUT_SECONDS,
     JOB_TEMP_DIR_CLEANUP_JOB_TIMEOUT_SECONDS,
+    MONTHLY_CREDIT_RESET_JOB_TIMEOUT_SECONDS,
     OPS_MONITOR_JOB_TIMEOUT_SECONDS,
     SCANS_QUEUE_NAME,
     SESSION_CLEANUP_JOB_TIMEOUT_SECONDS,
@@ -59,7 +60,7 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         assert call.args == ("scan_worker.jobs.run_health_check_sweep_job",)
         assert call.kwargs == {"job_timeout": HEALTH_SWEEP_JOB_TIMEOUT_SECONDS}
 
-    assert scans_queue.enqueue.call_count == 30
+    assert scans_queue.enqueue.call_count == 33
     session_cleanup_calls = [
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_session_cleanup_job",)
@@ -100,6 +101,10 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
         c for c in scans_queue.enqueue.call_args_list
         if c.args == ("scan_worker.jobs.run_ops_monitor_job",)
     ]
+    monthly_credit_reset_calls = [
+        c for c in scans_queue.enqueue.call_args_list
+        if c.args == ("scan_worker.jobs.run_monthly_credit_reset_sweep_job",)
+    ]
     assert len(session_cleanup_calls) == 3
     assert len(docs_catchup_calls) == 3
     assert len(wiki_catchup_calls) == 3
@@ -110,6 +115,14 @@ def test_run_forever_enqueues_health_sweep_and_session_cleanup_on_each_iteration
     assert len(endpoint_health_cleanup_calls) == 3
     assert len(flash_review_cache_cleanup_calls) == 3
     assert len(ops_monitor_calls) == 3
+    # The synthetic monthly credit reset for annual subscribers has to be
+    # enqueued every tick like the rest: it is the only thing that gives an
+    # annual AIR customer their monthly allotment (see
+    # run_monthly_credit_reset_sweep_job), so a scheduler that silently
+    # stopped enqueueing it would under-credit them for a year.
+    assert len(monthly_credit_reset_calls) == 3
+    for call in monthly_credit_reset_calls:
+        assert call.kwargs == {"job_timeout": MONTHLY_CREDIT_RESET_JOB_TIMEOUT_SECONDS}
     for call in endpoint_health_cleanup_calls:
         assert call.kwargs == {"job_timeout": ENDPOINT_HEALTH_CLEANUP_JOB_TIMEOUT_SECONDS}
     for call in flash_review_cache_cleanup_calls:

--- a/github-app/tests/test_send_transactional_email_job.py
+++ b/github-app/tests/test_send_transactional_email_job.py
@@ -107,11 +107,38 @@ def test_dict_template_arg_is_expanded_as_keyword_args(monkeypatch):
     assert "2 scans" in send_calls[0]["text"]
 
 
-def test_unknown_template_name_raises(monkeypatch):
+def test_unknown_template_name_is_skipped_with_a_warning_instead_of_raising(monkeypatch, caplog):
+    # Previously a KeyError. The credit-balance emails
+    # (credit_low_balance/credit_exhausted) are enqueued by
+    # reserve_llm_spend_with_email_hooks on this branch, but their templates
+    # land on the parallel dashboard/emails branch - so depending on merge
+    # order this worker really can be handed a template name it doesn't have
+    # yet. Unguarded, @log_job turns that KeyError into a failed RQ job plus
+    # an error alert for EVERY low-balance/exhausted event, which is a much
+    # worse failure mode than a missing email. The guard doesn't close the
+    # template gap (the other branch's templates do); it makes this branch
+    # deployable independently of merge order.
+    import logging
+
     monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
     monkeypatch.setattr("scan_worker.jobs.email_already_sent", lambda dsn, key: False)
 
-    import pytest
+    def _fail_if_called(*a, **k):
+        raise AssertionError("should not attempt to send an unrenderable template")
 
-    with pytest.raises(KeyError):
-        send_transactional_email_job("x:1", "not_a_real_template", "octocat", "o@example.com")
+    monkeypatch.setattr("scan_worker.jobs.send_transactional_email", _fail_if_called)
+    monkeypatch.setattr("scan_worker.jobs.record_sent_email", _fail_if_called)
+
+    with caplog.at_level(logging.WARNING, logger="scan_worker.jobs"):
+        send_transactional_email_job(
+            "credit_low_balance:42:1",
+            "credit_low_balance",
+            {"account_login": "acme"},
+            "o@example.com",
+            installation_id=42,
+        )
+
+    assert "no email template registered for credit_low_balance" in caplog.text
+    # Nothing recorded either: the dedupe key must stay unclaimed so the
+    # same event can send for real once the templates land.
+    assert "installation_id=42" in caplog.text

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -1708,6 +1708,13 @@ async def test_transaction_completed_credits_topup_purchase(pool):
             "customer_id": "ctm_test_1910",
             "custom_data": {"installation_token": _installation_token(installation_id)},
             "items": [{"price": {"id": CREDIT_TOPUP_PRICE_ID}, "quantity": 10}],
+            # details.totals.total (Paddle's actual collected amount, in
+            # cents) is what determines the credited amount, not quantity -
+            # this happens to be a round, undiscounted $10.00 (quantity * 100
+            # cents) so this test alone doesn't prove the fix; see
+            # test_transaction_completed_credits_topup_purchase_at_discounted_total
+            # below for the case where they deliberately diverge.
+            "details": {"totals": {"total": "1000"}},
             "billed_at": "2026-09-01T12:00:00Z",
         },
     }
@@ -1719,6 +1726,39 @@ async def test_transaction_completed_credits_topup_purchase(pool):
         installation_id,
     )
     assert float(row["topup_credit_balance_usd"]) == pytest.approx(10.00)
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_credits_topup_purchase_at_discounted_total(pool):
+    # Real production billing bug: crediting used to trust the line item's
+    # raw quantity (assuming exactly $1.00/unit was collected), ignoring
+    # any discount actually applied by Paddle. Here quantity is 10 (which
+    # would wrongly credit $10.00) but Paddle only collected $8.00 net of a
+    # discount - proving the fix credits details.totals.total, not
+    # quantity.
+    await upsert_installation(pool, 1914, "acme")
+    installation_id = 1914
+    payload = {
+        "event_id": "evt_topup_1914",
+        "event_type": "transaction.completed",
+        "data": {
+            "id": "txn_topup_wire_1914",
+            "customer_id": "ctm_test_1914",
+            "custom_data": {"installation_token": _installation_token(installation_id)},
+            "items": [{"price": {"id": CREDIT_TOPUP_PRICE_ID}, "quantity": 10}],
+            "details": {"totals": {"total": "800"}},
+            "billed_at": "2026-09-01T12:00:00Z",
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd, balance_epoch FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
     assert row["balance_epoch"] == 1
 
 
@@ -1741,6 +1781,7 @@ async def test_transaction_completed_topup_is_independent_of_referral_commission
             "customer_id": "ctm_test_1911",
             "custom_data": {"installation_token": _installation_token(installation_id)},
             "items": [{"price": {"id": CREDIT_TOPUP_PRICE_ID}, "quantity": 5}],
+            "details": {"totals": {"total": "500"}},
             "billed_at": "2026-09-01T12:00:00Z",
         },
     }

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -1574,6 +1574,129 @@ async def test_subscription_updated_replay_does_not_reset_spent_down_credit(pool
 
 
 @pytest.mark.asyncio
+async def test_mid_cycle_seat_purchase_credits_the_balance_immediately(pool):
+    # I5 of the final-review fix wave: a seat purchase fires
+    # subscription.updated with the SAME current_billing_period.starts_at, so
+    # reset_billing_period_credit is a deliberate no-op - the per-seat bonus
+    # baked into base_credit_for_plan never landed until the next real
+    # renewal, and a customer paid $6.99/seat for $0 of extra credit for up
+    # to a month. (The old flat cap recomputed itself live from
+    # get_extra_seats at every enforcement call site, so it used to rise
+    # immediately.)
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats, "
+        "base_credit_remaining_usd, current_billing_period_start) "
+        "VALUES (407, 'acme', 'air', 1, 12.00, '2026-09-01T00:00:00Z')"
+    )
+    payload = {
+        "event_id": "evt_seat_407",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_407",
+            "customer_id": "ctm_test_407",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(407)},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 3},
+            ],
+            # Same period as what's already stored - so the renewal reset is
+            # correctly a no-op and cannot be what applies the seat credit.
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_extra_seats(pool, 407) == 3
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, balance_epoch FROM installations "
+        "WHERE installation_id = $1",
+        407,
+    )
+    # 2 seats added (1 -> 3) x EXTRA_SEAT_LLM_CAP_USD (3.00), on top of the
+    # already-spent-down 12.00 - NOT a reset to base_credit_for_plan.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(12.00 + 2 * 3.00)
+    # Balance went up, so the low-balance email dedupe epoch advances too.
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_seat_removal_does_not_change_the_credit_balance(pool):
+    # Only an INCREASE credits. Removing a seat must not claw credit back
+    # mid-cycle (the customer already paid for the period it was bought in);
+    # the smaller allotment simply applies at the next renewal reset.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats, "
+        "base_credit_remaining_usd, current_billing_period_start) "
+        "VALUES (408, 'acme', 'air', 3, 12.00, '2026-09-01T00:00:00Z')"
+    )
+    payload = {
+        "event_id": "evt_seat_408",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_408",
+            "customer_id": "ctm_test_408",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(408)},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 1},
+            ],
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert await get_extra_seats(pool, 408) == 1
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd FROM installations WHERE installation_id = $1", 408
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(12.00)
+
+
+@pytest.mark.asyncio
+async def test_renewal_with_more_seats_resets_without_double_counting_the_seat_bonus(pool):
+    # A genuine renewal that ALSO carries a higher seat count: the reset
+    # already sets the balance to base_credit_for_plan(plan, extra_seats),
+    # which includes the new seats - crediting the mid-cycle bonus on top of
+    # that would double-count it.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats, "
+        "base_credit_remaining_usd, current_billing_period_start) "
+        "VALUES (409, 'acme', 'air', 1, 2.00, '2026-08-01T00:00:00Z')"
+    )
+    payload = {
+        "event_id": "evt_renewal_seats_409",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_409",
+            "customer_id": "ctm_test_409",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(409)},
+            "items": [
+                {"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 3},
+            ],
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd FROM installations WHERE installation_id = $1", 409
+    )
+    # base_credit_for_plan("air", 3) = 18.00 + 3 * 3.00 = 27.00, and nothing
+    # more on top of it.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(27.00)
+
+
+@pytest.mark.asyncio
 async def test_transaction_completed_credits_topup_purchase(pool):
     await upsert_installation(pool, 910 + 1000, "acme")
     installation_id = 1910

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -17,13 +17,15 @@ from app_server.db import (
     add_installation_member,
     claim_free_to_paid_plan,
     claim_webhook_delivery,
+    credit_topup_purchase,
     get_extra_seats,
     get_installation,
+    reset_billing_period_credit,
     upsert_github_user_email,
     upsert_installation,
 )
 from app_server.main import app
-from app_server.paddle_pricing import EXTRA_SEAT_PRICE_ID
+from app_server.paddle_pricing import CREDIT_TOPUP_PRICE_ID, EXTRA_SEAT_PRICE_ID
 from app_server.webhooks.paddle import handle_paddle_webhook_event
 
 WEBHOOK_SECRET = "pdl_ntfset_test_secret"
@@ -1348,3 +1350,230 @@ async def test_full_webhook_route_records_commission_for_referred_installation(p
     assert response.status_code == 200
     totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
     assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.05")
+
+
+# --- reset_billing_period_credit / credit_topup_purchase (Task 5) ---
+# Real per-installation dollar-credit balance mutations: a billing-period
+# renewal resets base_credit_remaining_usd to the plan's real included
+# credit, and a customer-purchased top-up adds to topup_credit_balance_usd
+# exactly once per Paddle transaction id. Both increment balance_epoch,
+# the dedupe key the low-balance/exhausted credit-notification emails
+# (Task 6) key off of.
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_period_credit_on_genuine_new_period(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (401, 'acme', 'air')"
+    )
+
+    changed = await reset_billing_period_credit(
+        pool, 401, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z"
+    )
+
+    assert changed is True
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, current_billing_period_start, balance_epoch "
+        "FROM installations WHERE installation_id = $1",
+        401,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_period_credit_is_a_noop_on_the_same_period(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (402, 'acme', 'air')"
+    )
+    await reset_billing_period_credit(
+        pool, 402, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z"
+    )
+    # Spend some of it down.
+    await pool.execute(
+        "UPDATE installations SET base_credit_remaining_usd = 2.00 WHERE installation_id = $1",
+        402,
+    )
+
+    # Same period_start delivered again (a replayed or unrelated subscription.updated).
+    changed = await reset_billing_period_credit(
+        pool, 402, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z"
+    )
+
+    assert changed is False
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd FROM installations WHERE installation_id = $1",
+        402,
+    )
+    # Must NOT have been reset back to 18.00 - the spent-down 2.00 survives.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(2.00)
+
+
+@pytest.mark.asyncio
+async def test_credit_topup_purchase_increments_topup_balance(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (403, 'acme', 'flash')"
+    )
+
+    credited = await credit_topup_purchase(pool, 403, 8.00, "txn_topup_403")
+
+    assert credited is True
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd, balance_epoch FROM installations WHERE installation_id = $1",
+        403,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_credit_topup_purchase_is_idempotent_on_replayed_transaction(pool):
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (404, 'acme', 'flash')"
+    )
+
+    first = await credit_topup_purchase(pool, 404, 8.00, "txn_topup_404")
+    second = await credit_topup_purchase(pool, 404, 8.00, "txn_topup_404")
+
+    assert first is True
+    assert second is False
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd FROM installations WHERE installation_id = $1",
+        404,
+    )
+    # Only credited once, not twice.
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
+
+
+# --- Webhook wiring for the two mutations above ---
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_with_current_billing_period_resets_credit(pool):
+    # A genuine renewal delivered as subscription.updated: current_billing_
+    # period.starts_at is new for this installation (NULL -> a real
+    # timestamp), so the base credit must reset to the plan's real included
+    # credit even though the balance had been spent down to 2.00.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, base_credit_remaining_usd) "
+        "VALUES (405, 'acme', 'air', 2.00)"
+    )
+    payload = {
+        "event_id": "evt_renewal_405",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_405",
+            "customer_id": "ctm_test_405",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(405)},
+            "items": [{"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1}],
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, balance_epoch, current_billing_period_start "
+        "FROM installations WHERE installation_id = $1",
+        405,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    assert row["balance_epoch"] == 1
+    assert row["current_billing_period_start"] is not None
+
+
+@pytest.mark.asyncio
+async def test_subscription_updated_replay_does_not_reset_spent_down_credit(pool):
+    # The same current_billing_period.starts_at delivered twice (a Paddle
+    # retry, or an unrelated subscription.updated within the same period)
+    # must not reset the balance back up a second time.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (406, 'acme', 'air')"
+    )
+    payload = {
+        "event_id": "evt_renewal_406a",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_406",
+            "customer_id": "ctm_test_406",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(406)},
+            "items": [{"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1}],
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+    await pool.execute(
+        "UPDATE installations SET base_credit_remaining_usd = 3.00 WHERE installation_id = $1", 406
+    )
+
+    payload["event_id"] = "evt_renewal_406b"
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd FROM installations WHERE installation_id = $1", 406
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(3.00)
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_credits_topup_purchase(pool):
+    await upsert_installation(pool, 910 + 1000, "acme")
+    installation_id = 1910
+    payload = {
+        "event_id": "evt_topup_1910",
+        "event_type": "transaction.completed",
+        "data": {
+            "id": "txn_topup_wire_1910",
+            "customer_id": "ctm_test_1910",
+            "custom_data": {"installation_token": _installation_token(installation_id)},
+            "items": [{"price": {"id": CREDIT_TOPUP_PRICE_ID}, "quantity": 10}],
+            "billed_at": "2026-09-01T12:00:00Z",
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd, balance_epoch FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(10.00)
+    assert row["balance_epoch"] == 1
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_topup_is_independent_of_referral_commission(pool):
+    # A topup purchase and a referral commission on the same transaction
+    # aren't mutually exclusive - both must apply. Also proves the topup
+    # branch isn't skipped by the referral early-return for unreferred
+    # transactions (the common case), since this installation has no
+    # referral on file at all.
+    installation_id = 1911
+    await upsert_installation(pool, installation_id, "acme")
+    payload = {
+        "event_id": "evt_topup_1911",
+        "event_type": "transaction.completed",
+        "data": {
+            "id": "txn_topup_wire_1911",
+            "customer_id": "ctm_test_1911",
+            "custom_data": {"installation_token": _installation_token(installation_id)},
+            "items": [{"price": {"id": CREDIT_TOPUP_PRICE_ID}, "quantity": 5}],
+            "billed_at": "2026-09-01T12:00:00Z",
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(5.00)
+    # No affiliate/referral was ever recorded for this installation - the
+    # referral early-return in _handle_transaction_completed doesn't
+    # prevent the (independent) topup branch from running.
+    assert await get_referral(pool, installation_id) is None

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -589,6 +589,60 @@ async def test_crash_between_writes_rolls_back_the_plan_change_atomically(pool):
 
 
 @pytest.mark.asyncio
+async def test_crash_between_reset_and_plan_write_rolls_back_the_credit_reset_too(pool):
+    # Fix round 1 regression test: reset_billing_period_credit used to run
+    # as its own standalone call BEFORE the "one transaction" block below,
+    # so a crash between the two left base_credit_remaining_usd/
+    # current_billing_period_start/balance_epoch already committed to the
+    # new period while plan/extra_seats/Paddle IDs stayed stale - exactly
+    # the split-write hazard the block's own comment (and the test above)
+    # documents, just with the reset on the wrong side of the boundary.
+    # Folding the reset into the same `conn`/`conn.transaction()` as the
+    # rest means a crash after the reset runs (here, injected at
+    # set_extra_seats, same crash point as the test above) must now roll
+    # the reset back too - proven below by asserting the credit/period/
+    # epoch columns are untouched, not just plan/extra_seats/Paddle IDs.
+    import app_server.webhooks.paddle as paddle_mod
+
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, base_credit_remaining_usd) "
+        "VALUES (407, 'acme', 'air', 2.00)"
+    )
+    payload = {
+        "event_id": "evt_crash_mid_reset_407",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_should_not_persist_407",
+            "customer_id": "ctm_should_not_persist_407",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(407)},
+            "items": [{"price": {"id": "pri_01kyhevc8bkcghfpwjymz16y2h"}, "quantity": 1}],
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+
+    async def _crash(*a, **k):
+        raise RuntimeError("simulated crash: pod killed here")
+
+    with patch.object(paddle_mod, "set_extra_seats", _crash):
+        with pytest.raises(RuntimeError):
+            await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=MagicMock())
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, current_billing_period_start, balance_epoch, "
+        "paddle_subscription_id FROM installations WHERE installation_id = $1",
+        407,
+    )
+    # The reset (18.00, a real current_billing_period_start, balance_epoch
+    # 1) must NOT have survived the crash, exactly like the Paddle-id write
+    # below it in the same transaction didn't.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(2.00)
+    assert row["current_billing_period_start"] is None
+    assert row["balance_epoch"] == 0
+    assert row["paddle_subscription_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_crash_after_plan_write_still_runs_setup_on_retry(pool):
     """Simulates a process death between the plan write committing and
     setup (wiki/docs build, attribution) running: claim_free_to_paid_plan

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -4,6 +4,7 @@ import ipaddress
 import json
 import logging
 import time
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
@@ -26,8 +27,13 @@ from app_server.db import (
     upsert_installation,
 )
 from app_server.main import app
-from app_server.paddle_pricing import CREDIT_TOPUP_PRICE_ID, EXTRA_SEAT_PRICE_ID
+from app_server.paddle_pricing import (
+    CREDIT_TOPUP_PRICE_ID,
+    EXTRA_SEAT_PRICE_ID,
+    PLAN_INTERVAL_TO_PRICE_ID,
+)
 from app_server.webhooks.paddle import handle_paddle_webhook_event
+from scan_worker.jobs import run_monthly_credit_reset_sweep_job
 
 WEBHOOK_SECRET = "pdl_ntfset_test_secret"
 # Matches conftest.py's SESSION_SECRET default - the webhook handler
@@ -1423,7 +1429,7 @@ async def test_reset_billing_period_credit_on_genuine_new_period(pool):
     )
 
     changed = await reset_billing_period_credit(
-        pool, 401, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z"
+        pool, 401, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z", is_annual=False
     )
 
     assert changed is True
@@ -1449,7 +1455,7 @@ async def test_reset_billing_period_credit_is_a_noop_on_the_same_period(pool):
         "INSERT INTO installations (installation_id, account_login, plan) VALUES (402, 'acme', 'air')"
     )
     await reset_billing_period_credit(
-        pool, 402, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z"
+        pool, 402, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z", is_annual=False
     )
     # Spend some of it down.
     await pool.execute(
@@ -1459,7 +1465,7 @@ async def test_reset_billing_period_credit_is_a_noop_on_the_same_period(pool):
 
     # Same period_start delivered again (a replayed or unrelated subscription.updated).
     changed = await reset_billing_period_credit(
-        pool, 402, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z"
+        pool, 402, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z", is_annual=False
     )
 
     assert changed is False
@@ -1469,6 +1475,78 @@ async def test_reset_billing_period_credit_is_a_noop_on_the_same_period(pool):
     )
     # Must NOT have been reset back to 18.00 - the spent-down 2.00 survives.
     assert float(row["base_credit_remaining_usd"]) == pytest.approx(2.00)
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_period_credit_arms_the_monthly_clock_for_an_annual_subscriber(pool):
+    # An annual subscriber's Paddle billing period only advances once a
+    # year, so this reset is the only one they will get from Paddle for the
+    # next 12 months. next_monthly_credit_reset_at is what lets
+    # run_monthly_credit_reset_sweep_job hand them the other 11 months of
+    # the $18/month allotment they actually paid for.
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (420, 'annual-co', 'air')"
+    )
+
+    changed = await reset_billing_period_credit(
+        pool, 420, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z", is_annual=True
+    )
+
+    assert changed is True
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, next_monthly_credit_reset_at "
+        "FROM installations WHERE installation_id = $1",
+        420,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    # One month past THIS reset, not past "now" - see the 30-day note in
+    # reset_billing_period_credit's docstring on why dateutil's exact
+    # relativedelta isn't used (it is not a dependency of this service).
+    assert row["next_monthly_credit_reset_at"] == datetime(
+        2026, 9, 1, tzinfo=timezone.utc
+    ) + timedelta(days=30)
+
+
+@pytest.mark.asyncio
+async def test_reset_billing_period_credit_leaves_the_monthly_clock_null_for_a_monthly_subscriber(pool):
+    # A monthly subscriber already gets a real reset from Paddle every
+    # month, so the synthetic sweep must never see them: this reset plus a
+    # sweep firing in the same month would credit them twice.
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (421, 'monthly-co', 'air')"
+    )
+
+    await reset_billing_period_credit(
+        pool, 421, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z", is_annual=False
+    )
+
+    row = await pool.fetchrow(
+        "SELECT next_monthly_credit_reset_at FROM installations WHERE installation_id = $1", 421
+    )
+    assert row["next_monthly_credit_reset_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_monthly_renewal_disarms_a_previously_armed_monthly_clock(pool):
+    # A customer who downgrades from the annual price to the monthly one
+    # keeps whatever next_monthly_credit_reset_at their annual renewal set,
+    # unless a monthly reset actively clears it - and if it survived, they
+    # would collect both a real monthly reset and a synthetic one every
+    # month. is_annual=False writing NULL is what makes that impossible.
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, "
+        "next_monthly_credit_reset_at) "
+        "VALUES (422, 'switched-co', 'air', '2026-10-01T00:00:00Z')"
+    )
+
+    await reset_billing_period_credit(
+        pool, 422, "air", extra_seats=0, period_start="2026-09-15T00:00:00Z", is_annual=False
+    )
+
+    row = await pool.fetchrow(
+        "SELECT next_monthly_credit_reset_at FROM installations WHERE installation_id = $1", 422
+    )
+    assert row["next_monthly_credit_reset_at"] is None
 
 
 @pytest.mark.asyncio
@@ -1622,6 +1700,119 @@ async def test_subscription_updated_with_current_billing_period_resets_credit(po
     assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
     assert row["balance_epoch"] == 1
     assert row["current_billing_period_start"] is not None
+
+
+@pytest.mark.asyncio
+async def test_monthly_air_subscription_updated_does_not_arm_the_monthly_credit_clock(pool):
+    # The monthly AIR price. Paddle already advances this subscription's
+    # current_billing_period every month, so the synthetic clock must stay
+    # NULL - a monthly subscriber picked up by the sweep would be credited
+    # twice a month.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (430, 'monthly-co', 'air')"
+    )
+    payload = {
+        "event_id": "evt_renewal_430",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_430",
+            "customer_id": "ctm_test_430",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(430)},
+            "items": [
+                {"price": {"id": PLAN_INTERVAL_TO_PRICE_ID[("air", "month")]}, "quantity": 1}
+            ],
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, next_monthly_credit_reset_at "
+        "FROM installations WHERE installation_id = $1",
+        430,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    assert row["next_monthly_credit_reset_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_annual_air_subscriber_really_gets_re_credited_mid_year(pool):
+    # End-to-end proof of the bug this whole mechanism exists to fix. An
+    # annual AIR subscriber's current_billing_period.starts_at advances once
+    # a YEAR, so before this the webhook reset below was the ONLY credit
+    # they would see for 12 months: $18 for the year instead of $18 a month.
+    #
+    # Two halves, in order: the real annual renewal webhook arms the
+    # synthetic monthly clock one month out, and then the sweep - the thing
+    # that actually runs monthly in production - re-credits them off that
+    # clock, with no Paddle event involved at all.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan) VALUES (431, 'annual-co', 'air')"
+    )
+    payload = {
+        "event_id": "evt_renewal_431",
+        "event_type": "subscription.updated",
+        "data": {
+            "id": "sub_test_431",
+            "customer_id": "ctm_test_431",
+            "status": "active",
+            "custom_data": {"installation_token": _installation_token(431)},
+            "items": [
+                {"price": {"id": PLAN_INTERVAL_TO_PRICE_ID[("air", "year")]}, "quantity": 1}
+            ],
+            "current_billing_period": {"starts_at": "2026-09-01T00:00:00Z"},
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, balance_epoch, next_monthly_credit_reset_at "
+        "FROM installations WHERE installation_id = $1",
+        431,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    assert row["balance_epoch"] == 1
+    assert row["next_monthly_credit_reset_at"] == datetime(
+        2026, 9, 1, tzinfo=timezone.utc
+    ) + timedelta(days=30)
+
+    # Now they spend the month's credit down and their synthetic due date
+    # arrives (moved into the past here rather than waiting a month - the
+    # sweep's own trigger is next_monthly_credit_reset_at <= now()).
+    await pool.execute(
+        "UPDATE installations SET base_credit_remaining_usd = 0.40, "
+        "next_monthly_credit_reset_at = now() - interval '1 minute' "
+        "WHERE installation_id = $1",
+        431,
+    )
+
+    run_monthly_credit_reset_sweep_job()
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, base_credit_allotment_usd, balance_epoch, "
+        "current_billing_period_start, next_monthly_credit_reset_at "
+        "FROM installations WHERE installation_id = $1",
+        431,
+    )
+    # The whole point: a full monthly allotment again, mid-year, with no
+    # Paddle renewal anywhere near it.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(18.00)
+    # Bumped so the low-balance/exhausted emails they may already have been
+    # sent this year don't suppress next month's (the dedupe key is
+    # f"credit_low_balance:{installation_id}:{balance_epoch}").
+    assert row["balance_epoch"] == 2
+    # Paddle still owns the real billing period - the sweep must not fake it
+    # forward, or the next genuine annual renewal would look like a replay
+    # and be skipped.
+    assert row["current_billing_period_start"] == datetime(2026, 9, 1, tzinfo=timezone.utc)
+    # And the clock is armed again for the month after.
+    assert row["next_monthly_credit_reset_at"] > datetime.now(timezone.utc)
 
 
 @pytest.mark.asyncio

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -1601,11 +1601,13 @@ async def test_transaction_completed_credits_topup_purchase(pool):
 
 @pytest.mark.asyncio
 async def test_transaction_completed_topup_is_independent_of_referral_commission(pool):
-    # A topup purchase and a referral commission on the same transaction
-    # aren't mutually exclusive - both must apply. Also proves the topup
-    # branch isn't skipped by the referral early-return for unreferred
-    # transactions (the common case), since this installation has no
-    # referral on file at all.
+    # Proves the topup branch isn't skipped by the referral early-return
+    # for unreferred transactions (the common case), since this
+    # installation has no referral on file at all. (For a *referred*
+    # installation, a topup transaction is deliberately excluded from
+    # commission entirely - see
+    # test_transaction_completed_topup_for_referred_installation_is_excluded_from_commission
+    # below.)
     installation_id = 1911
     await upsert_installation(pool, installation_id, "acme")
     payload = {
@@ -1631,3 +1633,68 @@ async def test_transaction_completed_topup_is_independent_of_referral_commission
     # referral early-return in _handle_transaction_completed doesn't
     # prevent the (independent) topup branch from running.
     assert await get_referral(pool, installation_id) is None
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_topup_for_referred_installation_is_excluded_from_commission(pool):
+    # Real production billing bug: credit top-ups are pass-through LLM
+    # spend with near-zero margin. Before this fix, a referred
+    # installation's top-up purchase still fell through into the
+    # unconditional commission block below and paid its referrer 15% of
+    # the top-up amount - a real, recurring loss with no offsetting
+    # revenue. The top-up must still be credited (that part is real
+    # revenue-neutral top-up crediting, unrelated to the affiliate
+    # program), but this transaction must NOT generate a commission.
+    affiliate = await create_affiliate(pool, "TOPUPEXCL10", "dsc_topupexcl_wh", "Topupexcl")
+    installation_id = 1912
+    await upsert_installation(pool, installation_id, "acme")
+    await record_referral(pool, installation_id, affiliate["id"])
+
+    payload = {
+        "event_id": "evt_topup_1912",
+        "event_type": "transaction.completed",
+        "data": {
+            "id": "txn_topup_wire_1912",
+            "customer_id": "ctm_test_1912",
+            "custom_data": {"installation_token": _installation_token(installation_id)},
+            "items": [{"price": {"id": CREDIT_TOPUP_PRICE_ID}, "quantity": 20}],
+            # A large total (20 * $1 topup unit price scope aside) - if the
+            # commission bug were still present this would pay a very
+            # visible $3.00 (15% of $20.00) commission.
+            "details": {"totals": {"total": "2000"}},
+            "billed_at": "2026-09-01T12:00:00Z",
+        },
+    }
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    # The top-up itself was still credited.
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(20.00)
+
+    # But no commission was recorded for the referring affiliate.
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_transaction_completed_regular_purchase_for_referred_installation_still_records_commission(pool):
+    # Companion to the exclusion test above: a referred installation's
+    # ordinary (non-topup) subscription/seat transaction must still earn
+    # its referrer commission exactly as before - the topup exclusion
+    # must not have broken the existing, correct commission path.
+    affiliate = await create_affiliate(pool, "REGULAR10", "dsc_regular_wh", "Regular")
+    installation_id = 1913
+    await upsert_installation(pool, installation_id, "acme")
+    await record_referral(pool, installation_id, affiliate["id"])
+
+    # $26.99 (2699 cents), no CREDIT_TOPUP_PRICE_ID item - same shape as
+    # test_transaction_completed_for_referred_installation_records_commission.
+    payload = _transaction_completed_payload(installation_id, "2699", transaction_id="txn_regular_1913")
+    await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    totals = {row["id"]: row for row in await list_affiliates_with_totals(pool)}
+    assert totals[affiliate["id"]]["total_owed_usd"] == Decimal("4.05")

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -17,6 +17,7 @@ from app_server.db import (
     add_installation_member,
     claim_free_to_paid_plan,
     claim_webhook_delivery,
+    credit_extra_seat_purchase,
     credit_topup_purchase,
     get_extra_seats,
     get_installation,
@@ -1427,11 +1428,18 @@ async def test_reset_billing_period_credit_on_genuine_new_period(pool):
 
     assert changed is True
     row = await pool.fetchrow(
-        "SELECT base_credit_remaining_usd, current_billing_period_start, balance_epoch "
+        "SELECT base_credit_remaining_usd, base_credit_allotment_usd, "
+        "current_billing_period_start, balance_epoch "
         "FROM installations WHERE installation_id = $1",
         401,
     )
     assert float(row["base_credit_remaining_usd"]) == pytest.approx(18.00)
+    # The ceiling resets with the balance, to the same number: it is what
+    # release_llm_spend_reservation caps a true-up refill at, so a stale
+    # allotment from a previous period/seat count would either strand credit
+    # (too low) or let base credit leak into the never-expiring topup bucket
+    # (too high).
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(18.00)
     assert row["balance_epoch"] == 1
 
 
@@ -1464,6 +1472,76 @@ async def test_reset_billing_period_credit_is_a_noop_on_the_same_period(pool):
 
 
 @pytest.mark.asyncio
+async def test_credit_extra_seat_purchase_cannot_be_farmed_by_removing_and_re_adding_a_seat(pool):
+    # Seat REMOVAL deliberately doesn't debit anything (the customer already
+    # paid for the period the seat was bought in - see
+    # test_seat_removal_does_not_change_the_credit_balance), and only an
+    # increase credits. With an unconditional "+= EXTRA_SEAT_LLM_CAP_USD"
+    # that made the pair asymmetric and self-service farmable: remove the
+    # seat, re-add it, collect another $3.00, repeat, all within one billing
+    # cycle and with no ceiling.
+    #
+    # The clamp at base_credit_for_plan(plan, extra_seats) - the CURRENT,
+    # post-purchase seat count - closes it: the balance can never exceed
+    # what the seats actually on the subscription right now entitle it to.
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats, "
+        "base_credit_remaining_usd, base_credit_allotment_usd) "
+        "VALUES (413, 'acme', 'flash', 0, 5.00, 5.00)"
+    )
+
+    # First purchase: 0 -> 1 seat. Ceiling is base_credit_for_plan("flash", 1)
+    # = 5.00 + 3.00 = 8.00, and 5.00 + 3.00 lands exactly on it.
+    await credit_extra_seat_purchase(pool, 413, added_seats=1, plan="flash", extra_seats=1)
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, base_credit_allotment_usd, balance_epoch "
+        "FROM installations WHERE installation_id = $1",
+        413,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(8.00)
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(8.00)
+    assert row["balance_epoch"] == 1
+
+    # The seat is now removed (no code path credits or debits for that) and
+    # re-added: the second purchase is again "one seat added, one extra seat
+    # in total afterwards", so the ceiling is still 8.00 - and the balance
+    # stays 8.00 instead of ratcheting to 11.00.
+    await credit_extra_seat_purchase(pool, 413, added_seats=1, plan="flash", extra_seats=1)
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, base_credit_allotment_usd FROM installations "
+        "WHERE installation_id = $1",
+        413,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(8.00)
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(8.00)
+
+
+@pytest.mark.asyncio
+async def test_credit_extra_seat_purchase_still_credits_a_spent_down_balance_in_full(pool):
+    # The clamp must not turn into a silent no-op for the normal case: a
+    # customer who has already spent most of the period's credit and then
+    # buys a seat still gets the whole EXTRA_SEAT_LLM_CAP_USD bonus, because
+    # 1.00 + 3.00 is nowhere near the 8.00 ceiling.
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, extra_seats, "
+        "base_credit_remaining_usd, base_credit_allotment_usd) "
+        "VALUES (414, 'acme', 'flash', 0, 1.00, 5.00)"
+    )
+
+    await credit_extra_seat_purchase(pool, 414, added_seats=1, plan="flash", extra_seats=1)
+
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, base_credit_allotment_usd FROM installations "
+        "WHERE installation_id = $1",
+        414,
+    )
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(4.00)
+    # The ceiling still moves to the new seat count's real allotment, even
+    # though the balance is far below it.
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(8.00)
+
+
+@pytest.mark.asyncio
 async def test_credit_topup_purchase_increments_topup_balance(pool):
     await pool.execute(
         "INSERT INTO installations (installation_id, account_login, plan) VALUES (403, 'acme', 'flash')"
@@ -1473,11 +1551,19 @@ async def test_credit_topup_purchase_increments_topup_balance(pool):
 
     assert credited is True
     row = await pool.fetchrow(
-        "SELECT topup_credit_balance_usd, balance_epoch FROM installations WHERE installation_id = $1",
+        "SELECT topup_credit_balance_usd, base_credit_remaining_usd, "
+        "base_credit_allotment_usd, balance_epoch "
+        "FROM installations WHERE installation_id = $1",
         403,
     )
     assert float(row["topup_credit_balance_usd"]) == pytest.approx(8.00)
     assert row["balance_epoch"] == 1
+    # A purchased top-up is never-expiring credit and touches NEITHER base
+    # column: raising base_credit_allotment_usd here would let the next
+    # true-up release convert purchased topup credit into monthly base
+    # credit that a renewal then wipes out.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(0.00)
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(0.00)
 
 
 @pytest.mark.asyncio
@@ -1611,13 +1697,20 @@ async def test_mid_cycle_seat_purchase_credits_the_balance_immediately(pool):
 
     assert await get_extra_seats(pool, 407) == 3
     row = await pool.fetchrow(
-        "SELECT base_credit_remaining_usd, balance_epoch FROM installations "
-        "WHERE installation_id = $1",
+        "SELECT base_credit_remaining_usd, base_credit_allotment_usd, balance_epoch "
+        "FROM installations WHERE installation_id = $1",
         407,
     )
     # 2 seats added (1 -> 3) x EXTRA_SEAT_LLM_CAP_USD (3.00), on top of the
-    # already-spent-down 12.00 - NOT a reset to base_credit_for_plan.
+    # already-spent-down 12.00 - NOT a reset to base_credit_for_plan. Well
+    # under the new ceiling, so the anti-farming clamp doesn't bite.
     assert float(row["base_credit_remaining_usd"]) == pytest.approx(12.00 + 2 * 3.00)
+    # And the ceiling itself moves to what 3 seats now entitle this
+    # installation to - base_credit_for_plan("air", 3) = 18.00 + 3 * 3.00.
+    # This is also what proves the webhook passes the CURRENT plan and seat
+    # count through to credit_extra_seat_purchase: with the pre-purchase
+    # seat count it would land at 21.00 instead.
+    assert float(row["base_credit_allotment_usd"]) == pytest.approx(27.00)
     # Balance went up, so the low-balance email dedupe epoch advances too.
     assert row["balance_epoch"] == 1
 


### PR DESCRIPTION
## Summary

Replaces the flat `PLAN_CAP_OVERRIDE_USD` LLM-spend ceiling with a real per-installation dollar balance:

- `base_credit_remaining_usd` - resets every billing-period renewal to $5 (flash) / $18 (AIR) + $3/extra seat, use-it-or-lose-it
- `topup_credit_balance_usd` - never-expiring, customer-purchased top-up credit ($1/unit, real live Paddle price `pri_01m23jw9qbsnm4zmv28bfebx4t`)
- Atomic reservation/release (`reserve_llm_spend`/`release_llm_spend_reservation`) wired through Flash Review, AIRview/Docs incremental budgets, and managed audits
- New Paddle webhook handling: renewal credit reset, top-up purchase crediting (real collected amount, not client-set quantity), and a fix for annual AIR subscribers who were only getting their $18 once a year instead of monthly (new synthetic monthly reset clock + scheduled sweep, independent of Paddle's own once-a-year billing period)
- Low-balance/exhausted email trigger hooks (stable interface for the parallel dashboard/emails branch, PR #645, to consume)

## Process

7 plan tasks (subagent-driven development, fresh implementer + review per task) → one final whole-branch review (3 Critical + 6 Important findings) → one fix wave → a scoped re-review, which found the fix wave itself introduced a new critical bug (true-up releases were leaking monthly base credit into never-expiring top-up credit) → one more fix round, spot-checked directly. Plus two real bugs an independent peer review caught and I verified/fixed separately: the true-up path silently under-crediting the balance on a failed reservation, and the annual-AIR yearly-not-monthly gap. Finally merged master in (resolved a real conflict against an unrelated, already-merged ledger-accuracy fix, PR #639, touching the same true-up call sites - both fixes kept, plus a pre-existing bug found and fixed in that merged PR's own test along the way).

Full suite after merge: **1855 passed, 8 skipped**.

## Test plan

- [x] Full backend test suite green post-merge (1855 passed, 8 skipped)
- [x] Real-Postgres atomicity tests for concurrent reservation/release
- [x] Negative-control verification on every peer-flagged fix (revert → test fails → restore → passes)
- [x] Real live Paddle top-up price created and verified via MCP
- [ ] Manual smoke test of the full renewal/top-up/exhaustion flow against a real Paddle sandbox subscription (not yet done - no real annual-AIR or top-up-purchasing customer exists yet, zero live blast radius today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)