### PR TITLE
fix: Zeitwerk-autoloaded Rails code outside controllers always flagged dead

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -265,6 +265,92 @@ def _referenced_by_dotted_string(path: str, token_index: dict[str, set[str]]) ->
     return False
 
 
+# A bare CamelCase constant reference, optionally namespaced with `::`
+# (User, Admin::UserHistory) - Ruby's own constant-reference syntax, no
+# quoting involved (unlike the dotted-string mechanism above, which exists
+# for languages that load modules by a quoted dotted string). The negative
+# lookbehind keeps a match from starting mid-reference (`Admin::User`
+# should never also register a spurious standalone `User` match starting
+# at its own `::`).
+_RUBY_CONSTANT_TOKEN_RE = re.compile(r"(?<![:\w])[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*")
+# Whether a token match sits right after `class`/`module` (its own
+# declaration, e.g. "class WidgetsController" or "module Admin") rather
+# than a genuine reference to it. Real bug caught by this file's own
+# existing ambiguous-basename test: two unrelated plugins/engines each
+# defining their own same-named WidgetsController falsely "referenced"
+# each other, since each file's own declaration line contains its own
+# class name as a token like any other use would - without excluding the
+# declaration site, any two files sharing a bare name always looked
+# mutually reachable regardless of whether anything actually used either.
+_RUBY_DEFINITION_KEYWORD_RE = re.compile(r"\b(?:class|module)\s*$")
+
+
+def _ruby_zeitwerk_constant_candidates(path: str) -> list[str]:
+    """The (possibly namespaced) constant name(s) Zeitwerk - Rails' own
+    autoloader, active by default since Rails 6 - would map this file to:
+    app/models/admin/user_history.rb -> ["Admin::UserHistory",
+    "UserHistory"]. Every immediate subdirectory of app/ is its own
+    autoload root by Rails convention regardless of what it's named
+    (models, jobs, mailers, services, serializers, channels, policies,
+    ... - no fixed directory allowlist needed, unlike the framework-
+    specific entry-point heuristics elsewhere in this file), so only
+    app/<root>/... is handled - lib/ is autoloaded only when an app
+    explicitly opts in via config.autoload_paths, which this module has no
+    way to see.
+
+    The full namespaced name is the precise match; the bare last segment
+    is a deliberately permissive fallback for Ruby's own lexical constant
+    lookup, where code already nested under (or sitting alongside) the
+    same namespace commonly refers to a sibling by its short name alone
+    (Ruby itself would resolve it the same way) - e.g. code inside
+    `module Admin` referring to `UserHistory` without ever spelling out
+    `Admin::`. This trades a narrow false-negative risk (an unrelated
+    class elsewhere in the app happening to share the same bare name)
+    for closing a false-positive rate that was 100% on every real Rails
+    app/ subdirectory tested (Discourse: models, jobs, mailers, services,
+    serializers) - consistent with this file's existing bias everywhere
+    else toward not flagging live code dead over never missing a
+    genuinely dead file.
+    """
+    parts = path.split("/")
+    if len(parts) < 3 or parts[0] != "app" or not path.endswith(".rb"):
+        return []
+    segments = parts[2:]
+    segments[-1] = segments[-1][: -len(".rb")]
+    camelized = ["".join(word.capitalize() for word in segment.split("_")) for segment in segments if segment]
+    if not camelized:
+        return []
+    full_name = "::".join(camelized)
+    return [full_name] if len(camelized) == 1 else [full_name, camelized[-1]]
+
+
+def _ruby_constant_token_index(sources: dict[str, str]) -> dict[str, set[str]]:
+    """Constant token -> set of file paths whose content contains it as a
+    genuine reference (excludes the token's own class/module declaration
+    site - see _RUBY_DEFINITION_KEYWORD_RE) - built once for the whole
+    corpus, same O(total source size) shape as _dotted_string_token_index
+    above, for the same reason (avoids an O(candidates x total source
+    size) rescan). The trailing-window slice before each match is
+    bounded (not `content[:match.start()]`) so this stays O(1) per match
+    rather than O(file size) per match."""
+    index: dict[str, set[str]] = {}
+    for path, content in sources.items():
+        for match in _RUBY_CONSTANT_TOKEN_RE.finditer(content):
+            window = content[max(0, match.start() - 24) : match.start()]
+            if _RUBY_DEFINITION_KEYWORD_RE.search(window):
+                continue
+            index.setdefault(match.group(0), set()).add(path)
+    return index
+
+
+def _referenced_by_ruby_constant(path: str, token_index: dict[str, set[str]]) -> bool:
+    for candidate in _ruby_zeitwerk_constant_candidates(path):
+        owners = token_index.get(candidate)
+        if owners and owners - {path}:
+            return True
+    return False
+
+
 def _is_entry_point(path: str, custom_entry_points: set[str]) -> bool:
     if path in custom_entry_points:
         return True
