### PR TITLE
fix: Flash Review grounding miscounted lines around a no-newline marker

### DIFF
--- a/github-app/scan_worker/flash_review.py
+++ b/github-app/scan_worker/flash_review.py
@@ -930,7 +930,27 @@ def _patch_valid_lines(patch: str) -> set[int]:
         if hunk_match:
             current_line = int(hunk_match.group(1))
             continue
-        if line == "":
+        if line == "" or line == r"\ No newline at end of file":
+            # Real bug found via audit: git emits this literal marker line
+            # immediately after a +/- line whenever that version of the
+            # file has no trailing newline - the same shape github_api.py's
+            # _trim_patch_context already has a dedicated fix and comment
+            # for, but this second, independent line-number parser (fed
+            # GitHub's raw, untrimmed patch text via diff_patches, unlike
+            # _diff_valid_lines' own text-only fallback below, which only
+            # ever sees _trim_patch_context's already-stripped output) had
+            # the identical gap. Its tag ("\\") matches neither "-" nor a
+            # real content line, so without this it fell through to the
+            # "any other line" branch: recorded as a real valid line (a
+            # phantom entry with no corresponding source line at all) and,
+            # since it doesn't start with "-", advanced current_line too -
+            # shifting every real line number after it within the same
+            # hunk. Confirmed directly: a hunk changing a file's final line
+            # when that file has no trailing newline carries this marker
+            # twice (once for the old content, once for the new), and the
+            # real new-file line recorded for that change came out one
+            # higher than its actual position, with two phantom entries
+            # (line numbers with no real content at all) added alongside it.
             continue
         if current_line is None:
             continue
@@ -983,6 +1003,18 @@ def _diff_valid_lines(
             continue
         if line == "":
             prev_blank = True
+            continue
+        if line == r"\ No newline at end of file":
+            # Same fix as _patch_valid_lines above, for symmetry - this
+            # branch only runs on diff_text built by github_api.py's
+            # _trim_patch_context, which already strips this marker before
+            # producing that text, so it's not reachable through the
+            # current production call path. Kept in sync anyway: nothing
+            # here guarantees a future caller always pre-strips it, and a
+            # text-based fallback silently re-introducing the identical
+            # bug the moment that assumption changes is exactly the kind
+            # of gap that goes unnoticed until a real citation is dropped.
+            prev_blank = False
             continue
         prev_blank = False
         if current_file is None or current_line is None:

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -133,6 +133,53 @@ def test_genuine_two_file_diff_with_blank_line_separators_still_works():
     assert 10 in result["b.py"]
 
 
+def test_structured_patches_do_not_count_no_newline_marker_as_a_real_line():
+    # Real bug found via audit: git emits "\ No newline at end of file"
+    # immediately after a +/- line whenever that version of the file has
+    # no trailing newline - the same shape github_api.py's
+    # _trim_patch_context already has a dedicated fix for. Editing a
+    # file's final line when the file has no trailing newline carries
+    # this marker twice (once for the removed old content, once for the
+    # added new content). Before the fix, each marker line was treated
+    # as real content: added to the valid set as a phantom entry with no
+    # corresponding source line, and (since its own line doesn't start
+    # with "-") advanced current_line too - shifting every real line
+    # number that follows within the same hunk.
+    patch = (
+        "@@ -8,2 +8,2 @@ def foo():\n"
+        " def foo():\n"
+        "-    return old_value\n"
+        "\\ No newline at end of file\n"
+        "+    return new_value\n"
+        "\\ No newline at end of file"
+    )
+
+    result = _diff_valid_lines("", (("app.py", patch),))
+
+    # Line 8 is the context line; line 9 is the real new-file line the
+    # addition lands on. Nothing past that (10, 11 - the two marker
+    # lines miscounted as content) should appear.
+    assert result == {"app.py": {8, 9}}
+
+
+def test_diff_valid_lines_text_fallback_does_not_count_no_newline_marker_as_a_real_line():
+    # Same fix, exercised through the text-only fallback path (patches=None)
+    # for symmetry with _patch_valid_lines above.
+    diff_text = (
+        "--- app.py ---\n"
+        "@@ -8,2 +8,2 @@\n"
+        " def foo():\n"
+        "-    return old_value\n"
+        "\\ No newline at end of file\n"
+        "+    return new_value\n"
+        "\\ No newline at end of file"
+    )
+
+    result = _diff_valid_lines(diff_text)
+
+    assert result == {"app.py": {8, 9}}
+
+
 def test_lookup_valid_lines_falls_back_to_unambiguous_path_suffix():
     valid_lines = {"benchmark-sandbox/case-1/pkg/module.py": {5, 6, 7}}
     assert _lookup_valid_lines("pkg/module.py", valid_lines) == {5, 6, 7}


### PR DESCRIPTION
## Summary
- \`_patch_valid_lines\` - the primary citation-grounding path, fed GitHub's raw, untrimmed patch text via \`diff_patches\` - treated git's literal \`\ No newline at end of file\` marker line as ordinary diff content: added it to the valid-lines set as a phantom entry with no corresponding source line, and (since its own line starts with neither \`+\` nor \`-\`) advanced \`current_line\` too, shifting every real line number that follows within the same hunk.
- This is the **identical bug class** \`github_api.py\`'s \`_trim_patch_context\` already has a dedicated fix and comment for (same marker, same "treated as real content" failure mode) - just unfixed in this second, independent line-number parser.
- Confirmed directly: a hunk that edits a file's final line when that file has no trailing newline carries this marker twice (once for the removed old content, once for the added new content). Before the fix:
  ```
  patch = a 2-line hunk changing the file's final line, no trailing newline
  _patch_valid_lines(patch) -> {8, 9, 10, 11}   # should be {8, 9}
  ```
  The real new-file line came out one higher than its actual position, with two phantom entries (line numbers with no real content at all) added alongside it. \`_line_is_near_diff\`'s own tolerance absorbs a lone one-line drift in the common case, but the phantom entries and the shift are real and unbounded by that tolerance's design intent - and this is grounding logic explicitly built (per its own docstring, citing a real production incident) to catch exactly this class of line-number error.

## Fix
Skip the marker line entirely - matching \`_trim_patch_context\`'s existing, endorsed fix for the same pattern. Also fixed the identical gap in \`_diff_valid_lines\`' own text-only fallback parser (\`patches=None\`) for symmetry, even though that path only ever sees text already pre-stripped of this marker by \`_trim_patch_context\` today - nothing guarantees a future caller keeps pre-stripping it.

## Test plan
- [x] Two new regression tests (structured-patches path and text-fallback path) - both confirmed failing against the pre-fix code (\`git stash\`) with the exact \`{8, 9, 10, 11}\` vs \`{8, 9}\` mismatch shown above, passing after
- [x] Full github-app suite: 1866 passed, 8 skipped (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)