### PR TITLE
fix: RSpec spec files never recognized as tests in dead-code detection

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -61,6 +61,23 @@ TEST_PATH_PATTERNS = [
     # "androidTest" isn't matched by the tests?/__tests__ pattern above
     # since it's one fused word, not "test" as its own path segment.
     re.compile(r"(^|/)(androidTest|test)/.+\.(kt|kts|java)$"),
+    # RSpec - Ruby's dominant test framework and the one actually in play
+    # for #664/#666's own Rails dead-code work - was never added here.
+    # Its spec files don't live under a directory named "test(s)" (the
+    # generic pattern above), so every *_spec.rb was silently treated as
+    # production code. Confirmed against a real Rails app (Discourse):
+    # 3,799 real *_spec.rb files across the main app and its plugins/
+    # migrations subprojects were completely unmatched by every existing
+    # pattern, dwarfing the false-positive count #664/#666 actually fixed.
+    re.compile(r"(^|/)[^/]+_spec\.rb$"),
+    # A spec/ directory also holds non-suffixed test infrastructure (spec_
+    # helper.rb, factories, shared examples, custom matchers) that is just
+    # as much test-only code as the specs themselves - same reasoning as
+    # the generic tests?/__tests__ directory rule above, scoped to Ruby's
+    # own directory name for it. Confirmed against Discourse: 711 such
+    # files (spec_helper.rb, spec/support/**, spec/factories/**) exist
+    # alongside the 3,799 *_spec.rb files above.
+    re.compile(r"(^|/)spec/.+\.rb$"),
 ]
 
 PACKAGE_IMPORT_ALIASES = {

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -32,6 +32,49 @@ def test_test_files_are_never_unreachable(tmp_path):
     assert result["unreachable_modules"] == []
 
 
+def test_rspec_spec_files_are_never_unreachable(tmp_path):
+    # RSpec - Ruby's dominant test framework - names its files with a
+    # "_spec.rb" suffix, not a "test(s)" directory, so the generic
+    # tests?/__tests__ pattern never matched them. Real repo confirmed
+    # (discourse/discourse): 3,799 real *_spec.rb files across the main
+    # app and its plugins/migrations subprojects were completely
+    # unmatched, dwarfing the false-positive count #664/#666 fixed for
+    # the same codebase.
+    modules = [
+        _module("spec/models/user_spec.rb"),
+        _module("spec/lib/discourse/converter_spec.rb"),
+        _module("plugins/discourse-events/spec/jobs/some_job_spec.rb"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_rspec_support_files_are_never_unreachable(tmp_path):
+    # A spec/ directory also holds non-suffixed test infrastructure
+    # (spec_helper.rb, factories, shared examples, custom matchers) that
+    # is just as much test-only code as the specs themselves. Real repo
+    # confirmed (discourse/discourse): 711 such files exist alongside the
+    # 3,799 *_spec.rb files above.
+    modules = [
+        _module("spec/spec_helper.rb"),
+        _module("spec/support/matchers/have_constant.rb"),
+        _module("spec/factories/users.rb"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_ruby_file_outside_spec_directory_still_unreachable(tmp_path):
+    # The new spec/ patterns must stay scoped to the RSpec convention -
+    # a Ruby file that merely mentions "spec" in its own name outside a
+    # spec/ directory, or lives under an unrelated directory, is regular
+    # application code and must still be flagged when nothing imports it.
+    modules = [_module("app/models/inspector.rb")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    paths = [module["path"] for module in result["unreachable_modules"]]
+    assert "app/models/inspector.rb" in paths
+
+
 def test_capitalized_test_directory_is_never_unreachable(tmp_path):
     # SwiftPM/Xcode universally capitalize the test directory ("Tests/") -
     # real repo confirmed: every test file in apple/swift-algorithms lives


### PR DESCRIPTION
## Summary
- `TEST_PATH_PATTERNS` in `dead_code.py` has entries for Python (`test_*.py`/`*_test.py`), JS/TS (`.test.js`/`.spec.js`), Swift (`Tests/`), and JVM (`*Test.kt`, `androidTest/`) - but nothing for RSpec, Ruby's dominant test framework, and the exact language #664/#666 targeted with their Rails dead-code work. RSpec names files with a `_spec.rb` suffix under a `spec/` directory, not a `test(s)` directory, so the existing generic pattern never matched them.
- Found while independently re-verifying #664/#666's claims against the same real Discourse clone those PRs used (see "Independent audit" below): 3,799 real `*_spec.rb` files across the main app and its plugins/migrations subprojects were completely unmatched by every existing pattern, plus 711 non-suffixed `spec/` support files (`spec_helper.rb`, factories, shared examples, custom matchers) - all misclassified as production code and, since nothing imports a spec file, flagged dead. This is a far larger false-positive source on any real RSpec-based repo than the ~325 files #664+#666 combined rescued.
- Adds two patterns: `_spec\.rb$` (the RSpec file-naming convention) and `spec/.+\.rb$` (RSpec's directory convention, for the non-suffixed support files), scoped narrowly enough that a Ruby file merely containing "spec" in its own name outside a `spec/` directory (e.g. `inspector.rb`) is unaffected.

## Independent audit of #664/#666 (what prompted this)
Re-ran #664/#666's own methodology (a real, full `git clone` of discourse/discourse, 68,183 commits) to re-verify their published numbers before trusting them:
- Module count (15,509) and endpoint counts (1,205 pre-fix, 2,389 post-fix) reproduce **exactly** - the routing/endpoint-extraction work is solid.
- The dead-code false-positive *counts* quoted in both PR descriptions (13,261 → 12,978 for #664; 254 → 285 rescued for #666) do not reproduce under an independent re-run with the merged code: I measured 14,415 unreachable modules pre-#664 and 14,090 post-#666 - both substantially higher than what was published, for reasons that trace at least partly to this same RSpec gap (spec files were never excluded in either measurement, in the PRs or in the code itself). I'm not asserting the exact cause of that specific numeric mismatch, since the two published figures (13,261 in the summary, 13,232 in the test plan) aren't even internally consistent with each other - just noting it as unverified.

## Test plan
- [x] New regression tests: `test_rspec_spec_files_are_never_unreachable`, `test_rspec_support_files_are_never_unreachable`, `test_ruby_file_outside_spec_directory_still_unreachable` (confirmed failing before the fix, passing after)
- [x] Full suite: 1865 passed
- [x] Verified against a real, full `git clone` of discourse/discourse: unreachable-module count drops from 14,090 to 9,580 with this fix alone (4,510 files rescued - over 13x #664+#666's combined ~325)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
