### PR TITLE
fix: CODEOWNERS unanchored directory patterns wrongly restricted to repo root

### DIFF
--- a/src/aletheore/evidence_resolution.py
+++ b/src/aletheore/evidence_resolution.py
@@ -178,8 +178,16 @@ def _codeowners_matches(pattern: str, file_path: str) -> bool:
     if normalized.endswith("/"):
         if anchored:
             return file_path.startswith(normalized)
+        # A trailing "/" means "directory", never "a regular file at this
+        # path" - GitHub's own docs: "apps/" owns files *in* an apps
+        # directory, not a plain file literally named "apps". Flash Review
+        # finding: the `file_path == dir_name` clause this line used to
+        # carry matched exactly that non-existent case. Confirmed directly
+        # (_codeowners_matches("apps/", "apps") returned True before this
+        # fix, for a bare file named "apps" with no such directory
+        # involved at all).
         dir_name = normalized.rstrip("/")
-        return file_path == dir_name or file_path.startswith(f"{dir_name}/") or f"/{dir_name}/" in f"/{file_path}"
+        return file_path.startswith(f"{dir_name}/") or f"/{dir_name}/" in f"/{file_path}"
     if "/" not in normalized:
         return fnmatch.fnmatch(Path(file_path).name, normalized)
     return fnmatch.fnmatch(file_path, normalized)

--- a/src/aletheore/evidence_resolution.py
+++ b/src/aletheore/evidence_resolution.py
@@ -160,9 +160,26 @@ def _parse_codeowners_line(line: str) -> tuple[str, list[str]] | None:
 
 
 def _codeowners_matches(pattern: str, file_path: str) -> bool:
+    # CODEOWNERS explicitly follows gitignore anchoring rules (GitHub's own
+    # docs): a "/" anywhere in the pattern except as a lone trailing
+    # character anchors it to the repo root; a bare name does not and can
+    # match at any depth. GitHub's own documented example makes this
+    # concrete: "apps/" (no leading slash) "owns any file in an apps
+    # directory anywhere in your repository", while "/docs/" (leading
+    # slash) is anchored to the repo root only. Stripping the leading "/"
+    # before checking threw this distinction away, silently treating every
+    # bare directory-name pattern ("apps/", "tests/") as if it had been
+    # written "/apps/" - matching only at the repo root and missing every
+    # nested directory of that name, the opposite of GitHub's documented
+    # behavior.
+    body = pattern[:-1] if pattern.endswith("/") else pattern
+    anchored = pattern.startswith("/") or "/" in body
     normalized = pattern.lstrip("/")
     if normalized.endswith("/"):
-        return file_path.startswith(normalized)
+        if anchored:
+            return file_path.startswith(normalized)
+        dir_name = normalized.rstrip("/")
+        return file_path == dir_name or file_path.startswith(f"{dir_name}/") or f"/{dir_name}/" in f"/{file_path}"
     if "/" not in normalized:
         return fnmatch.fnmatch(Path(file_path).name, normalized)
     return fnmatch.fnmatch(file_path, normalized)

--- a/src/tests/test_evidence_resolution.py
+++ b/src/tests/test_evidence_resolution.py
@@ -206,6 +206,21 @@ def test_resolve_owner_leading_slash_directory_pattern_stays_anchored_to_root(tm
     assert root["owner"] == ["@doctocat"]
 
 
+def test_resolve_owner_unanchored_directory_pattern_does_not_match_a_bare_file(tmp_path):
+    # Flash Review finding: an earlier fix's `file_path == dir_name` clause
+    # made "apps/" (a directory-only pattern per its trailing slash) match
+    # a plain FILE literally named "apps" - no such directory involved at
+    # all. A trailing slash in CODEOWNERS means "directory", never "a
+    # regular file at this exact path".
+    repo = tmp_path
+    (repo / ".github").mkdir()
+    (repo / ".github" / "CODEOWNERS").write_text("apps/ @octocat\n")
+
+    result = resolve_owner(repo, "apps")
+
+    assert result["owner"] is None
+
+
 def test_resolve_recent_commit_returns_file_commit(tmp_path):
     repo = tmp_path
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)

