### PR TITLE
fix: Python optional/dev dependencies invisible to CVE scanning and license checks

### DIFF
--- a/src/aletheore/vulnerabilities.py
+++ b/src/aletheore/vulnerabilities.py
@@ -122,6 +122,31 @@ def _parse_pip_pins(repo_path: Path) -> list[tuple[str, str, str]]:
         if pin:
             pins.append(pin)
 
+    # Real gap found via audit: [project.optional-dependencies] (PEP 621
+    # extras, e.g. a "test"/"dev" group) and Poetry's own
+    # [tool.poetry.group.<name>.dependencies] (1.2+) / [tool.poetry.
+    # dev-dependencies] (the older, pre-1.2 form of the same thing) are
+    # all real, direct, first-party declared dependencies - not
+    # transitive ones (see _parse_npm_direct_pins' own docstring on why
+    # transitive deps are deliberately excluded; that reasoning doesn't
+    # apply here) - yet none of them were read at all. This function's
+    # own two real callers are dependency-vulnerability scanning and
+    # license checking: a genuinely vulnerable pinned package declared
+    # only under a dev/test extras group (`pytest-xdist==1.0` with a
+    # real, published CVE) was invisible to CVE scanning entirely,
+    # regardless of how out of date or risky it actually was.
+    optional_deps = data.get("project", {}).get("optional-dependencies", {})
+    if isinstance(optional_deps, dict):
+        for group in optional_deps.values():
+            if not isinstance(group, list):
+                continue
+            for dependency in group:
+                if not isinstance(dependency, str):
+                    continue
+                pin = _parse_pep508_dependency(dependency)
+                if pin:
+                    pins.append(pin)
+
     poetry_deps = data.get("tool", {}).get("poetry", {}).get("dependencies", {})
     for name, value in poetry_deps.items():
         if name.lower() == "python":
@@ -129,6 +154,29 @@ def _parse_pip_pins(repo_path: Path) -> list[tuple[str, str, str]]:
         pin = _parse_python_dependency_value(name, value)
         if pin:
             pins.append(pin)
+
+    poetry_dev_deps = data.get("tool", {}).get("poetry", {}).get("dev-dependencies", {})
+    for name, value in poetry_dev_deps.items():
+        if name.lower() == "python":
+            continue
+        pin = _parse_python_dependency_value(name, value)
+        if pin:
+            pins.append(pin)
+
+    poetry_groups = data.get("tool", {}).get("poetry", {}).get("group", {})
+    if isinstance(poetry_groups, dict):
+        for group_config in poetry_groups.values():
+            if not isinstance(group_config, dict):
+                continue
+            group_deps = group_config.get("dependencies", {})
+            if not isinstance(group_deps, dict):
+                continue
+            for name, value in group_deps.items():
+                if name.lower() == "python":
+                    continue
+                pin = _parse_python_dependency_value(name, value)
+                if pin:
+                    pins.append(pin)
 
     return pins
 

--- a/src/tests/test_vulnerabilities.py
+++ b/src/tests/test_vulnerabilities.py
@@ -572,6 +572,60 @@ def test_parse_pip_pins_reads_pep621_pyproject_dependencies(tmp_path):
     assert ("tzdata", "*", "PyPI") in pins
 
 
+def test_parse_pip_pins_reads_pep621_optional_dependencies(tmp_path):
+    # Real gap found via audit: [project.optional-dependencies] (PEP 621
+    # extras, e.g. a "test"/"dev" group) is a real, direct, first-party
+    # declared dependency set - not a transitive one - yet was never read
+    # at all. This function's own two real callers are CVE scanning and
+    # license checking: a genuinely vulnerable pinned package declared
+    # only under a dev/test extras group was invisible to CVE scanning
+    # entirely, regardless of how out of date or risky it actually was.
+    from aletheore.vulnerabilities import _parse_pip_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "[project]\n"
+        'dependencies = ["requests>=2.0"]\n\n'
+        "[project.optional-dependencies]\n"
+        'test = ["pytest==6.0.0"]\n'
+        'dev = ["black==20.8b0"]\n'
+    )
+
+    pins = _parse_pip_pins(repo)
+
+    assert ("requests", "2.0", "PyPI") in pins
+    assert ("pytest", "6.0.0", "PyPI") in pins
+    assert ("black", "20.8b0", "PyPI") in pins
+
+
+def test_parse_pip_pins_reads_poetry_dependency_groups_and_legacy_dev_dependencies(tmp_path):
+    # Same gap, Poetry's own two forms of the same thing: [tool.poetry.
+    # group.<name>.dependencies] (1.2+) and [tool.poetry.dev-dependencies]
+    # (the older, pre-1.2 shape) - both real, direct dependency
+    # declarations, neither read at all before this fix.
+    from aletheore.vulnerabilities import _parse_pip_pins
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        "[tool.poetry.dependencies]\n"
+        'python = "^3.12"\n'
+        'django = "^5.1.0"\n\n'
+        "[tool.poetry.group.dev.dependencies]\n"
+        'pytest = "6.0.0"\n\n'
+        "[tool.poetry.dev-dependencies]\n"
+        'black = "20.8b0"\n'
+    )
+
+    pins = _parse_pip_pins(repo)
+
+    assert ("django", "5.1.0", "PyPI") in pins
+    assert ("pytest", "6.0.0", "PyPI") in pins
+    assert ("black", "20.8b0", "PyPI") in pins
+    assert not any(pin[0] == "python" for pin in pins)
+
+
 def test_parse_pip_pins_keeps_compound_compatible_and_unpinned_pep508_dependencies(tmp_path):
     from aletheore.vulnerabilities import _parse_pip_pins
 


### PR DESCRIPTION
## Summary
- `[project.optional-dependencies]` (PEP 621 extras, e.g. a "test"/"dev" group) and Poetry's own `[tool.poetry.group.<name>.dependencies]` (1.2+) / `[tool.poetry.dev-dependencies]` (the older, pre-1.2 shape) are all real, direct, first-party declared dependencies - not transitive ones (the reasoning `_parse_npm_direct_pins`' own docstring gives for excluding a lock file's transitive tree doesn't apply here) - yet none of them were read at all.
- This function's own two real callers are dependency-vulnerability scanning and license checking: a genuinely vulnerable pinned package declared only under a dev/test extras group (a real, published CVE) was invisible to CVE scanning entirely, regardless of how risky it actually was - a real gap in a security-focused feature, not a cosmetic one. The same pins also feed `dead_code.py`'s unused-dependency check, so a stale, no-longer-imported dev tool declared this way was equally invisible there.
- Confirmed by direct execution against the real function before fixing: packages declared under `[project.optional-dependencies]`, `[tool.poetry.group.dev.dependencies]`, and `[tool.poetry.dev-dependencies]` all produced zero pins.

## Fix
Read all three forms the same way their already-supported sibling tables are read, reusing the existing per-dependency parsers (`_parse_pep508_dependency` for the PEP 621 list form, `_parse_python_dependency_value` for Poetry's `{name: value}` form) rather than adding a third, independently drifting implementation.

## Test plan
- [x] Two new regression tests (PEP 621 optional-dependencies, Poetry groups + legacy dev-dependencies), confirmed failing before the fix, passing after
- [x] Full suite: 1915 passed, including every pre-existing `_parse_pip_pins` test (requirements.txt, PEP 621 `dependencies`, Poetry `dependencies`) - unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
