### PR TITLE
fix: guard top-up crediting against a transaction bundling other items

### DIFF
--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -479,11 +479,28 @@ async def _handle_transaction_completed(data: dict, pool) -> None:
         # transaction never bundles a top-up with any other line item (see
         # the buyCredit() comment below), so details.totals.total - Paddle's
         # collected amount net of discount, in the currency's minor unit, as
-        # a string - IS the real dollar amount collected for this top-up.
-        # Same parsing pattern as the referral commission calculation below.
+        # a string - IS the real dollar amount collected for this top-up,
+        # PROVIDED the top-up is the only item. This codebase has never
+        # parsed Paddle's per-line-item totals, only the transaction-level
+        # one, so a transaction with the top-up item plus anything else has
+        # no way to isolate just the top-up's share here - crediting the
+        # whole total in that case would over-credit by whatever the other
+        # item(s) cost. buyCredit() itself never sends more than one item,
+        # but nothing server-side enforced that until this check: a
+        # devtools-crafted Paddle.Checkout.open() call could otherwise bundle
+        # a top-up with another price and get topped up for the combined
+        # amount. Guarded rather than parsed because there has never been a
+        # real transaction shaped this way to build correct per-item parsing
+        # against - skip and log instead of guessing.
         transaction_id = data.get("id")
         total_raw = ((data.get("details") or {}).get("totals") or {}).get("total")
-        if transaction_id and total_raw is not None:
+        if len(items) != 1:
+            logger.warning(
+                "credit topup transaction.completed bundled with other line items, "
+                "skipping to avoid over-crediting: %s",
+                data.get("id"),
+            )
+        elif transaction_id and total_raw is not None:
             try:
                 total_minor_units = Decimal(str(total_raw))
             except InvalidOperation:

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -2047,6 +2047,46 @@ async def test_transaction_completed_credits_topup_purchase_at_discounted_total(
 
 
 @pytest.mark.asyncio
+async def test_transaction_completed_skips_topup_credit_when_bundled_with_another_item(pool, caplog):
+    # This codebase has never parsed Paddle's per-line-item totals, only the
+    # transaction-level total - crediting details.totals.total when the
+    # top-up isn't the only item would credit the OTHER item's cost too.
+    # buyCredit() itself never sends more than one item, but nothing
+    # server-side enforced that before this guard: a devtools-crafted
+    # Paddle.Checkout.open() call could otherwise bundle a top-up with
+    # another price (e.g. an extra seat) and get topped up for the combined
+    # amount. Proves the transaction is skipped, not partially credited.
+    installation_id = 1915
+    await upsert_installation(pool, installation_id, "acme")
+    payload = {
+        "event_id": "evt_topup_1915",
+        "event_type": "transaction.completed",
+        "data": {
+            "id": "txn_topup_wire_1915",
+            "customer_id": "ctm_test_1915",
+            "custom_data": {"installation_token": _installation_token(installation_id)},
+            "items": [
+                {"price": {"id": CREDIT_TOPUP_PRICE_ID}, "quantity": 10},
+                {"price": {"id": EXTRA_SEAT_PRICE_ID}, "quantity": 1},
+            ],
+            "details": {"totals": {"total": "1699"}},
+            "billed_at": "2026-09-01T12:00:00Z",
+        },
+    }
+
+    with caplog.at_level(logging.WARNING):
+        await handle_paddle_webhook_event(payload, pool, "redis://unused")
+
+    row = await pool.fetchrow(
+        "SELECT topup_credit_balance_usd, balance_epoch FROM installations WHERE installation_id = $1",
+        installation_id,
+    )
+    assert float(row["topup_credit_balance_usd"]) == pytest.approx(0.00)
+    assert row["balance_epoch"] == 0
+    assert "bundled with other line items" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_transaction_completed_topup_is_independent_of_referral_commission(pool):
     # Proves the topup branch isn't skipped by the referral early-return
     # for unreferred transactions (the common case), since this


### PR DESCRIPTION
## Summary
- Found during a fresh-eyes re-audit of the merged dollar-credit-pricing feature (#645, #646): `_handle_transaction_completed` (`webhooks/paddle.py`) credited `details.totals.total` — the whole transaction's collected amount — whenever a top-up line item was present, with nothing server-side verifying the top-up was the only item in the transaction.
- `buyCredit()` itself never sends more than one item, but nothing enforced that server-side: a devtools-crafted `Paddle.Checkout.open()` call could bundle a top-up with another price (e.g. an extra seat) and get topped up for the combined amount, since this codebase has never parsed Paddle's per-line-item totals — only the transaction-level one.
- Adds a `len(items) != 1` guard: skips crediting and logs a warning instead of guessing at the top-up's own share of a bundled total.

## Test plan
- [x] New test: `test_transaction_completed_skips_topup_credit_when_bundled_with_another_item` — bundles a top-up item with an extra-seat item in one transaction, asserts zero credit and the warning log line.
- [x] `tests/test_webhooks_paddle.py` full file: 83 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETdUnofd5h7XFEHpniTjEK