### PR TITLE
fix: AIRview's single-target write path never cached its own output

### DIFF
--- a/github-app/scan_worker/live_wiki.py
+++ b/github-app/scan_worker/live_wiki.py
@@ -612,12 +612,25 @@ def build_subsystem_record(
     """skip_files/prior_record: incremental-update optimization - see
     _splice_prior_files. Both default to None (full-build behavior,
     unchanged): every file in the brief is written fresh."""
+    # cache_eligible tracks whether this packet may be WRITTEN to cache
+    # (cache_write is not None), not whether a lookup happened on this
+    # particular call - the sole caller (generate_subsystems' single-target
+    # path) deliberately passes cache_lookup=None to skip a redundant
+    # lookup it already performed via _cached_subsystem_record, while still
+    # wanting the fresh result cached for next time. Using cache_lookup's
+    # presence here made cache_write's own early-return-on-ineligible
+    # (packet_cache.store_result) silently no-op forever for every cluster
+    # that ever takes this path - real, confirmed LLM spend with zero
+    # caching benefit for that cluster, found via audit. The other two
+    # packet-building call sites in this file (_cached_subsystem_record,
+    # _generate_subsystem_records_for_targets) already use the correct
+    # cache_eligible=True pattern; this one drifted from it.
     packet = build_evidence_packet(
         evidence,
         cluster,
         brief,
         model_used,
-        cache_eligible=cache_lookup is not None,
+        cache_eligible=cache_write is not None,
         prompt_version=AIRVIEW_PROMPT_VERSION,
     )
     parsed = None

--- a/github-app/tests/test_live_wiki.py
+++ b/github-app/tests/test_live_wiki.py
@@ -541,6 +541,38 @@ def test_build_subsystem_record_falls_through_to_model_when_cache_lookup_raises(
     writing_adapter.simple_completion.assert_called_once()
 
 
+def test_build_subsystem_record_still_caches_when_lookup_was_skipped():
+    # generate_subsystems' single-target path passes cache_lookup=None
+    # deliberately (it already checked the cache itself via
+    # _cached_subsystem_record) but still wants the fresh result cached -
+    # this must not be treated as "caching disabled".
+    evidence = make_evidence()
+    cluster = evidence["architecture"]["clusters"][0]
+    brief = _brief_for(evidence)
+    fresh_output = {
+        "description": "Handles authentication.",
+        "files": [{"path": "auth/login.py", "role": "Login.", "key_symbols": []}],
+    }
+    writing_adapter = _adapter(json.dumps(fresh_output))
+    cache_write = MagicMock()
+
+    record = build_subsystem_record(
+        evidence,
+        cluster,
+        brief,
+        "Authentication",
+        writing_adapter,
+        cache_lookup=None,
+        cache_write=cache_write,
+        model_used="deepseek-v4-pro",
+    )
+
+    assert record is not None
+    cache_write.assert_called_once()
+    written_packet = cache_write.call_args[0][0]
+    assert written_packet["cache_eligible"] is True
+
+
 def test_build_subsystem_record_without_cache_callables_is_unchanged():
     evidence = make_evidence()
     cluster = evidence["architecture"]["clusters"][0]


### PR DESCRIPTION
## Summary
Found while re-verifying PR #648's embedding-dedup changes to the AIRview similarity cache.

`build_subsystem_record` set `cache_eligible=cache_lookup is not None` on the packet it builds. `generate_subsystems`' single-target path (the sole real caller) deliberately passes `cache_lookup=None` - it already checked the cache via `_cached_subsystem_record` and just wants to skip a redundant re-lookup - while still passing a real `cache_write` callable to cache the fresh result.

Since `cache_eligible` tracked "did a lookup happen" instead of "is this packet allowed to be cached", every subsystem that took this path after a cache miss got `cache_eligible=False`, and `packet_cache.store_result` early-returns on a falsy `cache_eligible` - silently no-op, forever. Real LLM spend with zero caching benefit for any cluster reaching this path.

The other two packet-building call sites in this file (`_cached_subsystem_record`, `_generate_subsystem_records_for_targets`) already use the correct `cache_eligible=True` pattern - this one alone had drifted from it. Fixed by keying `cache_eligible` off `cache_write`'s presence instead.

Confirmed no Docs-side sibling: `live_docs.py` doesn't use `packet_cache` at all.

## Test plan
- [x] New regression test (`test_build_subsystem_record_still_caches_when_lookup_was_skipped`) - confirmed it fails before the fix (`cache_eligible` was `False`) and passes after.
- [x] `pytest tests/test_live_wiki.py` - 79 passed
- [x] `pytest tests/test_live_wiki.py tests/test_packet_cache.py tests/test_jobs.py` - 337 passed

Not merging - for review only, per this session's standing audit-sweep practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)