### PR TITLE
fix: Vapor route with no additional path segment was silently dropped

### DIFF
--- a/src/aletheore/endpoints.py
+++ b/src/aletheore/endpoints.py
@@ -1253,7 +1253,25 @@ def _extract_vapor_routes(root: Node, source: bytes, rel_path: str) -> list[dict
                     # must-start-with-"/" guard doesn't work here: unlike
                     # Express, real Vapor path segments never carry a leading
                     # "/" in source, so that signal isn't available.
-                    if path_segments and (trailing_closure is not None or handler_label is not None):
+                    #
+                    # Real bug found via audit: `path_segments` was ALSO
+                    # required to be non-empty, which drops a route
+                    # registered with no additional path segment at all -
+                    # `users.get(use: index)` for the idiomatic REST
+                    # "index" action living at a group's own base path
+                    # (`GET /users`, contrasted with `users.get(":id", use:
+                    # show)` for `GET /users/:id`), or even the simplest
+                    # possible case with no grouping at all,
+                    # `app.get(use: index)` (the literal application
+                    # root). Confirmed directly: both produced zero
+                    # entries, not just an imprecise path - the whole
+                    # route vanished, contradicting this function's own
+                    # "still caught" claim above. An empty path_segments
+                    # list is a valid state (root path relative to
+                    # whatever prefix applies), not "no route here" -
+                    # "/" + "/".join([]) already correctly produces "/"
+                    # on its own, so only the guard was wrong.
+                    if trailing_closure is not None or handler_label is not None:
                         entries.append(
                             {
                                 "method": method_name.upper(),

--- a/src/tests/test_endpoints.py
+++ b/src/tests/test_endpoints.py
@@ -1019,6 +1019,32 @@ def test_extract_vapor_route_with_use_labeled_handler_and_multi_segment_path():
     ]
 
 
+def test_extract_vapor_route_with_no_additional_path_segment():
+    # Real bug found via audit: a route registered with no additional path
+    # segment at all - the idiomatic REST "index"/"create" action living
+    # at a group's own base path (GET /users via `users.get(use: index)`,
+    # contrasted with GET /users/:id via `users.get(":id", use: show)`) -
+    # produced zero entries, not just an imprecise path. An empty
+    # path_segments list is a valid state (the route's own root, relative
+    # to whatever prefix applies), not "no route here".
+    root, source = parse_swift('app.get(use: index)\n')
+
+    entries = _extract_vapor_routes(root, source, "routes.swift")
+
+    assert entries == [
+        {
+            "method": "GET",
+            "path": "/",
+            "framework": "vapor",
+            "file": "routes.swift",
+            "line": 1,
+            "handler": "index",
+            "unresolved": False,
+            "note": None,
+        }
+    ]
+
+
 def test_extract_vapor_route_on_grouped_sub_router():
     # A route group ("api.get(...)" where api = app.grouped("api")) is
     # caught the same way Express's mounted sub-routers are: by matching


### PR DESCRIPTION
## Summary
- `_extract_vapor_routes` required `path_segments` to be non-empty **on top of** the intended false-positive guard (a trailing closure or `use:`-labeled handler present). This drops a route registered with no additional path segment at all - the idiomatic REST "index"/"create" action living at a group's own base path (`users.get(use: index)` for `GET /users`, contrasted with `users.get(":id", use: show)` for `GET /users/:id`), or even the simplest possible case with no grouping involved at all, `app.get(use: index)` (the literal application root).
- Confirmed by direct execution against the real function before fixing: both produced **zero entries** - not just an imprecise path, the whole route vanished, directly contradicting this function's own docstring claim that a route is "still caught" regardless of how its receiver got its prefix.

## Fix
Drop `path_segments` from the guard - `"/" + "/".join([])` already correctly produces `"/"` on its own, so only the guard condition needed fixing, not the path-building logic. The comment already described the intended guard correctly (closure or `use:` handler); only the code enforced something stricter than what was documented.

**Note**: this does not fix the separate, already-documented limitation that a `.grouped("api")` prefix isn't composed into the recorded path (a real but harder gap - the docstring's own design already accepts this tradeoff deliberately, unlike the bug fixed here, which wasn't disclosed anywhere). Verified this gap still exists and is unrelated in scope; not fixed here.

## Test plan
- [x] New regression test for the no-additional-path-segment case, confirmed failing before the fix, passing after
- [x] Full suite: 1903 passed, including the pre-existing Vapor tests (multi-segment path + `use:`, trailing closure, grouped sub-router, and the unrelated-`.get()`-call negative control) - all unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
