### PR TITLE
fix: pyproject.toml console-script targets at non-standard module names

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -1,4 +1,5 @@
 import re
+import tomllib
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -737,6 +738,85 @@ def _laravel_route_reachable_files(
     return reachable
 
 
+def _python_console_script_entry_points(repo_path: Path) -> set[str]:
+    """Every file a pyproject.toml [project.scripts]/[project.gui-scripts]
+    or [tool.poetry.scripts] entry points at ("name = "pkg.mod:func"") -
+    pip/setuptools/poetry dispatch these by installing a generated wrapper
+    that imports the target via importlib.metadata at install time, never
+    a plain `import` anywhere in the repo's own source, the same
+    convention-over-reference blind spot ENTRY_POINT_FILENAMES exists for.
+
+    Genuinely rare in practice, not common - measured, not assumed: of 85
+    real console_scripts entries sampled from a conda environment's own
+    entry_points.txt files, 42 (49%) point at a module name outside
+    ENTRY_POINT_FILENAMES, but checking a random sample of those 42
+    against every OTHER existing heuristic in this file found only 1 in
+    18 actually depended on this fix - most well-designed CLI entry
+    modules also carry their own `if __name__ == "__main__":` guard, a
+    sibling __main__.py, or get imported by their own test suite, so the
+    console_scripts declaration is usually a second, redundant signal
+    rather than the only one. Worth having regardless: the one confirmed
+    case (jupyter_client's real jupyter-kernel = jupyter_client.
+    kernelapp:main - no __main__.py, no main guard, no other importer
+    anywhere in that real, currently-installed package) is exactly the
+    shape this exists for, and the fix is simple enough that a lower hit
+    rate doesn't argue against having it.
+
+    Tries both a flat layout (module directly under the repo root) and a
+    src/ layout (this very project's own layout - pyproject.toml at the
+    root, packages under src/) since both are common and mutually
+    exclusive per project; never guesses a location that doesn't exist.
+    Only the repo-root pyproject.toml is read, matching
+    _parse_pip_pins' own existing scope (no recursive search for a
+    nested one in a monorepo)."""
+    pyproject = repo_path / "pyproject.toml"
+    if not pyproject.exists():
+        return set()
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8", errors="ignore"))
+    except tomllib.TOMLDecodeError:
+        return set()
+
+    targets: list[str] = []
+    project = data.get("project", {})
+    if isinstance(project, dict):
+        for table_name in ("scripts", "gui-scripts"):
+            table = project.get(table_name, {})
+            if isinstance(table, dict):
+                targets.extend(value for value in table.values() if isinstance(value, str))
+
+    poetry_scripts = data.get("tool", {}).get("poetry", {}).get("scripts", {})
+    if isinstance(poetry_scripts, dict):
+        for value in poetry_scripts.values():
+            if isinstance(value, str):
+                targets.append(value)
+            elif isinstance(value, dict) and isinstance(value.get("reference"), str):
+                # Poetry 1.2+'s extras-gated script form:
+                # {reference = "pkg.mod:func", extras = [...]} - only the
+                # reference is a real dotted-path target this can resolve.
+                targets.append(value["reference"])
+
+    search_roots = [repo_path, repo_path / "src"]
+    entry_points: set[str] = set()
+    for target in targets:
+        if ":" not in target:
+            continue
+        module_path = target.split(":", 1)[0].strip()
+        if not module_path:
+            continue
+        rel_parts = module_path.split(".")
+        for root in search_roots:
+            module_file = root.joinpath(*rel_parts).with_suffix(".py")
+            package_init = root.joinpath(*rel_parts, "__init__.py")
+            if module_file.is_file():
+                entry_points.add(module_file.relative_to(repo_path).as_posix())
+                break
+            if package_init.is_file():
+                entry_points.add(package_init.relative_to(repo_path).as_posix())
+                break
+    return entry_points
+
+
 def _html_script_entry_points(repo_path: Path, ignored_paths: list[str] | None = None) -> set[str]:
     # Plain <script src="..."> tags (no bundler, no ES module imports) are
     # invisible to the JS import graph - confirmed on this repo's website/:
@@ -908,6 +988,7 @@ def find_dead_code(
             custom_entry_points = {path for path in raw_entry_points if isinstance(path, str)}
 
     html_script_entry_points = _html_script_entry_points(repo_path, ignored_paths)
+    python_console_script_entry_points = _python_console_script_entry_points(repo_path)
     android_manifest_entry_points = _android_manifest_entry_points(repo_path, ignored_paths)
     jvm_package_reachable_files = _jvm_package_reachable_files(
         repo_path, modules, android_manifest_entry_points
@@ -935,6 +1016,7 @@ def find_dead_code(
         if not module.get("imported_by", []):
             if (
                 path in html_script_entry_points
+                or path in python_console_script_entry_points
                 or path in android_manifest_entry_points
                 or _has_main_guard(repo_path, path)
                 or _has_hilt_dagger_annotation(repo_path, path)

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -22,6 +22,79 @@ def test_recognized_entry_point_is_never_unreachable(tmp_path):
     assert set(result["entry_points_detected"]) == {"main.py", "app/__main__.py", "index.js"}
 
 
+def test_pyproject_console_script_at_a_non_standard_module_name_resolves(tmp_path):
+    # Real gap found via audit: pip/setuptools dispatch a
+    # [project.scripts] entry by installing a generated wrapper that
+    # imports the target via importlib.metadata at install time, never a
+    # plain `import` anywhere in the repo's own source - the same
+    # convention-over-reference blind spot ENTRY_POINT_FILENAMES exists
+    # for. Verified against real installed packages (jupyter_client's own
+    # `jupyter-kernel = jupyter_client.kernelapp:main`): kernelapp.py has
+    # no __main__.py sibling, no main guard, and nothing else in the
+    # package imports it - console_scripts is its only reachability
+    # signal at all.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "mytool"\n\n'
+        '[project.scripts]\n'
+        'mytool = "mytool.runner:main"\n'
+    )
+    pkg_dir = tmp_path / "mytool"
+    pkg_dir.mkdir()
+    (pkg_dir / "runner.py").write_text("def main():\n    pass\n")
+    modules = [_module("mytool/runner.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "mytool/runner.py" in result["entry_points_detected"]
+
+
+def test_pyproject_console_script_resolves_under_a_src_layout(tmp_path):
+    # A src/ layout (module under src/<package>/..., pyproject.toml at
+    # the repo root) is common - this very project uses it - and mutually
+    # exclusive with the flat layout above per project, so both must
+    # resolve independently rather than only whichever is tried first.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "mytool"\n\n'
+        '[project.scripts]\n'
+        'mytool = "mytool.runner:main"\n'
+    )
+    pkg_dir = tmp_path / "src" / "mytool"
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "runner.py").write_text("def main():\n    pass\n")
+    modules = [_module("src/mytool/runner.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "src/mytool/runner.py" in result["entry_points_detected"]
+
+
+def test_poetry_style_scripts_table_resolves(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.poetry]\nname = "mytool"\n\n'
+        '[tool.poetry.scripts]\n'
+        'mytool = "mytool.cmdline:entry"\n'
+    )
+    pkg_dir = tmp_path / "mytool"
+    pkg_dir.mkdir()
+    (pkg_dir / "cmdline.py").write_text("def entry():\n    pass\n")
+    modules = [_module("mytool/cmdline.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert result["unreachable_modules"] == []
+    assert "mytool/cmdline.py" in result["entry_points_detected"]
+
+
+def test_pyproject_without_a_scripts_table_does_not_crash(tmp_path):
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "mytool"\n')
+    modules = [_module("mytool/orphan.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["mytool/orphan.py"]
+
+
+def test_malformed_pyproject_toml_does_not_crash(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("this is not [ valid toml")
+    modules = [_module("mytool/orphan.py")]
+    result = find_dead_code(tmp_path, modules, config=None)
+    assert [m["path"] for m in result["unreachable_modules"]] == ["mytool/orphan.py"]
+
+
 def test_test_files_are_never_unreachable(tmp_path):
     modules = [
         _module("tests/test_thing.py"),


### PR DESCRIPTION
## Summary
- pip/setuptools/Poetry dispatch a `[project.scripts]`/`[tool.poetry.scripts]` entry by installing a generated wrapper that imports the target module via `importlib.metadata` at install time - never a plain `import` anywhere in the repo's own source. Same convention-over-reference blind spot `ENTRY_POINT_FILENAMES` already exists for (`manage.py`, `wsgi.py`, `routes.rb`, `management/commands/...`), just never extended to this one.
- The peer session working on the Rails/Laravel/ASP.NET/Django gaps in this same file explicitly flagged this as "deliberately deferred: low-prevalence" without independently verifying it. I checked rather than trusting that judgment either way.

## Honest measurement (this took two passes to get right)
- First pass: scanned 85 real `console_scripts` entries from a conda environment's own `entry_points.txt` files - **42 (49%)** point at a module name outside `ENTRY_POINT_FILENAMES` (pytest itself, numpy, coverage, jupyter_server, pygments, babel, ...). This looked like a large, clearly-not-low-prevalence gap.
- Second pass, more rigorous: checked those 42 candidates against every OTHER existing heuristic in this file (main guards, `__main__.py` siblings, ordinary imports from a package's own test suite, etc.) - only **1 in 18** tested actually depended on this fix. Most well-designed CLI entry modules already carry a redundant safety net (a `__main__.py` that imports them, or their own `if __name__ == "__main__":` guard), so the console_scripts declaration is usually a *second*, redundant signal rather than the only one. The 49% number measures naming, not actual scanner impact - worth remembering as a methodology note for future gap-hunting in this file.
- The one confirmed case is real and not contrived: `jupyter_client`'s actual, currently-installed package declares `jupyter-kernel = jupyter_client.kernelapp:main` for a 93-line `kernelapp.py` with no `__main__.py`, no main guard, and no other importer anywhere in that real package - `console_scripts` is its only reachability signal at all, and it was genuinely flagged dead without this fix.

## Why ship it anyway
The fix is small, correct, and low-risk - a lower real-world hit rate than initially estimated doesn't argue against having it, and the one confirmed real case (a widely-used package) is exactly the shape this exists to close.

## Implementation notes
- Handles both a flat layout and a `src/` layout (this very project's own layout - `pyproject.toml` at the root, packages under `src/`) since both are common and mutually exclusive per project.
- Handles both `[project.scripts]`/`[project.gui-scripts]` (PEP 621) and `[tool.poetry.scripts]` (including Poetry 1.2+'s extras-gated `{reference = "...", extras = [...]}` table form).
- Only reads the repo-root `pyproject.toml`, matching `_parse_pip_pins`'s own existing scope (no recursive search for a nested one in a monorepo).

## Test plan
- [x] 5 new regression tests: non-standard module name resolves (flat layout), src-layout resolves, Poetry-style table resolves, no-scripts-table doesn't crash, malformed TOML doesn't crash - the 3 positive tests confirmed failing before the fix, passing after
- [x] Full suite: 1867 passed
- [x] Verified against real, currently-installed package source (not synthetic stubs): jupyter_client's actual `kernelapp.py`/`kernelspecapp.py` correctly resolve using their real, actual `entry_points.txt` declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
