### PR TITLE
docs: record the 2026-09-10 second deploy (#651)

### DIFF
--- a/docs/operations/DEPLOYMENT-VERIFICATION.md
+++ b/docs/operations/DEPLOYMENT-VERIFICATION.md
@@ -39,7 +39,16 @@ Before claiming a hardening change is live, verify:
 
 ## Current Server Snapshot
 
-As of 2026-09-10, following a redeploy to `master` (`git fetch` + `git merge --ff-only
+**Superseded by a same-day follow-up:** a second, smaller redeploy landed after the snapshot below
+- commit `f8b2f36` (tag `github-app-deploy-2026-09-10-2`), `app-server` only (single-file frontend
+fix, #651 - settings-page CSS dead space and a stuck "Opening checkout..." status with no
+`eventCallback`). Rebuilt and force-recreated `app-server` alone; confirmed healthy, both fixes
+present in the running container's source (`inspect.getsource` checked for `align-items: start`
+and `eventCallback`, not re-read from the repo), zero errors in logs. The rest of this section (all
+five services, the migrations, the credit-balance schema) is unaffected and still accurate for
+everything except the `app-server` commit, which is now `f8b2f36`.
+
+As of 2026-09-10 (first deploy), following a redeploy to `master` (`git fetch` + `git merge --ff-only
 origin/master` + `docker compose build app-server scan-worker scan-worker-2 health-worker
 scheduler` + `docker compose up -d --no-deps --force-recreate` for those five - the usual five, no
 lockfile changes in this batch), live inspection found:

--- a/docs/operations/DEPLOYMENT-VERIFICATION.md
+++ b/docs/operations/DEPLOYMENT-VERIFICATION.md
@@ -40,6 +40,7 @@ Before claiming a hardening change is live, verify:
 ## Current Server Snapshot
 
 **Superseded by a same-day follow-up:** a second, smaller redeploy landed after the snapshot below
+
 - commit `f8b2f36` (tag `github-app-deploy-2026-09-10-2`), `app-server` only (single-file frontend
 fix, #651 - settings-page CSS dead space and a stuck "Opening checkout..." status with no
 `eventCallback`). Rebuilt and force-recreated `app-server` alone; confirmed healthy, both fixes

--- a/github-app/CHANGELOG.md
+++ b/github-app/CHANGELOG.md
@@ -65,6 +65,19 @@ plus an independent 10-PR hardening/feature batch and one cost-focused cleanup.
 
 Full per-PR detail in each PR's own description; this entry summarizes rather than duplicates it.
 
+## 2026-09-10 (second deploy)
+
+One commit since the first 2026-09-10 deploy, tagged `github-app-deploy-2026-09-10-2` (commit
+`f8b2f36`) - a small, real UI fix on the just-shipped dollar-credit dashboard (#651), caught from a
+live screenshot of the deployed settings page: `.settings-grid` defaulted to `align-items:
+stretch`, so the shorter Team/API tokens column was force-stretched to match the taller
+Alert-channels/Endpoint-health/Managed-audit column, leaving a large visible gap before the Usage
+section - fixed with `align-items: start`. Separately, `buyCredit()`'s "Opening checkout..." status
+text never updated again after `Paddle.Checkout.open()`, since `Paddle.Initialize()` had no
+`eventCallback` - added one that clears the status once the overlay loads, shows success on
+`checkout.completed`, clears on `checkout.closed` (unless a purchase just completed), and surfaces
+a real message on `checkout.error`.
+
 ## 2026-09-08
 
 12 commits since the previous deploy, tagged `github-app-deploy-2026-09-08` (commit `fd7c2c3`) -


### PR DESCRIPTION
Records the small follow-up deploy after #651 (settings-page CSS dead space + stuck checkout status fix) - \`app-server\` only, rebuilt and redeployed to \`f8b2f36\` (tag \`github-app-deploy-2026-09-10-2\`). Verified live: both fixes present in the running container's source, health check green, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)