### PR TITLE
fix: Alembic alter_column's new_column_name rename was never modeled

### DIFF
--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -906,6 +906,26 @@ def _alembic_batch_op_events(
         col_name = _py_string_text(positional[0], source)
         if not col_name:
             return []
+        events: list[dict] = []
+        # A real, documented Alembic idiom - alter_column's new_column_name
+        # kwarg renames a column, the same operation as a standalone
+        # op.rename_column would be if Alembic had one (it doesn't; this
+        # is the only way to rename via op.*). Without checking for it,
+        # a pure rename (new_column_name with no type_/nullable/
+        # server_default change alongside it) produced zero events at
+        # all - not just an imprecise one, completely invisible - and a
+        # rename combined with another real change (e.g. nullable=False)
+        # still applied that other change but silently kept the column
+        # under its old name in the tracked schema forever. Confirmed by
+        # direct execution against the real function before fixing.
+        new_name_kw = _py_kwarg(args, "new_column_name", source)
+        new_name = _py_string_text(new_name_kw, source) if new_name_kw is not None else None
+        if new_name:
+            events.append(
+                {"kind": "rename_column", "table": table, "old_name": col_name,
+                 "new_name": new_name, "file": rel_path, "line": line}
+            )
+            col_name = new_name
         changes: dict = {}
         type_kw = _py_kwarg(args, "type_", source)
         if type_kw is not None and type_kw.type == "call":
@@ -916,10 +936,12 @@ def _alembic_batch_op_events(
         default_kw = _py_kwarg(args, "server_default", source)
         if default_kw is not None:
             changes["default"] = _py_scalar_default(default_kw, source)
-        if not changes:
-            return []
-        return [{"kind": "alter_column", "table": table, "name": col_name,
-                 "changes": changes, "file": rel_path, "line": line}]
+        if changes:
+            events.append(
+                {"kind": "alter_column", "table": table, "name": col_name,
+                 "changes": changes, "file": rel_path, "line": line}
+            )
+        return events
 
     if method == "create_index":
         if not positional:
@@ -1161,6 +1183,19 @@ def _alembic_upgrade_events(upgrade_body: Node, source: bytes, rel_path: str) ->
             col_name = _py_string_text(positional[1], source)
             if not table or not col_name:
                 continue
+            # See the matching comment in _alembic_batch_op_events - a
+            # pure rename via new_column_name (no type_/nullable/
+            # server_default alongside it) previously produced no event
+            # at all, and a rename combined with another change silently
+            # kept the column under its old name.
+            new_name_kw = _py_kwarg(args, "new_column_name", source)
+            new_name = _py_string_text(new_name_kw, source) if new_name_kw is not None else None
+            if new_name:
+                events.append(
+                    {"kind": "rename_column", "table": table, "old_name": col_name,
+                     "new_name": new_name, "file": rel_path, "line": line}
+                )
+                col_name = new_name
             changes: dict = {}
             type_kw = _py_kwarg(args, "type_", source)
             if type_kw is not None and type_kw.type == "call":

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -1295,6 +1295,102 @@ def upgrade():
     assert result["indexes"] == []
 
 
+def test_alembic_alter_column_new_column_name_renames_it(tmp_path):
+    # Real bug found via audit: alter_column's new_column_name kwarg is a
+    # real, documented Alembic idiom for renaming a column - the only way
+    # op.* offers to rename one at all (there is no op.rename_column). A
+    # pure rename (no type_/nullable/server_default alongside it)
+    # produced no event whatsoever before this fix - not just imprecise,
+    # completely invisible, so the column kept its old name in the
+    # tracked schema forever.
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+import sqlalchemy as sa
+
+revision = "abc123"
+down_revision = None
+
+def upgrade():
+    op.create_table('users',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('old_email', sa.String(length=100)),
+    )
+    op.alter_column('users', 'old_email', new_column_name='email')
+"""
+        },
+    )
+    result = extract_schema(repo, ["alembic/versions"])
+    users = next(t for t in result["tables"] if t["name"] == "users")
+    names = [c["name"] for c in users["columns"]]
+    assert "email" in names
+    assert "old_email" not in names
+
+
+def test_alembic_alter_column_rename_combined_with_another_change(tmp_path):
+    # A rename combined with a real change (nullable=False here) must
+    # apply that change to the column's NEW name, not silently keep
+    # applying it to (and leaving the column tracked under) the old one.
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+import sqlalchemy as sa
+
+revision = "abc123"
+down_revision = None
+
+def upgrade():
+    op.create_table('users',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('old_phone', sa.String(length=20), nullable=True),
+    )
+    op.alter_column('users', 'old_phone', new_column_name='phone', nullable=False)
+"""
+        },
+    )
+    result = extract_schema(repo, ["alembic/versions"])
+    users = next(t for t in result["tables"] if t["name"] == "users")
+    names = [c["name"] for c in users["columns"]]
+    assert "phone" in names
+    assert "old_phone" not in names
+    phone_col = next(c for c in users["columns"] if c["name"] == "phone")
+    assert phone_col["nullable"] is False
+
+
+def test_alembic_batch_alter_table_new_column_name_renames_it(tmp_path):
+    # Same bug, reached through the batch_op form (SQLite's ALTER TABLE
+    # workaround) rather than a top-level op.alter_column call.
+    repo = write_files(
+        tmp_path,
+        {
+            "alembic/versions/abc123_init.py": """
+from alembic import op
+import sqlalchemy as sa
+
+revision = "abc123"
+down_revision = None
+
+def upgrade():
+    op.create_table('users',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('old_email', sa.String(length=100)),
+    )
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.alter_column('old_email', new_column_name='email')
+"""
+        },
+    )
+    result = extract_schema(repo, ["alembic/versions"])
+    users = next(t for t in result["tables"] if t["name"] == "users")
+    names = [c["name"] for c in users["columns"]]
+    assert "email" in names
+    assert "old_email" not in names
+
+
 def test_alembic_drop_constraint_stays_unsupported(tmp_path):
     repo = write_files(
         tmp_path,


### PR DESCRIPTION
## Summary
- `op.alter_column(table, col, new_column_name="new", ...)` is a real, documented Alembic idiom - the only way `op.*` offers to rename a column at all (there is no `op.rename_column`). Neither `alter_column` handler (the top-level `op.*` form or the `batch_op` form used inside `with op.batch_alter_table(...)`) checked for `new_column_name` at all.
- Confirmed by direct execution against the real function before fixing: a pure rename (`new_column_name="email"`, no `type_`/`nullable`/`server_default` alongside it) produced **zero events** - not just an imprecise one, completely invisible, so the column kept its old name in the tracked schema forever. A rename combined with a real change (e.g. `nullable=False`) still applied that other change, but kept targeting (and left the schema tracking) the column under its OLD name, since the "name" used for the `alter_column` event was never updated to reflect the rename.

## Fix
Both handlers now check for `new_column_name` first and, when present, emit a `rename_column` event before any `alter_column` event for the same call - the `alter_column` event (if there's another real change alongside the rename) then correctly targets the NEW name, matching the order `_merge_schema_events` needs to apply them in.

## Test plan
- [x] 3 new regression tests: pure rename (top-level `op.*`), rename combined with another change, and the same pure-rename case via the `batch_op` form - all confirmed failing before the fix, passing after
- [x] Full suite: 1903 passed, including the pre-existing `alter_column` test covering `nullable`/`type_` changes with no rename (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
