### PR TITLE
fix: settings page column gap was still there - align-items:start never worked

### DIFF
--- a/github-app/app_server/frontend.py
+++ b/github-app/app_server/frontend.py
@@ -2474,6 +2474,14 @@ async function loadSettings() {{
       '</div>' +
     '</section>';
 
+  // Managed audit content sits in the LEFT column deliberately, not with
+  // Alert channels/Endpoint health where it reads more naturally - Alert
+  // channels alone (3 webhook/email/Pushover forms) is taller than the
+  // other 4 cards combined, so grid's one implicit row sizes to whichever
+  // column holds it regardless of align-items, and the other column just
+  // shows blank space below its shorter content. Pairing Managed audit
+  // content with Team/API tokens instead keeps both columns close to
+  // even height; moving it back re-lopsides the layout.
   body.innerHTML =
     '<div class="settings-grid">' +
       '<div>' +
@@ -2492,6 +2500,21 @@ async function loadSettings() {{
           '<button class="btn" onclick="generateToken()">Generate</button></div>' +
           '<div id="token-reveal"></div>' +
           '<div class="settings-block-hint">Used to authenticate the CLI (<code>aletheore login</code> or <code>ALETHEORE_API_TOKEN</code>) and the MCP server\\'s <code>aletheore_managed_audit</code> tool against this installation\\'s hosted managed audits, and to send runtime events from your app into Aletheore. Give each token a label so you can tell them apart later, and revoke one any time without affecting the others.</div>' +
+        '</div>' +
+        '<div class="settings-block">' +
+          '<div class="settings-block-label">Managed audit content</div>' +
+          '<label style="display:flex;align-items:center;gap:7px;font-size:12.5px;">' +
+          '<input type="checkbox" id="llm-suggestions-toggle"' +
+          (installation.llm_suggestions_enabled === false ? '' : ' checked') +
+          ' onchange="saveLlmSuggestions(this)">' +
+          'Include the model\\'s second opinion' +
+          '</label>' +
+          '<div id="llm-suggestions-status" class="settings-block-hint"></div>' +
+          '<div class="settings-block-hint">Every finding in an audit is tied to a citation in your code. ' +
+          'This one optional section is not: it is the model\\'s own overall rating and improvement ideas, ' +
+          'appended after the evidence-backed findings and labelled as such. Turn it off to have audits ' +
+          'contain only cited findings - the signed report and its verification page will then confirm ' +
+          'the report is fully evidence-backed.</div>' +
         '</div>' +
       '</div>' +
       '<div>' +
@@ -2525,21 +2548,6 @@ async function loadSettings() {{
         '<div class="settings-block">' +
           '<div class="settings-block-label">Endpoint health targets</div>' +
           '<div class="settings-block-hint">Configure staging/production URLs and see live results on the <a data-href="/health">Endpoint health</a> page.</div>' +
-        '</div>' +
-        '<div class="settings-block">' +
-          '<div class="settings-block-label">Managed audit content</div>' +
-          '<label style="display:flex;align-items:center;gap:7px;font-size:12.5px;">' +
-          '<input type="checkbox" id="llm-suggestions-toggle"' +
-          (installation.llm_suggestions_enabled === false ? '' : ' checked') +
-          ' onchange="saveLlmSuggestions(this)">' +
-          'Include the model\\'s second opinion' +
-          '</label>' +
-          '<div id="llm-suggestions-status" class="settings-block-hint"></div>' +
-          '<div class="settings-block-hint">Every finding in an audit is tied to a citation in your code. ' +
-          'This one optional section is not: it is the model\\'s own overall rating and improvement ideas, ' +
-          'appended after the evidence-backed findings and labelled as such. Turn it off to have audits ' +
-          'contain only cited findings - the signed report and its verification page will then confirm ' +
-          'the report is fully evidence-backed.</div>' +
         '</div>' +
       '</div>' +
     '</div>' +


### PR DESCRIPTION
## Summary
PR #651's `align-items: start` fix for the settings page column gap did not actually work, as the follow-up screenshot after deploy showed. Root cause of the earlier miss: `.settings-grid` has exactly one implicit grid row (only 2 wrapper divs = 1 row), and automatic row-track sizing is based on each item's content height regardless of `align-items` - that property only controls how a *shorter* item is positioned within an already-tall row, it doesn't shrink the row. So the row height still matched the taller column no matter what, and the earlier fix was a visual no-op.

I verified this, and the actual fix, with a real headless-Chrome render of the **real, current `loadSettings()` markup** extracted from `frontend.py` (not a hand-typed approximation) before shipping this time:
- Confirmed the align-items fix reproduces the exact bug from the screenshot.
- Tried switching `.settings-grid` to CSS multi-column (`columns: 2`) - didn't help either, since "Alert channels" alone (Slack/Teams + Email + Pushover forms, ~430px) outweighs the other 4 cards combined, and multi-column can only pick a split point in DOM order, not reorder content - it converges on the same lopsided split.
- The fix that actually works: move "Managed audit content" into the left column (with Team/API tokens) instead of the right (with Alert channels/Endpoint health targets) - the best 2-way partition of these 5 cards by rendered height. Cuts the empty gap from ~400px to ~50px. Endpoint health targets stays paired with Alert channels, which still reads fine (both are monitoring/alerting settings).

(This branch also picked up a `smol-toml` dependency fix along the way, but #653 landed the same fix on `master` first - rebased this branch on top of it and dropped the now-duplicate commit, so this PR is just the layout fix.)

## Test plan
- [x] `python3 -m py_compile github-app/app_server/frontend.py`
- [x] `pytest tests/test_frontend_js_syntax.py` (11 passed, 1 skipped)
- [x] `pytest tests/test_admin.py tests/test_frontend_subscribe.py` (125 passed)
- [x] Rendered the actual extracted `loadSettings()` markup in headless Chrome with mock data before/after the change and confirmed the gap visually shrinks from ~400px to ~50px.
- [ ] Manual: load `/admin` for a paid installation in a real browser to eyeball the final result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)