@@ -966,6 +1052,43 @@ def find_dead_code(
         still_unreachable = []
         for entry in unreachable_modules:
             if entry["path"].endswith(".py") and _referenced_by_dotted_string(entry["path"], token_index):
+                entry_points_detected.append(entry["path"])
+            else:
+                still_unreachable.append(entry)
+        unreachable_modules = still_unreachable
+
+    # Rails' Zeitwerk autoloader (default since Rails 6) means idiomatic
+    # app/ code is essentially never require'd anywhere - it's referenced
+    # purely by constant name, autoloaded on first use. rails_route_
+    # reachable_files above only covers controllers (dispatched from
+    # routes.rb); everything else under app/ - models, jobs, mailers,
+    # services, serializers, channels, policies - had no reachability
+    # signal at all beyond "does some other file import this," which is
+    # never true for Zeitwerk-autoloaded code. Confirmed on a real repo
+    # (discourse/discourse): every one of app/models' 391, app/jobs' 241,
+    # app/mailers' 10, app/services' 245, and app/serializers' 242 files
+    # was flagged dead code-wide before this fix - 100% false positive
+    # rate on the most fundamental Rails conventions there are, not an
+    # edge case.
+    if any(entry["path"].startswith("app/") and entry["path"].endswith(".rb") for entry in unreachable_modules):
+        rb_sources = {}
+        for module in modules:
+            if not module["path"].endswith(".rb"):
+                continue
+            try:
+                rb_sources[module["path"]] = (repo_path / module["path"]).read_text(
+                    encoding="utf-8", errors="ignore"
+                )
+            except OSError:
+                continue
+        ruby_token_index = _ruby_constant_token_index(rb_sources)
+        still_unreachable = []
+        for entry in unreachable_modules:
+            if (
+                entry["path"].startswith("app/")
+                and entry["path"].endswith(".rb")
+                and _referenced_by_ruby_constant(entry["path"], ruby_token_index)
+            ):
                 entry_points_detected.append(entry["path"])
             else:
                 still_unreachable.append(entry)

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -266,12 +266,30 @@ def _referenced_by_dotted_string(path: str, token_index: dict[str, set[str]]) ->
 
 
 # A bare CamelCase constant reference, optionally namespaced with `::`
-# (User, Admin::UserHistory) - Ruby's own constant-reference syntax, no
-# quoting involved (unlike the dotted-string mechanism above, which exists
-# for languages that load modules by a quoted dotted string). The negative
-# lookbehind keeps a match from starting mid-reference (`Admin::User`
-# should never also register a spurious standalone `User` match starting
-# at its own `::`).
+# (User, Admin::UserHistory), and optionally anchored with a LEADING `::`
+# (::Jobs::TopicTimerBase - Ruby's own "start lookup at the absolute
+# top-level namespace" syntax, real and common enough that a superclass
+# reference is routinely written this way to disambiguate against a
+# same-named nested constant). The leading `(?:::)?` is consumed but not
+# captured - group(1) is always just the constant name itself, with no
+# leading colons in the stored token.
+#
+# Real bug found via a real Discourse scan (68,183-commit clone): every
+# one of its own job-hierarchy superclass references
+# (`class CloseTopic < ::Jobs::TopicTimerBase`) uses this exact leading-
+# `::` form, and the OLD regex's `(?<![:\w])` lookbehind rejected a match
+# starting right after the leading `::`'s own second colon - not just for
+# the whole "Jobs::TopicTimerBase" run, but for EVERY position inside it
+# (including a later attempt at the bare "TopicTimerBase" tail, since
+# that position is also colon-preceded) - so a real superclass reference
+# written this way was completely invisible to this index, not just
+# imprecisely captured. The lookbehind's only remaining job is
+# preventing a match from starting mid-identifier (`_word` after a
+# `.`/etc.) - `(?<!\w)` alone still does that; dropping `:` from it does
+# not reopen the "spurious standalone User inside Admin::User" case this
+# was originally written to prevent, since finditer's greedy, non-
+# overlapping scan already consumes "Admin::User" as one run before
+# ever revisiting "User" on its own.
 #
 # Known, deliberate limitation: this is a plain text scan, not a real
 # parse - a class name mentioned only inside a `#` comment or a string
@@ -280,7 +298,7 @@ def _referenced_by_dotted_string(path: str, token_index: dict[str, set[str]]) ->
 # everywhere else (favor not flagging live code dead over precision), and
 # a real parse for every unreachable file's own repo would cost far more
 # than this rescue pass is worth - left as a known tradeoff, not silently.
-_RUBY_CONSTANT_TOKEN_RE = re.compile(r"(?<![:\w])[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*")
+_RUBY_CONSTANT_TOKEN_RE = re.compile(r"(?<!\w)(?:::)?([A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*)")
 # Whether a token match sits right after `class`/`module` (its own
 # declaration, e.g. "class WidgetsController" or "module Admin") rather
 # than a genuine reference to it. Real bug caught by this file's own
@@ -344,16 +362,63 @@ def _ruby_constant_token_index(sources: dict[str, str]) -> dict[str, set[str]]:
     index: dict[str, set[str]] = {}
     for path, content in sources.items():
         for match in _RUBY_CONSTANT_TOKEN_RE.finditer(content):
-            window = content[max(0, match.start() - 24) : match.start()]
+            # Window before the actual identifier (group 1), not before
+            # an optional leading `::` - `class ::Foo` is not idiomatic
+            # Ruby, but checking here rather than at match.start(0) keeps
+            # this correct even in that unusual case.
+            window = content[max(0, match.start(1) - 24) : match.start(1)]
             if _RUBY_DEFINITION_KEYWORD_RE.search(window):
                 continue
-            index.setdefault(match.group(0), set()).add(path)
+            index.setdefault(match.group(1), set()).add(path)
     return index
 
 
 def _referenced_by_ruby_constant(path: str, token_index: dict[str, set[str]]) -> bool:
     for candidate in _ruby_zeitwerk_constant_candidates(path):
         owners = token_index.get(candidate)
+        if owners and owners - {path}:
+            return True
+    return False
+
+
+# A bare symbol literal (:bump_topic) - deliberately NOT a `key:` keyword-
+# argument label, which this shape excludes on its own since the colon
+# there trails the identifier instead of leading it. Symbols are Ruby's
+# own idiomatic way to name-then-camelize-and-constantize a class from a
+# snake_case identifier - real, common code beyond any one framework
+# (`"#{name}".classify.constantize`, an STI/polymorphic type column, a
+# registry keyed by symbol) - not just Discourse's own `Jobs.enqueue
+# (:bump_topic, ...)`, the case that surfaced this gap. Left as a
+# genuinely separate index from _RUBY_CONSTANT_TOKEN_RE's, rather than
+# merged into the same one, since a symbol literal is never itself a
+# class/module declaration site the way a CamelCase token can be -
+# keeping them apart avoids complicating that exclusion for no benefit.
+_RUBY_SYMBOL_LITERAL_RE = re.compile(r"(?<![:\w]):([a-z_][a-z0-9_]*)\b")
+
+
+def _ruby_symbol_token_index(sources: dict[str, str]) -> dict[str, set[str]]:
+    """Camelized symbol literal -> set of file paths containing it
+    (:bump_topic -> "BumpTopic") - same O(total source size) shape as
+    _ruby_constant_token_index above."""
+    index: dict[str, set[str]] = {}
+    for path, content in sources.items():
+        for match in _RUBY_SYMBOL_LITERAL_RE.finditer(content):
+            camelized = "".join(word.capitalize() for word in match.group(1).split("_"))
+            index.setdefault(camelized, set()).add(path)
+    return index
+
+
+def _referenced_by_ruby_symbol_dispatch(path: str, symbol_index: dict[str, set[str]]) -> bool:
+    """Whether some other file's bare :snake_case symbol, camelized,
+    names this file's own Zeitwerk constant - the real gap this closes:
+    Discourse's own `Jobs.enqueue(:bump_topic, ...)` (app/jobs/regular/
+    bump_topic.rb) is dispatched by symbol name, never a class reference
+    anywhere, so _referenced_by_ruby_constant alone never rescues it.
+    Confirmed on a real repo (discourse/discourse): 87 additional
+    app/jobs files rescued beyond what the bare-constant check alone
+    found, on top of the 20 it already caught."""
+    for candidate in _ruby_zeitwerk_constant_candidates(path):
+        owners = symbol_index.get(candidate)
         if owners and owners - {path}:
             return True
     return False
@@ -1089,13 +1154,34 @@ def find_dead_code(
                 )
             except OSError:
                 continue
+        # .rake files are real Ruby (Rake tasks routinely dispatch a job
+        # by symbol, e.g. `Jobs.enqueue(:prepare_nested_reply_stats, ...)`
+        # - confirmed on a real repo, lib/tasks/nested_replies.rake in
+        # discourse/discourse) but aren't part of `modules` at all - the
+        # scanner's dependency graph doesn't track them as a language unit
+        # the way .rb files are, so they're invisible to both indexes
+        # below unless read here explicitly. They're a reference SOURCE
+        # only, never a rescue TARGET (they can never appear in
+        # unreachable_modules to begin with), so adding their content to
+        # rb_sources is safe with no risk of a .rake file "rescuing
+        # itself."
+        rake_patterns = ignored_paths or []
+        for rake_file in repo_path.rglob("*.rake"):
+            rel_path = rake_file.relative_to(repo_path).as_posix()
+            rel_parts = rake_file.relative_to(repo_path).parts
+            if any(part in IGNORED_DIRS for part in rel_parts) or is_ignored(rel_path, rake_patterns):
+                continue
+            try:
+                rb_sources[rel_path] = rake_file.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
         ruby_token_index = _ruby_constant_token_index(rb_sources)
+        ruby_symbol_index = _ruby_symbol_token_index(rb_sources)
         still_unreachable = []
         for entry in unreachable_modules:
-            if (
-                entry["path"].startswith("app/")
-                and entry["path"].endswith(".rb")
-                and _referenced_by_ruby_constant(entry["path"], ruby_token_index)
+            if entry["path"].startswith("app/") and entry["path"].endswith(".rb") and (
+                _referenced_by_ruby_constant(entry["path"], ruby_token_index)
+                or _referenced_by_ruby_symbol_dispatch(entry["path"], ruby_symbol_index)
             ):
                 entry_points_detected.append(entry["path"])
             else:

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -272,6 +272,14 @@ def _referenced_by_dotted_string(path: str, token_index: dict[str, set[str]]) ->
 # lookbehind keeps a match from starting mid-reference (`Admin::User`
 # should never also register a spurious standalone `User` match starting
 # at its own `::`).
+#
+# Known, deliberate limitation: this is a plain text scan, not a real
+# parse - a class name mentioned only inside a `#` comment or a string
+# literal (a log message, an error string) counts as a "reference" the
+# same as real code would. Consistent with this file's existing bias
+# everywhere else (favor not flagging live code dead over precision), and
+# a real parse for every unreachable file's own repo would cost far more
+# than this rescue pass is worth - left as a known tradeoff, not silently.
 _RUBY_CONSTANT_TOKEN_RE = re.compile(r"(?<![:\w])[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*")
 # Whether a token match sits right after `class`/`module` (its own
 # declaration, e.g. "class WidgetsController" or "module Admin") rather

--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -277,19 +277,33 @@ def _referenced_by_dotted_string(path: str, token_index: dict[str, set[str]]) ->
 # Real bug found via a real Discourse scan (68,183-commit clone): every
 # one of its own job-hierarchy superclass references
 # (`class CloseTopic < ::Jobs::TopicTimerBase`) uses this exact leading-
-# `::` form, and the OLD regex's `(?<![:\w])` lookbehind rejected a match
+# `::` form, and the original `(?<![:\w])` lookbehind rejected a match
 # starting right after the leading `::`'s own second colon - not just for
 # the whole "Jobs::TopicTimerBase" run, but for EVERY position inside it
 # (including a later attempt at the bare "TopicTimerBase" tail, since
 # that position is also colon-preceded) - so a real superclass reference
 # written this way was completely invisible to this index, not just
-# imprecisely captured. The lookbehind's only remaining job is
-# preventing a match from starting mid-identifier (`_word` after a
-# `.`/etc.) - `(?<!\w)` alone still does that; dropping `:` from it does
-# not reopen the "spurious standalone User inside Admin::User" case this
-# was originally written to prevent, since finditer's greedy, non-
-# overlapping scan already consumes "Admin::User" as one run before
-# ever revisiting "User" on its own.
+# imprecisely captured.
+#
+# Flash Review finding on this same fix's first attempt (which simply
+# dropped `:` from the lookbehind everywhere, not just before a genuine
+# leading `::`): reproduced directly - "registry::User" (a lowercase
+# expression, itself never matching `[A-Z]`, "::"-qualified into a
+# constant that is NOT the top-level Zeitwerk `User`) let the lookbehind
+# alone accept a match starting right at "User", since a colon isn't a
+# `\w` character either. That first attempt's own comment claimed
+# finditer's greedy scan already prevented this the way it does for
+# "Admin::User" - true only when the qualifying prefix is itself
+# `[A-Z]`-starting and so gets absorbed into one earlier match; false
+# here, since "registry" never matches `[A-Z]` at all and so is never
+# consumed by anything, leaving "User" free to start its own match.
+#
+# Fixed with two distinct alternatives instead of one shared lookbehind:
+# a leading `::` is allowed ONLY when it is itself not preceded by a word
+# character (a genuine absolute-top-level reference, `(?<!\w)::` followed
+# by the constant) - not just anywhere a colon happens to precede an
+# uppercase letter. Every other position keeps the original, stricter
+# `(?<![:\w])` rule with no leading `::` consumed at all.
 #
 # Known, deliberate limitation: this is a plain text scan, not a real
 # parse - a class name mentioned only inside a `#` comment or a string
@@ -298,7 +312,9 @@ def _referenced_by_dotted_string(path: str, token_index: dict[str, set[str]]) ->
 # everywhere else (favor not flagging live code dead over precision), and
 # a real parse for every unreachable file's own repo would cost far more
 # than this rescue pass is worth - left as a known tradeoff, not silently.
-_RUBY_CONSTANT_TOKEN_RE = re.compile(r"(?<!\w)(?:::)?([A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*)")
+_RUBY_CONSTANT_TOKEN_RE = re.compile(
+    r"(?:(?<!\w)::(?=[A-Z])|(?<![:\w]))([A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*)"
+)
 # Whether a token match sits right after `class`/`module` (its own
 # declaration, e.g. "class WidgetsController" or "module Admin") rather
 # than a genuine reference to it. Real bug caught by this file's own
@@ -381,19 +397,42 @@ def _referenced_by_ruby_constant(path: str, token_index: dict[str, set[str]]) ->
     return False
 
 
-# A bare symbol literal (:bump_topic) - deliberately NOT a `key:` keyword-
-# argument label, which this shape excludes on its own since the colon
-# there trails the identifier instead of leading it. Symbols are Ruby's
-# own idiomatic way to name-then-camelize-and-constantize a class from a
-# snake_case identifier - real, common code beyond any one framework
-# (`"#{name}".classify.constantize`, an STI/polymorphic type column, a
-# registry keyed by symbol) - not just Discourse's own `Jobs.enqueue
-# (:bump_topic, ...)`, the case that surfaced this gap. Left as a
-# genuinely separate index from _RUBY_CONSTANT_TOKEN_RE's, rather than
-# merged into the same one, since a symbol literal is never itself a
-# class/module declaration site the way a CamelCase token can be -
-# keeping them apart avoids complicating that exclusion for no benefit.
-_RUBY_SYMBOL_LITERAL_RE = re.compile(r"(?<![:\w]):([a-z_][a-z0-9_]*)\b")
+# A bare symbol literal used as the first argument of what looks like a
+# method call (`Jobs.enqueue(:bump_topic, ...)`, a bare `enqueue(:x)`,
+# a namespaced `SomeModule::Jobs.enqueue(:x)`) - deliberately NOT a `key:`
+# keyword-argument label (the colon there trails the identifier instead
+# of leading it) and, just as deliberately, NOT a bare symbol appearing
+# anywhere else in the source. Symbols are Ruby's own idiomatic way to
+# name-then-camelize-and-constantize a class from a snake_case identifier
+# - real, common code beyond any one framework (a registry keyed by
+# symbol, an STI/polymorphic type column) - not just Discourse's own
+# `Jobs.enqueue(:bump_topic, ...)`, the case that surfaced this gap.
+#
+# Flash Review finding on this fix's first attempt (`(?<![:\w]):([a-z_]
+# [a-z0-9_]*)\b` alone, no call-shape requirement at all despite this
+# comment's own earlier claim of being scoped to "dispatch-shaped"
+# calls): reproduced directly - an ordinary `{status: :active}` hash
+# value, a `enum status: [:active, :inactive]` declaration, or any other
+# bare `:some_common_word` symbol used as plain data (not a dispatch
+# target at all) registered exactly the same as a real
+# `Jobs.enqueue(:bump_topic, ...)` call, since nothing in the old pattern
+# actually required call-argument position - only the trailing "keyword-
+# label" shape was excluded, not every other place a bare symbol can
+# legally appear. Fixed by requiring the symbol to be the first thing
+# after a call's opening parenthesis, preceded by what looks like a
+# method reference (an identifier, optionally `.`/`::`-chained) -
+# verified this still matches every real shape confirmed on Discourse
+# (`Jobs.enqueue(:x, ...)`, multi-line-formatted calls) while correctly
+# excluding a symbol used as a hash value/enum member/anything else not
+# in that specific syntactic position.
+#
+# Left as a genuinely separate index from _RUBY_CONSTANT_TOKEN_RE's,
+# rather than merged into the same one, since a symbol literal is never
+# itself a class/module declaration site the way a CamelCase token can be
+# - keeping them apart avoids complicating that exclusion for no benefit.
+_RUBY_SYMBOL_LITERAL_RE = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*(?:(?:\.|::)[A-Za-z_][A-Za-z0-9_]*)*\(\s*:([a-z_][a-z0-9_]*)\b"
+)
 
 
 def _ruby_symbol_token_index(sources: dict[str, str]) -> dict[str, set[str]]:

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1231,6 +1231,92 @@ def test_rails_unprefixed_resource_in_a_plugin_engine_routes_file_still_resolves
     assert result["unreachable_modules"] == []
 
 
+def test_rails_model_referenced_only_by_bare_constant_is_never_unreachable(tmp_path):
+    # Real bug found via a real Discourse scan: Rails' Zeitwerk autoloader
+    # (default since Rails 6) means app/ code outside controllers is never
+    # require'd anywhere at all - it's referenced purely by bare constant
+    # name (User.find(...), never `require "user"`). rails_route_
+    # reachable_files only ever covers controllers dispatched from
+    # routes.rb; a model has no routes.rb entry to be rescued by at all.
+    # Every one of Discourse's 391 app/models files was flagged dead
+    # before this fix - not an edge case, the single most fundamental
+    # Rails convention there is.
+    models_dir = tmp_path / "app" / "models"
+    models_dir.mkdir(parents=True)
+    (models_dir / "user.rb").write_text("class User < ApplicationRecord\nend\n")
+    controllers_dir = tmp_path / "app" / "controllers"
+    controllers_dir.mkdir(parents=True)
+    (controllers_dir / "sessions_controller.rb").write_text(
+        "class SessionsController < ApplicationController\n"
+        "  def show\n    @user = User.find(params[:id])\n  end\nend\n"
+    )
+    modules = [
+        _module("app/models/user.rb"),
+        _module("app/controllers/sessions_controller.rb", imported_by=["app/controllers/sessions_controller.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_rails_namespaced_file_referenced_by_bare_last_segment_resolves(tmp_path):
+    # Ruby's own lexical constant lookup lets code refer to a namespaced
+    # class by its short name alone once already inside (or alongside) the
+    # same namespace - real code commonly does this rather than always
+    # spelling out the full qualified name.
+    jobs_dir = tmp_path / "app" / "jobs" / "regular"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "bump_topic.rb").write_text(
+        "module Jobs\n  class BumpTopic < Jobs::Base\n  end\nend\n"
+    )
+    other_dir = tmp_path / "lib"
+    other_dir.mkdir(parents=True)
+    (other_dir / "topic_bumper.rb").write_text(
+        "class TopicBumper\n  def bump\n    BumpTopic.new.execute({})\n  end\nend\n"
+    )
+    modules = [
+        _module("app/jobs/regular/bump_topic.rb"),
+        _module("lib/topic_bumper.rb", imported_by=["lib/topic_bumper.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_rails_model_with_no_reference_anywhere_stays_unreachable(tmp_path):
+    # The rescue must not become a rescue-everything hack - a genuinely
+    # orphaned model, referenced nowhere in the corpus, still gets flagged.
+    models_dir = tmp_path / "app" / "models"
+    models_dir.mkdir(parents=True)
+    (models_dir / "abandoned_draft.rb").write_text(
+        "class AbandonedDraft < ApplicationRecord\nend\n"
+    )
+    modules = [_module("app/models/abandoned_draft.rb")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["app/models/abandoned_draft.rb"]
+
+
+def test_ruby_zeitwerk_rescue_is_scoped_to_app_directory_only(tmp_path):
+    # lib/ is only Zeitwerk-autoloaded when an app explicitly opts in via
+    # config.autoload_paths, which this module has no way to see - so a
+    # lib/ file must NOT be rescued by this mechanism even when its own
+    # class name happens to appear as a bare word elsewhere (it should
+    # still be resolved some other way - a real `require`, or left dead -
+    # never guessed via the app/-only Zeitwerk convention).
+    lib_dir = tmp_path / "lib"
+    lib_dir.mkdir(parents=True)
+    (lib_dir / "helper_util.rb").write_text("class HelperUtil\nend\n")
+    other_dir = tmp_path / "app" / "models"
+    other_dir.mkdir(parents=True)
+    (other_dir / "unrelated.rb").write_text(
+        "class Unrelated\n  def call\n    HelperUtil.new\n  end\nend\n"
+    )
+    modules = [
+        _module("lib/helper_util.rb"),
+        _module("app/models/unrelated.rb", imported_by=["app/models/unrelated.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["lib/helper_util.rb"]
+
+
 def test_laravel_backslash_qualified_string_handler_resolves_a_nested_controller(tmp_path):
     # Flash Review finding on #666: the legacy string handler resolver
     # reduced every handler to its bare class name and always anchored

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1281,6 +1281,108 @@ def test_rails_namespaced_file_referenced_by_bare_last_segment_resolves(tmp_path
     assert result["unreachable_modules"] == []
 
 
+def test_rails_job_dispatched_only_by_symbol_name_resolves(tmp_path):
+    # Real gap found via audit against a real repo (discourse/discourse):
+    # a custom job-dispatch layer (`Jobs.enqueue(:bump_topic, ...)`) built
+    # on top of Zeitwerk's own autoloading, common enough to be worth
+    # closing generally (any `dispatch(:snake_case_name)`-shaped call,
+    # not hardcoded to any one method name) - 87 of Discourse's 241
+    # app/jobs files were rescued by this alone, beyond what a bare
+    # constant reference check already caught.
+    jobs_dir = tmp_path / "app" / "jobs" / "regular"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "bump_topic.rb").write_text(
+        "module Jobs\n  class BumpTopic < Jobs::Base\n  end\nend\n"
+    )
+    caller_dir = tmp_path / "app" / "models"
+    caller_dir.mkdir(parents=True)
+    (caller_dir / "topic.rb").write_text(
+        "class Topic < ApplicationRecord\n"
+        "  def bump\n    Jobs.enqueue(:bump_topic, topic_id: id)\n  end\nend\n"
+    )
+    modules = [
+        _module("app/jobs/regular/bump_topic.rb"),
+        _module("app/models/topic.rb", imported_by=["app/models/topic.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_symbol_dispatch_does_not_match_a_keyword_argument_label(tmp_path):
+    # A `key:` keyword-argument label (colon trailing the identifier) must
+    # never be mistaken for a `:key` symbol literal (colon leading it) -
+    # they look similar but mean something completely different in Ruby,
+    # and the former is far more common in ordinary code that has nothing
+    # to do with dispatch.
+    jobs_dir = tmp_path / "app" / "jobs" / "regular"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "bump_topic.rb").write_text(
+        "module Jobs\n  class BumpTopic < Jobs::Base\n  end\nend\n"
+    )
+    caller_dir = tmp_path / "app" / "models"
+    caller_dir.mkdir(parents=True)
+    (caller_dir / "topic.rb").write_text(
+        "class Topic < ApplicationRecord\n"
+        "  def some_unrelated_method(bump_topic: false)\n    bump_topic\n  end\nend\n"
+    )
+    modules = [
+        _module("app/jobs/regular/bump_topic.rb"),
+        _module("app/models/topic.rb", imported_by=["app/models/topic.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["app/jobs/regular/bump_topic.rb"]
+
+
+def test_rake_task_dispatching_a_job_by_symbol_resolves_it(tmp_path):
+    # Real gap found via audit: .rake files are real Ruby (Rake tasks
+    # routinely dispatch a job, e.g. lib/tasks/nested_replies.rake in
+    # discourse/discourse) but aren't part of the module graph at all -
+    # invisible to the rescue passes above unless read explicitly.
+    jobs_dir = tmp_path / "app" / "jobs" / "regular"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "prepare_stats.rb").write_text(
+        "module Jobs\n  class PrepareStats < Jobs::Base\n  end\nend\n"
+    )
+    tasks_dir = tmp_path / "lib" / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "stats.rake").write_text(
+        'task "stats:prepare" => :environment do\n'
+        "  Jobs.enqueue(:prepare_stats)\nend\n"
+    )
+    modules = [_module("app/jobs/regular/prepare_stats.rb")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
+def test_leading_double_colon_superclass_reference_resolves(tmp_path):
+    # Real bug found via a real Discourse scan: a top-level-anchored
+    # constant reference (`::Admin::UserHistory` - Ruby's own syntax for
+    # "start lookup at the absolute top-level namespace", commonly used
+    # for a superclass reference to disambiguate against a same-named
+    # nested constant) was completely invisible to the constant-token
+    # index - not just imprecisely captured, but missed entirely,
+    # including for the bare last-segment fallback, since the leading
+    # `::` blocked a match from starting anywhere inside the reference
+    # (confirmed directly: discourse/discourse's own
+    # `class CloseTopic < ::Jobs::TopicTimerBase` never registered at
+    # all before this fix).
+    base_dir = tmp_path / "app" / "models" / "admin"
+    base_dir.mkdir(parents=True)
+    (base_dir / "user_history.rb").write_text(
+        "module Admin\n  class UserHistory < ApplicationRecord\n  end\nend\n"
+    )
+    subclass_dir = tmp_path / "app" / "models" / "admin"
+    (subclass_dir / "staff_action_log.rb").write_text(
+        "module Admin\n  class StaffActionLog < ::Admin::UserHistory\n  end\nend\n"
+    )
+    modules = [
+        _module("app/models/admin/user_history.rb"),
+        _module("app/models/admin/staff_action_log.rb", imported_by=["app/models/admin/staff_action_log.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
 def test_rails_model_with_no_reference_anywhere_stays_unreachable(tmp_path):
     # The rescue must not become a rescue-everything hack - a genuinely
     # orphaned model, referenced nowhere in the corpus, still gets flagged.

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1396,6 +1396,123 @@ def test_rails_model_with_no_reference_anywhere_stays_unreachable(tmp_path):
     assert [m["path"] for m in result["unreachable_modules"]] == ["app/models/abandoned_draft.rb"]
 
 
+def test_ruby_constant_qualified_off_a_lowercase_expression_does_not_match(tmp_path):
+    # Flash Review finding: `registry::User` is valid Ruby (:: after any
+    # expression that evaluates to a module/class, not just a literal
+    # constant chain) and refers to whatever "User" is nested under
+    # registry's return value - NOT the top-level Zeitwerk `User`. The
+    # lookbehind alone can't tell "::" preceded by a real absolute-
+    # reference boundary from "::" preceded by a lowercase expression;
+    # only the latter must be rejected.
+    models_dir = tmp_path / "app" / "models"
+    models_dir.mkdir(parents=True)
+    (models_dir / "user.rb").write_text("class User < ApplicationRecord\nend\n")
+    other_dir = tmp_path / "lib"
+    other_dir.mkdir(parents=True)
+    (other_dir / "consumer.rb").write_text(
+        "class Consumer\n  def call\n    registry::User.new\n  end\nend\n"
+    )
+    modules = [
+        _module("app/models/user.rb"),
+        _module("lib/consumer.rb", imported_by=["lib/consumer.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["app/models/user.rb"]
+
+
+def test_ruby_top_level_anchored_constant_reference_still_resolves(tmp_path):
+    # Must not regress while fixing the case above: a genuine absolute
+    # top-level reference (Ruby's own "start lookup at the top-level
+    # namespace" syntax, real and common for a superclass reference that
+    # disambiguates against a same-named nested constant - confirmed on
+    # Discourse's own `class CloseTopic < ::Jobs::TopicTimerBase`) must
+    # still resolve.
+    #
+    # Path chosen so the referenced file's own Zeitwerk-derived full name
+    # (segments after app/) is exactly "Jobs::TopicTimerBase", matching
+    # the reference verbatim - this isolates the regex fix itself (does a
+    # leading `::` reference still get indexed and matched at all) from
+    # a separate, real gap this PR doesn't address: Discourse's actual
+    # app/jobs root is registered with a custom Zeitwerk namespace
+    # (`push_dir(..., namespace: Jobs)`), which _ruby_zeitwerk_constant_
+    # candidates has no way to see from a plain file path - confirmed
+    # directly against the real repo, discourse/discourse's own
+    # app/jobs/regular/topic_timer_base.rb (candidates "Regular::
+    # TopicTimerBase"/"TopicTimerBase") still doesn't match a real
+    # "Jobs::TopicTimerBase" reference and stays unreachable even with
+    # this fix applied - a distinct, deeper limitation than what either
+    # Flash Review finding here asked for.
+    jobs_dir = tmp_path / "app" / "jobs" / "jobs"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "topic_timer_base.rb").write_text(
+        "module Jobs\n  class TopicTimerBase < Jobs::Base\n  end\nend\n"
+    )
+    other_dir = tmp_path / "app" / "jobs" / "regular"
+    other_dir.mkdir(parents=True)
+    (other_dir / "close_topic.rb").write_text(
+        "class CloseTopic < ::Jobs::TopicTimerBase\nend\n"
+    )
+    modules = [
+        _module("app/jobs/jobs/topic_timer_base.rb"),
+        _module(
+            "app/jobs/regular/close_topic.rb",
+            imported_by=["app/jobs/regular/close_topic.rb"],
+        ),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert "app/jobs/jobs/topic_timer_base.rb" not in [
+        m["path"] for m in result["unreachable_modules"]
+    ]
+
+
+def test_ruby_symbol_as_hash_value_does_not_dispatch(tmp_path):
+    # Flash Review finding: the symbol-dispatch index matched ANY bare
+    # symbol literal anywhere in the source, not just one in a real
+    # dispatch-call position - an ordinary `{status: :active}` hash value,
+    # an `enum status: [:active, :inactive]` declaration, or any other
+    # bare `:some_word` used as plain data would register exactly like a
+    # real `Jobs.enqueue(:bump_topic, ...)` call.
+    jobs_dir = tmp_path / "app" / "jobs"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "active.rb").write_text("class Active < ApplicationRecord\nend\n")
+    other_dir = tmp_path / "lib"
+    other_dir.mkdir(parents=True)
+    (other_dir / "widget.rb").write_text(
+        "class Widget\n  enum status: [:active, :inactive]\n"
+        "  def describe\n    {status: :active}\n  end\nend\n"
+    )
+    modules = [
+        _module("app/jobs/active.rb"),
+        _module("lib/widget.rb", imported_by=["lib/widget.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["app/jobs/active.rb"]
+
+
+def test_ruby_symbol_dispatch_call_still_resolves(tmp_path):
+    # Must not regress while fixing the case above: a genuine dispatch
+    # call (confirmed on Discourse's own `Jobs.enqueue(:bump_topic, ...)`)
+    # must still resolve, including across a multi-line call.
+    jobs_dir = tmp_path / "app" / "jobs" / "regular"
+    jobs_dir.mkdir(parents=True)
+    (jobs_dir / "bump_topic.rb").write_text(
+        "module Jobs\n  class BumpTopic < Jobs::Base\n  end\nend\n"
+    )
+    other_dir = tmp_path / "lib"
+    other_dir.mkdir(parents=True)
+    (other_dir / "bumper.rb").write_text(
+        "class Bumper\n  def call\n"
+        "    Jobs.enqueue(\n      :bump_topic,\n      topic_id: 1\n    )\n"
+        "  end\nend\n"
+    )
+    modules = [
+        _module("app/jobs/regular/bump_topic.rb"),
+        _module("lib/bumper.rb", imported_by=["lib/bumper.rb"]),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+
+
 def test_ruby_zeitwerk_rescue_is_scoped_to_app_directory_only(tmp_path):
     # lib/ is only Zeitwerk-autoloaded when an app explicitly opts in via
     # config.autoload_paths, which this module has no way to see - so a


### PR DESCRIPTION
## Summary
- Rails' Zeitwerk autoloader (default since Rails 6) means idiomatic `app/` code is essentially never `require`'d anywhere - it's referenced purely by bare constant name (`User.find(...)`, never `require "user"`), autoloaded on first use. `rails_route_reachable_files` (#664/#666) only ever covers controllers, since routes.rb is the one place that dispatches by name - every other `app/` convention (models, jobs, mailers, services, serializers, channels, policies) had **no reachability signal at all** beyond "does some other file import this," which Zeitwerk never makes true.
- Confirmed on a real repo (discourse/discourse, 68,183 commits): every one of `app/models`' 391, `app/jobs`' 241, `app/mailers`' 10, `app/services`' 245, and `app/serializers`' 242 files was flagged dead code-wide before this fix - a **100% false-positive rate** on the most fundamental Rails conventions there are. This dwarfs every framework-convention gap fixed in this file so far (#664/#666/#667 combined rescued on the order of a few hundred files; this one rescues ~800+ on the same repo).
- Fix: a corpus-wide index of bare Ruby constant tokens (`User`, `Admin::UserHistory`), mirroring the existing Python dotted-string mechanism's shape (built once, O(total source size)) but for Ruby's own unquoted constant-reference syntax rather than a quoted dynamic-import string. A file under `app/<any-root>/` is rescued if its own Zeitwerk-derived constant name (full namespaced form, or the bare last segment, for Ruby's own lexical short-name lookup) appears as a genuine reference somewhere else in the corpus.
- Every immediate subdirectory of `app/` is treated as its own autoload root, matching Rails' own convention exactly (no fixed directory allowlist needed, unlike the framework-specific heuristics elsewhere in this file) - so this also covers custom app dirs like `app/decorators`, `app/queries`, etc. without any extra code.

## A real bug caught during development
Excluding a token's own class/module declaration line from counting as a "reference" turned out to matter: without it, two files each independently defining a same-named class falsely "referenced" each other purely because each one's own declaration contains its own name as a token - exactly the ambiguous-same-basename shape this file's own existing `test_rails_ambiguous_controller_basename_is_left_unresolved` test already covers, and it caught this immediately when the full suite ran. Fixed by skipping a match preceded by `class`/`module`.

## Deliberately out of scope (noted, not silently dropped)
- `app/jobs` only drops from 241 to 224 dead (vs. mailers/services/serializers essentially going to zero) because most of Discourse's jobs are dispatched via its own `Jobs.enqueue(:snake_case_symbol, ...)` convention - a string/symbol lookup, not a bare constant reference at all. Real, but a different mechanism (closer in shape to the *existing* Python dotted-string index than to this fix) - a natural, separate follow-up rather than scope-creeping this PR.
- Scoped to `app/` only, not `lib/` - `lib/` is Zeitwerk-autoloaded only when an app opts in via `config.autoload_paths`, which this module has no way to see from static analysis. Guessing there risks the opposite failure mode (silently hiding a genuinely dead `lib/` file) this file's own design otherwise consistently avoids.

## Test plan
- [x] 4 new regression tests: bare-constant model rescue, namespaced-file bare-last-segment rescue, genuinely-orphaned-model-stays-dead (negative control), and app/-only scoping (negative control) - the two positive tests confirmed failing before the fix, passing after
- [x] Full suite: 1866 passed, including the pre-existing ambiguous-basename test that caught the definition-exclusion bug above
- [x] Verified against a real, full `git clone` of discourse/discourse: `app/mailers` 10->0 dead, `app/services` 245->2, `app/serializers` 242->9, `app/models` 391->69, `app/jobs` 241->224 (see "deliberately out of scope" above); scan wall-clock time unaffected (~27s total, same as before this fix, on the full 15,509-module repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
