### PR TITLE
fix: pin smol-toml to patched version (Dependabot alert #98)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -906,19 +906,6 @@
         "node": ">=22.18.0"
       }
     },
-    "node_modules/cspell-config-lib/node_modules/smol-toml": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
-      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
-      }
-    },
     "node_modules/cspell-dictionary": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.2.2.tgz",
@@ -2365,9 +2352,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prettier": "3.9.6"
   },
   "overrides": {
-    "js-yaml": "^5.2.2"
+    "js-yaml": "^5.2.2",
+    "smol-toml": "^1.7.1"
   }
 }


### PR DESCRIPTION
## Summary
- `markdownlint-cli2` (dev dependency) depends on `smol-toml@1.7.0`, vulnerable to a DoS via malformed TOML: a value in an array/inline-table followed by a comment with no trailing newline sends `parse()` into an infinite loop, pinning CPU at 100% ([GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2), CVE-2026-85730, HIGH).
- No `markdownlint-cli2` release fixes this upstream yet (latest 0.23.2 still requires `smol-toml@1.7.0`), so add an `overrides` entry forcing `smol-toml@^1.7.1`, following the existing `js-yaml` override already in `package.json`.
- Resolves GitHub Dependabot alert #98.

## Test plan
- [x] `npm install` — lockfile now resolves a single `smol-toml@1.8.0` everywhere (previously two copies: `1.7.0` top-level, `1.8.0` nested under `cspell-config-lib`)
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run lint:markdown` — runs cleanly against the new dependency tree (pre-existing, unrelated markdown formatting errors in `docs/audits/immediate_issue_PRs.md` are unchanged by this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)