### PR TITLE
fix: Django ForeignKey's to_field= option was ignored, to_column hardcoded to "id"

### DIFF
--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -387,11 +387,23 @@ def _django_column_from_field(
         # check as resolved_name above, same reason: an explicit
         # db_column="" must not be treated as absent via truthiness.
         column["name"] = f"{field_name}_id" if db_column is None else db_column
+        # to_field (real bug found via audit, same shape as db_column's
+        # own fix above but on the TARGET side instead of the source
+        # side): a real, documented Django option for referencing a
+        # unique field other than the target model's primary key - a
+        # slug/username/UUID-based FK, a real and common pattern, not a
+        # rare one. Was hardcoded to "id" unconditionally, so any such FK
+        # got a to_column that doesn't exist in the real target table's
+        # own schema for that role. Same `is None` reasoning as
+        # db_column: an explicit to_field="" must not be treated as
+        # absent via truthiness.
+        to_field_node = _py_kwarg(args, "to_field", source)
+        to_field = _py_string_text(to_field_node, source) if to_field_node is not None else None
         if target_text is not None:
             relation = {
                 "from_column": column["name"],
                 "to_table": target_text,
-                "to_column": "id",
+                "to_column": "id" if to_field is None else to_field,
                 "on_delete": on_delete,
                 "file": rel_path,
                 "line": line,

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -251,6 +251,67 @@ class Migration(migrations.Migration):
     assert relation["to_table"] == "accounts_user"
 
 
+def test_django_foreign_key_to_field_overrides_the_target_column(tmp_path):
+    # Real bug found via audit: to_field=... is a real, documented Django
+    # option for referencing a unique field other than the target
+    # model's primary key (a slug/username/UUID-based FK - a common
+    # pattern, not a rare one). to_column was hardcoded to "id"
+    # unconditionally, so any such FK got a to_column that doesn't exist
+    # in the real target table's own schema for that role.
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[
+                ('id', models.AutoField(primary_key=True)),
+                ('author', models.ForeignKey(
+                    to='accounts.User', to_field='username', on_delete=models.CASCADE,
+                )),
+            ],
+        ),
+    ]
+"""
+        },
+    )
+    events, _ = extract_django_migrations(repo, ["blog/migrations"])
+    create = next(e for e in events if e["kind"] == "create_table")
+    relation = create["relations"][0]
+    assert relation["from_column"] == "author_id"
+    assert relation["to_table"] == "accounts_user"
+    assert relation["to_column"] == "username"
+
+
+def test_django_foreign_key_without_to_field_still_defaults_to_id(tmp_path):
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[
+                ('id', models.AutoField(primary_key=True)),
+                ('author', models.ForeignKey(to='accounts.User', on_delete=models.CASCADE)),
+            ],
+        ),
+    ]
+"""
+        },
+    )
+    events, _ = extract_django_migrations(repo, ["blog/migrations"])
+    create = next(e for e in events if e["kind"] == "create_table")
+    assert create["relations"][0]["to_column"] == "id"
+
+
 def test_django_db_column_empty_string_is_not_treated_as_absent(tmp_path):
     # Real bug found via Flash Review's own dogfooded review of the PR
     # that introduced db_column support: `db_column or field_name` uses


### PR DESCRIPTION
## Summary
- `to_field=` is a real, documented Django option for referencing a unique field other than the target model's primary key - a slug/username/UUID-based FK, a common pattern (legacy schema integration, natural keys), not a rare one. The FK-relation builder hardcoded `to_column` to `"id"` unconditionally, so any such FK got a `to_column` that doesn't exist in the real target table's own schema for that role.
- Same class of gap `db_column`'s own earlier fix (already merged in this sweep) closed on the SOURCE side (this file's own column name) - just missed here on the TARGET side of the same relation.
- Confirmed by direct execution against the real function before fixing: `ForeignKey(to='accounts.User', to_field='username', on_delete=...)` produced a relation with `to_column="id"`.

## Fix
Read `to_field` the same careful way `db_column` already is - an `is None` check, not truthiness, so an explicit `to_field=""` isn't treated as absent - and use it for `to_column` when present. Falls back to `"id"` unchanged when absent.

Single shared builder function (`_django_column_from_field`) is used by `CreateModel`/`AddField`/`AlterField` alike, so one fix covers every Django code path - no duplication to chase here, unlike the Rails `foreign_key: { to_table: ... }` fix earlier in this sweep which needed the same fix in two places.

## Test plan
- [x] Two new regression tests: `to_field` override honored, and the no-`to_field` case still defaults to `"id"` (negative control) - the positive test confirmed failing before the fix, passing after
- [x] Full suite: 1904 passed, including every pre-existing Django FK/db_column test (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
