### PR TITLE
fix: settings page column-height dead space and stuck credit checkout status

### DIFF
--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -357,7 +357,7 @@ table.findings tr:last-child td { border-bottom: none; }
 .wiki-md-list li { font-size: 12.5px; color: var(--slate-600); line-height: 1.6; margin-bottom: 3px; }
 .wiki-md code { font-family: var(--font-mono); font-size: 11.5px; background: var(--slate-100); padding: 1px 4px; border-radius: 4px; overflow-wrap: anywhere; }
 
-.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }
+.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; align-items: start; }
 .settings-section { margin-top: 24px; }
 .settings-block { background: var(--paper); border: 1px solid var(--border); border-radius: 12px;
   padding: 16px 18px; box-shadow: var(--shadow-card); margin-bottom: 16px; }
@@ -1989,7 +1989,32 @@ def _settings_html() -> str:
 // the bottom that renders the whole page.
 if (typeof Paddle !== "undefined") {{
   Paddle.Environment.set("{get_settings().paddle_environment}");
-  Paddle.Initialize({{ token: "{get_settings().paddle_client_token}" }});
+  // eventCallback is global (Paddle.Initialize() runs once for the whole
+  // page) - buyCredit() is the only flow that opens a checkout here, so
+  // topup-status is the only element it needs to drive. Without this,
+  // buyCredit()'s "Opening checkout..." status never changes again: there
+  // was no handler for the overlay actually loading, the user closing it,
+  // a mid-checkout error, or a completed payment, so the text just sat
+  // there regardless of what happened next.
+  Paddle.Initialize({{
+    token: "{get_settings().paddle_client_token}",
+    eventCallback: function (event) {{
+      const status = document.getElementById('topup-status');
+      if (!status || !event || !event.name) return;
+      if (event.name === 'checkout.loaded') {{
+        status.textContent = '';
+      }} else if (event.name === 'checkout.completed') {{
+        window._creditCheckoutCompleted = true;
+        status.textContent = 'Purchase complete - your balance updates once the payment is confirmed.';
+        status.style.color = 'var(--success)';
+      }} else if (event.name === 'checkout.closed' && !window._creditCheckoutCompleted) {{
+        status.textContent = '';
+      }} else if (event.name === 'checkout.error') {{
+        status.textContent = 'Checkout failed to open - try again.';
+        status.style.color = 'var(--critical)';
+      }}
+    }},
+  }});
 }}
 
 async function revokeToken(tokenId, btn) {{
@@ -2218,6 +2243,7 @@ async function buyCredit() {{
     return;
   }}
   statusEl.textContent = 'Opening checkout...';
+  window._creditCheckoutCompleted = false;
   // The installation token is minted with a 30-minute TTL (auth.py's
   // sign_checkout_installation_id) - re-fetch it fresh here instead of
   // reusing loadSettings()'s page-load-time copy, so a tab left open past

--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -2010,7 +2010,7 @@ if (typeof Paddle !== "undefined") {{
       }} else if (event.name === 'checkout.closed' && !window._creditCheckoutCompleted) {{
         status.textContent = '';
       }} else if (event.name === 'checkout.error') {{
-        status.textContent = 'Checkout failed to open - try again.';
+        status.textContent = 'Checkout error - try again.';
         status.style.color = 'var(--critical)';
       }}
     }},
@@ -2243,6 +2243,7 @@ async function buyCredit() {{
     return;
   }}
   statusEl.textContent = 'Opening checkout...';
+  statusEl.style.color = '';
   window._creditCheckoutCompleted = false;
   // The installation token is minted with a 30-minute TTL (auth.py's
   // sign_checkout_installation_id) - re-fetch it fresh here instead of


### PR DESCRIPTION
## Summary
- `.settings-grid` defaulted to `align-items: stretch`, so the shorter Team/API tokens column was force-stretched to match the taller Alert channels/Endpoint health/Managed audit column, leaving a large visible gap before the Usage section. Fixed with `align-items: start`.
- `buyCredit()`'s "Opening checkout..." status text never updated again after `Paddle.Checkout.open()` was called, since the page's `Paddle.Initialize()` had no `eventCallback`. Added one that clears the status once the overlay actually loads, shows success on `checkout.completed`, clears on `checkout.closed` (unless a purchase just completed), and surfaces a real message on `checkout.error`.

Both bugs were visible together in a live screenshot of the deployed settings page (dollar-credit pricing feature, #645-649).

## Test plan
- [x] `python3 -m py_compile github-app/app_server/frontend.py`
- [x] `pytest tests/test_frontend_js_syntax.py` (11 passed, 1 skipped)
- [x] `pytest tests/test_admin.py tests/test_frontend_subscribe.py` (125 passed)
- [ ] Manual: load `/admin` for a paid installation and confirm the Team/API tokens column no longer leaves dead space, and that clicking "Buy more credit" updates the status text once the Paddle overlay opens/closes/completes/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)