### PR TITLE
fix: Rails add_reference/t.references foreign_key: to_table override dropped the whole relation

### DIFF
--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -1396,6 +1396,38 @@ def _pluralize(word: str) -> str:
     return lower + "s"
 
 
+def _rails_reference_foreign_key_target_table(args: list[Node], source: bytes, ref_name: str) -> str | None:
+    """The real target table for a `references`/`belongs_to`/`add_reference`/
+    `add_belongs_to` column's foreign key, or None if no FK is declared at
+    all - `foreign_key:` bare `true` means "on, target the pluralized
+    reference name" (Rails' own default), but `foreign_key: { to_table:
+    :users }` (needed whenever the reference name itself doesn't match its
+    real target table, e.g. `approved_by`/`assigned_to`/`reviewer` all
+    pointing at `users`) was treated identically to `foreign_key: false` -
+    `_rb_bool_kwarg`'s `value.type == "true"` check is false for a hash
+    node just as much as for the literal `false`, silently dropping a
+    real, explicit FK relationship rather than just getting its target
+    table wrong. Real, common enough to matter: any "who did this" style
+    reference (approver, assignee, reviewer, last-modified-by) needs
+    exactly this override, since none of those names pluralize to their
+    real target table.
+    """
+    value = _rb_kwarg(args, "foreign_key", source)
+    if value is None or value.type == "false":
+        return None
+    if value.type == "true":
+        return _pluralize(ref_name)
+    if value.type == "hash":
+        hash_pairs = [c for c in value.named_children if c.type == "pair"]
+        to_table_node = _rb_kwarg(hash_pairs, "to_table", source)
+        if to_table_node is not None:
+            explicit = _rb_symbol_text(to_table_node, source)
+            if explicit:
+                return explicit
+        return _pluralize(ref_name)
+    return None
+
+
 def _rails_column_from_typed_call(
     call: Node, source: bytes, rel_path: str, line: int
 ) -> tuple[dict | None, dict | None]:
