### PR TITLE
fix: out-of-order Paddle webhook could reset a newer period's credit back to a stale allotment

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -203,9 +203,22 @@ async def reset_billing_period_credit(
     """Resets base_credit_remaining_usd - and base_credit_allotment_usd,
     this billing period's ceiling, to the same value - to this plan's
     real included credit (base_credit_for_plan, same per-seat bonus the
-    old flat cap used) only if period_start is genuinely new for this
-    installation; a no-op on a replayed or unrelated subscription.updated
-    event.
+    old flat cap used) only if period_start is genuinely NEWER than what's
+    already on file for this installation; a no-op on a replayed,
+    unrelated, or out-of-order (older) subscription.updated event.
+
+    Paddle does not guarantee in-order webhook delivery - a retry of an
+    older event can arrive after a newer one already committed. The guard
+    used to be `current_billing_period_start IS DISTINCT FROM $3`, which
+    only checks "different", not "later": a stale event with an OLDER
+    period_start satisfied it too, silently re-running the reset with
+    that older event's (possibly stale) plan/extra_seats, wiping out
+    whatever the customer had already spent down in the real, newer
+    period AND rewinding current_billing_period_start itself backward -
+    which could then let the next genuine newer-period webhook re-fire
+    the reset yet again. `IS NULL OR current_billing_period_start < $3`
+    only ever advances the stored period forward (or sets it for the
+    first time), so an older or equal event can never re-trigger this.
     Increments balance_epoch on a real reset, which doubles as the
     dedupe key both new credit-notification emails key off of. Returns
     whether a reset actually happened.
@@ -255,7 +268,7 @@ async def reset_billing_period_credit(
             next_monthly_credit_reset_at = $4,
             balance_epoch = balance_epoch + 1
         WHERE installation_id = $1
-            AND (current_billing_period_start IS DISTINCT FROM $3)
+            AND (current_billing_period_start IS NULL OR current_billing_period_start < $3)
         RETURNING installation_id
         """,
         installation_id, new_credit, period_start_dt, next_monthly_reset,

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -1478,6 +1478,44 @@ async def test_reset_billing_period_credit_is_a_noop_on_the_same_period(pool):
 
 
 @pytest.mark.asyncio
+async def test_reset_billing_period_credit_rejects_an_out_of_order_older_period(pool):
+    # Paddle does not guarantee in-order webhook delivery - a retry of an
+    # OLDER subscription.updated can land after a newer one already
+    # committed. The old IS DISTINCT FROM guard only checked "different",
+    # not "later", so a stale older event could re-fire the reset, wiping
+    # out real spend-down progress and rewinding current_billing_period_
+    # start backward.
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, "
+        "base_credit_remaining_usd, base_credit_allotment_usd, current_billing_period_start, balance_epoch) "
+        "VALUES (409, 'acme', 'air', 2.50, 18.00, '2026-10-01T00:00:00Z', 5)"
+    )
+
+    # An older, out-of-order event for the PREVIOUS period arrives late.
+    changed = await reset_billing_period_credit(
+        pool, 409, "air", extra_seats=0, period_start="2026-09-01T00:00:00Z", is_annual=False
+    )
+
+    assert changed is False
+    row = await pool.fetchrow(
+        "SELECT base_credit_remaining_usd, current_billing_period_start, balance_epoch "
+        "FROM installations WHERE installation_id = $1",
+        409,
+    )
+    # Must NOT have wiped the real spent-down balance back to a fresh 18.00,
+    # and must NOT have rewound current_billing_period_start backward.
+    assert float(row["base_credit_remaining_usd"]) == pytest.approx(2.50)
+    assert row["current_billing_period_start"].isoformat() == "2026-10-01T00:00:00+00:00"
+    assert row["balance_epoch"] == 5
+
+    # A genuinely newer period must still reset correctly.
+    changed_forward = await reset_billing_period_credit(
+        pool, 409, "air", extra_seats=0, period_start="2026-11-01T00:00:00Z", is_annual=False
+    )
+    assert changed_forward is True
+
+
+@pytest.mark.asyncio
 async def test_reset_billing_period_credit_arms_the_monthly_clock_for_an_annual_subscriber(pool):
     # An annual subscriber's Paddle billing period only advances once a
     # year, so this reset is the only one they will get from Paddle for the


### PR DESCRIPTION
## Summary
Part of the ongoing backward audit sweep, this round targeting the newly-shipped dollar-credit-pricing feature (#645/#646/#647/#648).

`reset_billing_period_credit`'s guard was `current_billing_period_start IS DISTINCT FROM $3` - checks "different", not "later". Paddle does not guarantee in-order webhook delivery: a retried/delayed `subscription.updated` for an OLDER billing period can arrive after a newer one already committed.

**Confirmed by real execution** (real Postgres, not just reasoning about the SQL): an installation at `period_start=2026-10-01` with `base_credit_remaining_usd` spent down to `2.50` gets wiped back to a fresh `18.00` allotment by a stale `2026-09-01` event, and `current_billing_period_start` gets rewound backward - which could then let the real `2026-10-01` event, if it were ever redelivered, re-fire the reset again.

Fixed by only ever advancing the stored period forward: `IS NULL OR current_billing_period_start < $3`. A same-or-older `period_start` is now correctly rejected; a genuinely newer one still resets exactly as before.

The rest of this money path (seat farming via remove/re-add, top-up idempotency via `processed_paddle_transactions`, top-up bundled-with-other-items guard, replay-does-not-reset-spent-down-credit, mid-cycle seat crediting, annual-vs-monthly clock arming) came back clean - all already have real, passing tests covering exactly those scenarios (`test_credit_extra_seat_purchase_cannot_be_farmed_by_removing_and_re_adding_a_seat`, `test_credit_topup_purchase_is_idempotent_on_replayed_transaction`, `test_transaction_completed_skips_topup_credit_when_bundled_with_another_item`, `test_subscription_updated_replay_does_not_reset_spent_down_credit`, `test_seat_removal_does_not_change_the_credit_balance` - the last one is a deliberate, documented, correct design choice, not a gap).

## Test plan
- [x] New regression test `test_reset_billing_period_credit_rejects_an_out_of_order_older_period` - confirmed it fails on the old code (`assert True is False`) and passes with the fix.
- [x] Full `tests/test_webhooks_paddle.py` suite: 84 passed.
- [x] `tests/test_admin.py` + `tests/test_migrate.py`: 120 passed (3 initially-flaky failures traced to a local Redis timeout unrelated to this change, confirmed by reproducing on the pre-fix code too and by a clean rerun).

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)