### PR TITLE
fix: Django management commands always flagged dead code

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -40,6 +40,23 @@ ENTRY_POINT_FILENAMES = {
     "routes.rb",
 }
 
+# Django's own management-command loader (django.core.management,
+# invoked by `python manage.py <name>` or programmatically via
+# call_command) discovers every file directly under an app's
+# management/commands/ directory purely by walking that directory -
+# never a plain `import` anywhere in the app's own source, the same
+# convention-over-reference blind spot as ENTRY_POINT_FILENAMES above.
+# Confirmed on a real repo (wagtail/wagtail): 17 of its 20 real
+# management commands (move_pages.py, publish_scheduled_pages.py,
+# rebuild_references_index.py, ...) were flagged dead code before this -
+# not a Wagtail-specific quirk, this is true of any Django app's command
+# directory. `management/commands/` is specific enough to Django (unlike
+# "admin.py") that no corroborating import check is needed, matching the
+# same reasoning as "routes.rb" above. Also matches a stray
+# management/commands/__init__.py, already its own entry point via
+# ENTRY_POINT_FILENAMES - harmless overlap, not worth excluding.
+_DJANGO_MANAGEMENT_COMMAND_RE = re.compile(r"(^|/)management/commands/[^/]+\.py$")
+
 TEST_PATH_PATTERNS = [
     re.compile(r"(^|/)test_[^/]+\.py$"),
     re.compile(r"(^|/)[^/]+_test\.py$"),
@@ -268,7 +285,9 @@ def _referenced_by_dotted_string(path: str, token_index: dict[str, set[str]]) ->
 def _is_entry_point(path: str, custom_entry_points: set[str]) -> bool:
     if path in custom_entry_points:
         return True
-    return path.rsplit("/", 1)[-1] in ENTRY_POINT_FILENAMES
+    if path.rsplit("/", 1)[-1] in ENTRY_POINT_FILENAMES:
+        return True
+    return bool(_DJANGO_MANAGEMENT_COMMAND_RE.search(path))
 
 
 def _has_main_guard(repo_path: Path, path: str) -> bool:

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -22,6 +22,38 @@ def test_recognized_entry_point_is_never_unreachable(tmp_path):
     assert set(result["entry_points_detected"]) == {"main.py", "app/__main__.py", "index.js"}
 
 
+def test_django_management_command_is_never_unreachable(tmp_path):
+    # Real gap found via audit against a real repo (wagtail/wagtail):
+    # Django's management-command loader (`python manage.py <name>`,
+    # django.core.management.call_command) discovers every file directly
+    # under an app's management/commands/ directory purely by walking
+    # that directory - never a plain `import` anywhere in the app's own
+    # source. 17 of Wagtail's 20 real management commands (move_pages.py,
+    # publish_scheduled_pages.py, rebuild_references_index.py, ...) were
+    # flagged dead code before this - not a Wagtail quirk, true of any
+    # Django app's command directory.
+    modules = [
+        _module("myapp/management/commands/do_thing.py"),
+        _module("blog/management/commands/publish_scheduled.py"),
+    ]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert set(result["entry_points_detected"]) == {
+        "myapp/management/commands/do_thing.py",
+        "blog/management/commands/publish_scheduled.py",
+    }
+
+
+def test_python_file_merely_named_commands_is_still_unreachable(tmp_path):
+    # The management/commands/ pattern must stay scoped to Django's own
+    # directory shape - an unrelated file that just happens to sit in a
+    # directory named "commands" (no "management/" parent) is regular
+    # application code and must still be flagged when nothing imports it.
+    modules = [_module("app/commands/do_thing.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["app/commands/do_thing.py"]
+
+
 def test_test_files_are_never_unreachable(tmp_path):
     modules = [
         _module("tests/test_thing.py"),


### PR DESCRIPTION
## Summary
- Django's management-command loader (`django.core.management`, invoked by `python manage.py <name>` or programmatically via `call_command`) discovers every file directly under an app's `management/commands/` directory purely by walking that directory - never a plain `import` anywhere in the app's own source. This is the exact same convention-over-reference blind spot `ENTRY_POINT_FILENAMES` already exists to close for `manage.py`/`wsgi.py`/`routes.rb`, just never extended to this Django-specific directory convention.
- Confirmed on a real repo (**wagtail/wagtail**, deliberately a different repo than any other fix in this sweep used, to test generality rather than one codebase's quirks): **17 of its 20 real management commands** (`move_pages.py`, `publish_scheduled_pages.py`, `rebuild_references_index.py`, `purge_revisions.py`, ...) were flagged dead code before this fix. The remaining 3 were already rescued for unrelated, mundane reasons (imported by their own test file, imported by a sibling command, or already covered by an existing check) - not evidence this pattern is rare, just that those particular 3 happened to also have an ordinary import edge.
- Fix: `management/commands/<name>.py` is recognized as an entry point by path shape alone, matching `routes.rb`'s existing precedent - the directory name is specific enough to Django that no corroborating import/content check is needed (unlike `admin.py`, a generic filename many unrelated frameworks could also use for something else).

## Test plan
- [x] Two new regression tests: `test_django_management_command_is_never_unreachable` (confirmed failing before the fix, passing after) and `test_python_file_merely_named_commands_is_still_unreachable` (negative control - a file in an unrelated `commands/` directory with no `management/` parent stays correctly flagged)
- [x] Full suite: 1864 passed
- [x] Verified against wagtail/wagtail directly: all 20 real management command files resolve correctly post-fix, 0 remain flagged dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