@@ -1409,7 +1441,6 @@ def _rails_column_from_typed_call(
         ref_name = _rb_symbol_text(positional[0], source)
         if not ref_name:
             return None, None
-        fk_flag = _rb_bool_kwarg(args, "foreign_key", source)
         column = {
             "name": f"{ref_name}_id", "type": "BIGINT", "primary_key": False,
             "nullable": _rb_bool_kwarg(args, "null", source) is not False,
@@ -1418,14 +1449,17 @@ def _rails_column_from_typed_call(
         relation = None
         # Rails' own default for foreign_key: on a reference/belongs_to
         # column is false - unlike `null:` (nullable by default), a real
-        # FK constraint is opt-in, only added when foreign_key: true is
+        # FK constraint is opt-in, only added when foreign_key: true (or
+        # an options hash, e.g. `foreign_key: { to_table: :users }`) is
         # explicit. Treating a missing kwarg as "assume true" (this
-        # module's behavior until this fix) fabricated a constraint that
-        # does not exist in the real schema for the common, undecorated
-        # `t.references :author` / `add_reference :posts, :author` shape.
-        if fk_flag is True:
+        # module's behavior until an earlier fix) fabricated a constraint
+        # that does not exist in the real schema for the common,
+        # undecorated `t.references :author` / `add_reference :posts,
+        # :author` shape.
+        target_table = _rails_reference_foreign_key_target_table(args, source, ref_name)
+        if target_table is not None:
             relation = {
-                "from_column": column["name"], "to_table": _pluralize(ref_name),
+                "from_column": column["name"], "to_table": target_table,
                 "to_column": "id", "on_delete": None, "file": rel_path, "line": line,
             }
         return column, relation
@@ -1693,7 +1727,6 @@ def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[di
         ref_name = _rb_symbol_text(positional[1], source)
         if not table or not ref_name:
             return []
-        fk_flag = _rb_bool_kwarg(args, "foreign_key", source)
         column = {
             "name": f"{ref_name}_id", "type": "BIGINT", "primary_key": False,
             "nullable": _rb_bool_kwarg(args, "null", source) is not False,
@@ -1701,10 +1734,11 @@ def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[di
         }
         events = [{"kind": "add_column", "table": table, "file": rel_path, "line": line,
                    "column": column, "relation": None}]
-        if fk_flag is True:
+        target_table = _rails_reference_foreign_key_target_table(args, source, ref_name)
+        if target_table is not None:
             events.append(
                 {"kind": "add_relation", "table": table, "file": rel_path, "line": line,
-                 "relation": {"from_column": column["name"], "to_table": _pluralize(ref_name),
+                 "relation": {"from_column": column["name"], "to_table": target_table,
                               "to_column": "id", "on_delete": None,
                               "file": rel_path, "line": line}}
             )

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -584,6 +584,68 @@ end
     assert create["relations"] == []
 
 
+def test_rails_reference_foreign_key_to_table_override_is_honored(tmp_path):
+    # Real bug found via audit: `foreign_key: { to_table: :users }` -
+    # needed whenever a reference's own name doesn't match its real
+    # target table (approved_by/assigned_to/reviewer all pointing at
+    # users, not a table named "approved_bies") - was treated identically
+    # to `foreign_key: false` by the old code: `_rb_bool_kwarg`'s
+    # `value.type == "true"` check is false for a hash value just as much
+    # as for the literal `false`, so a real, explicit FK relationship was
+    # silently dropped entirely rather than just pointed at the wrong
+    # table. Covers both the create_table-block form and the standalone
+    # add_reference form, which duplicate this same logic.
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_posts.rb": """
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.references :approved_by, foreign_key: { to_table: :users }
+    end
+    add_reference :posts, :last_editor, foreign_key: { to_table: :users }
+  end
+end
+"""
+        },
+    )
+    events, _ = extract_rails_migrations(repo, ["db/migrate"])
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert len(create["relations"]) == 1
+    block_relation = create["relations"][0]
+    assert block_relation["from_column"] == "approved_by_id"
+    assert block_relation["to_table"] == "users"
+
+    standalone_relation = next(e for e in events if e["kind"] == "add_relation")["relation"]
+    assert standalone_relation["from_column"] == "last_editor_id"
+    assert standalone_relation["to_table"] == "users"
+
+
+def test_rails_reference_foreign_key_hash_without_to_table_still_defaults(tmp_path):
+    # `foreign_key: { ... }` with no to_table: key still enables the FK
+    # (any truthy value does, per Rails' own semantics) and falls back to
+    # the pluralized reference name, same as bare `foreign_key: true`.
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_posts.rb": """
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.references :author, foreign_key: { on_delete: :cascade }
+    end
+  end
+end
+"""
+        },
+    )
+    events, _ = extract_rails_migrations(repo, ["db/migrate"])
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert len(create["relations"]) == 1
+    assert create["relations"][0]["to_table"] == "authors"
+
+
 def test_rails_up_down_migration_only_reads_up_not_down(tmp_path):
     # Real bug, found via a real Discourse migration from 2012
     # (db/migrate/20120423151548_remove_last_post_id.rb): older Rails


### PR DESCRIPTION
## Summary
- `t.references`/`add_reference`'s foreign-key handling used `_rb_bool_kwarg(args, "foreign_key", source)` and checked `if fk_flag is True:`. `_rb_bool_kwarg` returns `value.type == "true"` - which is `False` for a hash value just as much as for the literal `false`. `foreign_key: { to_table: :users }` (needed whenever a reference's own name doesn't match its real target table - `approved_by`/`assigned_to`/`reviewer` all pointing at `users`, never a table literally named e.g. "approved_bies") was therefore indistinguishable from `foreign_key: false`: **the whole relation was silently dropped**, not just pointed at the wrong table.
- Same failure mode/shape as the Rails and Laravel route-override bugs already fixed elsewhere in this file this sweep (`resources :keys, controller: "api"`) - an explicit override option being ignored rather than honored.
- Confirmed by direct execution against the real function before fixing: `t.references :approved_by, foreign_key: { to_table: :users }` produced zero relations.
- Duplicated in two places - `t.references`/`t.belongs_to` inside a `create_table`/`change_table` block, and the standalone `add_reference`/`add_belongs_to` form - both fixed via one shared helper.

## Fix
New `_rails_reference_foreign_key_target_table` helper reads the raw `foreign_key:` value node directly instead of coercing it to a bool first:
- `true` -> pluralize the reference name (existing default, unchanged)
- a hash -> FK is on; honor `to_table:` if present, otherwise fall back to the pluralized name (matches Rails' own semantics: any truthy value enables the FK, the hash just carries options)
- `false`/absent -> no relation (existing default, unchanged)

## Test plan
- [x] Two new regression tests: `to_table:` override honored (both block and standalone forms), and a hash *without* `to_table:` still defaults correctly - both confirmed failing before the fix, passing after
- [x] Full suite: 1897 passed, including every pre-existing Rails reference/FK test (unchanged behavior for `true`/`false`/absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
