### PR TITLE
docs: record the 2026-09-10 third deploy (#654)

### DIFF
--- a/docs/operations/DEPLOYMENT-VERIFICATION.md
+++ b/docs/operations/DEPLOYMENT-VERIFICATION.md
@@ -5,12 +5,25 @@
 **Owner:** Arihant Kaul
 **Related Documents:** [README.md](README.md), [INCIDENT-RESPONSE.md](INCIDENT-RESPONSE.md), [../../github-app/README.md](../../github-app/README.md)
 **Last Updated:** 2026-09-10
-**Snapshot Freshness:** CURRENT as of 2026-09-10 - production was redeployed to `master` (commit
-`ee927c8`, tagged `github-app-deploy-2026-09-10`) and re-verified live via SSH the same session.
-25 commits since the previous deploy tag (`github-app-deploy-2026-09-08-2`): the dollar-credit
-pricing launch (real per-installation LLM-spend balance replacing the flat cap, live Paddle top-up
-purchases, a new scheduled monthly-credit-reset job for annual AIR subscribers), a Flash Review
-prompt-caching fix, and an independent 10-PR hardening/feature batch. Full detail in
+**Snapshot Freshness:** CURRENT as of 2026-09-10 (third deploy) - production's `app-server` was
+redeployed to `master` (commit `428e8fd`, tagged `github-app-deploy-2026-09-10-3`) and re-verified
+live via SSH the same session. Single-file fix (#654): PR #651's `align-items: start` fix for the
+settings-page column gap was a visual no-op (that property only repositions a shorter item within
+an already-tall grid row, it doesn't shrink the row) - the real fix moves "Managed audit content"
+into the left column instead of the right, the best 2-way height partition of the five settings
+cards, cutting the empty gap from ~400px to ~50px. `app-server` alone rebuilt and force-recreated;
+confirmed healthy, the fix present in the running container's actual source (`inspect.getsource`
+checked for the "Managed audit content sits in the LEFT column deliberately" comment, not re-read
+from the repo), zero errors in logs. The rest of this section (all five services, the migrations,
+the credit-balance schema) is unaffected and still accurate for everything except the `app-server`
+commit, which is now `428e8fd`.
+
+**Previous:** CURRENT as of 2026-09-10 (first deploy) - production was redeployed to `master`
+(commit `ee927c8`, tagged `github-app-deploy-2026-09-10`) and re-verified live via SSH the same
+session. 25 commits since the previous deploy tag (`github-app-deploy-2026-09-08-2`): the
+dollar-credit pricing launch (real per-installation LLM-spend balance replacing the flat cap, live
+Paddle top-up purchases, a new scheduled monthly-credit-reset job for annual AIR subscribers), a
+Flash Review prompt-caching fix, and an independent 10-PR hardening/feature batch. Full detail in
 `github-app/CHANGELOG.md`'s own 2026-09-10 entry - this section is the live-verification record,
 not a duplicate of the changelog.
 
@@ -39,15 +52,23 @@ Before claiming a hardening change is live, verify:
 
 ## Current Server Snapshot
 
-**Superseded by a same-day follow-up:** a second, smaller redeploy landed after the snapshot below
+**Superseded by two same-day follow-ups:** two further, smaller redeploys landed after the
+snapshot below
 
 - commit `f8b2f36` (tag `github-app-deploy-2026-09-10-2`), `app-server` only (single-file frontend
 fix, #651 - settings-page CSS dead space and a stuck "Opening checkout..." status with no
 `eventCallback`). Rebuilt and force-recreated `app-server` alone; confirmed healthy, both fixes
 present in the running container's source (`inspect.getsource` checked for `align-items: start`
-and `eventCallback`, not re-read from the repo), zero errors in logs. The rest of this section (all
-five services, the migrations, the credit-balance schema) is unaffected and still accurate for
-everything except the `app-server` commit, which is now `f8b2f36`.
+and `eventCallback`, not re-read from the repo), zero errors in logs.
+- commit `428e8fd` (tag `github-app-deploy-2026-09-10-3`), `app-server` only (single-file frontend
+fix, #654 - the `align-items: start` fix above turned out to be a visual no-op; the real fix moves
+"Managed audit content" into the left settings column instead of the right, the best 2-way height
+partition of the five cards). Rebuilt and force-recreated `app-server` alone; confirmed healthy,
+the fix present in the running container's actual source, zero errors in logs.
+
+The rest of this section (all five services, the migrations, the credit-balance schema) is
+unaffected by either follow-up and still accurate for everything except the `app-server` commit,
+which is now `428e8fd`.
 
 As of 2026-09-10 (first deploy), following a redeploy to `master` (`git fetch` + `git merge --ff-only
 origin/master` + `docker compose build app-server scan-worker scan-worker-2 health-worker

--- a/github-app/CHANGELOG.md
+++ b/github-app/CHANGELOG.md
@@ -78,6 +78,24 @@ text never updated again after `Paddle.Checkout.open()`, since `Paddle.Initializ
 `checkout.completed`, clears on `checkout.closed` (unless a purchase just completed), and surfaces
 a real message on `checkout.error`.
 
+## 2026-09-10 (third deploy)
+
+One commit since the second 2026-09-10 deploy, tagged `github-app-deploy-2026-09-10-3` (commit
+`428e8fd`) - a real follow-up fix to #651's own fix (#654): the `align-items: start` change did not
+actually work, as a post-deploy screenshot showed. Root cause of the miss: `.settings-grid` has
+exactly one implicit grid row (two wrapper divs, one row), and automatic row-track sizing is based
+on each item's content height regardless of `align-items` - that property only repositions a
+*shorter* item within an already-tall row, it doesn't shrink the row itself, so the row height
+still matched the taller column no matter what. Switching to CSS multi-column (`columns: 2`) was
+tried and rejected too: "Alert channels" alone (Slack/Teams + Email + Pushover forms, ~430px)
+outweighs the other four cards combined, and multi-column can only pick a split point in DOM order,
+not reorder content, so it converges on the same lopsided split. The fix that actually works: move
+"Managed audit content" into the left column (with Team/API tokens) instead of the right (with
+Alert channels/Endpoint health targets) - the best 2-way partition of the five cards by rendered
+height, cutting the empty gap from ~400px to ~50px. Verified this time with a real headless-Chrome
+render of the actual extracted `loadSettings()` markup before shipping, not a hand-typed
+approximation.
+
 ## 2026-09-08
 
 12 commits since the previous deploy, tagged `github-app-deploy-2026-09-08` (commit `fd7c2c3`) -


### PR DESCRIPTION
## Summary
- Records the third same-day production deploy: `app-server` redeployed to commit `428e8fd` (#654, `github-app-deploy-2026-09-10-3`), verified live via SSH.
- #654 is a real follow-up fix to #651's own fix - the earlier `align-items: start` change for the settings-page column gap was a visual no-op; the real fix moves "Managed audit content" into the left column, the best 2-way height partition of the five settings cards.
- Updates `docs/operations/DEPLOYMENT-VERIFICATION.md`'s freshness header and superseded-snapshot note, and adds the matching `github-app/CHANGELOG.md` entry.

## Test plan
- [x] `npx markdownlint-cli2` on both edited files — 0 issues
- [x] Deploy itself verified live: `docker compose ps app-server` healthy, zero errors in logs, `inspect.getsource` on the running container confirmed the actual fix (the "Managed audit content sits in the LEFT column deliberately" comment) is present — not assumed from the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)