### PR TITLE
fix: composite foreign keys mapped every local column to the first target column

### DIFF
--- a/src/aletheore/schema_map.py
+++ b/src/aletheore/schema_map.py
@@ -383,7 +383,7 @@ def _sql_on_delete(options: list | None) -> str | None:
 
 def _sql_relation_from_reference(
     local_column: str, reference: exp.Expression, rel_path: str, line: int,
-    *, table: str | None = None, name: str | None = None,
+    *, table: str | None = None, name: str | None = None, to_column_index: int = 0,
 ) -> dict | None:
     target = reference.args.get("this")
     if target is None:
@@ -393,7 +393,20 @@ def _sql_relation_from_reference(
         return None
     to_table = table_node.name
     to_columns = target.expressions if isinstance(target, exp.Schema) else []
-    to_column = to_columns[0].name if to_columns else "id"
+    # A composite FK's `to_column_index`-th local column corresponds
+    # positionally to the `to_column_index`-th referenced column, not
+    # always the first - REFERENCES(x, y) for local columns (a, b) means
+    # a -> x and b -> y, never a -> x and b -> x. Falls back to the first
+    # (or "id") when the reference is malformed/shorter than expected
+    # (mismatched arity is invalid SQL, but this module never crashes on
+    # invalid input elsewhere either), same as the pre-existing default.
+    if to_columns:
+        if 0 <= to_column_index < len(to_columns):
+            to_column = to_columns[to_column_index].name
+        else:
+            to_column = to_columns[0].name
+    else:
+        to_column = "id"
     if not to_table:
         return None
     # An explicit `CONSTRAINT name ...` wins; otherwise `<table>_<column>_fkey`
@@ -478,9 +491,15 @@ def _sql_foreign_key_relations(
     # single-column case - `naming_table` is left unset otherwise so
     # _sql_relation_from_reference's own fallback doesn't guess one either.
     naming_table = table if (name or len(local_columns) == 1) else None
-    for local_column in local_columns:
+    for index, local_column in enumerate(local_columns):
+        # Positional: REFERENCES(x, y) pairs local_columns[i] with
+        # to_columns[i] - a real bug found via audit had every local column
+        # of a composite FK pointing at the first referenced column only
+        # (e.g. FOREIGN KEY (order_id, product_id) REFERENCES t(oid, pid)
+        # recorded BOTH order_id and product_id as referencing "oid").
         relation = _sql_relation_from_reference(
-            local_column, reference, rel_path, line, table=naming_table, name=name
+            local_column, reference, rel_path, line,
+            table=naming_table, name=name, to_column_index=index,
         )
         if relation is not None:
             relations.append(relation)

--- a/src/tests/test_schema_map.py
+++ b/src/tests/test_schema_map.py
@@ -121,6 +121,55 @@ def test_table_level_foreign_key_constraint_is_captured(tmp_path):
     assert result["relations"][0]["to_table"] == "parents"
 
 
+def test_composite_foreign_key_maps_columns_positionally(tmp_path):
+    # Real bug found via audit: a composite (multi-column) FK was decomposed
+    # into one relation per local column, but every one of them pointed at
+    # the FIRST referenced column only - REFERENCES(x, y) recorded BOTH
+    # order_id -> x and product_id -> x, never product_id -> y. Positional
+    # pairing (order_id <-> x, product_id <-> y) is what the SQL itself
+    # actually declares.
+    repo = write_migrations(
+        tmp_path,
+        {
+            "001.sql": """
+            CREATE TABLE order_line_targets (oid BIGINT, pid BIGINT);
+            CREATE TABLE order_items (
+                order_id BIGINT,
+                product_id BIGINT,
+                FOREIGN KEY (order_id, product_id) REFERENCES order_line_targets(oid, pid)
+            );
+            """
+        },
+    )
+    relations = extract_schema(repo, ["migrations"])["relations"]
+
+    assert len(relations) == 2
+    by_column = {r["from_column"]: r for r in relations}
+    assert by_column["order_id"]["to_column"] == "oid"
+    assert by_column["product_id"]["to_column"] == "pid"
+
+
+def test_composite_foreign_key_via_add_constraint_maps_columns_positionally(tmp_path):
+    # Same bug, reached through ALTER TABLE ... ADD CONSTRAINT ... FOREIGN
+    # KEY rather than a table-level constraint in CREATE TABLE.
+    repo = write_migrations(
+        tmp_path,
+        {
+            "001.sql": """
+            CREATE TABLE a (x BIGINT, y BIGINT);
+            CREATE TABLE b (aid BIGINT, bid BIGINT);
+            ALTER TABLE b ADD CONSTRAINT fk_ab FOREIGN KEY (aid, bid) REFERENCES a(x, y);
+            """
+        },
+    )
+    relations = extract_schema(repo, ["migrations"])["relations"]
+
+    assert len(relations) == 2
+    by_column = {r["from_column"]: r for r in relations}
+    assert by_column["aid"]["to_column"] == "x"
+    assert by_column["bid"]["to_column"] == "y"
+
+
 def test_references_inside_a_comment_is_not_a_relation(tmp_path):
     """Found on the real repo: a naive grep counted 43 REFERENCES where only
     42 were real, because one sat inside a `--` comment explaining why the


### PR DESCRIPTION
## Summary
- `_sql_foreign_key_relations` in `schema_map.py` decomposes a multi-column (composite) `FOREIGN KEY` into one relation per local column, but `_sql_relation_from_reference` always read `to_columns[0]` regardless of which local column was actually being processed.
- A real, common pattern - a composite FK like `FOREIGN KEY (order_id, product_id) REFERENCES order_line_targets(oid, pid)` - recorded **both** `order_id -> oid` and `product_id -> oid`, silently dropping the real `product_id -> pid` pairing the SQL itself declares. Confirmed by direct execution against `sql_events_from_text` before fixing (not just read through the code).
- Affects both places a composite FK can appear: a table-level `FOREIGN KEY (...)` constraint inside `CREATE TABLE`, and `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` - both funnel through the same `_sql_foreign_key_relations`/`_sql_relation_from_reference` pair, verified both are fixed.
- Fix: `_sql_relation_from_reference` takes a new `to_column_index` (default 0, so every existing single-column caller - inline `REFERENCES` on a column, unnamed/named single-column table constraints - is completely unaffected), and `_sql_foreign_key_relations` now passes each local column's own position in the list via `enumerate()`, pairing local and target columns positionally exactly as the SQL declares. Falls back to the first target column if the reference is malformed/shorter than the local column list (invalid SQL, but this module doesn't crash on invalid input elsewhere either, so kept consistent).

## Context
Found while independently sweeping `src/aletheore/` for unaudited gaps (separate from the ongoing Rails/Laravel/ASP.NET/Django dead-code work in #664/#666/#668) - `schema_map.py` had previously only gotten a "broad, lighter-touch" pass, not a dedicated adversarial one. Real-world impact: any app using composite foreign keys (junction/many-to-many tables, tenant-scoped FKs like `(tenant_id, user_id) REFERENCES users(tenant_id, id)`) gets a schema diagram with silently wrong relation targets for every column after the first in the FK.

## Test plan
- [x] Two new regression tests: `test_composite_foreign_key_maps_columns_positionally` (table-level constraint) and `test_composite_foreign_key_via_add_constraint_maps_columns_positionally` (ALTER TABLE ADD CONSTRAINT) - both confirmed failing before the fix, passing after
- [x] Full suite: 1864 passed
- [x] Re-ran the full existing FK test battery (`test_extracts_foreign_keys_with_on_delete`, `test_table_level_foreign_key_constraint_is_captured`, self-referencing FK, inline `REFERENCES`, named FK constraints) to confirm zero regression on single-column FKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
