### PR TITLE
fix: push webhook silently capped compare-API changed files at 300

### DIFF
--- a/github-app/app_server/webhooks/push.py
+++ b/github-app/app_server/webhooks/push.py
@@ -8,7 +8,23 @@ from app_server.http_client import get_github_api_client
 
 logger = logging.getLogger(__name__)
 
-COMPARE_FILES_PER_PAGE = 100
+# GitHub's own compare-commits docs are explicit: "the list of changed
+# files is only shown on the first page of results, and it includes up
+# to 300 changed files for the entire comparison." page/per_page paginate
+# the COMMITS in the response, not the files - confirmed directly against
+# GitHub's docs (fetched twice, consistent both times). A prior version of
+# this function looped page numbers expecting each page to carry the next
+# slice of files, the way a normal paginated list endpoint works; in
+# reality every page past the first comes back with no files at all, so
+# the loop always terminated after page 1 regardless - it just silently
+# capped at 300 changed files with no signal that more existed, on
+# exactly the payloads (a mass rebase, a bulk import, a huge squash) most
+# likely to actually exceed that cap. There is no documented way to
+# retrieve file 301+ from this endpoint at all, so the fix here is a
+# single request plus an honest, logged truncation warning - the same
+# "silent truncation is not acceptable" standard this codebase applies
+# everywhere else - not a way to actually retrieve the rest.
+GITHUB_COMPARE_FILES_HARD_CAP = 300
 
 
 def _changed_files_from_commits(commits: list[dict]) -> set[str]:
@@ -37,27 +53,27 @@ def _fetch_compare_changed_files_sync(
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
     }
+    response = client.get(
+        f"/repos/{repo_full_name}/compare/{before_sha}...{after_sha}",
+        headers=headers,
+    )
+    response.raise_for_status()
+    files = response.json().get("files", [])
     changed_files: set[str] = set()
-    page = 1
+    for file_info in files:
+        filename = file_info.get("filename")
+        if filename:
+            changed_files.add(filename)
+        previous_filename = file_info.get("previous_filename")
+        if previous_filename:
+            changed_files.add(previous_filename)
 
