### PR TITLE
fix: SPDX OR license expression reported the most restrictive alternative

### DIFF
--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -132,9 +132,44 @@ def _contains_marker(text: str, marker: str) -> bool:
     return re.search(r"\b" + re.escape(marker) + r"\b", text) is not None
 
 
+# A real, common SPDX license-expression idiom - "MIT OR Apache-2.0",
+# "(MIT OR Apache-2.0)" - offered as the repo/dependency's own `license`
+# field verbatim by npm's package.json, Cargo.toml, and PEP 639
+# pyproject.toml, all of which document SPDX expression syntax as a
+# real, first-class shape for that field, not just a bare identifier.
+# Whitespace-delimited and case-insensitive so it never matches the
+# unrelated, hyphenated "-or-later" suffix inside real SPDX ids like
+# "GPL-2.0-or-later"/"LGPL-3.0-or-later" (confirmed directly - those
+# have no surrounding whitespace around "or" to match).
+_SPDX_OR_SPLIT_RE = re.compile(r"\s+OR\s+", re.IGNORECASE)
+
+# Real bug found via audit: an SPDX "OR" expression is a CHOICE - the
+# licensee may comply under whichever alternative they prefer - so the
+# correct category is the most PERMISSIVE alternative offered, the one
+# a compliant downstream user would actually elect to use. The old
+# marker-scan (checking copyleft markers before permissive ones,
+# unconditionally) always returned the MOST restrictive category found
+# anywhere in the string regardless of "OR" - "GPL-3.0-only OR MIT" and
+# "MIT OR GPL-3.0-only" both came back "copyleft-strong" even though
+# either one is legitimately usable under MIT alone. Ranked low-to-high
+# restrictiveness; "unknown" ranks last (least preferred) since a real,
+# identified category from any other alternative is more useful than
+# reporting "we don't know" when at least one alternative IS known.
+_PERMISSIVENESS_RANK = {
+    "permissive": 0,
+    "copyleft-weak": 1,
+    "copyleft-strong": 2,
+    "unknown": 3,
+}
+
+
 def categorize_license(license_text: str | None) -> str:
     if not license_text:
         return "unknown"
+    alternatives = _SPDX_OR_SPLIT_RE.split(license_text)
+    if len(alternatives) > 1:
+        results = [categorize_license(alt) for alt in alternatives]
+        return min(results, key=lambda category: _PERMISSIVENESS_RANK[category])
     text = license_text.lower()
     if any(_contains_marker(text, marker) for marker in _AGPL_MARKERS):
         return "copyleft-strong"

--- a/src/aletheore/licenses.py
+++ b/src/aletheore/licenses.py
@@ -259,12 +259,21 @@ def detect_repo_license(repo_path: Path) -> dict:
             data = {}
         license_field = data.get("license")
         # Composer's schema allows a bare string or a dual/multi-license
-        # array ("license": ["MIT", "GPL-2.0"]) - matches how
-        # _fetch_packagist_license already treats the identical shape from
-        # Packagist's own API response (licenses[0] if licenses else None).
+        # array ("license": ["MIT", "GPL-2.0"]) - the same real "you may
+        # comply under whichever you prefer" choice an SPDX "OR"
+        # expression represents, just spelled as a JSON array instead of
+        # a string. Real bug found via audit: this used to just take
+        # array[0] - not "most permissive", genuinely arbitrary, entirely
+        # dependent on how the package's own author happened to order the
+        # array. Joining into an "A OR B" string and handing it to
+        # categorize_license (which now resolves an OR expression to its
+        # most permissive alternative, see that function's own fix) makes
+        # this order-independent instead of order-dependent, and matches
+        # _fetch_packagist_license's identical fix below for the same
+        # shape from Packagist's own API response.
         if isinstance(license_field, list) and license_field:
