### PR TITLE
fix: Rails change_column_default's reversible from:/to: form produced no event

### DIFF
--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -1847,17 +1847,34 @@ def _rails_top_level_events(call: Node, source: bytes, rel_path: str) -> list[di
                                "(relations are not individually addressable for removal)"}]
 
     if method in ("change_column_null", "change_column_default"):
-        if len(positional) < 3:
+        if len(positional) < 2:
             return []
         table = _rb_symbol_text(positional[0], source)
         col_name = _rb_symbol_text(positional[1], source)
         if not table or not col_name:
             return []
-        value_node = positional[2]
         if method == "change_column_null":
-            changes = {"nullable": value_node.type == "true"}
+            if len(positional) < 3:
+                return []
+            changes = {"nullable": positional[2].type == "true"}
         else:
-            changes = {"default": _rb_text(value_node, source)}
+            # change_column_default(table, column, value) - the plain
+            # form - OR Rails' own officially recommended reversible
+            # form, change_column_default(table, column, from: ...,
+            # to: ...) (a plain value has no way to be reversed on
+            # rollback, so Rails' own migration guides push this form
+            # specifically). `to:` is a keyword pair, not a 3rd
+            # positional arg, so it was invisible to a len(positional) <
+            # 3 check - not just imprecise, this whole call produced no
+            # event at all. Confirmed by direct execution against the
+            # real function before fixing.
+            if len(positional) >= 3:
+                changes = {"default": _rb_text(positional[2], source)}
+            else:
+                to_kwarg = _rb_kwarg(args, "to", source)
+                if to_kwarg is None:
+                    return []
+                changes = {"default": _rb_text(to_kwarg, source)}
         return [{"kind": "alter_column", "table": table, "name": col_name, "changes": changes,
                  "file": rel_path, "line": line}]
 

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -1064,6 +1064,41 @@ end
     assert views["default"] == "0"
 
 
+def test_rails_change_column_default_reversible_from_to_form(tmp_path):
+    # Real bug found via audit: change_column_default(table, column,
+    # from: ..., to: ...) is Rails' own officially recommended form for
+    # this operation specifically because a plain value has no way to be
+    # reversed on rollback - Rails' own migration guides push this form,
+    # not a rare alternative. `to:` is a keyword pair, not a 3rd
+    # positional argument, so a `len(positional) < 3` check made this
+    # whole call invisible - not just imprecise, no event at all.
+    repo = write_files(
+        tmp_path,
+        {
+            "db/migrate/20230101000000_create_posts.rb": """
+class CreatePosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :posts do |t|
+      t.string :status
+    end
+  end
+end
+""",
+            "db/migrate/20230102000000_alter_posts.rb": """
+class AlterPosts < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :posts, :status, from: nil, to: "draft"
+  end
+end
+""",
+        },
+    )
+    result = extract_schema(repo, ["db/migrate"])
+    table = next(t for t in result["tables"] if t["name"] == "posts")
+    status = next(c for c in table["columns"] if c["name"] == "status")
+    assert status["default"] == '"draft"'
+
+
 def test_rails_execute_replays_through_sql_parser(tmp_path):
     repo = write_files(
         tmp_path,


### PR DESCRIPTION
## Summary
- `change_column_default(table, column, from: ..., to: ...)` is Rails' own officially recommended form for this operation - a plain value (`change_column_default(table, column, value)`) has no way to be reversed on rollback, so Rails' own migration guides and generators push the `from:`/`to:` form specifically, not as a rare alternative.
- `to:` is a keyword pair, not a 3rd positional argument - the old `if len(positional) < 3: return []` guard made the whole call invisible whenever this form was used, not just imprecisely captured.
- Confirmed by direct execution against the real function before fixing: `change_column_default :posts, :status, from: nil, to: "draft"` produced zero events; the plain-value form worked correctly.

## Fix
When fewer than 3 positional args are present, fall back to reading the `to:` keyword argument for the new default value; returns `[]` only when neither form supplies one. `change_column_null`'s own 3-positional-arg requirement is unchanged - it has no `from:`/`to:` keyword form to account for.

## Test plan
- [x] New regression test for the `from:`/`to:` form, confirmed failing before the fix, passing after
- [x] Full suite: 1903 passed, including the pre-existing plain-value `change_column_default`/`change_column_null` test (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
