### PR TITLE
fix: CODEOWNERS glob "*" incorrectly crossed path separators

### DIFF
--- a/src/aletheore/evidence_resolution.py
+++ b/src/aletheore/evidence_resolution.py
@@ -159,13 +159,39 @@ def _parse_codeowners_line(line: str) -> tuple[str, list[str]] | None:
     return parts[0], parts[1:]
 
 
+def _glob_segments_match(pattern_segments: list[str], path_segments: list[str]) -> bool:
+    if not pattern_segments:
+        return not path_segments
+    head, rest = pattern_segments[0], pattern_segments[1:]
+    if head == "**":
+        # gitignore/CODEOWNERS "**" matches zero or more whole path
+        # segments - the one construct that IS meant to cross "/".
+        return any(_glob_segments_match(rest, path_segments[i:]) for i in range(len(path_segments) + 1))
+    if not path_segments:
+        return False
+    return fnmatch.fnmatch(path_segments[0], head) and _glob_segments_match(rest, path_segments[1:])
+
+
 def _codeowners_matches(pattern: str, file_path: str) -> bool:
     normalized = pattern.lstrip("/")
     if normalized.endswith("/"):
         return file_path.startswith(normalized)
     if "/" not in normalized:
         return fnmatch.fnmatch(Path(file_path).name, normalized)
-    return fnmatch.fnmatch(file_path, normalized)
+    # A single "*"/"?" in a gitignore-style (and thus CODEOWNERS-style,
+    # per GitHub's own docs) pattern matches within one path segment
+    # only - it does not cross a "/". fnmatch.fnmatch has no concept of
+    # path segments at all: it translates "*" to ".*", which happily
+    # matches straight through slashes. GitHub's own documented example
+    # makes the intended behavior concrete: "docs/*" matches
+    # "docs/getting-started.md" but explicitly NOT the further-nested
+    # "docs/build-app/troubleshooting.md" - confirmed directly that
+    # fnmatch.fnmatch("docs/build-app/troubleshooting.md", "docs/*")
+    # returns True, the opposite of the documented behavior. Matching
+    # segment-by-segment (with "**" as the one construct allowed to
+    # cross "/") fixes this without losing "*"'s existing behavior
+    # within a single segment.
+    return _glob_segments_match(normalized.split("/"), file_path.split("/"))
 
 
 def resolve_owner(repo_path: Path, file_path: str) -> dict:

--- a/src/tests/test_evidence_resolution.py
+++ b/src/tests/test_evidence_resolution.py
@@ -176,6 +176,22 @@ def test_resolve_owner_returns_unavailable_without_codeowners(tmp_path):
     assert result["owner_status"] == "unavailable"
 
 
+def test_resolve_owner_glob_star_does_not_cross_a_path_separator(tmp_path):
+    # GitHub's own CODEOWNERS docs give this exact example: "docs/*"
+    # matches "docs/getting-started.md" but explicitly NOT a further
+    # nested file like "docs/build-app/troubleshooting.md" - a single
+    # "*" matches within one path segment only, gitignore-style.
+    repo = tmp_path
+    (repo / ".github").mkdir()
+    (repo / ".github" / "CODEOWNERS").write_text("docs/* @doctocat\n")
+
+    direct_child = resolve_owner(repo, "docs/getting-started.md")
+    nested = resolve_owner(repo, "docs/build-app/troubleshooting.md")
+
+    assert direct_child["owner"] == ["@doctocat"]
+    assert nested["owner"] is None
+
+
 def test_resolve_recent_commit_returns_file_commit(tmp_path):
     repo = tmp_path
     subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)


### PR DESCRIPTION
## Summary
- \`_codeowners_matches\` fell back to \`fnmatch.fnmatch(file_path, normalized)\` for any pattern containing a \`/\`. \`fnmatch\` has no concept of path segments - it translates \`*\` to a plain \`.*\`, which matches straight through \`/\` characters.
- gitignore-style patterns (which CODEOWNERS explicitly follows, per GitHub's own docs) mean something narrower: a single \`*\` matches **within one path segment only**.
- GitHub's own documented example is exact about this: \`docs/*\` matches \`docs/getting-started.md\` but explicitly does **NOT** match the further-nested \`docs/build-app/troubleshooting.md\`.
- Confirmed directly: \`fnmatch.fnmatch("docs/build-app/troubleshooting.md", "docs/*")\` returns \`True\` - the opposite of the documented behavior. This is a real gap in this codebase's own CODEOWNERS-based ownership resolution (\`resolve_owner\`): a pattern meant to scope owners to one directory's direct children silently also claimed ownership of everything nested arbitrarily deep underneath it.

This is the same function touched by #686 (the unanchored-directory-pattern fix), but a different, independent bug - that PR only changes the directory (`pattern.endswith("/")`) branch; this one only changes the full-path fnmatch fallback branch. Opened separately since they're unrelated fixes with their own test stories, following this session's convention of one focused fix per PR.

## Fix
Match segment-by-segment (splitting both pattern and \`file_path\` on \`/\`) instead of handing the whole path to \`fnmatch\` at once, with \`**\` recognized as the one construct gitignore/CODEOWNERS semantics do mean to cross \`/\` (matches zero or more whole segments). \`fnmatch\` itself is still used per-segment, so within a segment \`*\`/\`?\`/character classes keep behaving exactly as before.

## Test plan
- [x] New regression test: \`docs/*\` matches a direct child but not a nested-further file - confirmed failing before the fix, passing after
- [x] Full suite: 1926 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)