--- a/src/tests/test_evidence_resolution.py
+++ b/src/tests/test_evidence_resolution.py
@@ -176,6 +176,36 @@ def test_resolve_owner_returns_unavailable_without_codeowners(tmp_path):
     assert result["owner_status"] == "unavailable"
 
 
+def test_resolve_owner_matches_unanchored_directory_pattern_at_any_depth(tmp_path):
+    # CODEOWNERS follows gitignore anchoring rules, and GitHub's own docs
+    # give this exact example: "apps/" (no leading slash) "owns any file
+    # in an apps directory anywhere in your repository" - not just an
+    # "apps" directory at the repo root.
+    repo = tmp_path
+    (repo / ".github").mkdir()
+    (repo / ".github" / "CODEOWNERS").write_text("apps/ @octocat\n")
+
+    result = resolve_owner(repo, "src/apps/main.py")
+
+    assert result["owner"] == ["@octocat"]
+
+
+def test_resolve_owner_leading_slash_directory_pattern_stays_anchored_to_root(tmp_path):
+    # The counterpart to the unanchored case above (GitHub's own docs,
+    # same page): "/docs/" (leading slash) "owns any file in the `/docs`
+    # directory in the root of your repository and any of its
+    # subdirectories" - explicitly NOT any docs/ directory at any depth.
+    repo = tmp_path
+    (repo / ".github").mkdir()
+    (repo / ".github" / "CODEOWNERS").write_text("/docs/ @doctocat\n")
+
+    nested = resolve_owner(repo, "src/docs/readme.md")
+    root = resolve_owner(repo, "docs/readme.md")
+
+    assert nested["owner"] is None
+    assert root["owner"] == ["@doctocat"]
+
+
 def test_resolve_recent_commit_returns_file_commit(tmp_path):
     repo = tmp_path
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)


### PR DESCRIPTION
## Summary
- \`_codeowners_matches\` stripped a pattern's leading \`/\` before checking it - throwing away the one piece of information that tells an anchored pattern (\`/docs/\`) apart from an unanchored one (\`docs/\`).
- CODEOWNERS explicitly follows gitignore's own anchoring rules (per GitHub's docs): a \`/\` anywhere in a pattern except as a lone trailing character anchors that pattern to the repo root; a bare directory name does not, and can match at any depth.
- GitHub's own documented example is exact about this: \`apps/\` (no leading slash) "owns any file in an apps directory **anywhere** in your repository", while \`/docs/\` (leading slash) "owns any file in the \`/docs\` directory **in the root** of your repository and any of its subdirectories" - two different, explicitly documented behaviors that this function collapsed into one.
- Confirmed directly by execution: a CODEOWNERS rule \`apps/ @octocat\` failed to match \`src/apps/main.py\` before this fix - a real gap in this codebase's own ownership-resolution path (\`resolve_owner\`, used to attribute findings and code evidence to owners), silently leaving nested directories' real owners unattributed for any repo using the common unanchored directory-pattern style.

## Fix
Track whether a pattern actually anchors (a leading \`/\`, or any \`/\` before the final character) separately from the lstrip'd string used for the actual match. An anchored directory pattern keeps its existing \`startswith\` check unchanged; an unanchored one now also matches when the directory name appears as a path segment anywhere in \`file_path\`, not just at the root.

## Test plan
- [x] Two new regression tests: an unanchored pattern (\`apps/\`) matches a nested directory (confirmed failing before the fix, passing after), and a leading-slash pattern (\`/docs/\`) stays anchored to the root only (passes both before and after - a regression guard confirming the already-correct anchored case wasn't broken)
- [x] Full suite: 1927 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)