### PR TITLE
fix: remaining framework dead-code gaps (Laravel resource(), ASP.NET global using, Django admin.py, Rails controller: override)

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -22,6 +22,14 @@ ENTRY_POINT_FILENAMES = {
     "manage.py",
     "server.py",
     "wsgi.py",
+    # django.contrib.admin.autodiscover() (called automatically by
+    # AdminConfig.ready() in every modern Django project) dynamically
+    # imports every installed app's own admin.py by convention - never a
+    # plain top-level import anywhere in the app's own source. Confirmed
+    # on a real repo (wagtail/wagtail): wagtail/documents/admin.py and
+    # wagtail/images/admin.py both carry a real, live @admin.register()-
+    # equivalent Django admin customization and zero imported_by.
+    "admin.py",
     # SwiftPM's build manifest - always this exact name, read by the swift
     # toolchain itself, never imported by the repo's own application code.
     "Package.swift",
@@ -174,6 +182,19 @@ _SPRING_STEREOTYPE_ANNOTATION_PATTERN = re.compile(
 # attribute/base-class signal avoids matching an unrelated project-defined
 # "Controller" base class that has nothing to do with ASP.NET Core.
 _ASPNETCORE_MVC_IMPORT_PATTERN = re.compile(r"^\s*using\s+Microsoft\.AspNetCore\.Mvc\b", re.MULTILINE)
+# C# 10's `global using` (the default in every `dotnet new` template since
+# .NET 6, almost always collected into one GlobalUsings.cs) applies the
+# import project-wide from a single declaration - a controller file itself
+# then carries no local `using Microsoft.AspNetCore.Mvc` at all. Confirmed
+# on a real repo (dotnet/eShop): every one of its MVC-style controllers
+# (HomeController.cs, ConsentController.cs, ...) declares neither a
+# same-file `using` nor the attribute/base-class import any other way -
+# the project's GlobalUsings.cs is the only place it's declared - so
+# without also checking for a project-wide `global using`, this check
+# never fired on a single real controller in a modern (.NET 6+) app.
+_ASPNET_GLOBAL_USING_MVC_PATTERN = re.compile(
+    r"^\s*global\s+using\s+Microsoft\.AspNetCore\.Mvc\b", re.MULTILINE
+)
 _ASPNET_API_CONTROLLER_ATTRIBUTE_PATTERN = re.compile(r"^\s*\[ApiController\]", re.MULTILINE)
 _ASPNET_CONTROLLER_BASE_CLASS_PATTERN = re.compile(
     r"\bclass\s+\w+\s*:\s*(?:[\w.]+\.)?(?:Controller|ControllerBase)\b"
@@ -344,14 +365,43 @@ def _has_spring_stereotype_annotation(repo_path: Path, path: str) -> bool:
     )
 
 
-def _has_aspnet_controller_convention(repo_path: Path, path: str) -> bool:
+def _aspnet_global_using_mvc_present(repo_path: Path, ignored_paths: list[str] | None = None) -> bool:
+    """Whether ANY .cs file anywhere in the repo declares `global using
+    Microsoft.AspNetCore.Mvc` - computed once repo-wide (mirroring
+    _android_manifest_entry_points/_html_script_entry_points above) rather
+    than per-file, since a global using's whole point is that it isn't
+    local to any one file. Not scoped to a single .csproj's file set (this
+    codebase has no general C# project-boundary model to scope it to) -
+    a multi-project repo where only one project declares the global using
+    could over-apply it to another project's unrelated same-named
+    "Controller" class, the same narrow false-positive risk every other
+    heuristic in this file already accepts in exchange for not missing the
+    common case entirely.
+    """
+    patterns = ignored_paths or []
+    for cs_path in repo_path.rglob("*.cs"):
+        rel_path = cs_path.relative_to(repo_path).as_posix()
+        if is_ignored(rel_path, patterns):
+            continue
+        try:
+            content = cs_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if _ASPNET_GLOBAL_USING_MVC_PATTERN.search(content):
+            return True
+    return False
+
+
+def _has_aspnet_controller_convention(
+    repo_path: Path, path: str, *, global_using_mvc: bool = False
+) -> bool:
     if not path.endswith(".cs"):
         return False
     try:
         content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return False
-    if not _ASPNETCORE_MVC_IMPORT_PATTERN.search(content):
+    if not (global_using_mvc or _ASPNETCORE_MVC_IMPORT_PATTERN.search(content)):
         return False
     return bool(
         _ASPNET_API_CONTROLLER_ATTRIBUTE_PATTERN.search(content)
@@ -710,9 +760,19 @@ def _laravel_route_reachable_files(
         handler = entry.get("handler")
         if not handler:
             continue
-        match = _LARAVEL_STRING_HANDLER_PATTERN.match(handler)
-        if not match:
-            continue
+        if entry.get("unresolved"):
+            # Route::resource()/apiResource() - handler is already the
+            # qualified controller class name straight from the route
+            # declaration (Laravel requires it explicit, unlike Rails'
+            # `resources`, which infers a controller name from the
+            # resource name by convention - no naming-convention guessing
+            # needed here at all).
+            controller_class = handler
+        else:
+            match = _LARAVEL_STRING_HANDLER_PATTERN.match(handler)
+            if not match:
+                continue
+            controller_class = match.group(1)
         # "Admin\UserController" -> ["Admin", "UserController.php"] - a
         # fully backslash-qualified handler already names its own
         # namespace segments; preserve them for a precise multi-segment
@@ -727,7 +787,7 @@ def _laravel_route_reachable_files(
         # does. Confirmed by Flash Review on #666: without this, a real
         # nested controller like app/Http/Controllers/Admin/User.php named
         # by "Admin\User@index" was wrongly left flagged as dead code.
-        segments = match.group(1).split("\\")
+        segments = controller_class.split("\\")
         segments[-1] = f"{segments[-1]}.php"
         matches = _controller_suffix_matches(
             controller_paths, segments, anchor_single_segment=False
@@ -915,6 +975,7 @@ def find_dead_code(
     swift_reachable_files = _swift_target_reachable_files(repo_path, modules, ignored_paths)
     rails_route_reachable_files = _rails_route_reachable_files(modules, api_endpoints)
     laravel_route_reachable_files = _laravel_route_reachable_files(modules, api_endpoints)
+    aspnet_global_using_mvc = _aspnet_global_using_mvc_present(repo_path, ignored_paths)
 
     unreachable_modules = []
     entry_points_detected = []
@@ -939,7 +1000,9 @@ def find_dead_code(
                 or _has_main_guard(repo_path, path)
                 or _has_hilt_dagger_annotation(repo_path, path)
                 or _has_spring_stereotype_annotation(repo_path, path)
-                or _has_aspnet_controller_convention(repo_path, path)
+                or _has_aspnet_controller_convention(
+                    repo_path, path, global_using_mvc=aspnet_global_using_mvc
+                )
                 or _has_go_main_function(repo_path, path)
                 or _has_rust_main_function(repo_path, path)
                 or _has_java_main_method(repo_path, path)

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -390,20 +390,54 @@ def _has_spring_stereotype_annotation(repo_path: Path, path: str) -> bool:
     )
 
 
-def _aspnet_global_using_mvc_present(repo_path: Path, ignored_paths: list[str] | None = None) -> bool:
-    """Whether ANY .cs file anywhere in the repo declares `global using
-    Microsoft.AspNetCore.Mvc` - computed once repo-wide (mirroring
-    _android_manifest_entry_points/_html_script_entry_points above) rather
-    than per-file, since a global using's whole point is that it isn't
-    local to any one file. Not scoped to a single .csproj's file set (this
-    codebase has no general C# project-boundary model to scope it to) -
-    a multi-project repo where only one project declares the global using
-    could over-apply it to another project's unrelated same-named
-    "Controller" class, the same narrow false-positive risk every other
-    heuristic in this file already accepts in exchange for not missing the
-    common case entirely.
+def _nearest_csproj_root(repo_path: Path, path: str) -> str | None:
+    """The directory (relative to repo_path, "" for the repo root itself)
+    of the nearest ancestor .csproj to `path` - the real C# project
+    boundary a global using's file-scope actually respects. None if no
+    .csproj exists anywhere above it (rare for a real repo - almost every
+    C# project the SDK builds has one - and handled by the caller as an
+    unscopeable file, not silently treated as its own single-file
+    project)."""
+    current = (repo_path / path).parent
+    while True:
+        try:
+            if any(current.glob("*.csproj")):
+                return current.relative_to(repo_path).as_posix()
+        except OSError:
+            pass
+        if current == repo_path:
+            return None
+        current = current.parent
+
+
+def _aspnet_global_using_mvc_projects(
+    repo_path: Path, ignored_paths: list[str] | None = None
+) -> tuple[set[str], bool]:
+    """(project roots that declare `global using Microsoft.AspNetCore.Mvc`
+    in one of their own .cs files, whether any *unscopeable* .cs file -
+    no discoverable .csproj above it at all - declares it).
+
+    Real bug found via Flash Review on #668, confirmed directly against a
+    synthetic two-project repro (ProjectA declares the global using,
+    ProjectB doesn't and has no ASP.NET Core dependency at all) after the
+    first fix attempt (obj/ IGNORED_DIRS only) turned out not to address
+    it: a single repo-wide boolean, even with generated build output
+    correctly excluded, still over-applies one real project's own global
+    using to every unrelated project sharing the same git repository - a
+    very real shape for .NET (eShop, this fix's own real-repo test
+    subject, is itself a multi-project microservices repo: Identity.API,
+    Ordering.API, Catalog.API, Basket.API each their own project).
+
+    Scoping to the nearest .csproj (the real project boundary a global
+    using's file-scope respects) instead of the whole repo closes that
+    gap. The rare .csproj-less file (no SDK project structure at all
+    above it) can't be scoped to anything, so it still applies repo-wide
+    for other similarly-unscopeable files only - not to files that DO
+    have their own, different, csproj that simply doesn't declare it.
     """
     patterns = ignored_paths or []
+    projects: set[str] = set()
+    unscopeable_present = False
     for cs_path in repo_path.rglob("*.cs"):
         rel_path = cs_path.relative_to(repo_path).as_posix()
         rel_parts = cs_path.relative_to(repo_path).parts
@@ -412,25 +446,30 @@ def _aspnet_global_using_mvc_present(repo_path: Path, ignored_paths: list[str] |
         # this module's own IGNORED_DIRS comment documents that .NET's
         # `obj/` build directory fills with SDK-generated files, including
         # a GlobalUsings.g.cs that itself declares `global using
-        # Microsoft.AspNetCore.Mvc`. Without this check, real,
-        # SDK-generated build output from ANY one project would leak this
-        # signal repo-wide (this function has no per-project scoping - see
-        # its docstring) and wrongly mark an unrelated Controller class in
-        # a completely different project as an entry point. Confirmed via
-        # a real repo audit (peer session review of this PR).
+        # Microsoft.AspNetCore.Mvc`. Confirmed via a real repo audit (peer
+        # session review of this PR).
         if any(part in IGNORED_DIRS for part in rel_parts) or is_ignored(rel_path, patterns):
             continue
         try:
             content = cs_path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        if _ASPNET_GLOBAL_USING_MVC_PATTERN.search(content):
-            return True
-    return False
+        if not _ASPNET_GLOBAL_USING_MVC_PATTERN.search(content):
+            continue
+        project_root = _nearest_csproj_root(repo_path, rel_path)
+        if project_root is not None:
+            projects.add(project_root)
+        else:
+            unscopeable_present = True
+    return projects, unscopeable_present
 
 
 def _has_aspnet_controller_convention(
-    repo_path: Path, path: str, *, global_using_mvc: bool = False
+    repo_path: Path,
+    path: str,
+    *,
+    global_using_mvc_projects: set[str] | None = None,
+    global_using_mvc_unscopeable: bool = False,
 ) -> bool:
     if not path.endswith(".cs"):
         return False
@@ -438,7 +477,16 @@ def _has_aspnet_controller_convention(
         content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return False
-    if not (global_using_mvc or _ASPNETCORE_MVC_IMPORT_PATTERN.search(content)):
+    project_root = _nearest_csproj_root(repo_path, path)
+    has_global_using = (
+        (project_root in global_using_mvc_projects if global_using_mvc_projects else False)
+        if project_root is not None
+        # No discoverable .csproj for this file either - fall back to the
+        # unscoped signal, since there's no project boundary to scope
+        # either side to.
+        else global_using_mvc_unscopeable
+    )
+    if not (has_global_using or _ASPNETCORE_MVC_IMPORT_PATTERN.search(content)):
         return False
     return bool(
         _ASPNET_API_CONTROLLER_ATTRIBUTE_PATTERN.search(content)
@@ -1036,7 +1084,9 @@ def find_dead_code(
     swift_reachable_files = _swift_target_reachable_files(repo_path, modules, ignored_paths)
     rails_route_reachable_files = _rails_route_reachable_files(modules, api_endpoints)
     laravel_route_reachable_files = _laravel_route_reachable_files(modules, api_endpoints)
-    aspnet_global_using_mvc = _aspnet_global_using_mvc_present(repo_path, ignored_paths)
+    aspnet_global_using_mvc_projects, aspnet_global_using_mvc_unscopeable = (
+        _aspnet_global_using_mvc_projects(repo_path, ignored_paths)
+    )
 
     unreachable_modules = []
     entry_points_detected = []
@@ -1063,7 +1113,10 @@ def find_dead_code(
                 or _has_hilt_dagger_annotation(repo_path, path)
                 or _has_spring_stereotype_annotation(repo_path, path)
                 or _has_aspnet_controller_convention(
-                    repo_path, path, global_using_mvc=aspnet_global_using_mvc
+                    repo_path,
+                    path,
+                    global_using_mvc_projects=aspnet_global_using_mvc_projects,
+                    global_using_mvc_unscopeable=aspnet_global_using_mvc_unscopeable,
                 )
                 or _has_go_main_function(repo_path, path)
                 or _has_rust_main_function(repo_path, path)

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -22,14 +22,6 @@ ENTRY_POINT_FILENAMES = {
     "manage.py",
     "server.py",
     "wsgi.py",
-    # django.contrib.admin.autodiscover() (called automatically by
-    # AdminConfig.ready() in every modern Django project) dynamically
-    # imports every installed app's own admin.py by convention - never a
-    # plain top-level import anywhere in the app's own source. Confirmed
-    # on a real repo (wagtail/wagtail): wagtail/documents/admin.py and
-    # wagtail/images/admin.py both carry a real, live @admin.register()-
-    # equivalent Django admin customization and zero imported_by.
-    "admin.py",
     # SwiftPM's build manifest - always this exact name, read by the swift
     # toolchain itself, never imported by the repo's own application code.
     "Package.swift",
@@ -352,6 +344,39 @@ def _has_csharp_main_method(repo_path: Path, path: str) -> bool:
     return bool(_CSHARP_MAIN_METHOD_PATTERN.search(content))
 
 
+# django.contrib.admin.autodiscover() (called automatically by
+# AdminConfig.ready() in every modern Django project) dynamically imports
+# every installed app's own admin.py by convention - never a plain
+# top-level import anywhere in the app's own source. Confirmed on a real
+# repo (wagtail/wagtail): wagtail/documents/admin.py and
+# wagtail/images/admin.py both carry a real, live admin registration and
+# zero imported_by. Gated on a same-file Django admin import rather than
+# added to ENTRY_POINT_FILENAMES as a bare basename - "admin.py" is a
+# common enough filename outside Django (this module's own routes.rb
+# addition explicitly rejected Laravel's web.php/api.php on that same
+# risk) that an unconditional basename match would exempt a genuinely
+# dead, unrelated admin.py in any non-Django repo from ever being
+# flagged. Confirmed via a real repo audit (peer session review of this
+# PR).
+_DJANGO_CONTRIB_ADMIN_MODULE_PATTERN = re.compile(r"\bdjango\.contrib\.admin\b")
+_DJANGO_CONTRIB_IMPORT_ADMIN_PATTERN = re.compile(
+    r"^\s*from\s+django\.contrib\s+import\s+.*\badmin\b", re.MULTILINE
+)
+
+
+def _has_django_admin_import(repo_path: Path, path: str) -> bool:
+    if path.rsplit("/", 1)[-1] != "admin.py":
+        return False
+    try:
+        content = (repo_path / path).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return bool(
+        _DJANGO_CONTRIB_ADMIN_MODULE_PATTERN.search(content)
+        or _DJANGO_CONTRIB_IMPORT_ADMIN_PATTERN.search(content)
+    )
+
+
 def _has_spring_stereotype_annotation(repo_path: Path, path: str) -> bool:
     if not path.endswith((".java", ".kt", ".kts")):
         return False
@@ -381,7 +406,19 @@ def _aspnet_global_using_mvc_present(repo_path: Path, ignored_paths: list[str] |
     patterns = ignored_paths or []
     for cs_path in repo_path.rglob("*.cs"):
         rel_path = cs_path.relative_to(repo_path).as_posix()
-        if is_ignored(rel_path, patterns):
+        rel_parts = cs_path.relative_to(repo_path).parts
+        # Same IGNORED_DIRS check _html_script_entry_points already makes
+        # above - critical here specifically, not just for consistency:
+        # this module's own IGNORED_DIRS comment documents that .NET's
+        # `obj/` build directory fills with SDK-generated files, including
+        # a GlobalUsings.g.cs that itself declares `global using
+        # Microsoft.AspNetCore.Mvc`. Without this check, real,
+        # SDK-generated build output from ANY one project would leak this
+        # signal repo-wide (this function has no per-project scoping - see
+        # its docstring) and wrongly mark an unrelated Controller class in
+        # a completely different project as an entry point. Confirmed via
+        # a real repo audit (peer session review of this PR).
+        if any(part in IGNORED_DIRS for part in rel_parts) or is_ignored(rel_path, patterns):
             continue
         try:
             content = cs_path.read_text(encoding="utf-8", errors="ignore")
@@ -787,7 +824,31 @@ def _laravel_route_reachable_files(
         # does. Confirmed by Flash Review on #666: without this, a real
         # nested controller like app/Http/Controllers/Admin/User.php named
         # by "Admin\User@index" was wrongly left flagged as dead code.
-        segments = controller_class.split("\\")
+        #
+        # A leading backslash (`\App\Http\Controllers\UserController`, a
+        # valid, fairly common fully-root-qualified PHP class reference)
+        # must be stripped before splitting - otherwise the leading empty
+        # string it produces derails every segment after it, so the query
+        # never matches any real path. Confirmed via a real repo audit
+        # (peer session review of this PR): reproduced end-to-end for both
+        # this resolver's `unresolved` branch and the pre-existing legacy
+        # string-handler branch above (`_LARAVEL_STRING_HANDLER_PATTERN`
+        # already permitted a leading backslash on that form too, since
+        # #666 - a shared bug in this one resolver, not specific to either
+        # branch).
+        segments = controller_class.lstrip("\\").split("\\")
+        # Laravel's own default composer.json PSR-4 mapping is
+        # "App\\": "app/" - the namespace root stays capitalized ("App")
+        # while the directory it maps to is lowercase ("app/"), confirmed
+        # against a real repo's actual composer.json (koel/koel). Every
+        # other segment matches its directory/file name exactly
+        # case-sensitively; only this one, near-universal root mapping
+        # needs normalizing - caught by this PR's own new leading-backslash
+        # regression tests still failing after the lstrip fix alone, since
+        # a fully-qualified "App\Http\Controllers\UserController" produces
+        # segment "App", which no real path (lowercase "app/...") matches.
+        if segments and segments[0] == "App":
+            segments[0] = "app"
         segments[-1] = f"{segments[-1]}.php"
         matches = _controller_suffix_matches(
             controller_paths, segments, anchor_single_segment=False
@@ -998,6 +1059,7 @@ def find_dead_code(
                 path in html_script_entry_points
                 or path in android_manifest_entry_points
                 or _has_main_guard(repo_path, path)
+                or _has_django_admin_import(repo_path, path)
                 or _has_hilt_dagger_annotation(repo_path, path)
                 or _has_spring_stereotype_annotation(repo_path, path)
                 or _has_aspnet_controller_convention(

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -390,21 +390,46 @@ def _has_spring_stereotype_annotation(repo_path: Path, path: str) -> bool:
     )
 
 
-def _nearest_csproj_root(repo_path: Path, path: str) -> str | None:
+# Sentinel for _nearest_csproj_root: more than one .csproj shares the
+# nearest ancestor directory (sibling projects flattened into one folder -
+# a real but rare layout; standard SDK/IDE tooling always gives each
+# project its own directory). Distinct from "no .csproj found at all" -
+# merging the two would still recreate the exact cross-project leak this
+# whole mechanism exists to prevent: a candidate file and the file
+# declaring the global using could sit in the very same ambiguous
+# directory, so both would land in the same "unscopeable" fallback bucket
+# and the global using would still wrongly apply to a sibling project's
+# unrelated same-named "Controller" class. Confirmed by a second, distinct
+# Flash Review finding on this same PR (#668) after the first
+# project-scoping fix - real, verified directly with a synthetic
+# same-directory two-.csproj repro before implementing this.
+_AMBIGUOUS_CSPROJ_DIR = object()
+
+
+def _nearest_csproj_root(repo_path: Path, path: str) -> str | None | object:
     """The directory (relative to repo_path, "" for the repo root itself)
     of the nearest ancestor .csproj to `path` - the real C# project
-    boundary a global using's file-scope actually respects. None if no
-    .csproj exists anywhere above it (rare for a real repo - almost every
-    C# project the SDK builds has one - and handled by the caller as an
-    unscopeable file, not silently treated as its own single-file
-    project)."""
+    boundary a global using's file-scope actually respects.
+
+    None if no .csproj exists anywhere above it (rare for a real repo -
+    almost every C# project the SDK builds has one - handled by the
+    caller as an unscopeable file, not silently treated as its own
+    single-file project). _AMBIGUOUS_CSPROJ_DIR if the nearest ancestor
+    directory contains more than one .csproj - project membership can't
+    be determined from directory alone, so the caller must not attribute
+    ANY project's global using to a file in this state, in either
+    direction (never assume it has one THAT ISN'T ITS OWN, and never
+    contribute its own declared global using to any project's set)."""
     current = (repo_path / path).parent
     while True:
         try:
-            if any(current.glob("*.csproj")):
-                return current.relative_to(repo_path).as_posix()
+            matches = list(current.glob("*.csproj"))
         except OSError:
-            pass
+            matches = []
+        if len(matches) > 1:
+            return _AMBIGUOUS_CSPROJ_DIR
+        if len(matches) == 1:
+            return current.relative_to(repo_path).as_posix()
         if current == repo_path:
             return None
         current = current.parent
@@ -457,10 +482,13 @@ def _aspnet_global_using_mvc_projects(
         if not _ASPNET_GLOBAL_USING_MVC_PATTERN.search(content):
             continue
         project_root = _nearest_csproj_root(repo_path, rel_path)
-        if project_root is not None:
-            projects.add(project_root)
-        else:
+        if project_root is None:
             unscopeable_present = True
+        elif project_root is not _AMBIGUOUS_CSPROJ_DIR:
+            projects.add(project_root)
+        # else: ambiguous directory - contribute nothing either way (see
+        # _AMBIGUOUS_CSPROJ_DIR's own docstring for why merging this into
+        # either the "projects" or "unscopeable" bucket would still leak).
     return projects, unscopeable_present
 
 
@@ -478,14 +506,15 @@ def _has_aspnet_controller_convention(
     except OSError:
         return False
     project_root = _nearest_csproj_root(repo_path, path)
-    has_global_using = (
-        (project_root in global_using_mvc_projects if global_using_mvc_projects else False)
-        if project_root is not None
+    if project_root is _AMBIGUOUS_CSPROJ_DIR:
+        has_global_using = False
+    elif project_root is not None:
+        has_global_using = project_root in global_using_mvc_projects if global_using_mvc_projects else False
+    else:
         # No discoverable .csproj for this file either - fall back to the
         # unscoped signal, since there's no project boundary to scope
         # either side to.
-        else global_using_mvc_unscopeable
-    )
+        has_global_using = global_using_mvc_unscopeable
     if not (has_global_using or _ASPNETCORE_MVC_IMPORT_PATTERN.search(content)):
         return False
     return bool(

--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -38,6 +38,16 @@ _SPRING_VERB_ANNOTATIONS = {
 _VAPOR_VERB_METHODS = {"get", "post", "put", "delete", "patch"}
 _RAILS_ROUTE_METHODS = {"get", "post", "put", "patch", "delete"}
 _LARAVEL_ROUTE_METHODS = {"get", "post", "put", "delete", "patch", "any"}
+# Laravel's direct equivalent of Rails' `resources` - generates all 7
+# RESTful actions for a controller in one call. Unlike Rails, the
+# controller is always an explicit second argument (::class reference or,
+# in older code, a bare string), never inferred from the resource name by
+# naming convention - confirmed empirically: this call form was completely
+# unextracted before, a real gap of exactly the same shape and likely
+# equal or greater real-world prevalence as the Rails `resources` gap
+# #664 fixed, since Route::resource()/apiResource() is Laravel's own
+# standard CRUD-controller idiom.
+_LARAVEL_RESOURCE_METHODS = {"resource", "apiResource"}
 _ASPNET_ATTRIBUTE_METHODS = {
     "HttpGet": "GET",
     "HttpPost": "POST",
@@ -1408,6 +1418,26 @@ def _extract_rails_routes(root: Node, source: bytes, rel_path: str) -> list[dict
                         resource_name = source[
                             named[0].start_byte : named[0].end_byte
                         ].decode().lstrip(":")
+                        # `resources :keys, controller: "api"` - a real,
+                        # live line in Discourse's own config/routes.rb
+                        # (config/routes.rb:356) - routes the "keys"
+                        # resource to ApiController, not KeysController.
+                        # Without checking for this override, the resource
+                        # name alone silently names the wrong controller.
+                        for arg in named:
+                            if arg.type != "pair":
+                                continue
+                            key = arg.child_by_field_name("key")
+                            value = arg.child_by_field_name("value")
+                            if (
+                                key is not None
+                                and key.type == "hash_key_symbol"
+                                and source[key.start_byte : key.end_byte].decode() == "controller"
+                                and value is not None
+                                and value.type == "string"
+                            ):
+                                resource_name = _ruby_string_content(value, source)
+                                break
                         module_prefix = _rails_enclosing_module_prefix(n, source)
                         if module_prefix:
                             resource_name = "/".join([*module_prefix, resource_name])
@@ -1457,6 +1487,25 @@ def _laravel_handler_label(node: Node | None, source: bytes) -> str:
     if node.type == "anonymous_function":
         return "<inline handler>"
     return "unknown"
+
+
+def _laravel_resource_controller_class(node: Node | None, source: bytes) -> str | None:
+    """The qualified controller class name from a Route::resource()/
+    apiResource() second argument - either `Admin\\UserController::class`
+    (a class_constant_access_expression whose first child is a `name` for
+    an unqualified reference or `qualified_name` for a namespaced one,
+    text already backslash-joined either way) or the older bare-string
+    form, `'UserController'`."""
+    if node is None:
+        return None
+    if node.type == "class_constant_access_expression" and node.children:
+        first = node.children[0]
+        if first.type in ("name", "qualified_name"):
+            return source[first.start_byte : first.end_byte].decode()
+        return None
+    if node.type == "string":
+        return _php_string_content(node, source)
+    return None
 
 
 def _laravel_group_note(call_node: Node, source: bytes) -> str | None:
@@ -1548,6 +1597,29 @@ def _extract_laravel_routes(root: Node, source: bytes, rel_path: str) -> list[di
                                     "line": line,
                                     "handler": handler,
                                     "unresolved": False,
+                                    "note": note,
+                                }
+                            )
+                    elif (
+                        method_name in _LARAVEL_RESOURCE_METHODS
+                        and len(arg_values) >= 2
+                        and arg_values[0] is not None
+                        and arg_values[0].type == "string"
+                    ):
+                        path = _php_string_content(arg_values[0], source)
+                        controller_class = _laravel_resource_controller_class(
+                            arg_values[1], source
+                        )
+                        if controller_class is not None:
+                            entries.append(
+                                {
+                                    "method": None,
+                                    "path": path,
+                                    "framework": "laravel",
+                                    "file": rel_path,
+                                    "line": line,
+                                    "handler": controller_class,
+                                    "unresolved": True,
                                     "note": note,
                                 }
                             )

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -22,6 +22,20 @@ def test_recognized_entry_point_is_never_unreachable(tmp_path):
     assert set(result["entry_points_detected"]) == {"main.py", "app/__main__.py", "index.js"}
 
 
+def test_django_admin_py_is_never_unreachable(tmp_path):
+    # Real gap found via audit against a real repo (wagtail/wagtail):
+    # django.contrib.admin.autodiscover() (called automatically by
+    # AdminConfig.ready() in every modern Django project) dynamically
+    # imports every installed app's own admin.py by convention - never a
+    # plain top-level import anywhere in the app's own source. Confirmed:
+    # wagtail/documents/admin.py and wagtail/images/admin.py both carry
+    # real, live admin registrations and zero imported_by.
+    modules = [_module("myapp/admin.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "myapp/admin.py" in result["entry_points_detected"]
+
+
 def test_test_files_are_never_unreachable(tmp_path):
     modules = [
         _module("tests/test_thing.py"),
@@ -1029,6 +1043,35 @@ def test_aspnet_controller_pattern_requires_aspnetcore_mvc_import(tmp_path):
     assert "Foo.cs" in [m["path"] for m in result["unreachable_modules"]]
 
 
+def test_aspnet_controller_via_project_wide_global_using_is_never_unreachable(tmp_path):
+    # Real gap found via audit against a real repo (dotnet/eShop): C# 10's
+    # `global using` (the default in every `dotnet new` template since
+    # .NET 6, almost always collected into one GlobalUsings.cs) applies
+    # project-wide from a single declaration, so a real controller file
+    # can carry neither a same-file `using Microsoft.AspNetCore.Mvc` nor
+    # any other local import at all - confirmed on eShop's own
+    # HomeController.cs/ConsentController.cs/etc, none of which declare
+    # the import locally. Without checking for a global using anywhere in
+    # the repo, this check never fired on a single real controller in a
+    # modern (.NET 6+) app.
+    (tmp_path / "GlobalUsings.cs").write_text(
+        "global using Microsoft.AspNetCore.Mvc;\n"
+    )
+    quickstart_dir = tmp_path / "Quickstart" / "Home"
+    quickstart_dir.mkdir(parents=True)
+    (quickstart_dir / "HomeController.cs").write_text(
+        "namespace IdentityServerHost.Quickstart.UI\n{\n"
+        "    public class HomeController : Controller\n    {\n"
+        "        public IActionResult Index() { return View(); }\n    }\n}\n"
+    )
+    modules = [
+        _module("GlobalUsings.cs"),
+        _module("Quickstart/Home/HomeController.cs"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "Quickstart/Home/HomeController.cs" in result["entry_points_detected"]
+
+
 def test_rails_controller_named_only_in_routes_rb_is_never_unreachable(tmp_path):
     # Real bug found via a real Discourse scan (68,183-commit clone): Rails
     # dispatches `to: "users#show"` and `resources :name` route entries to
@@ -1253,6 +1296,85 @@ def test_laravel_backslash_qualified_string_handler_resolves_a_nested_controller
             "handler": "Admin\\UserController@index",
             "path": "/admin/users",
             "unresolved": False,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []
+
+
+def test_laravel_route_resource_controller_is_never_unreachable(tmp_path):
+    # Real gap found via audit: Route::resource()/apiResource() - Laravel's
+    # own standard CRUD-controller idiom, direct equivalent of Rails'
+    # `resources` - was completely unextracted, so any controller wired up
+    # this way (arguably Laravel's single most common controller pattern)
+    # was always flagged dead code.
+    controllers_dir = tmp_path / "app" / "Http" / "Controllers"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "UserController.php").write_text(
+        "<?php\nnamespace App\\Http\\Controllers;\n\nclass UserController {\n"
+        "    public function index() { return []; }\n}\n"
+    )
+    modules = [_module("app/Http/Controllers/UserController.php")]
+    api_endpoints = [
+        {
+            "framework": "laravel",
+            "handler": "UserController",
+            "path": "users",
+            "unresolved": True,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []
+
+
+def test_laravel_route_resource_namespaced_controller_resolves_uniquely(tmp_path):
+    controllers_dir = tmp_path / "app" / "Http" / "Controllers" / "Admin"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "UserController.php").write_text(
+        "<?php\nnamespace App\\Http\\Controllers\\Admin;\n\nclass UserController {}\n"
+    )
+    other_dir = tmp_path / "app" / "Http" / "Controllers"
+    (other_dir / "UserController.php").write_text(
+        "<?php\nnamespace App\\Http\\Controllers;\n\nclass UserController {}\n"
+    )
+    modules = [
+        _module("app/Http/Controllers/Admin/UserController.php"),
+        _module("app/Http/Controllers/UserController.php"),
+    ]
+    api_endpoints = [
+        {
+            "framework": "laravel",
+            "handler": "Admin\\UserController",
+            "path": "admin/users",
+            "unresolved": True,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    unreachable_paths = {m["path"] for m in result["unreachable_modules"]}
+    # The namespaced one resolves via its full qualified name...
+    assert "app/Http/Controllers/Admin/UserController.php" not in unreachable_paths
+    # ...while the unrelated top-level one, never named by any route here,
+    # correctly stays flagged.
+    assert "app/Http/Controllers/UserController.php" in unreachable_paths
+
+
+def test_rails_resources_controller_override_resolves_the_real_controller(tmp_path):
+    # End-to-end version of the config/routes.rb:356 Discourse bug: without
+    # honoring the `controller:` override, dead_code.py would look for
+    # (and fail to find) a nonexistent keys_controller.rb instead of the
+    # real api_controller.rb.
+    (tmp_path / "app" / "controllers").mkdir(parents=True)
+    (tmp_path / "app" / "controllers" / "api_controller.rb").write_text(
+        "class ApiController < ApplicationController\nend\n"
+    )
+    modules = [_module("app/controllers/api_controller.rb")]
+    api_endpoints = [
+        {
+            "framework": "rails",
+            "handler": "resources(...)",
+            "path": "api",
+            "unresolved": True,
+            "file": "config/routes.rb",
         },
     ]
     result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1187,6 +1187,41 @@ def test_aspnet_global_using_falls_back_to_repo_wide_with_no_csproj_anywhere(tmp
     assert "Foo.cs" in result["entry_points_detected"]
 
 
+def test_aspnet_global_using_in_ambiguous_shared_csproj_dir_is_not_applied(tmp_path):
+    # Second, distinct Flash Review finding on #668 after the first
+    # project-scoping fix: two .csproj files sharing one directory (a
+    # real but rare layout - standard SDK/IDE tooling always gives each
+    # project its own directory) means directory alone can't determine
+    # project membership. Simply merging this into the "no .csproj found"
+    # bucket would NOT actually fix the leak, confirmed by reasoning
+    # through it directly before implementing: the declaring file and a
+    # candidate file could both sit in this same ambiguous directory, so
+    # both would land in the identical fallback bucket and the leak would
+    # reproduce exactly as before. Must instead apply NO global-using
+    # signal at all to a file in an ambiguous directory, in either
+    # direction.
+    shared_dir = tmp_path / "SharedDir"
+    shared_dir.mkdir()
+    (shared_dir / "ProjectA.csproj").write_text(
+        '<Project Sdk="Microsoft.NET.Sdk.Web"></Project>\n'
+    )
+    (shared_dir / "ProjectB.csproj").write_text(
+        '<Project Sdk="Microsoft.NET.Sdk"></Project>\n'
+    )
+    (shared_dir / "GlobalUsings.cs").write_text(
+        "global using Microsoft.AspNetCore.Mvc;\n"
+    )
+    (shared_dir / "Foo.cs").write_text(
+        "namespace SharedDir {\n    class Foo : Controller {}\n}\n"
+    )
+    modules = [
+        _module("SharedDir/GlobalUsings.cs"),
+        _module("SharedDir/Foo.cs"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "SharedDir/Foo.cs" in [m["path"] for m in result["unreachable_modules"]]
+
+
 def test_rails_controller_named_only_in_routes_rb_is_never_unreachable(tmp_path):
     # Real bug found via a real Discourse scan (68,183-commit clone): Rails
     # dispatches `to: "users#show"` and `resources :name` route entries to

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -30,10 +30,32 @@ def test_django_admin_py_is_never_unreachable(tmp_path):
     # plain top-level import anywhere in the app's own source. Confirmed:
     # wagtail/documents/admin.py and wagtail/images/admin.py both carry
     # real, live admin registrations and zero imported_by.
+    app_dir = tmp_path / "myapp"
+    app_dir.mkdir()
+    (app_dir / "admin.py").write_text(
+        "from django.contrib import admin\n\nfrom myapp.models import Widget\n\n"
+        "admin.site.register(Widget)\n"
+    )
     modules = [_module("myapp/admin.py")]
     result = find_dead_code(tmp_path, modules, config=None)
     assert result["unreachable_modules"] == []
     assert "myapp/admin.py" in result["entry_points_detected"]
+
+
+def test_unrelated_non_django_admin_py_is_not_exempted(tmp_path):
+    # Real false-negative risk found via peer review of this PR: "admin.py"
+    # is a common enough filename outside Django (this same module's own
+    # routes.rb addition explicitly rejected Laravel's web.php/api.php on
+    # this exact risk) that an unconditional basename match would exempt a
+    # genuinely dead, unrelated admin.py with no Django import at all.
+    app_dir = tmp_path / "myapp"
+    app_dir.mkdir()
+    (app_dir / "admin.py").write_text(
+        "def totally_unrelated_dead_function():\n    pass\n"
+    )
+    modules = [_module("myapp/admin.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "myapp/admin.py" in [m["path"] for m in result["unreachable_modules"]]
 
 
 def test_test_files_are_never_unreachable(tmp_path):
@@ -1072,6 +1094,30 @@ def test_aspnet_controller_via_project_wide_global_using_is_never_unreachable(tm
     assert "Quickstart/Home/HomeController.cs" in result["entry_points_detected"]
 
 
+def test_aspnet_global_using_in_obj_build_dir_is_ignored(tmp_path):
+    # Real bug found via peer review of this PR: .NET's `obj/` intermediate
+    # build directory fills with SDK-generated files, including a
+    # GlobalUsings.g.cs that itself declares `global using
+    # Microsoft.AspNetCore.Mvc` for every project the SDK builds - this
+    # repo's own IGNORED_DIRS already documents exactly that. Without
+    # skipping obj/ here the same way _html_script_entry_points already
+    # skips it, generated build output from ANY one project would leak
+    # this signal repo-wide and wrongly mark an unrelated same-named
+    # "Controller" class in a completely different, non-ASP.NET project as
+    # an entry point.
+    obj_dir = tmp_path / "SomeOtherProject" / "obj" / "Debug"
+    obj_dir.mkdir(parents=True)
+    (obj_dir / "GlobalUsings.g.cs").write_text(
+        "global using Microsoft.AspNetCore.Mvc;\n"
+    )
+    (tmp_path / "Foo.cs").write_text(
+        "namespace MyApp {\n    class Foo : Controller {}\n}\n"
+    )
+    modules = [_module("Foo.cs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "Foo.cs" in [m["path"] for m in result["unreachable_modules"]]
+
+
 def test_rails_controller_named_only_in_routes_rb_is_never_unreachable(tmp_path):
     # Real bug found via a real Discourse scan (68,183-commit clone): Rails
     # dispatches `to: "users#show"` and `resources :name` route entries to
@@ -1356,6 +1402,55 @@ def test_laravel_route_resource_namespaced_controller_resolves_uniquely(tmp_path
     # ...while the unrelated top-level one, never named by any route here,
     # correctly stays flagged.
     assert "app/Http/Controllers/UserController.php" in unreachable_paths
+
+
+def test_laravel_leading_backslash_fully_qualified_class_ref_resolves(tmp_path):
+    # Real bug found via peer review of this PR: `\App\Http\Controllers\
+    # UserController::class` (a valid, fairly common fully-root-qualified
+    # PHP class reference) parses with the leading backslash included in
+    # its text span. Splitting that on "\\" produces a leading empty
+    # string, which derails every segment after it and never matches any
+    # real path - reproduced end-to-end before the fix, both for this
+    # resolver's `unresolved` (Route::resource()) branch here and for the
+    # pre-existing legacy string-handler branch below, which shared the
+    # same bug since #666.
+    controllers_dir = tmp_path / "app" / "Http" / "Controllers"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "UserController.php").write_text(
+        "<?php\nnamespace App\\Http\\Controllers;\n\nclass UserController {}\n"
+    )
+    modules = [_module("app/Http/Controllers/UserController.php")]
+    api_endpoints = [
+        {
+            "framework": "laravel",
+            "handler": "\\App\\Http\\Controllers\\UserController",
+            "path": "users",
+            "unresolved": True,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []
+
+
+def test_laravel_leading_backslash_legacy_string_handler_resolves(tmp_path):
+    # Same bug, the pre-existing (#666) legacy string-handler branch.
+    controllers_dir = tmp_path / "app" / "Http" / "Controllers"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "UserController.php").write_text(
+        "<?php\nnamespace App\\Http\\Controllers;\n\nclass UserController {\n"
+        "    public function index() {}\n}\n"
+    )
+    modules = [_module("app/Http/Controllers/UserController.php")]
+    api_endpoints = [
+        {
+            "framework": "laravel",
+            "handler": "\\App\\Http\\Controllers\\UserController@index",
+            "path": "/users",
+            "unresolved": False,
+        },
+    ]
+    result = find_dead_code(tmp_path, modules, config=None, api_endpoints=api_endpoints)
+    assert result["unreachable_modules"] == []
 
 
 def test_rails_resources_controller_override_resolves_the_real_controller(tmp_path):

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1118,6 +1118,75 @@ def test_aspnet_global_using_in_obj_build_dir_is_ignored(tmp_path):
     assert "Foo.cs" in [m["path"] for m in result["unreachable_modules"]]
 
 
+def test_aspnet_global_using_does_not_leak_across_csproj_projects(tmp_path):
+    # Real bug found via Flash Review on #668, confirmed directly after the
+    # obj/ fix above turned out not to address it: a single repo-wide
+    # boolean, even with generated build output excluded, still
+    # over-applies one project's own global using to a completely
+    # unrelated project sharing the same git repository - a very real
+    # shape for .NET (eShop, this fix's own real-repo test subject, is
+    # itself multi-project: Identity.API, Ordering.API, Catalog.API,
+    # Basket.API each their own project).
+    (tmp_path / "ProjectA").mkdir()
+    (tmp_path / "ProjectA" / "ProjectA.csproj").write_text(
+        '<Project Sdk="Microsoft.NET.Sdk.Web"></Project>\n'
+    )
+    (tmp_path / "ProjectA" / "GlobalUsings.cs").write_text(
+        "global using Microsoft.AspNetCore.Mvc;\n"
+    )
+    (tmp_path / "ProjectB").mkdir()
+    (tmp_path / "ProjectB" / "ProjectB.csproj").write_text(
+        '<Project Sdk="Microsoft.NET.Sdk"></Project>\n'
+    )
+    (tmp_path / "ProjectB" / "Foo.cs").write_text(
+        "namespace ProjectB {\n    class Foo : Controller {}\n}\n"
+    )
+    modules = [
+        _module("ProjectA/GlobalUsings.cs"),
+        _module("ProjectB/Foo.cs"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    # ProjectB has no ASP.NET Core dependency and no global using of its
+    # own - Foo.cs must stay flagged, not get swept up by ProjectA's.
+    assert "ProjectB/Foo.cs" in [m["path"] for m in result["unreachable_modules"]]
+
+
+def test_aspnet_global_using_still_applies_within_its_own_project(tmp_path):
+    (tmp_path / "ProjectA").mkdir()
+    (tmp_path / "ProjectA" / "ProjectA.csproj").write_text(
+        '<Project Sdk="Microsoft.NET.Sdk.Web"></Project>\n'
+    )
+    (tmp_path / "ProjectA" / "GlobalUsings.cs").write_text(
+        "global using Microsoft.AspNetCore.Mvc;\n"
+    )
+    (tmp_path / "ProjectA" / "Foo.cs").write_text(
+        "namespace ProjectA {\n    class Foo : Controller {}\n}\n"
+    )
+    modules = [
+        _module("ProjectA/GlobalUsings.cs"),
+        _module("ProjectA/Foo.cs"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "ProjectA/Foo.cs" in result["entry_points_detected"]
+
+
+def test_aspnet_global_using_falls_back_to_repo_wide_with_no_csproj_anywhere(tmp_path):
+    # A repo with no .csproj at all (no discoverable project boundary for
+    # either the declaring file or the candidate file) can't be scoped to
+    # anything real - falls back to the pre-scoping repo-wide behavior for
+    # this specific case only, matching every earlier synthetic test in
+    # this file that never bothered creating a .csproj fixture.
+    (tmp_path / "GlobalUsings.cs").write_text(
+        "global using Microsoft.AspNetCore.Mvc;\n"
+    )
+    (tmp_path / "Foo.cs").write_text(
+        "namespace MyApp {\n    class Foo : Controller {}\n}\n"
+    )
+    modules = [_module("GlobalUsings.cs"), _module("Foo.cs")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "Foo.cs" in result["entry_points_detected"]
+
+
 def test_rails_controller_named_only_in_routes_rb_is_never_unreachable(tmp_path):
     # Real bug found via a real Discourse scan (68,183-commit clone): Rails
     # dispatches `to: "users#show"` and `resources :name` route entries to

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -1179,6 +1179,21 @@ def test_extract_rails_resources_is_unresolved():
     ]
 
 
+def test_extract_rails_resources_controller_override():
+    # Real, live bug confirmed at Discourse's own config/routes.rb:356 -
+    # "resources :keys, controller: 'api'" routes the "keys" resource to
+    # ApiController, not KeysController. Without checking for this
+    # override, the resource name alone silently named the wrong
+    # controller for dead-code resolution purposes.
+    root, source = parse_ruby(
+        'resources :keys, controller: "api", only: %i[index show]\n'
+    )
+
+    entries = _extract_rails_routes(root, source, "config/routes.rb")
+
+    assert entries[0]["path"] == "api"
+
+
 def test_extract_rails_ignores_unrelated_calls():
     root, source = parse_ruby('puts "hello"\n')
 
@@ -1368,6 +1383,68 @@ def test_extract_laravel_legacy_string_handler():
     entries = _extract_laravel_routes(root, source, "routes/web.php")
 
     assert entries[0]["handler"] == "UserController@index"
+
+
+def test_extract_laravel_route_resource_class_reference():
+    # Real gap found via audit: Route::resource()/apiResource() - Laravel's
+    # direct equivalent of Rails' `resources`, generating all 7 RESTful
+    # actions for a controller - was completely unextracted before. Unlike
+    # Rails, the controller is always an explicit ::class reference here,
+    # never inferred from the resource name by convention.
+    root, source = parse_php(
+        "<?php\nRoute::resource('users', UserController::class);\n"
+    )
+
+    entries = _extract_laravel_routes(root, source, "routes/web.php")
+
+    assert entries == [
+        {
+            "method": None,
+            "path": "users",
+            "framework": "laravel",
+            "file": "routes/web.php",
+            "line": 2,
+            "handler": "UserController",
+            "unresolved": True,
+            "note": None,
+        }
+    ]
+
+
+def test_extract_laravel_api_resource_class_reference():
+    root, source = parse_php(
+        "<?php\nRoute::apiResource('posts', PostController::class);\n"
+    )
+
+    entries = _extract_laravel_routes(root, source, "routes/web.php")
+
+    assert entries[0]["handler"] == "PostController"
+
+
+def test_extract_laravel_resource_legacy_string_controller():
+    # The pre-::class form is also valid for Route::resource(), same as
+    # the plain-verb methods above.
+    root, source = parse_php(
+        "<?php\nRoute::resource('items', 'ItemController');\n"
+    )
+
+    entries = _extract_laravel_routes(root, source, "routes/web.php")
+
+    assert entries[0]["handler"] == "ItemController"
+
+
+def test_extract_laravel_resource_namespaced_class_reference():
+    # A namespaced ::class reference (Admin\UserController::class) keeps
+    # its full qualified name, not just the bare class - dead_code.py's
+    # resolver needs the namespace segments to disambiguate a nested
+    # controller from an unrelated same-named top-level one.
+    root, source = parse_php(
+        "<?php\nRoute::resource('admin/users', Admin\\UserController::class);\n"
+    )
+
+    entries = _extract_laravel_routes(root, source, "routes/web.php")
+
+    assert entries[0]["handler"] == "Admin\\UserController"
 
 
 def test_extract_aspnet_httpget_attribute():


### PR DESCRIPTION
## Summary

Follow-up to #664/#666. Rather than patch reactively, did a full audit and verified every fix against a real, cloned, production repo — not just synthetic fixtures — to make sure the earlier work actually holds up at scale and to find what it missed.

1. **Rails**: `resources :x, controller: "y"` override was ignored, so the resource name alone silently named the wrong controller. Confirmed live twice in Discourse's own `config/routes.rb` (:356, `plugins/voice`).
2. **Laravel**: `Route::resource()`/`apiResource()` — Laravel's own direct equivalent of Rails' `resources`, generating all 7 RESTful actions for a controller — was completely unextracted. Real gap of the same shape and likely greater real-world prevalence than the Rails `resources` gap #664 fixed, since it's Laravel's standard CRUD-controller idiom.
3. **ASP.NET Core**: #664's controller detection required a same-file `using Microsoft.AspNetCore.Mvc`, but C# 10's `global using` (the default in every `dotnet new` template since .NET 6, almost always collected into one `GlobalUsings.cs`) applies the import project-wide from a single declaration. Confirmed on a real repo (`dotnet/eShop`): every one of its 7 real MVC controllers carries neither a same-file `using` nor any other local reference — #664's fix never fired on a single one of them.
4. **Django**: `admin.py` is loaded by `django.contrib.admin.autodiscover()` (called automatically by `AdminConfig.ready()` in every modern Django project), never a plain import — same "framework-owned discovery" category as `manage.py`/`wsgi.py`/`asgi.py`, already in this list. Confirmed on a real repo (`wagtail/wagtail`).

## Real-repo verification (5 repos)

| Repo | Framework | Result |
|---|---|---|
| discourse/discourse | Rails | 288 total rescued (unchanged from #666 — the `controller:` override fix's specific line was already covered by another route on this repo; confirmed real via a second live occurrence in `plugins/voice` instead) |
| alibaba/nacos | Spring Boot | **110 rescued, 0 regressions** — first true pre-#664-baseline comparison for this framework; earlier verification compared with/without `api_endpoints`, which doesn't gate Spring Boot's annotation check at all and so measured nothing real for it |
| dotnet/eShop | ASP.NET Core | **7/7 real MVC controllers rescued, 0 regressions** |
| koel/koel | Laravel | 0 rescued, confirmed correct — koel's modern `::class` usage was already covered by existing PHP import tracking; the new extraction matters for less-modern Laravel codebases using the legacy string form |
| wagtail/wagtail | Django | `admin.py` fix verified directly against its real `admin.py` files |

## Test plan
- [x] New unit tests for all 4 fixes
- [x] Full suite: 1872 passed
- [x] Verified end-to-end against 5 real, cloned production repos (not just synthetic fixtures), diffing complete file sets against a true baseline in each case