### PR TITLE
feat: track namespace/scope module blocks in Rails route extraction

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -713,8 +713,25 @@ def _laravel_route_reachable_files(
         match = _LARAVEL_STRING_HANDLER_PATTERN.match(handler)
         if not match:
             continue
-        controller_class = match.group(1).rsplit("\\", 1)[-1]
-        matches = _controller_suffix_matches(controller_paths, [f"{controller_class}.php"])
+        # "Admin\UserController" -> ["Admin", "UserController.php"] - a
+        # fully backslash-qualified handler already names its own
+        # namespace segments; preserve them for a precise multi-segment
+        # match instead of discarding them down to the bare class name.
+        # Never anchored to a controllers/ boundary even for the bare
+        # (single-segment) case, unlike Rails' config/routes.rb: Laravel's
+        # legacy string handler can equally sit inside an enclosing
+        # `Route::group(['namespace' => 'Admin'], function () {...})`,
+        # invisible from the handler string alone, so an unqualified name
+        # here carries none of the "this really is top-level" guarantee a
+        # bare Rails `resources` call declared directly in config/routes.rb
+        # does. Confirmed by Flash Review on #666: without this, a real
+        # nested controller like app/Http/Controllers/Admin/User.php named
+        # by "Admin\User@index" was wrongly left flagged as dead code.
+        segments = match.group(1).split("\\")
+        segments[-1] = f"{segments[-1]}.php"
+        matches = _controller_suffix_matches(
+            controller_paths, segments, anchor_single_segment=False
+        )
         if len(matches) == 1:
             reachable.update(matches)
     return reachable

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -556,16 +556,66 @@ def _swift_target_reachable_files(
     return reachable_files
 
 
-def _controller_suffix_matches(controller_paths: set[str], suffix: str) -> set[str]:
-    """Every path in controller_paths whose final path segment(s) equal
-    suffix - e.g. suffix "admin/users_controller.rb" matches
-    "app/controllers/admin/users_controller.rb" and, for a plugin/engine
-    that keeps its own controllers dir, "plugins/x/app/controllers/admin/
-    users_controller.rb" too. Deliberately a suffix match rather than
-    assuming a fixed "app/controllers/" prefix - real repos scatter
-    controllers across multiple roots (Rails engines, Discourse plugins)
-    that a hardcoded prefix would miss entirely."""
-    return {p for p in controller_paths if p == suffix or p.endswith(f"/{suffix}")}
+def _controller_suffix_matches(
+    controller_paths: set[str], segments: list[str], *, anchor_single_segment: bool = True
+) -> set[str]:
+    """Every path in controller_paths whose final path segments exactly
+    equal `segments`.
+
+    When `anchor_single_segment` and `segments` is a single (unprefixed)
+    name, matches are additionally anchored at a real controllers-directory
+    boundary - the whole path is just that one segment, or the segment
+    immediately before it is a "controllers" directory (case-insensitive:
+    Rails lowercases it, Laravel's convention capitalizes it
+    "Controllers"). Confirmed by a real end-to-end test: without this, an
+    unprefixed lookup for "badges" also matched
+    "app/controllers/admin/badges_controller.rb" two levels down, colliding
+    with the real top-level app/controllers/badges_controller.rb - Rails'
+    own unqualified `resources :badges`, declared directly in
+    config/routes.rb outside any namespace, can only ever mean the
+    controller sitting directly in a controllers/ dir, never a nested one.
+
+    `anchor_single_segment=False` (see the config/routes.rb-only gating in
+    _rails_route_reachable_files) skips that anchor even for a single
+    segment - needed for exactly the opposite real reason, also confirmed
+    end-to-end against Discourse: an unprefixed `resources :workflows`
+    declared inside a PLUGIN's own routes file (mounted under
+    `SomeEngine.routes.draw do ... end`) does NOT mean the top-level
+    controller - Rails engines implicitly namespace every controller under
+    the engine's own module (isolate_namespace) regardless of anything the
+    routes file itself says, a segment this extractor has no way to see
+    since it isn't a namespace/scope call at all. Anchoring there would
+    wrongly reject the one real controller (e.g.
+    plugins/discourse-workflows/app/controllers/discourse_workflows/
+    workflows_controller.rb) an unprefixed plugin route already uniquely
+    identifies, just because that untracked engine-module segment sits
+    between "controllers/" and it.
+
+    A multi-segment (prefixed) query is always a plain tail match with no
+    adjacency requirement, for the same untracked-engine-segment reason -
+    e.g. a `namespace :api do resources :channels end` inside the chat
+    plugin's own engine-mounted routes file records "api/channels", but the
+    real file is .../controllers/chat/api/channels_controller.rb with an
+    extra untracked "chat" engine-module segment before "api".
+    """
+    n = len(segments)
+    matches = {p for p in controller_paths if p.split("/")[-n:] == segments}
+    if n == 1 and anchor_single_segment:
+        matches = {
+            p for p in matches
+            if len(p.split("/")) == 1 or p.split("/")[-2].lower() == "controllers"
+        }
+    return matches
+
+
+def _controller_path_segments(controller_part: str) -> list[str]:
+    """"admin/badges" -> ["admin", "badges_controller.rb"]; "badges" ->
+    ["badges_controller.rb"] - controller_part may already carry a
+    namespace/module prefix (see _rails_enclosing_module_prefix in
+    endpoints.py), only the final segment names the controller itself."""
+    parts = controller_part.split("/")
+    parts[-1] = f"{parts[-1]}_controller.rb"
+    return parts
 
 
 def _rails_route_reachable_files(
@@ -585,16 +635,18 @@ def _rails_route_reachable_files(
     map_api_endpoints for the API Endpoints feature) instead of re-parsing
     routes.rb here - same data, no second tree-sitter pass over the repo.
 
-    A route nested in a `namespace :admin do ... end` block is invisible
-    to this function today - the Rails route extractor in endpoints.py
-    doesn't track enclosing namespace/scope blocks, so a bare `resources
-    :badges` inside one records resource name "badges", not "admin/
-    badges". The suffix match above still resolves these correctly
-    whenever the base controller name is unique repo-wide (the common
-    case), and safely leaves an ambiguous one unresolved rather than
-    guessing - but a namespaced route whose base name collides with
-    another controller elsewhere in the repo stays a false positive until
-    endpoints.py itself learns to track namespace scope.
+    A `resources :badges` nested in a `namespace :admin do ... end` block
+    now resolves as "admin/badges" (endpoints.py's Rails extractor tracks
+    enclosing namespace/`scope module:` blocks - see
+    _rails_enclosing_module_prefix), so it no longer collides with an
+    unrelated top-level `badges` resource the way it used to. A route
+    inside a bare `scope "/logs" do ... end` (URL-only, no module change -
+    the far more common form on a real repo, 20 to 3 on Discourse's own
+    routes.rb) still isn't prefixed here, correctly, since Rails itself
+    doesn't remodule those. The suffix match above still safely leaves a
+    genuinely ambiguous name (same controller basename reused across two
+    unrelated engines/plugins, not a namespace collision) unresolved
+    rather than guessing.
     """
     if not api_endpoints:
         return set()
@@ -616,7 +668,18 @@ def _rails_route_reachable_files(
             continue
         if not controller_part:
             continue
-        matches = _controller_suffix_matches(controller_paths, f"{controller_part}_controller.rb")
+        # Only a route declared directly in the app's own top-level
+        # config/routes.rb executes with no implicit engine module wrapping
+        # it - a route from any other file (a plugin/gem's own routes file,
+        # almost always mounted via `SomeEngine.routes.draw do ... end`)
+        # can't safely assume an unprefixed name means "the top-level
+        # controller" the way _controller_suffix_matches' anchor does.
+        anchor = entry.get("file") == "config/routes.rb"
+        matches = _controller_suffix_matches(
+            controller_paths,
+            _controller_path_segments(controller_part),
+            anchor_single_segment=anchor,
+        )
         if len(matches) == 1:
             reachable.update(matches)
     return reachable
@@ -651,7 +714,7 @@ def _laravel_route_reachable_files(
         if not match:
             continue
         controller_class = match.group(1).rsplit("\\", 1)[-1]
-        matches = _controller_suffix_matches(controller_paths, f"{controller_class}.php")
+        matches = _controller_suffix_matches(controller_paths, [f"{controller_class}.php"])
         if len(matches) == 1:
             reachable.update(matches)
     return reachable

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -1343,14 +1343,24 @@ def _rails_enclosing_module_prefix(call_node: Node, source: bytes) -> list[str]:
                                 continue
                             key = arg.child_by_field_name("key")
                             value = arg.child_by_field_name("value")
-                            if (
+                            if not (
                                 key is not None
                                 and key.type == "hash_key_symbol"
                                 and source[key.start_byte : key.end_byte].decode() == "module"
                                 and value is not None
-                                and value.type == "string"
                             ):
+                                continue
+                            if value.type == "string":
                                 segment = _ruby_string_content(value, source)
+                            elif value.type == "simple_symbol":
+                                # `scope module: :admin do` - equally valid
+                                # Rails syntax alongside `module: "admin"`,
+                                # confirmed by Flash Review on #666 and
+                                # missed entirely before: only the string
+                                # form was handled.
+                                segment = (
+                                    source[value.start_byte : value.end_byte].decode().lstrip(":")
+                                )
                     if segment:
                         segments.append(segment)
         node = node.parent

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -1304,6 +1304,67 @@ def _rails_path_and_to(
     return path, to_value
 
 
+def _rails_enclosing_module_prefix(call_node: Node, source: bytes) -> list[str]:
+    """Every `namespace :x do ... end` / `scope module: "x" do ... end`
+    block enclosing call_node, outermost first - Rails' *module* (not URL-
+    path) namespacing, which is what determines a route's real controller
+    file. `namespace :x` affects both the controller module and the URL
+    path; a bare `scope "/logs" do` or `scope path: "..." do` affects only
+    the URL and must NOT contribute a module segment - confirmed on
+    Discourse's own routes.rb, where bare/path-only `scope` outnumbers
+    `namespace` 20 to 3, and none of those 20 renamespace their contents'
+    controllers.
+
+    Walks upward from call_node rather than a push/pop descent - each
+    do_block's owning `call` is checked in turn, so arbitrary nesting depth
+    (namespace inside scope inside namespace, ...) falls out for free
+    without a separate stateful traversal."""
+    segments: list[str] = []
+    node = call_node.parent
+    while node is not None:
+        if node.type == "do_block":
+            enclosing_call = node.parent
+            if enclosing_call is not None and enclosing_call.type == "call":
+                method_node = enclosing_call.child_by_field_name("method")
+                block_args = enclosing_call.child_by_field_name("arguments")
+                if method_node is not None and block_args is not None:
+                    block_method = source[method_node.start_byte : method_node.end_byte].decode()
+                    segment = None
+                    if block_method == "namespace":
+                        first = next(
+                            (a for a in block_args.named_children if a.type == "simple_symbol"),
+                            None,
+                        )
+                        if first is not None:
+                            segment = source[first.start_byte : first.end_byte].decode().lstrip(":")
+                    elif block_method == "scope":
+                        for arg in block_args.named_children:
+                            if arg.type != "pair":
+                                continue
+                            key = arg.child_by_field_name("key")
+                            value = arg.child_by_field_name("value")
+                            if (
+                                key is not None
+                                and key.type == "hash_key_symbol"
+                                and source[key.start_byte : key.end_byte].decode() == "module"
+                                and value is not None
+                                and value.type == "string"
+                            ):
+                                segment = _ruby_string_content(value, source)
+                    if segment:
+                        segments.append(segment)
+        node = node.parent
+    segments.reverse()
+    return segments
+
+
+def _apply_rails_module_prefix(to_value: str, module_prefix: list[str]) -> str:
+    if not module_prefix or "#" not in to_value:
+        return to_value
+    controller_part, action = to_value.split("#", 1)
+    return "/".join([*module_prefix, controller_part]) + "#" + action
+
+
 def _extract_rails_routes(root: Node, source: bytes, rel_path: str) -> list[dict]:
     entries: list[dict] = []
 
@@ -1318,6 +1379,7 @@ def _extract_rails_routes(root: Node, source: bytes, rel_path: str) -> list[dict
                         args, source, is_root=(method_name == "root")
                     )
                     if to_value is not None and path is not None:
+                        module_prefix = _rails_enclosing_module_prefix(n, source)
                         entries.append(
                             {
                                 "method": "GET" if method_name == "root" else method_name.upper(),
@@ -1325,7 +1387,7 @@ def _extract_rails_routes(root: Node, source: bytes, rel_path: str) -> list[dict
                                 "framework": "rails",
                                 "file": rel_path,
                                 "line": n.start_point[0] + 1,
-                                "handler": to_value,
+                                "handler": _apply_rails_module_prefix(to_value, module_prefix),
                                 "unresolved": False,
                                 "note": None,
                             }
@@ -1336,6 +1398,9 @@ def _extract_rails_routes(root: Node, source: bytes, rel_path: str) -> list[dict
                         resource_name = source[
                             named[0].start_byte : named[0].end_byte
                         ].decode().lstrip(":")
+                        module_prefix = _rails_enclosing_module_prefix(n, source)
+                        if module_prefix:
+                            resource_name = "/".join([*module_prefix, resource_name])
                         entries.append(
                             {
                                 "method": None,

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1229,3 +1229,31 @@ def test_rails_unprefixed_resource_in_a_plugin_engine_routes_file_still_resolves
     ]
     result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
     assert result["unreachable_modules"] == []
+
+
+def test_laravel_backslash_qualified_string_handler_resolves_a_nested_controller(tmp_path):
+    # Flash Review finding on #666: the legacy string handler resolver
+    # reduced every handler to its bare class name and always anchored
+    # single-segment queries to a controllers/-directory boundary, so a
+    # real, fully-qualified handler like "Admin\UserController@index"
+    # naming a controller under app/Http/Controllers/Admin/ was wrongly
+    # left flagged as dead code - anchoring assumes an unqualified name
+    # means "top level", which doesn't apply here since the handler
+    # string already names its own namespace segment.
+    controllers_dir = tmp_path / "app" / "Http" / "Controllers" / "Admin"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "UserController.php").write_text(
+        "<?php\nnamespace App\\Http\\Controllers\\Admin;\n\nclass UserController {\n"
+        "    public function index() { return []; }\n}\n"
+    )
+    modules = [_module("app/Http/Controllers/Admin/UserController.php")]
+    api_endpoints = [
+        {
+            "framework": "laravel",
+            "handler": "Admin\\UserController@index",
+            "path": "/admin/users",
+            "unresolved": False,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1056,12 +1056,20 @@ def test_rails_controller_named_only_in_routes_rb_is_never_unreachable(tmp_path)
             "handler": "users#show",
             "path": "/users/:id",
             "unresolved": False,
+            "file": "config/routes.rb",
         },
         {
+            # "admin/badges", not bare "badges" - this controller sits under
+            # app/controllers/admin/, and endpoints.py's Rails extractor
+            # tracks the enclosing `namespace :admin do` block (see
+            # _rails_enclosing_module_prefix) precisely so this resolves to
+            # the right one of two same-named controllers instead of
+            # colliding with an unrelated top-level `badges_controller.rb`.
             "framework": "rails",
             "handler": "resources(...)",
-            "path": "badges",
+            "path": "admin/badges",
             "unresolved": True,
+            "file": "config/routes.rb",
         },
     ]
     result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
@@ -1091,7 +1099,13 @@ def test_rails_ambiguous_controller_basename_is_left_unresolved(tmp_path):
         _module("plugins/a/app/controllers/widgets_controller.rb"),
     ]
     api_endpoints = [
-        {"framework": "rails", "handler": "resources(...)", "path": "widgets", "unresolved": True},
+        {
+            "framework": "rails",
+            "handler": "resources(...)",
+            "path": "widgets",
+            "unresolved": True,
+            "file": "config/routes.rb",
+        },
     ]
     result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
     unreachable_paths = {m["path"] for m in result["unreachable_modules"]}
@@ -1142,3 +1156,76 @@ def test_laravel_array_class_handler_method_name_is_not_mistaken_for_a_controlle
     assert "app/Http/Controllers/UserController.php" in [
         m["path"] for m in result["unreachable_modules"]
     ]
+
+
+def test_rails_namespaced_and_top_level_same_named_controllers_both_resolve(tmp_path):
+    # Follow-up to test_rails_ambiguous_controller_basename_is_left_unresolved
+    # above: once endpoints.py's Rails extractor tracks namespace/scope
+    # module prefixes (see _rails_enclosing_module_prefix), the two real
+    # "badges" entries carry distinct scoped names ("badges" vs
+    # "admin/badges") instead of colliding, so both controllers resolve
+    # correctly instead of both being left unreachable.
+    (tmp_path / "app" / "controllers" / "admin").mkdir(parents=True)
+    (tmp_path / "app" / "controllers" / "badges_controller.rb").write_text(
+        "class BadgesController < ApplicationController\nend\n"
+    )
+    (tmp_path / "app" / "controllers" / "admin" / "badges_controller.rb").write_text(
+        "class Admin::BadgesController < Admin::AdminController\nend\n"
+    )
+    modules = [
+        _module("app/controllers/badges_controller.rb"),
+        _module("app/controllers/admin/badges_controller.rb"),
+    ]
+    api_endpoints = [
+        {
+            "framework": "rails",
+            "handler": "resources(...)",
+            "path": "badges",
+            "unresolved": True,
+            "file": "config/routes.rb",
+        },
+        {
+            "framework": "rails",
+            "handler": "resources(...)",
+            "path": "admin/badges",
+            "unresolved": True,
+            "file": "config/routes.rb",
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []
+
+
+def test_rails_unprefixed_resource_in_a_plugin_engine_routes_file_still_resolves(tmp_path):
+    # Real regression caught by a real end-to-end check against Discourse:
+    # a plugin's own routes file (mounted via `SomeEngine.routes.draw do
+    # ... end`, not config/routes.rb) implicitly namespaces every
+    # controller under the engine's own module (isolate_namespace) even
+    # for an unprefixed `resources :workflows` - so the real controller
+    # lives at plugins/.../app/controllers/discourse_workflows/
+    # workflows_controller.rb, one level deeper than an unprefixed
+    # config/routes.rb resource would ever be. Anchoring an unprefixed
+    # name to "must be a direct child of controllers/" (correct for
+    # config/routes.rb - see the namespace-collision test above) would
+    # wrongly leave this real, uniquely-identified controller unresolved.
+    controllers_dir = tmp_path / "plugins" / "discourse-workflows" / "app" / "controllers" / "discourse_workflows"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "workflows_controller.rb").write_text(
+        "class DiscourseWorkflows::WorkflowsController < DiscourseWorkflows::AdminController\nend\n"
+    )
+    modules = [
+        _module(
+            "plugins/discourse-workflows/app/controllers/discourse_workflows/workflows_controller.rb"
+        ),
+    ]
+    api_endpoints = [
+        {
+            "framework": "rails",
+            "handler": "resources(...)",
+            "path": "workflows",
+            "unresolved": True,
+            "file": "plugins/discourse-workflows/config/routes.rb",
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -1256,6 +1256,20 @@ def test_extract_rails_bare_scope_does_not_add_a_module_prefix():
     assert entries[0]["path"] == "items"
 
 
+def test_extract_rails_scope_module_symbol_value_gets_module_prefix():
+    # Flash Review finding on #666: `scope module: :admin do` (a symbol
+    # value) is equally valid Rails syntax alongside `module: "admin"` (a
+    # string) - only the string form was handled, so this variant silently
+    # produced no module prefix at all.
+    root, source = parse_ruby(
+        "scope module: :admin do\n  resources :badges\nend\n"
+    )
+
+    entries = _extract_rails_routes(root, source, "config/routes.rb")
+
+    assert entries[0]["path"] == "admin/badges"
+
+
 def test_extract_rails_hash_rocket_route():
     # Real gap found via a real Discourse scan: config/routes.rb uses this
     # "path" => "controller#action" form 819 times vs only 15 uses of the

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -1187,6 +1187,75 @@ def test_extract_rails_ignores_unrelated_calls():
     assert entries == []
 
 
+def test_extract_rails_resources_inside_namespace_gets_module_prefix():
+    # Real gap found via a real Discourse scan: a `resources :badges`
+    # nested in `namespace :admin do ... end` previously recorded resource
+    # name "badges" - identical to an unrelated top-level `resources
+    # :badges` elsewhere in the same routes.rb, which made dead_code.py's
+    # resolver correctly refuse to guess between the two real controllers
+    # and leave both flagged dead code.
+    root, source = parse_ruby(
+        "namespace :admin do\n  resources :badges\nend\n"
+    )
+
+    entries = _extract_rails_routes(root, source, "config/routes.rb")
+
+    assert entries == [
+        {
+            "method": None,
+            "path": "admin/badges",
+            "framework": "rails",
+            "file": "config/routes.rb",
+            "line": 2,
+            "handler": "resources(...)",
+            "unresolved": True,
+            "note": None,
+        }
+    ]
+
+
+def test_extract_rails_to_route_inside_namespace_gets_module_prefix():
+    root, source = parse_ruby(
+        'namespace :admin do\n  get "users", to: "users#index"\nend\n'
+    )
+
+    entries = _extract_rails_routes(root, source, "config/routes.rb")
+
+    assert entries[0]["handler"] == "admin/users#index"
+
+
+def test_extract_rails_nested_namespace_and_scope_module_compose_in_order():
+    # Arbitrary nesting depth (namespace inside scope inside namespace, ...)
+    # falls out of the upward-walk design for free - no separate stack
+    # needed, just each enclosing do_block's owning call checked in turn.
+    root, source = parse_ruby(
+        'namespace :admin do\n'
+        '  scope module: "extra" do\n'
+        '    resources :widgets\n'
+        "  end\n"
+        "end\n"
+    )
+
+    entries = _extract_rails_routes(root, source, "config/routes.rb")
+
+    assert entries[0]["path"] == "admin/extra/widgets"
+
+
+def test_extract_rails_bare_scope_does_not_add_a_module_prefix():
+    # A bare `scope "/logs" do ... end` (or `scope path: "..." do`) changes
+    # only the URL, never the controller module - confirmed on Discourse's
+    # own routes.rb, where this form outnumbers `namespace` 20 to 3 and
+    # none of those 20 renamespace their contents' controllers. Must NOT
+    # be treated the same as `namespace`/`scope module:`.
+    root, source = parse_ruby(
+        'scope "/logs" do\n  resources :items\nend\n'
+    )
+
+    entries = _extract_rails_routes(root, source, "config/routes.rb")
+
+    assert entries[0]["path"] == "items"
+
+
 def test_extract_rails_hash_rocket_route():
     # Real gap found via a real Discourse scan: config/routes.rb uses this
     # "path" => "controller#action" form 819 times vs only 15 uses of the


### PR DESCRIPTION
Closes #665.

## Summary
- `_extract_rails_routes` had no concept of an enclosing `namespace :admin do ... end` or `scope module: "x" do ... end` block, so a namespaced resource and a same-named top-level resource both recorded the identical bare name (e.g. `resources :badges` at the top level and inside `namespace :admin do` both recorded "badges"). #664's dead-code resolver correctly refused to guess between the two real controllers this produced, leaving both flagged dead code.
- Adds `_rails_enclosing_module_prefix`, which walks upward from a route call through its enclosing `do_block` chain, only counting `namespace :x` and `scope module: "x"` - verified against Discourse's own `routes.rb` that a bare `scope "/logs" do` (URL-only) outnumbers those 20 to 3 and must NOT contribute a module segment.
- Along the way, found and fixed a real bug in #664's own `_controller_suffix_matches`: a loose trailing-substring check let an unprefixed lookup for "badges" also match a *nested* `admin/badges_controller.rb` two levels down - so the improved namespace data alone didn't fix the collision until the matcher was anchored at a real `controllers/`-directory boundary for unprefixed (single-segment) queries.
- That anchor in turn broke several real Discourse plugins (chat, boards, discourse_automation, discourse-workflows, ...) whose engines implicitly namespace every controller under the engine's own module (`isolate_namespace`) even for an unprefixed `resources` call declared in the plugin's own routes file - a segment this extractor can't see since it isn't a namespace/scope call at all. Fixed by scoping the strict anchor to routes declared in the app's own top-level `config/routes.rb` specifically (the only file guaranteed to execute with no implicit engine wrapping); every other file keeps the original tail match.

## Test plan
- [x] 5 new unit tests: namespace/scope-module prefix composition (including arbitrary nesting depth), the bare-`scope` non-contribution case, and a dedicated regression test for the plugin-engine case that caught my own anchor-rule bug
- [x] Full suite: 1860 passed
- [x] Verified against a real, full `git clone` of discourse/discourse: 254 → 285 rescued controllers, **zero regressions** - confirmed by diffing the complete rescued-file set against the #664 baseline (not just comparing aggregate counts, which is what let the intermediate anchor-rule bug slip through undetected until I checked)