### PR TITLE
fix: composite UNIQUE constraint marked every individual column unique

### DIFF
--- a/src/aletheore/schema_map.py
+++ b/src/aletheore/schema_map.py
@@ -534,10 +534,28 @@ def _sql_apply_table_constraint(
     elif isinstance(node, exp.UniqueColumnConstraint):
         target = node.args.get("this")
         names = target.expressions if isinstance(target, exp.Schema) else []
-        for identifier in names:
-            column = by_name.get(identifier.name)
+        # Real bug found via audit: a composite UNIQUE (a, b) constrains
+        # the PAIR, not either column alone - a very common real pattern
+        # (UNIQUE (tenant_id, email), scoping uniqueness per-tenant, the
+        # same email legitimately reusable across different tenants).
+        # Marking each individual column column["unique"] = True fabricates
+        # a materially stronger, wrong claim (that email alone has no
+        # duplicates table-wide) - unlike PRIMARY KEY, whose per-column
+        # "is this column part of the [possibly composite] key" flag is
+        # already a defensible membership fact regardless of arity, this
+        # module's "unique" flag has no such composite-safe interpretation
+        # anywhere else it's read. Single-column UNIQUE (the common case)
+        # is unaffected; only 2+ columns falls through to unsupported
+        # rather than fabricating a false single-column guarantee.
+        if len(names) == 1:
+            column = by_name.get(names[0].name)
             if column is not None:
                 column["unique"] = True
+        elif len(names) > 1:
+            unsupported.append(
+                {"file": rel_path, "line": line,
+                 "statement": _summarize(f"{label} {node.sql(dialect=_SQL_DIALECT)}")}
+            )
     elif isinstance(node, exp.ForeignKey):
         relations.extend(
             _sql_foreign_key_relations(node, rel_path, line, table=table, name=constraint_name)
@@ -799,10 +817,22 @@ def _sql_alter_table_events(stmt: exp.Alter, rel_path: str, line: int) -> list[d
                     elif isinstance(inner, exp.UniqueColumnConstraint):
                         target = inner.args.get("this")
                         names = target.expressions if isinstance(target, exp.Schema) else []
-                        for identifier in names:
+                        # Same real bug, ADD CONSTRAINT shape: a composite
+                        # UNIQUE (a, b) constrains the pair, not either
+                        # column alone - see the matching fix/comment in
+                        # _sql_apply_table_constraint for the CREATE TABLE
+                        # shape of this same constraint.
+                        if len(names) == 1:
                             events.append(
-                                {"kind": "alter_column", "table": table, "name": identifier.name,
+                                {"kind": "alter_column", "table": table, "name": names[0].name,
                                  "changes": {"unique": True}, "file": rel_path, "line": line}
+                            )
+                        elif len(names) > 1:
+                            events.append(
+                                {"kind": "unsupported", "file": rel_path, "line": line,
+                                 "statement": _summarize(
+                                     f"ALTER TABLE {table} ADD CONSTRAINT {inner.sql(dialect=_SQL_DIALECT)}"
+                                 )}
                             )
                     elif isinstance(inner, (exp.PrimaryKeyColumnConstraint, exp.PrimaryKey)):
                         names = inner.expressions if isinstance(inner, exp.PrimaryKey) else []

--- a/src/tests/test_schema_map.py
+++ b/src/tests/test_schema_map.py
@@ -453,6 +453,56 @@ def test_composite_primary_key_and_table_level_unique(tmp_path):
     assert columns["user_id"]["unique"] is True
 
 
+def test_composite_unique_constraint_does_not_mark_either_column_unique(tmp_path):
+    # Real bug found via audit: a composite UNIQUE (a, b) constrains the
+    # PAIR, not either column alone - a common real pattern (UNIQUE
+    # (tenant_id, email), scoping uniqueness per-tenant, the same email
+    # legitimately reusable across different tenants). Marking each
+    # individual column unique=True fabricated a materially stronger,
+    # wrong claim (email alone has no duplicates table-wide).
+    repo = write_migrations(
+        tmp_path,
+        {
+            "001.sql": """
+            CREATE TABLE memberships (
+                tenant_id BIGINT NOT NULL,
+                email TEXT NOT NULL,
+                UNIQUE (tenant_id, email)
+            );
+            """
+        },
+    )
+    result = extract_schema(repo, ["migrations"])
+    columns = {c["name"]: c for c in result["tables"][0]["columns"]}
+    assert columns["tenant_id"]["unique"] is False
+    assert columns["email"]["unique"] is False
+    assert any(
+        "UNIQUE (tenant_id, email)" in u["statement"] for u in result["unsupported"]
+    )
+
+
+def test_composite_unique_via_add_constraint_does_not_mark_either_column_unique(tmp_path):
+    repo = write_migrations(
+        tmp_path,
+        {
+            "001.sql": """
+            CREATE TABLE memberships (
+                tenant_id BIGINT NOT NULL,
+                email TEXT NOT NULL
+            );
+            ALTER TABLE memberships ADD CONSTRAINT uq_tenant_email UNIQUE (tenant_id, email);
+            """
+        },
+    )
+    result = extract_schema(repo, ["migrations"])
+    columns = {c["name"]: c for c in result["tables"][0]["columns"]}
+    assert columns["tenant_id"]["unique"] is False
+    assert columns["email"]["unique"] is False
+    assert any(
+        "UNIQUE (tenant_id, email)" in u["statement"] for u in result["unsupported"]
+    )
+
+
 def test_column_level_check_constraint_is_modeled(tmp_path):
     repo = write_migrations(
         tmp_path,


### PR DESCRIPTION
## Summary
- A composite `UNIQUE (a, b)` constrains the PAIR, not either column alone - a common real pattern (`UNIQUE (tenant_id, email)`, scoping uniqueness per-tenant, the same email legitimately reusable across different tenants). Marking each individual column `column["unique"] = True` fabricated a materially stronger, wrong claim - that `email` alone has no duplicates table-wide - when the real database constraint only guarantees no two rows share the exact same `(tenant_id, email)` pair.
- Confirmed by direct execution against the real function before fixing, both call shapes: `UNIQUE (tenant_id, email)` inside `CREATE TABLE`, and `ALTER TABLE ... ADD CONSTRAINT ... UNIQUE (tenant_id, email)` - both marked `tenant_id` and `email` individually unique.
- **Not touching `PRIMARY KEY`**: unlike `UNIQUE`, a composite primary key's per-column "is this column part of the (possibly composite) key" flag is already a defensible membership fact regardless of arity - real schema-introspection tools commonly represent it this way, and nothing downstream reads `primary_key` as "this single column alone determines row identity." `UNIQUE` has no equivalent composite-safe interpretation anywhere this flag is read, so only `UNIQUE` needed fixing.

## Fix
Single-column `UNIQUE` (the common case) is unaffected; 2+ columns falls through to `unsupported` rather than fabricating a false single-column guarantee - matching this module's own established convention for a real constraint it can't precisely model (the same pattern already used for named constraints it can't resolve elsewhere in this file).

## Test plan
- [x] Two new regression tests (`CREATE TABLE`-level and `ADD CONSTRAINT`-level composite `UNIQUE`), confirmed failing before the fix, passing after
- [x] Full suite: 1909 passed, including the pre-existing composite-primary-key-and-single-column-unique test (unchanged behavior for both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
