### PR TITLE
fix: Django AddIndex recorded a descending field's "-" prefix as part of the column name

### DIFF
--- a/src/aletheore/orm_migrations.py
+++ b/src/aletheore/orm_migrations.py
@@ -504,7 +504,14 @@ def _django_model_operations(
                 for f in fields_node.named_children:
                     text = _py_string_text(f, source)
                     if text:
-                        field_names.append(text)
+                        # A real, documented Django Index feature: a
+                        # leading "-" sorts that column descending within
+                        # the index (`models.Index(fields=['-created_at',
+                        # 'title'])`) - it's DSL syntax for sort
+                        # direction, not part of the real column name.
+                        # Left unstripped, the recorded "column" doesn't
+                        # match anything in the table's own real schema.
+                        field_names.append(text.lstrip("-"))
             name_node = _py_kwarg(index_args, "name", source)
             index_name = _py_string_text(name_node, source) if name_node else None
             if not index_name:

--- a/src/tests/test_orm_migrations.py
+++ b/src/tests/test_orm_migrations.py
@@ -323,6 +323,41 @@ class Migration(migrations.Migration):
     assert result["dialect"] == ["django"]
 
 
+def test_django_add_index_strips_descending_field_prefix(tmp_path):
+    # Real bug found via audit: a leading "-" in models.Index(fields=[...])
+    # is real, documented Django syntax for sorting that column descending
+    # WITHIN the index - it's DSL notation, not part of the real column
+    # name. Left unstripped, the recorded index column ("-created_at")
+    # never matches the table's own real column ("created_at").
+    repo = write_files(
+        tmp_path,
+        {
+            "blog/migrations/0001_initial.py": """
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[
+                ('id', models.AutoField(primary_key=True)),
+                ('created_at', models.DateTimeField()),
+                ('title', models.CharField(max_length=200)),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name='post',
+            index=models.Index(fields=['-created_at', 'title'], name='post_recent_idx'),
+        ),
+    ]
+"""
+        },
+    )
+    result = extract_schema(repo, ["blog/migrations"])
+    index = result["indexes"][0]
+    assert index["columns"] == ["created_at", "title"]
+
+
 def test_django_remove_field_alter_field_rename_field_delete_model(tmp_path):
     repo = write_files(
         tmp_path,


### PR DESCRIPTION
## Summary
- A leading `-` in `models.Index(fields=[...])` is real, documented Django syntax for sorting that column descending within the index (`models.Index(fields=['-created_at', 'title'], ...)`) - DSL notation for sort direction, not part of the real column name. Left unstripped, the recorded index column (`"-created_at"`) never matches the table's own real column (`"created_at"`) anywhere else in the tracked schema.
- Confirmed by direct execution against the real function before fixing: `fields=['-created_at', 'title']` produced `columns=['-created_at', 'title']`.

## Fix
Strip a leading `-` when building the index's column list. No other place in this module parses an `Index(fields=[...])` list, so this is the only fix needed - unlike the Rails `foreign_key: { to_table: ... }` gap earlier in this sweep, which was duplicated across two call sites.

## Test plan
- [x] New regression test, confirmed failing before the fix, passing after
- [x] Full suite: 1903 passed, including the pre-existing `AddIndex` test with a plain (non-descending) field list (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
