### PR TITLE
fix: cancelling an annual AIR subscription never disarms the monthly credit clock

### DIFF
--- a/github-app/app_server/db.py
+++ b/github-app/app_server/db.py
@@ -340,6 +340,36 @@ async def credit_topup_purchase(
     return True
 
 
+async def disarm_monthly_credit_reset_clock(pool: asyncpg.Pool, installation_id: int) -> None:
+    """Clears next_monthly_credit_reset_at on a transition to the free
+    plan (cancel/pause/past-due) - the same reasoning webhooks/paddle.py
+    already applies to extra_seats on that same transition, just for the
+    synthetic annual-AIR monthly clock instead.
+
+    Without this, an ANNUAL AIR subscriber who cancels keeps whatever
+    next_monthly_credit_reset_at their last renewal armed. Nothing else
+    ever clears it on a plan==free transition (unlike a real downgrade to
+    a monthly price, where reset_billing_period_credit's own is_annual=
+    False write already disarms it) - confirmed live: it stays in the
+    past, so scan_worker/db.py's list_installations_due_for_monthly_
+    credit_reset keeps matching this installation on every ~3-minute
+    sweep tick, and jobs.py's run_monthly_credit_reset_sweep_job keeps
+    "resetting" its credit (to $0, since base_credit_for_plan("free", ...)
+    is 0 - no money is actually lost) while still advancing the clock by
+    another month and incrementing balance_epoch, forever, for as long as
+    the installation row exists and never resubscribes. Harmless in
+    dollars, real in wasted per-tick work and a balance_epoch that never
+    stops climbing on a churned row.
+
+    Guarded on the column already being set so a free installation that
+    was never annual (the overwhelming majority) costs no extra write."""
+    await pool.execute(
+        "UPDATE installations SET next_monthly_credit_reset_at = NULL "
+        "WHERE installation_id = $1 AND next_monthly_credit_reset_at IS NOT NULL",
+        installation_id,
+    )
+
+
 async def list_installations_for_ids(pool: asyncpg.Pool, installation_ids: list[int]) -> list[dict]:
     if not installation_ids:
         return []

--- a/github-app/app_server/webhooks/paddle.py
+++ b/github-app/app_server/webhooks/paddle.py
@@ -15,6 +15,7 @@ from app_server.db import (
     claim_paid_setup,
     credit_extra_seat_purchase,
     credit_topup_purchase,
+    disarm_monthly_credit_reset_clock,
     get_extra_seats,
     get_installation,
     list_installation_member_emails,
@@ -322,6 +323,11 @@ async def handle_paddle_webhook_event(payload: dict, pool, redis_url: str, queue
                     await set_paid_installation_plan(conn, installation_id, plan)
             else:
                 await set_installation_plan(conn, installation_id, plan)
+                # A cancel/pause/past-due transition is the one place a
+                # previously-armed annual-AIR monthly clock is never
+                # otherwise disarmed - see disarm_monthly_credit_reset_
+                # clock's own docstring for what leaving it armed causes.
+                await disarm_monthly_credit_reset_clock(conn, installation_id)
 
             if "id" in data and "customer_id" in data:
                 await add_paddle_ids_to_installation(conn, installation_id, data["id"], data["customer_id"])

--- a/github-app/tests/test_webhooks_paddle.py
+++ b/github-app/tests/test_webhooks_paddle.py
@@ -3,6 +3,7 @@ import hmac
 import ipaddress
 import json
 import logging
+import os
 import time
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -33,7 +34,13 @@ from app_server.paddle_pricing import (
     PLAN_INTERVAL_TO_PRICE_ID,
 )
 from app_server.webhooks.paddle import handle_paddle_webhook_event
+from scan_worker.db import list_installations_due_for_monthly_credit_reset
 from scan_worker.jobs import run_monthly_credit_reset_sweep_job
+
+TEST_DATABASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://postgres:test@localhost:55433/aletheore_test",
+)
 
 WEBHOOK_SECRET = "pdl_ntfset_test_secret"
 # Matches conftest.py's SESSION_SECRET default - the webhook handler
@@ -714,6 +721,39 @@ async def test_subscription_canceled_revokes_to_free(pool):
     installation = await get_installation(pool, 300)
     assert installation["plan"] == "free"
     fake_queue.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_canceling_an_annual_air_subscription_disarms_the_monthly_credit_clock(pool):
+    # A downgrade to a monthly price already disarms next_monthly_credit_
+    # reset_at via reset_billing_period_credit's own is_annual=False write
+    # (see test_a_monthly_renewal_disarms_a_previously_armed_monthly_clock)
+    # - but a full CANCEL never reaches that function at all (it's gated
+    # on plan != "free"), so nothing else ever cleared this column on that
+    # transition. Left armed, run_monthly_credit_reset_sweep_job keeps
+    # matching this now-free installation on every sweep tick forever: no
+    # money is at risk (base_credit_for_plan("free", ...) is 0), but the
+    # clock keeps advancing and balance_epoch keeps climbing on a churned
+    # row that will never look at either again.
+    fake_queue = MagicMock()
+    await pool.execute(
+        "INSERT INTO installations (installation_id, account_login, plan, "
+        "base_credit_remaining_usd, base_credit_allotment_usd, "
+        "next_monthly_credit_reset_at, balance_epoch) "
+        "VALUES (303, 'churn-co', 'air', 18.00, 18.00, "
+        "'2026-08-31T00:00:00Z'::timestamptz, 1)"
+    )
+    payload = _subscription_event_payload("subscription.canceled", "canceled", 303)
+
+    await handle_paddle_webhook_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    installation = await get_installation(pool, 303)
+    assert installation["plan"] == "free"
+    row = await pool.fetchrow(
+        "SELECT next_monthly_credit_reset_at FROM installations WHERE installation_id = $1", 303
+    )
+    assert row["next_monthly_credit_reset_at"] is None
+    assert 303 not in list_installations_due_for_monthly_credit_reset(TEST_DATABASE_URL)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Part of the ongoing backward-audit sweep, this round targeting the newly-shipped dollar-credit-pricing feature (#645/#646/#647/#648).

`next_monthly_credit_reset_at` (migration 065, the synthetic monthly clock that gives annual AIR subscribers their real $18/month allotment instead of once a year) is only ever cleared by `reset_billing_period_credit`'s own `is_annual=False` write - which only runs on the `plan != "free"` branch of the Paddle webhook handler. A full cancel/pause/past-due transition (`plan` resolving to `"free"`) never reaches that function at all, so an annual AIR subscriber's clock stays armed at whatever value their last renewal set.

**Confirmed live** (real Postgres, not just read-and-reasoned): after cancelling an installation that had `next_monthly_credit_reset_at` set, it still matched `list_installations_due_for_monthly_credit_reset`'s due-list query. Running `run_monthly_credit_reset_sweep_job` against it advanced the clock by another month and incremented `balance_epoch` - and would keep doing so forever, every month, for as long as the row exists and never resubscribes.

No money is at risk (`base_credit_for_plan("free", ...)` is `0`), but it's a permanent per-installation sweep-tick write/query leak on every churned annual-AIR row - the exact same class of gap `extra_seats` already had a fix for on this same transition.

## Fix
New `disarm_monthly_credit_reset_clock` in `app_server/db.py`, called alongside `set_installation_plan` on the webhook's free-plan branch - same place/pattern `set_extra_seats` already resets seats to 0 for a cancelled installation.

## Test plan
- [x] New regression test `test_canceling_an_annual_air_subscription_disarms_the_monthly_credit_clock` - confirmed it fails without the fix (`next_monthly_credit_reset_at` stays set) and passes with it.
- [x] Full suite: `tests/test_webhooks_paddle.py tests/test_jobs.py tests/test_scan_worker_db.py tests/test_admin.py` - 600 passed.

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)