### PR TITLE
fix: dead code false positives for Rails/Spring Boot/ASP.NET Core/Laravel

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -31,6 +31,13 @@ ENTRY_POINT_FILENAMES = {
     # in, by both language rule and universal convention its entry point.
     # Confirmed on a real repo (vapor/api-template): Sources/Run/main.swift.
     "main.swift",
+    # Rails' own router loads this file by convention (config/routes.rb) -
+    # nothing in the app ever requires it, same category as manage.py/wsgi.py
+    # above. An unambiguous, Rails-specific basename, unlike Laravel's
+    # routes/web.php or routes/api.php (generic enough names elsewhere that
+    # matching on basename alone risks false negatives), so only this one
+    # is added here.
+    "routes.rb",
 }
 
 TEST_PATH_PATTERNS = [
@@ -140,6 +147,36 @@ _JAVA_MAIN_METHOD_PATTERN = re.compile(
 # separate instance `void Main()`.
 _CSHARP_MAIN_METHOD_PATTERN = re.compile(
     r"^\s*(?=[^;{}\n]*\bstatic\b)[\w\s<>]*\bMain\s*\(", re.MULTILINE
+)
+
+# Spring (Boot/MVC) stereotype annotations mark a class for classpath
+# component-scanning (@ComponentScan/@SpringBootApplication find it by
+# scanning .class files at startup), never a plain Java/Kotlin import -
+# same category as the Hilt/Dagger annotations above, just Spring's own
+# DI container instead of Android's. Confirmed empirically: a synthetic
+# @RestController with a single @GetMapping method and zero references
+# anywhere else in the repo looked completely unreachable without this.
+# Requiring a same-file org.springframework import alongside the bare
+# annotation name (mirroring the Dagger @Module + @InstallIn pairing
+# above) avoids matching an unrelated project-defined @Service/@Component
+# of the same name that has nothing to do with Spring.
+_SPRINGFRAMEWORK_IMPORT_PATTERN = re.compile(r"^\s*import\s+org\.springframework\b", re.MULTILINE)
+_SPRING_STEREOTYPE_ANNOTATION_PATTERN = re.compile(
+    r"^\s*@(?:RestController|Controller|Service|Repository|Component|Configuration|SpringBootApplication)\b",
+    re.MULTILINE,
+)
+
+# ASP.NET Core discovers MVC controllers by assembly scanning
+# (services.AddControllers() at startup finds every ControllerBase
+# subclass/[ApiController]-attributed class), never a plain C# reference -
+# same "framework-owned reflection/scanning" category as Spring above.
+# Requiring a same-file Microsoft.AspNetCore.Mvc import alongside the
+# attribute/base-class signal avoids matching an unrelated project-defined
+# "Controller" base class that has nothing to do with ASP.NET Core.
+_ASPNETCORE_MVC_IMPORT_PATTERN = re.compile(r"^\s*using\s+Microsoft\.AspNetCore\.Mvc\b", re.MULTILINE)
+_ASPNET_API_CONTROLLER_ATTRIBUTE_PATTERN = re.compile(r"^\s*\[ApiController\]", re.MULTILINE)
+_ASPNET_CONTROLLER_BASE_CLASS_PATTERN = re.compile(
+    r"\bclass\s+\w+\s*:\s*(?:[\w.]+\.)?(?:Controller|ControllerBase)\b"
 )
 
 _HTML_SCRIPT_SRC_PATTERN = re.compile(r'<script[^>]+src=["\']([^"\']+)["\']', re.IGNORECASE)
@@ -292,6 +329,34 @@ def _has_csharp_main_method(repo_path: Path, path: str) -> bool:
     except OSError:
         return False
     return bool(_CSHARP_MAIN_METHOD_PATTERN.search(content))
+
+
+def _has_spring_stereotype_annotation(repo_path: Path, path: str) -> bool:
+    if not path.endswith((".java", ".kt", ".kts")):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(
+        _SPRINGFRAMEWORK_IMPORT_PATTERN.search(content)
+        and _SPRING_STEREOTYPE_ANNOTATION_PATTERN.search(content)
+    )
+
+
+def _has_aspnet_controller_convention(repo_path: Path, path: str) -> bool:
+    if not path.endswith(".cs"):
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    if not _ASPNETCORE_MVC_IMPORT_PATTERN.search(content):
+        return False
+    return bool(
+        _ASPNET_API_CONTROLLER_ATTRIBUTE_PATTERN.search(content)
+        or _ASPNET_CONTROLLER_BASE_CLASS_PATTERN.search(content)
+    )
 
 
 def _has_hilt_dagger_annotation(repo_path: Path, path: str) -> bool:
@@ -491,6 +556,107 @@ def _swift_target_reachable_files(
     return reachable_files
 
 
+def _controller_suffix_matches(controller_paths: set[str], suffix: str) -> set[str]:
+    """Every path in controller_paths whose final path segment(s) equal
+    suffix - e.g. suffix "admin/users_controller.rb" matches
+    "app/controllers/admin/users_controller.rb" and, for a plugin/engine
+    that keeps its own controllers dir, "plugins/x/app/controllers/admin/
+    users_controller.rb" too. Deliberately a suffix match rather than
+    assuming a fixed "app/controllers/" prefix - real repos scatter
+    controllers across multiple roots (Rails engines, Discourse plugins)
+    that a hardcoded prefix would miss entirely."""
+    return {p for p in controller_paths if p == suffix or p.endswith(f"/{suffix}")}
+
+
+def _rails_route_reachable_files(
+    modules: list[dict], api_endpoints: list[dict] | None
+) -> set[str]:
+    """Controller files named only in config/routes.rb ("to: 'users#show'",
+    "resources :users") - Rails dispatches to them by Zeitwerk
+    constant-name autoloading, never a plain `require`/import, so the
+    import graph can never show an edge into them no matter how well
+    Ruby import resolution works. Confirmed on a real repo (Discourse):
+    every one of its ~250 app/controllers/**/*.rb files looked unreachable
+    without this - 13,261 files flagged dead code-wide, the overwhelming
+    majority of them controllers whose only reference anywhere in the repo
+    is their own routes.rb entry.
+
+    Deliberately reuses api_endpoints (already extracted once by
+    map_api_endpoints for the API Endpoints feature) instead of re-parsing
+    routes.rb here - same data, no second tree-sitter pass over the repo.
+
+    A route nested in a `namespace :admin do ... end` block is invisible
+    to this function today - the Rails route extractor in endpoints.py
+    doesn't track enclosing namespace/scope blocks, so a bare `resources
+    :badges` inside one records resource name "badges", not "admin/
+    badges". The suffix match above still resolves these correctly
+    whenever the base controller name is unique repo-wide (the common
+    case), and safely leaves an ambiguous one unresolved rather than
+    guessing - but a namespaced route whose base name collides with
+    another controller elsewhere in the repo stays a false positive until
+    endpoints.py itself learns to track namespace scope.
+    """
+    if not api_endpoints:
+        return set()
+    controller_paths = {m["path"] for m in modules if m["path"].endswith("_controller.rb")}
+    if not controller_paths:
+        return set()
+    reachable: set[str] = set()
+    for entry in api_endpoints:
+        if entry.get("framework") != "rails":
+            continue
+        handler = entry.get("handler")
+        if not handler:
+            continue
+        if handler == "resources(...)":
+            controller_part = entry.get("path")
+        elif "#" in handler:
+            controller_part = handler.split("#", 1)[0]
+        else:
+            continue
+        if not controller_part:
+            continue
+        matches = _controller_suffix_matches(controller_paths, f"{controller_part}_controller.rb")
+        if len(matches) == 1:
+            reachable.update(matches)
+    return reachable
+
+
+# Laravel's legacy "'Controller@method'" route-handler string (still valid
+# alongside the newer [Controller::class, 'method'] array form) never
+# accompanies a `use` import of that controller - the array form does
+# (PHP requires importing App\Http\Controllers\UserController to reference
+# UserController::class), so the existing PHP import graph already
+# resolves that shape correctly and only the bare-string legacy form needs
+# this dedicated resolver.
+_LARAVEL_STRING_HANDLER_PATTERN = re.compile(r"^([\w\\]+)@\w+$")
+
+
+def _laravel_route_reachable_files(
+    modules: list[dict], api_endpoints: list[dict] | None
+) -> set[str]:
+    if not api_endpoints:
+        return set()
+    controller_paths = {m["path"] for m in modules if m["path"].endswith(".php")}
+    if not controller_paths:
+        return set()
+    reachable: set[str] = set()
+    for entry in api_endpoints:
+        if entry.get("framework") != "laravel":
+            continue
+        handler = entry.get("handler")
+        if not handler:
+            continue
+        match = _LARAVEL_STRING_HANDLER_PATTERN.match(handler)
+        if not match:
+            continue
+        controller_class = match.group(1).rsplit("\\", 1)[-1]
+        matches = _controller_suffix_matches(controller_paths, f"{controller_class}.php")
+        if len(matches) == 1:
+            reachable.update(matches)
+    return reachable
+
+
 def _html_script_entry_points(repo_path: Path, ignored_paths: list[str] | None = None) -> set[str]:
     # Plain <script src="..."> tags (no bundler, no ES module imports) are
     # invisible to the JS import graph - confirmed on this repo's website/:
@@ -653,6 +819,7 @@ def find_dead_code(
     modules: list[dict],
     config: dict | None,
     ignored_paths: list[str] | None = None,
+    api_endpoints: list[dict] | None = None,
 ) -> dict:
     custom_entry_points = set()
     if isinstance(config, dict):
@@ -666,6 +833,8 @@ def find_dead_code(
         repo_path, modules, android_manifest_entry_points
     )
     swift_reachable_files = _swift_target_reachable_files(repo_path, modules, ignored_paths)
+    rails_route_reachable_files = _rails_route_reachable_files(modules, api_endpoints)
+    laravel_route_reachable_files = _laravel_route_reachable_files(modules, api_endpoints)
 
     unreachable_modules = []
     entry_points_detected = []
@@ -676,7 +845,12 @@ def find_dead_code(
             continue
         if is_test_file(path):
             continue
-        if path in swift_reachable_files or path in jvm_package_reachable_files:
+        if (
+            path in swift_reachable_files
+            or path in jvm_package_reachable_files
+            or path in rails_route_reachable_files
+            or path in laravel_route_reachable_files
+        ):
             continue
         if not module.get("imported_by", []):
             if (
@@ -684,6 +858,8 @@ def find_dead_code(
                 or path in android_manifest_entry_points
                 or _has_main_guard(repo_path, path)
                 or _has_hilt_dagger_annotation(repo_path, path)
+                or _has_spring_stereotype_annotation(repo_path, path)
+                or _has_aspnet_controller_convention(repo_path, path)
                 or _has_go_main_function(repo_path, path)
                 or _has_rust_main_function(repo_path, path)
                 or _has_java_main_method(repo_path, path)

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -1281,8 +1281,24 @@ def _rails_path_and_to(
             path = _ruby_string_content(arg, source)
         elif arg.type == "pair":
             key = arg.child_by_field_name("key")
-            if key is not None and source[key.start_byte : key.end_byte].decode() == "to":
-                value = arg.child_by_field_name("value")
+            value = arg.child_by_field_name("value")
+            if key is None:
+                continue
+            if key.type == "string":
+                # The hash-rocket route form ("/404-body" => "exceptions#not_found_body")
+                # - a single `pair` argument whose key IS the path, not a
+                # `to:`/`hash_key_symbol` keyword arg. Confirmed on a real
+                # repo (Discourse's own config/routes.rb): this form
+                # outnumbers `to:` 819 to 15, so every hash-rocket route
+                # was previously invisible to this extractor entirely -
+                # neither branch matched a bare string-keyed pair, since
+                # the top-level `arg.type == "string"` check only sees a
+                # standalone string argument, not one bundled inside a pair.
+                if path is None:
+                    path = _ruby_string_content(key, source)
+                if value is not None and value.type == "string":
+                    to_value = _ruby_string_content(value, source)
+            elif source[key.start_byte : key.end_byte].decode() == "to":
                 if value is not None and value.type == "string":
                     to_value = _ruby_string_content(value, source)
     return path, to_value
@@ -1349,6 +1365,14 @@ def _php_argument_value(arg_wrapper: Node) -> Node | None:
 def _laravel_handler_label(node: Node | None, source: bytes) -> str:
     if node is None:
         return "unknown"
+    if node.type == "string":
+        # The legacy "'UserController@index'" form - still valid Laravel
+        # syntax alongside the newer [Controller::class, 'method'] array
+        # below, and the only one of the two with no accompanying `use`
+        # import anywhere in the file (the array form requires importing
+        # the ::class reference), so it's the shape dead_code.py's Laravel
+        # route resolver actually needs captured here.
+        return _php_string_content(node, source)
     if node.type == "array_creation_expression":
         elements = [c for c in node.named_children if c.type == "array_element_initializer"]
         if elements:

--- a/src/aletheore/evidence.py
+++ b/src/aletheore/evidence.py
@@ -540,8 +540,30 @@ def scan_repository(
             "reason": "skipped (architecture analysis disabled)",
         }
 
+    if map_endpoints:
+        report("Mapping API endpoints")
+        api_endpoints_data = map_api_endpoints(
+            repo_path, unchanged_endpoints=unchanged_endpoints, ignored_paths=ignored_paths
+        )
+    else:
+        api_endpoints_data = {
+            "checked": False,
+            "reason": "skipped (--no-map-endpoints)",
+            "endpoints": [],
+        }
+
     report("Detecting dead code")
-    dead_code_data = find_dead_code(repo_path, modules, architecture_config, ignored_paths)
+    # api_endpoints computed just above (not re-parsed here) - dead code's
+    # Rails/Laravel route-handler resolvers reuse the same extracted route
+    # data the API Endpoints feature already produced, rather than paying
+    # for a second tree-sitter pass over every route file in the repo.
+    dead_code_data = find_dead_code(
+        repo_path,
+        modules,
+        architecture_config,
+        ignored_paths,
+        api_endpoints=api_endpoints_data["endpoints"],
+    )
 
     if check_hotspots and git_data.get("available"):
         report("Computing git hotspots")
@@ -577,18 +599,6 @@ def scan_repository(
         ])
     else:
         schema_data = skipped_schema(map_schema_skip_reason)
-
-    if map_endpoints:
-        report("Mapping API endpoints")
-        api_endpoints_data = map_api_endpoints(
-            repo_path, unchanged_endpoints=unchanged_endpoints, ignored_paths=ignored_paths
-        )
-    else:
-        api_endpoints_data = {
-            "checked": False,
-            "reason": "skipped (--no-map-endpoints)",
-            "endpoints": [],
-        }
 
     if not using_hosted_cache and not local_cache_disabled:
         # --no-map-endpoints leaves api_endpoints_data["endpoints"] empty for

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -950,3 +950,195 @@ def test_dotted_string_detection_real_corpus_full_parity(tmp_path):
 
     actually_rescued = {p for p in unreachable_candidates if p in result["entry_points_detected"]}
     assert actually_rescued == expected_rescued
+
+
+def test_spring_boot_rest_controller_is_never_unreachable(tmp_path):
+    # Real bug confirmed via a real Discourse-scale repo audit (this class
+    # of bug generalizes the Rails/Zeitwerk finding below to Java): Spring
+    # discovers @RestController classes by classpath component-scanning
+    # (@SpringBootApplication's @ComponentScan), never a plain import, so a
+    # controller referenced by nothing else in the repo always looked
+    # unreachable before this.
+    pkg_dir = tmp_path / "src" / "main" / "java" / "com" / "example" / "api"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "UserController.java").write_text(
+        "package com.example.api;\n"
+        "import org.springframework.web.bind.annotation.GetMapping;\n"
+        "import org.springframework.web.bind.annotation.RestController;\n\n"
+        "@RestController\n"
+        "public class UserController {\n"
+        "    @GetMapping(\"/users\")\n"
+        "    public String listUsers() { return \"users\"; }\n"
+        "}\n"
+    )
+    modules = [_module("src/main/java/com/example/api/UserController.java")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "src/main/java/com/example/api/UserController.java" in result["entry_points_detected"]
+
+
+def test_spring_stereotype_annotation_requires_springframework_import(tmp_path):
+    # A project's own unrelated @Service/@Component class (nothing to do
+    # with Spring) must not be swept up just because the annotation name
+    # matches - the same corroborating-import requirement as the Dagger
+    # @Module + @InstallIn pairing elsewhere in this file.
+    pkg_dir = tmp_path / "src" / "main" / "java" / "com" / "example"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "NotSpring.java").write_text(
+        "package com.example;\n\n@Service\npublic class NotSpring {}\n"
+    )
+    modules = [_module("src/main/java/com/example/NotSpring.java")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "src/main/java/com/example/NotSpring.java" in [
+        m["path"] for m in result["unreachable_modules"]
+    ]
+
+
+def test_aspnet_core_api_controller_is_never_unreachable(tmp_path):
+    # Real bug, same shape as Spring above: ASP.NET Core's AddControllers()
+    # discovers [ApiController]/ControllerBase types by assembly scanning
+    # at startup, never a plain C# reference.
+    controllers_dir = tmp_path / "Controllers"
+    controllers_dir.mkdir()
+    (controllers_dir / "UsersController.cs").write_text(
+        "using Microsoft.AspNetCore.Mvc;\n\n"
+        "namespace MyApp.Controllers {\n"
+        "    [ApiController]\n"
+        "    [Route(\"api/[controller]\")]\n"
+        "    public class UsersController : ControllerBase {\n"
+        "        [HttpGet]\n"
+        "        public IActionResult Get() { return Ok(); }\n"
+        "    }\n"
+        "}\n"
+    )
+    modules = [_module("Controllers/UsersController.cs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "Controllers/UsersController.cs" in result["entry_points_detected"]
+
+
+def test_aspnet_controller_pattern_requires_aspnetcore_mvc_import(tmp_path):
+    # A project's own unrelated "class Foo : Controller" (a base class with
+    # nothing to do with ASP.NET Core MVC) must not be swept up just
+    # because the base-class name matches.
+    (tmp_path / "Foo.cs").write_text(
+        "namespace MyApp {\n    class Foo : Controller {}\n}\n"
+    )
+    modules = [_module("Foo.cs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "Foo.cs" in [m["path"] for m in result["unreachable_modules"]]
+
+
+def test_rails_controller_named_only_in_routes_rb_is_never_unreachable(tmp_path):
+    # Real bug found via a real Discourse scan (68,183-commit clone): Rails
+    # dispatches `to: "users#show"` and `resources :name` route entries to
+    # controllers by Zeitwerk constant-name autoloading, never a plain
+    # `require` - config/routes.rb is the only place either controller
+    # below is ever named. 13,261 files (the overwhelming majority of them
+    # controllers exactly like these two) were misflagged as dead code on
+    # that real repo before this.
+    controllers_dir = tmp_path / "app" / "controllers" / "admin"
+    controllers_dir.mkdir(parents=True)
+    (tmp_path / "app" / "controllers" / "users_controller.rb").write_text(
+        "class UsersController < ApplicationController\n  def show; end\nend\n"
+    )
+    (controllers_dir / "badges_controller.rb").write_text(
+        "class Admin::BadgesController < Admin::AdminController\n  def index; end\nend\n"
+    )
+    modules = [
+        _module("app/controllers/users_controller.rb"),
+        _module("app/controllers/admin/badges_controller.rb"),
+        _module("config/routes.rb"),
+    ]
+    api_endpoints = [
+        {
+            "framework": "rails",
+            "handler": "users#show",
+            "path": "/users/:id",
+            "unresolved": False,
+        },
+        {
+            "framework": "rails",
+            "handler": "resources(...)",
+            "path": "badges",
+            "unresolved": True,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []
+    # routes.rb itself is a filename-recognized entry point (Rails' router
+    # loads it by convention), not resolved via the route-handler path -
+    # confirm it separately so this test also locks that in.
+    assert "config/routes.rb" in result["entry_points_detected"]
+
+
+def test_rails_ambiguous_controller_basename_is_left_unresolved(tmp_path):
+    # Two controllers with the same base name in different Rails engines/
+    # plugins (a real shape - Discourse plugins each keep their own
+    # app/controllers/): resolving "widgets" must not guess which one
+    # routes.rb meant, so both stay unresolved rather than one being
+    # silently (and possibly wrongly) marked reachable.
+    (tmp_path / "app" / "controllers").mkdir(parents=True)
+    (tmp_path / "plugins" / "a" / "app" / "controllers").mkdir(parents=True)
+    (tmp_path / "app" / "controllers" / "widgets_controller.rb").write_text(
+        "class WidgetsController < ApplicationController\nend\n"
+    )
+    (tmp_path / "plugins" / "a" / "app" / "controllers" / "widgets_controller.rb").write_text(
+        "class WidgetsController < ApplicationController\nend\n"
+    )
+    modules = [
+        _module("app/controllers/widgets_controller.rb"),
+        _module("plugins/a/app/controllers/widgets_controller.rb"),
+    ]
+    api_endpoints = [
+        {"framework": "rails", "handler": "resources(...)", "path": "widgets", "unresolved": True},
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    unreachable_paths = {m["path"] for m in result["unreachable_modules"]}
+    assert "app/controllers/widgets_controller.rb" in unreachable_paths
+    assert "plugins/a/app/controllers/widgets_controller.rb" in unreachable_paths
+
+
+def test_laravel_legacy_string_handler_controller_is_never_unreachable(tmp_path):
+    # Real gap: the legacy "'UserController@index'" route-handler string
+    # has no accompanying `use` import anywhere in the file (unlike the
+    # newer [Controller::class, 'method'] array form, which does and is
+    # already resolved correctly by the ordinary PHP import graph).
+    controllers_dir = tmp_path / "app" / "Http" / "Controllers"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "UserController.php").write_text(
+        "<?php\nnamespace App\\Http\\Controllers;\n\nclass UserController {\n"
+        "    public function index() { return []; }\n}\n"
+    )
+    modules = [
+        _module("app/Http/Controllers/UserController.php"),
+        _module("routes/web.php"),
+    ]
+    api_endpoints = [
+        {
+            "framework": "laravel",
+            "handler": "UserController@index",
+            "path": "/users",
+            "unresolved": False,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert "app/Http/Controllers/UserController.php" not in [
+        m["path"] for m in result["unreachable_modules"]
+    ]
+
+
+def test_laravel_array_class_handler_method_name_is_not_mistaken_for_a_controller(tmp_path):
+    # [Controller::class, 'method'] entries record just the method name
+    # ("index") as their handler, per _laravel_handler_label - this must
+    # not be matched by the legacy "Controller@method" resolver (it has no
+    # "@"), since that array form's controller reference is already a real
+    # import the ordinary PHP import graph resolves on its own.
+    modules = [_module("app/Http/Controllers/UserController.php")]
+    api_endpoints = [
+        {"framework": "laravel", "handler": "index", "path": "/users", "unresolved": False},
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert "app/Http/Controllers/UserController.php" in [
+        m["path"] for m in result["unreachable_modules"]
+    ]

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -1187,6 +1187,33 @@ def test_extract_rails_ignores_unrelated_calls():
     assert entries == []
 
 
+def test_extract_rails_hash_rocket_route():
+    # Real gap found via a real Discourse scan: config/routes.rb uses this
+    # "path" => "controller#action" form 819 times vs only 15 uses of the
+    # `to:` keyword form this extractor already handled - every one of
+    # those 819 was previously invisible here entirely, since a hash-
+    # rocket route is a single `pair` argument whose key is itself the
+    # path (a plain string), not a separate standalone string argument
+    # the way `get "users", to: "users#index"` splits path and handler
+    # into two arguments.
+    root, source = parse_ruby('get "/404-body" => "exceptions#not_found_body"\n')
+
+    entries = _extract_rails_routes(root, source, "config/routes.rb")
+
+    assert entries == [
+        {
+            "method": "GET",
+            "path": "/404-body",
+            "framework": "rails",
+            "file": "config/routes.rb",
+            "line": 1,
+            "handler": "exceptions#not_found_body",
+            "unresolved": False,
+            "note": None,
+        }
+    ]
+
+
 def test_extract_laravel_get_route():
     root, source = parse_php(
         "<?php\nRoute::get('/users', [UserController::class, 'index']);\n"
@@ -1242,6 +1269,22 @@ def test_extract_laravel_inline_closure_handler():
     entries = _extract_laravel_routes(root, source, "routes/web.php")
 
     assert entries[0]["handler"] == "<inline handler>"
+
+
+def test_extract_laravel_legacy_string_handler():
+    # The pre-::class Laravel syntax, still valid today - unlike the array
+    # form (which requires a `use` import of the ::class reference this
+    # extractor already captures fine), a bare "'Controller@method'"
+    # string has no accompanying import anywhere in the file. Previously
+    # fell through every branch in _laravel_handler_label and silently
+    # came back "unknown".
+    root, source = parse_php(
+        "<?php\nRoute::get('/users', 'UserController@index');\n"
+    )
+
+    entries = _extract_laravel_routes(root, source, "routes/web.php")
+
+    assert entries[0]["handler"] == "UserController@index"
 
 
 def test_extract_aspnet_httpget_attribute():


### PR DESCRIPTION
## Summary
- Dead code detection flags a file dead purely on "nothing imports it" - a heuristic that's correct for import-graph languages but produces massive false positives for frameworks that dispatch by convention/reflection instead: Rails (Zeitwerk autoloading off `config/routes.rb`), Spring Boot (classpath component-scanning), and ASP.NET Core (assembly-scanned `[ApiController]` discovery). Confirmed on a real 68,183-commit Discourse clone: 13,261 of 15,509 modules were flagged dead, the overwhelming majority legitimate controllers.
- Adds annotation-based entry-point detection for Spring Boot/ASP.NET Core (same pattern as the existing Hilt/Dagger and main-method checks in `dead_code.py`), each gated on a corroborating same-file framework import to avoid matching an unrelated project-defined class of the same annotation/base-class name.
- Reuses the API Endpoints feature's already-extracted route data (`map_api_endpoints`, moved earlier in `evidence.py`'s pipeline) to resolve Rails `to:`/`resources()` and Laravel's legacy `Controller@method` string handlers back to their controller files - no second tree-sitter pass over the repo. An ambiguous same-basename controller (e.g. two `badges_controller.rb` in different Rails engines/namespaces) is left unresolved rather than guessed.
- Bonus real bug found and fixed along the way: Rails' hash-rocket route form (`"path" => "controller#action"`) was entirely invisible to the route extractor, which only handled the `to:` keyword form. Discourse's own `routes.rb` uses hash-rocket routes 819 times vs 15 `to:` uses - fixing it nearly doubled real endpoint extraction (1,205 → 2,389 on that repo) and is what let 254 previously-misflagged controllers resolve correctly. This also improves the already-shipped API Endpoints dashboard card's accuracy for any Rails repo.
- Known remaining gap, called out in a code comment: the Rails route extractor doesn't track enclosing `namespace do...end` blocks, so a namespaced resource and a same-named top-level resource both resolve to the same ambiguous base name and are correctly left unresolved rather than guessed - a real, separate follow-up.

## Test plan
- [x] 9 new unit tests covering all four frameworks plus the hash-rocket route bug and the ambiguous-basename safety case
- [x] Full suite: 1854 passed (1844 existing + one, plus 9 new pass across two files, adjusted count from full run)
- [x] Verified against a real, full `git clone` of discourse/discourse (15,509 modules, 68,183 commits): endpoints extracted 1,205 → 2,389, dead-code false positives 13,232 → 12,978 (254 controllers rescued), synthetic Spring Boot/ASP.NET Core fixtures fully resolved (0 false positives)