-            license_field = license_field[0]
-        if isinstance(license_field, str):
+            license_field = " OR ".join(x for x in license_field if isinstance(x, str))
+        if isinstance(license_field, str) and license_field:
             return {
                 "category": categorize_license(license_field),
                 "detected_from": f"composer.json: {license_field}",
@@ -441,7 +450,14 @@ def _fetch_rubygems_license(name: str, version: str, timeout: int) -> str | None
     with urllib.request.urlopen(request, timeout=timeout, context=_SSL_CONTEXT) as response:
         data = json.loads(response.read())
     licenses = data.get("licenses") or []
-    return licenses[0] if licenses else None
+    # Real bug found via audit: a dual/multi-licensed gem's `licenses`
+    # array is the same real "you may comply under whichever you
+    # prefer" choice as an SPDX "OR" expression - taking licenses[0]
+    # picked whichever the gem's own author happened to list first, not
+    # the most permissive option actually available. Joined into an
+    # "A OR B" string, categorize_license (see its own OR-expression
+    # fix) resolves this order-independently instead.
+    return " OR ".join(l for l in licenses if isinstance(l, str)) or None
 
 
 def _fetch_packagist_license(name: str, version: str, timeout: int) -> str | None:
@@ -451,7 +467,10 @@ def _fetch_packagist_license(name: str, version: str, timeout: int) -> str | Non
     for entry in data.get("packages", {}).get(name, []):
         if entry.get("version") == version:
             licenses = entry.get("license") or []
-            return licenses[0] if licenses else None
+            # Same fix as _fetch_rubygems_license above, for the
+            # identical dual/multi-license array shape Packagist's own
+            # API returns.
+            return " OR ".join(l for l in licenses if isinstance(l, str)) or None
     return None
 
 

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -190,6 +190,25 @@ def test_detect_repo_license_from_composer_json_dual_license_array(tmp_path):
     assert "composer.json" in result["detected_from"]
 
 
+def test_detect_repo_license_from_composer_json_dual_license_array_is_order_independent(tmp_path):
+    # Real bug found via audit: the test right above this one only ever
+    # exercised ["MIT", "GPL-2.0"] (permissive first) and passed for the
+    # wrong reason - the old code took array[0] unconditionally, not
+    # "whichever is most permissive". Reversing the array order used to
+    # flip the result to "copyleft-strong" even though the exact same
+    # licensing choice is being offered either way - fixed by joining
+    # the array into an SPDX "A OR B" expression and letting
+    # categorize_license's own OR-resolution (most permissive wins,
+    # order-independent) handle it.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "composer.json").write_text(json.dumps({"name": "vendor/app", "license": ["GPL-2.0", "MIT"]}))
+
+    result = detect_repo_license(repo)
+
+    assert result["category"] == "permissive"
+
+
 def test_detect_repo_license_from_gemspec(tmp_path):
     # Real bug found via audit: same gap for Ruby.
     repo = tmp_path / "repo"
@@ -871,6 +890,23 @@ def test_fetch_rubygems_license_reads_licenses_array():
     assert result == "MIT"
 
 
+def test_fetch_rubygems_license_joins_a_dual_license_array_as_an_or_expression(tmp_path):
+    # Real bug found via audit: a dual/multi-licensed gem's `licenses`
+    # array is the same real "you may comply under whichever you
+    # prefer" choice an SPDX "OR" expression represents - taking
+    # licenses[0] picked whichever the gem's own author happened to
+    # list first, not the most permissive option actually available.
+    from aletheore.licenses import _fetch_rubygems_license, categorize_license
+
+    response = _mock_response({"licenses": ["GPL-2.0", "MIT"]})
+
+    with patch("aletheore.licenses.urllib.request.urlopen", return_value=response):
+        result = _fetch_rubygems_license("somegem", "1.0.0", timeout=10)
+
+    assert result == "GPL-2.0 OR MIT"
+    assert categorize_license(result) == "permissive"
+
+
 def test_check_dependency_licenses_reports_a_ruby_dependency(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -906,6 +942,28 @@ def test_fetch_packagist_license_matches_exact_version():
         result = _fetch_packagist_license("laravel/framework", "11.30.0", timeout=10)
 
     assert result == "MIT"
+
+
+def test_fetch_packagist_license_joins_a_dual_license_array_as_an_or_expression():
+    # Same real gap as RubyGems above, for Packagist's own identical
+    # dual/multi-license array shape.
+    from aletheore.licenses import _fetch_packagist_license, categorize_license
+
+    response = _mock_response(
+        {
+            "packages": {
+                "vendor/pkg": [
+                    {"version": "1.0.0", "license": ["GPL-2.0", "MIT"]},
+                ]
+            }
+        }
+    )
+
+    with patch("aletheore.licenses.urllib.request.urlopen", return_value=response):
+        result = _fetch_packagist_license("vendor/pkg", "1.0.0", timeout=10)
+
+    assert result == "GPL-2.0 OR MIT"
+    assert categorize_license(result) == "permissive"
 
 
 def test_check_dependency_licenses_reports_a_php_dependency(tmp_path):

--- a/src/tests/test_licenses.py
+++ b/src/tests/test_licenses.py
@@ -59,6 +59,43 @@ def test_categorize_license_recognizes_mpl_as_weak_copyleft():
     assert categorize_license("MPL-2.0") == "copyleft-weak"
 
 
+def test_categorize_license_spdx_or_expression_uses_most_permissive_alternative():
+    # Real bug found via audit: an SPDX "OR" expression is a CHOICE - the
+    # licensee may comply under whichever alternative they prefer - a
+    # real, common idiom offered verbatim as the `license` field by npm's
+    # package.json, Cargo.toml, and PEP 639 pyproject.toml. The old
+    # marker-scan always returned the MOST restrictive category found
+    # anywhere in the string regardless of "OR" or alternative order -
+    # "GPL-3.0-only OR MIT" and "MIT OR GPL-3.0-only" both came back
+    # "copyleft-strong" even though either is legitimately usable under
+    # MIT alone.
+    assert categorize_license("MIT OR GPL-3.0-only") == "permissive"
+    assert categorize_license("GPL-3.0-only OR MIT") == "permissive"
+    assert categorize_license("(MIT OR Apache-2.0)") == "permissive"
+    assert categorize_license("MIT OR GPL-3.0-only OR BSD-3-Clause") == "permissive"
+    assert categorize_license("AGPL-3.0 OR LGPL-2.1") == "copyleft-weak"
+
+
+def test_categorize_license_or_split_does_not_false_match_hyphenated_or_later_suffix():
+    # A real SPDX id's own "-or-later" suffix (GPL-2.0-or-later,
+    # LGPL-3.0-or-later - both real, common identifiers) has no
+    # surrounding whitespace around "or", so it must not be mistaken for
+    # an OR-expression split point.
+    assert categorize_license("GPL-2.0-or-later") == "copyleft-strong"
+    assert categorize_license("LGPL-3.0-or-later") == "copyleft-weak"
+
+
+def test_categorize_license_and_expression_still_uses_most_restrictive_component():
+    # An "AND" expression means compliance is required with BOTH
+    # components simultaneously, the opposite of "OR" - the existing
+    # restrictive-first marker scan already gets this right (a real
+    # restriction can't be opted out of just because a permissive
+    # component is also present), so this locks in that this fix didn't
+    # change AND's own, already-correct behavior.
+    assert categorize_license("GPL-3.0-only AND MIT") == "copyleft-strong"
+    assert categorize_license("MIT AND Apache-2.0") == "permissive"
+
+
 def test_categorize_license_unknown_for_none_or_unrecognized():
     assert categorize_license(None) == "unknown"
     assert categorize_license("") == "unknown"


### PR DESCRIPTION
## Summary
- An SPDX "OR" expression (`"MIT OR Apache-2.0"`) is a CHOICE - the licensee may comply under whichever alternative they prefer - a real, common idiom offered verbatim as the `license` field by npm's `package.json`, `Cargo.toml`, and PEP 639 `pyproject.toml` (all three already feed a raw license string straight into `categorize_license`).
- The existing marker scan checks copyleft markers before permissive ones unconditionally, so it always returned the MOST restrictive category found anywhere in the string regardless of "OR" or which alternative came first: `"GPL-3.0-only OR MIT"` and `"MIT OR GPL-3.0-only"` both came back `"copyleft-strong"`, even though either license is legitimately usable under MIT alone - the opposite of what a real license-compliance reading of "OR" means.
- Confirmed by direct execution against the real function before fixing.

## Fix
Detect a top-level, whitespace-delimited "OR" split (case-insensitive; requires surrounding whitespace so it never matches the unrelated hyphenated `-or-later` suffix inside real SPDX ids like `GPL-2.0-or-later`/`LGPL-3.0-or-later` - confirmed directly) and, when found, categorize each alternative recursively and return the most permissive result.

**"AND" expressions are deliberately left alone**: they mean compliance is required with every component simultaneously, and the existing restrictive-first scan already gets that right by coincidence (a real restriction can't be opted out of just because a permissive component is also present) - locked in with its own regression test so this fix doesn't accidentally change that behavior.

## Test plan
- [x] Three new regression tests: OR uses the most permissive alternative (both orderings, parenthesized form, 3-way), hyphenated `-or-later` SPDX ids aren't mistaken for a split point, AND expressions keep their existing (already-correct) behavior - the OR test confirmed failing before the fix, passing after
- [x] Full suite (original commit): 1922 passed, including every pre-existing `categorize_license` test (bare identifiers, license body text, AGPL/LGPL-before-generic-GPL precedence) - unchanged behavior

## Follow-up commit: the same array-order bug, three more places
Found while reviewing this PR: `composer.json`'s `"license": ["MIT", "GPL-2.0"]` array, RubyGems' own `licenses` API field, and Packagist's own `license` API field all represent the identical "you may comply under whichever you prefer" choice as an SPDX "OR" expression - just spelled as a JSON array. All three took `array[0]` unconditionally: genuinely arbitrary, not "most permissive," entirely dependent on how the package's own author happened to order the array. Reversing the array order flipped the reported category from `permissive` to `copyleft-strong` for the exact same licensing choice - and the existing composer.json test only ever exercised the order that happened to already produce the right answer, so it never caught this.

Fix: join the array into an SPDX `"A OR B"` expression and hand it to `categorize_license` - order-independent instead of order-dependent, reusing the same OR-resolution logic from the first commit rather than a third, separately-arbitrary implementation.

- [x] Three more regression tests: composer.json array order-independence, RubyGems array joined as OR, Packagist array joined as OR - all three confirmed failing before this commit, passing after
- [x] Full suite (with both commits): 1925 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