-    while True:
-        response = client.get(
-            f"/repos/{repo_full_name}/compare/{before_sha}...{after_sha}",
-            headers=headers,
-            params={"per_page": COMPARE_FILES_PER_PAGE, "page": page},
+    if len(files) >= GITHUB_COMPARE_FILES_HARD_CAP:
+        logger.warning(
+            "push webhook compare %s...%s for %s hit the compare API's %d-file cap; "
+            "changed files beyond this are not visible to this scan",
+            before_sha, after_sha, repo_full_name, GITHUB_COMPARE_FILES_HARD_CAP,
         )
-        response.raise_for_status()
-        files = response.json().get("files", [])
-        for file_info in files:
-            filename = file_info.get("filename")
-            if filename:
-                changed_files.add(filename)
-            previous_filename = file_info.get("previous_filename")
-            if previous_filename:
-                changed_files.add(previous_filename)
-        if len(files) < COMPARE_FILES_PER_PAGE:
-            break
-        page += 1
 
     return changed_files
 

--- a/github-app/tests/test_push_webhook.py
+++ b/github-app/tests/test_push_webhook.py
@@ -41,6 +41,13 @@ async def test_push_to_default_branch_enqueues_scan_job(pool):
 
 @pytest.mark.asyncio
 async def test_truncated_push_payload_uses_compare_api_for_complete_changed_files(pool, monkeypatch):
+    # GitHub's own compare-commits docs: "the list of changed files is
+    # only shown on the first page of results" - page/per_page paginate
+    # the commits in the response, not the files, so this must be a
+    # single request, not a page-number loop (a prior version of this
+    # test modeled the loop the production code used to have, which
+    # doesn't match how the real API behaves - see push.py's
+    # GITHUB_COMPARE_FILES_HARD_CAP for the fix).
     payload_commits = [
         {"added": [f"payload-{i}.py"], "removed": [], "modified": []} for i in range(20)
     ]
@@ -53,14 +60,7 @@ async def test_truncated_push_payload_uses_compare_api_for_complete_changed_file
         assert request.url.path == "/repos/octocat/hello-world/compare/base123...head123"
         assert request.headers["Authorization"] == "Bearer installation-token"
         seen_params.append(dict(request.url.params))
-        page = int(request.url.params["page"])
-        assert request.url.params["per_page"] == "100"
-        start = (page - 1) * 100
-        return httpx.Response(
-            200,
-            json={"files": compare_files[start:start + 100]},
-            request=request,
-        )
+        return httpx.Response(200, json={"files": compare_files}, request=request)
 
     client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
     monkeypatch.setattr("app_server.webhooks.push.generate_app_jwt", lambda *a, **k: "app-jwt")
@@ -77,7 +77,44 @@ async def test_truncated_push_payload_uses_compare_api_for_complete_changed_file
     _, kwargs = fake_queue.enqueue.call_args
     assert kwargs["changed_files"] == sorted(file_info["filename"] for file_info in compare_files)
     assert "payload-0.py" not in kwargs["changed_files"]
-    assert seen_params == [{"per_page": "100", "page": "1"}, {"per_page": "100", "page": "2"}]
+    assert seen_params == [{}]
+
+
+@pytest.mark.asyncio
+async def test_truncated_push_payload_logs_when_compare_api_hits_the_300_file_cap(
+    pool, monkeypatch, caplog
+):
+    # Real gap found via audit: GitHub's compare API hard-caps its files
+    # list at 300 with no documented way to retrieve more - a prior
+    # version of this code silently returned only those 300 with no
+    # signal anything was missing. This confirms the fix logs a warning
+    # instead, on exactly the boundary (300 files back) that trips it.
+    payload_commits = [
+        {"added": [f"payload-{i}.py"], "removed": [], "modified": []} for i in range(20)
+    ]
+    payload = _payload(commits=payload_commits)
+    payload["size"] = 101
+    compare_files = [{"filename": f"compare-{i}.py"} for i in range(300)]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"files": compare_files}, request=request)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com")
+    monkeypatch.setattr("app_server.webhooks.push.generate_app_jwt", lambda *a, **k: "app-jwt")
+    monkeypatch.setattr(
+        "app_server.webhooks.push.get_installation_token",
+        lambda installation_id, app_jwt: "installation-token",
+    )
+    monkeypatch.setattr("app_server.webhooks.push.get_github_api_client", lambda: client)
+
+    fake_queue = MagicMock()
+    with caplog.at_level("WARNING", logger="app_server.webhooks.push"):
+        await handle_push_event(payload, pool, "redis://unused", queue=fake_queue)
+
+    assert any("300-file cap" in record.message for record in caplog.records)
+    fake_queue.enqueue.assert_called_once()
+    _, kwargs = fake_queue.enqueue.call_args
+    assert len(kwargs["changed_files"]) == 300
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- \`_fetch_compare_changed_files_sync\` (used for a push webhook whose commit list GitHub truncated - a mass rebase, bulk import, or huge squash push) looped page numbers, expecting each page to carry the next slice of changed files, the way a normal paginated list endpoint works.
- Confirmed against GitHub's own "Compare two commits" docs (fetched twice, consistently): **"the list of changed files is only shown on the first page of results, and it includes up to 300 changed files for the entire comparison."** \`page\`/\`per_page\` paginate the *commits* in the response, not the files - every page past the first comes back with no \`files\` key at all.
- Verified directly with a standalone before/after script against a mock modeling this real behavior (page 1 → up to 300 files, page 2+ → no files key): the old loop made a pointless second request (which always returns nothing) and silently collected exactly 300 files with **zero signal** that a real diff of 305+ files had files missing beyond the cap - on exactly the payloads most likely to actually exceed 300 (the same "commit list got truncated" condition that triggers this code path in the first place).

## Fix
A single request (dropping the pointless, always-empty second call), plus a logged warning when the response hits the documented 300-file cap - the same "silent truncation is not acceptable" standard this codebase already applies everywhere else (\`MAX_CONTEXT_FILE_BYTES\`, \`budget_omitted_files\`, \`ast_pattern\`'s \`truncated\` flag, etc.). There is no documented way to actually retrieve files beyond the cap from this endpoint, so this makes the truncation honest rather than fixing what can't be fixed.

## Test plan
- [x] Updated the existing test, which had modeled the old (incorrect) page-loop assumption about the API, to match GitHub's actual documented behavior
- [x] New regression test: hitting the 300-file cap logs the expected warning
- [x] Standalone before/after script confirmed the exact behavioral difference (2 requests + silent cap vs. 1 request + logged cap) against a mock of the real API shape
- [x] Full github-app suite: 1865 passed, 8 skipped (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)