### PR TITLE
fix: concurrent scans of the same repo could lose git graph store updates

### DIFF
--- a/github-app/scan_worker/postgres_graph_store.py
+++ b/github-app/scan_worker/postgres_graph_store.py
@@ -30,6 +30,76 @@ class PostgresRepoGraphStore:
         self._installation_id = installation_id
         self._repo_full_name = repo_full_name
 
+    def _load_with_cursor(self, cur, branch: str) -> GraphSnapshot:
+        cur.execute(
+            "SELECT last_synced_sha, last_synced_at FROM evidence_git_sync_state "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
+        sync_row = cur.fetchone()
+        if sync_row is None:
+            return GraphSnapshot.empty()
+
+        ownership: dict[str, OwnershipTotal] = {}
+        cur.execute(
+            "SELECT email, names, commit_count FROM evidence_git_ownership "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
+        for email, names, commit_count in cur.fetchall():
+            ownership[email] = OwnershipTotal(email=email, names=set(names), commit_count=commit_count)
+
+        cadence: dict[date, int] = {}
+        cur.execute(
+            "SELECT week_start, commit_count FROM evidence_git_cadence "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
+        for week_start, commit_count in cur.fetchall():
+            cadence[week_start] = commit_count
+
+        file_churn: dict[str, FileChurnTotal] = {}
+        cur.execute(
+            "SELECT path, churn_count, recent_commits, co_change_counts, owners FROM evidence_git_file_churn "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
+        for path, churn_count, recent_commits, co_change_counts, owners in cur.fetchall():
+            file_churn[path] = FileChurnTotal(
+                path=path,
+                churn_count=churn_count,
+                recent_commits=[
+                    RecentCommit(
+                        sha=r["sha"],
+                        author_name=r["author_name"],
+                        author_email=r["author_email"],
+                        committed_at=datetime.fromisoformat(r["committed_at"]),
+                        # .get(): rows written before subject-capture
+                        # was added have no such key - default ""
+                        # rather than KeyError.
+                        subject=r.get("subject", ""),
+                    )
+                    for r in recent_commits
+                ],
+                co_change_counts=co_change_counts,
+                owners={
+                    email: OwnershipTotal(
+                        email=email,
+                        names=set(owner["names"]),
+                        commit_count=owner["commit_count"],
+                    )
+                    for email, owner in (owners or {}).items()
+                },
+            )
+
+        return GraphSnapshot(
+            last_synced_sha=sync_row[0],
+            last_synced_at=sync_row[1],
+            ownership=ownership,
+            cadence_weekly_counts=cadence,
+            file_churn=file_churn,
+        )
+
     def load(self, repo_key: str, branch: str) -> GraphSnapshot:
         # repo_key is part of the RepoGraphStore protocol (the CLI's local
         # store uses it as its identity), but the hosted store already has
@@ -40,74 +110,7 @@ class PostgresRepoGraphStore:
 
         with psycopg.connect(self._dsn) as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT last_synced_sha, last_synced_at FROM evidence_git_sync_state "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
-                sync_row = cur.fetchone()
-                if sync_row is None:
-                    return GraphSnapshot.empty()
-
-                ownership: dict[str, OwnershipTotal] = {}
-                cur.execute(
-                    "SELECT email, names, commit_count FROM evidence_git_ownership "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
-                for email, names, commit_count in cur.fetchall():
-                    ownership[email] = OwnershipTotal(email=email, names=set(names), commit_count=commit_count)
-
-                cadence: dict[date, int] = {}
-                cur.execute(
-                    "SELECT week_start, commit_count FROM evidence_git_cadence "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
-                for week_start, commit_count in cur.fetchall():
-                    cadence[week_start] = commit_count
-
-                file_churn: dict[str, FileChurnTotal] = {}
-                cur.execute(
-                    "SELECT path, churn_count, recent_commits, co_change_counts, owners FROM evidence_git_file_churn "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
-                for path, churn_count, recent_commits, co_change_counts, owners in cur.fetchall():
-                    file_churn[path] = FileChurnTotal(
-                        path=path,
-                        churn_count=churn_count,
-                        recent_commits=[
-                            RecentCommit(
-                                sha=r["sha"],
-                                author_name=r["author_name"],
-                                author_email=r["author_email"],
-                                committed_at=datetime.fromisoformat(r["committed_at"]),
-                                # .get(): rows written before subject-capture
-                                # was added have no such key - default ""
-                                # rather than KeyError.
-                                subject=r.get("subject", ""),
-                            )
-                            for r in recent_commits
-                        ],
-                        co_change_counts=co_change_counts,
-                        owners={
-                            email: OwnershipTotal(
-                                email=email,
-                                names=set(owner["names"]),
-                                commit_count=owner["commit_count"],
-                            )
-                            for email, owner in (owners or {}).items()
-                        },
-                    )
-
-        return GraphSnapshot(
-            last_synced_sha=sync_row[0],
-            last_synced_at=sync_row[1],
-            ownership=ownership,
-            cadence_weekly_counts=cadence,
-            file_churn=file_churn,
-        )
+                return self._load_with_cursor(cur, branch)
 
     def apply_commits(
         self,
@@ -119,106 +122,165 @@ class PostgresRepoGraphStore:
         *,
         reset: bool,
     ) -> None:
+        """Real bug found via audit: this used to read the current snapshot
+        (self.load, its own separate connection) before opening the
+        connection that deletes and re-inserts the merged result - a plain
+        read-modify-write with nothing serializing two concurrent callers
+        for the same (installation_id, repo_full_name, branch). Nothing
+        upstream prevents that: no webhook handler enqueues a scan job with
+        a dedup key (confirmed directly - grepped every `Queue(...).enqueue`
+        call site), so a second push landing while the first push's scan is
+        still running, or a push and a PR sync event racing each other,
+        both call this. Whichever writer's DELETE+INSERT commits last wins
+        outright - the other writer's merged commits are not merged with
+        it, they are gone, since each independently read the same stale
+        `current` snapshot before either had written anything.
+
+        Fixed with a session-scoped Postgres advisory lock
+        (pg_advisory_lock, not pg_advisory_xact_lock - the read and the
+        write need to be serialized together as one critical section, and
+        xact-level locks release at COMMIT, before this method is done)
+        keyed on the same (installation_id, repo_full_name, branch) the
+        rows themselves are keyed on, held for this whole method on one
+        connection spanning both the read and the write - unlike before,
+        where the read used a separate connection/session entirely and so
+        could never have been serialized by a lock scoped to the write's
+        own transaction alone. A concurrent caller for a DIFFERENT
+        installation/repo/branch hashes to a different lock key and is not
+        blocked by this at all.
+
+        No explicit pg_advisory_unlock: a session-scoped lock is released
+        when the session (this connection) ends regardless of how it ends,
+        and `with psycopg.connect(...)` below already guarantees that on
+        every exit path, success or exception. An explicit unlock in a
+        `finally` was tried and rejected - if _write_merged raises mid-
+        transaction, the transaction is left in Postgres's own "aborted"
+        state, and the unlock statement would itself fail in that state
+        (InFailedSqlTransaction), replacing the real error with a
+        confusing one about the failed cleanup attempt instead. Letting
+        connection teardown release the lock avoids that entirely and
+        still releases it correctly either way.
+        """
         import psycopg
 
-        current = GraphSnapshot.empty() if reset else self.load(repo_key, branch)
-        merged = fold(current, commits)
+        lock_key = f"{self._installation_id}:{self._repo_full_name}:{branch}"
 
         with psycopg.connect(self._dsn) as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    "DELETE FROM evidence_git_sync_state "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
-                cur.execute(
-                    "DELETE FROM evidence_git_ownership "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
-                cur.execute(
-                    "DELETE FROM evidence_git_cadence "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
-                cur.execute(
-                    "DELETE FROM evidence_git_file_churn "
-                    "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
-                    (self._installation_id, self._repo_full_name, branch),
-                )
+                # hashtextextended(text, seed) -> bigint: a stable, built-in
+                # way to turn an arbitrary string key into the single bigint
+                # pg_advisory_lock takes, without hand-rolling a hash in
+                # Python that would need to match Postgres's own hashing to
+                # be useful for anything (it doesn't need to - only this
+                # process ever calls pg_advisory_lock with this key shape,
+                # so any stable hash function works; hashtextextended just
+                # avoids writing one).
+                cur.execute("SELECT pg_advisory_lock(hashtextextended(%s, 0))", (lock_key,))
+                current = GraphSnapshot.empty() if reset else self._load_with_cursor(cur, branch)
+                merged = fold(current, commits)
+                self._write_merged(cur, branch, merged, new_sync_sha, new_sync_at)
+                conn.commit()
 
-                cur.execute(
-                    "INSERT INTO evidence_git_sync_state "
-                    "(installation_id, repo_full_name, branch, last_synced_sha, last_synced_at) "
-                    "VALUES (%s, %s, %s, %s, %s)",
-                    (self._installation_id, self._repo_full_name, branch, new_sync_sha, new_sync_at),
-                )
+    def _write_merged(
+        self,
+        cur,
+        branch: str,
+        merged: GraphSnapshot,
+        new_sync_sha: str,
+        new_sync_at: datetime,
+    ) -> None:
+        cur.execute(
+            "DELETE FROM evidence_git_sync_state "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
+        cur.execute(
+            "DELETE FROM evidence_git_ownership "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
+        cur.execute(
+            "DELETE FROM evidence_git_cadence "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
+        cur.execute(
+            "DELETE FROM evidence_git_file_churn "
+            "WHERE installation_id = %s AND repo_full_name = %s AND branch = %s",
+            (self._installation_id, self._repo_full_name, branch),
+        )
 
-                if merged.ownership:
-                    cur.executemany(
-                        "INSERT INTO evidence_git_ownership "
-                        "(installation_id, repo_full_name, branch, email, names, commit_count) "
-                        "VALUES (%s, %s, %s, %s, %s::jsonb, %s)",
-                        (
-                            (
-                                self._installation_id,
-                                self._repo_full_name,
-                                branch,
-                                email,
-                                json.dumps(sorted(total.names)),
-                                total.commit_count,
-                            )
-                            for email, total in merged.ownership.items()
+        cur.execute(
+            "INSERT INTO evidence_git_sync_state "
+            "(installation_id, repo_full_name, branch, last_synced_sha, last_synced_at) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (self._installation_id, self._repo_full_name, branch, new_sync_sha, new_sync_at),
+        )
+
+        if merged.ownership:
+            cur.executemany(
+                "INSERT INTO evidence_git_ownership "
+                "(installation_id, repo_full_name, branch, email, names, commit_count) "
+                "VALUES (%s, %s, %s, %s, %s::jsonb, %s)",
+                (
+                    (
+                        self._installation_id,
+                        self._repo_full_name,
+                        branch,
+                        email,
+                        json.dumps(sorted(total.names)),
+                        total.commit_count,
+                    )
+                    for email, total in merged.ownership.items()
+                ),
+            )
+
+        if merged.cadence_weekly_counts:
+            cur.executemany(
+                "INSERT INTO evidence_git_cadence "
+                "(installation_id, repo_full_name, branch, week_start, commit_count) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                (
+                    (self._installation_id, self._repo_full_name, branch, week_start, count)
+                    for week_start, count in merged.cadence_weekly_counts.items()
+                ),
+            )
+
+        if merged.file_churn:
+            cur.executemany(
+                "INSERT INTO evidence_git_file_churn "
+                "(installation_id, repo_full_name, branch, path, churn_count, recent_commits, "
+                "co_change_counts, owners) VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb)",
+                (
+                    (
+                        self._installation_id,
+                        self._repo_full_name,
+                        branch,
+                        path,
+                        churn.churn_count,
+                        json.dumps(
+                            [
+                                {
+                                    "sha": r.sha,
+                                    "author_name": r.author_name,
+                                    "author_email": r.author_email,
+                                    "committed_at": r.committed_at.isoformat(),
+                                    "subject": r.subject,
+                                }
+                                for r in churn.recent_commits
+                            ]
+                        ),
+                        json.dumps(churn.co_change_counts),
+                        json.dumps(
+                            {
+                                email: {
+                                    "names": sorted(owner.names),
+                                    "commit_count": owner.commit_count,
+                                }
+                                for email, owner in churn.owners.items()
+                            }
                         ),
                     )
-
-                if merged.cadence_weekly_counts:
-                    cur.executemany(
-                        "INSERT INTO evidence_git_cadence "
-                        "(installation_id, repo_full_name, branch, week_start, commit_count) "
-                        "VALUES (%s, %s, %s, %s, %s)",
-                        (
-                            (self._installation_id, self._repo_full_name, branch, week_start, count)
-                            for week_start, count in merged.cadence_weekly_counts.items()
-                        ),
-                    )
-
-                if merged.file_churn:
-                    cur.executemany(
-                        "INSERT INTO evidence_git_file_churn "
-                        "(installation_id, repo_full_name, branch, path, churn_count, recent_commits, "
-                        "co_change_counts, owners) VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb)",
-                        (
-                            (
-                                self._installation_id,
-                                self._repo_full_name,
-                                branch,
-                                path,
-                                churn.churn_count,
-                                json.dumps(
-                                    [
-                                        {
-                                            "sha": r.sha,
-                                            "author_name": r.author_name,
-                                            "author_email": r.author_email,
-                                            "committed_at": r.committed_at.isoformat(),
-                                            "subject": r.subject,
-                                        }
-                                        for r in churn.recent_commits
-                                    ]
-                                ),
-                                json.dumps(churn.co_change_counts),
-                                json.dumps(
-                                    {
-                                        email: {
-                                            "names": sorted(owner.names),
-                                            "commit_count": owner.commit_count,
-                                        }
-                                        for email, owner in churn.owners.items()
-                                    }
-                                ),
-                            )
-                            for path, churn in merged.file_churn.items()
-                        ),
-                    )
-            conn.commit()
+                    for path, churn in merged.file_churn.items()
+                ),
+            )

--- a/github-app/tests/test_postgres_graph_store.py
+++ b/github-app/tests/test_postgres_graph_store.py
@@ -1,5 +1,8 @@
 import os
+import threading
+import time
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 
@@ -171,6 +174,127 @@ async def test_different_branches_are_isolated(pool):
 
     assert store.load("unused", "main").ownership.keys() == {"a@example.com"}
     assert store.load("unused", "feature").ownership.keys() == {"b@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_apply_commits_does_not_lose_either_writers_commits(pool):
+    # Real bug found via audit: apply_commits used to read the current
+    # snapshot (self.load, its own separate connection) before opening the
+    # connection that deletes and re-inserts the merged result, with
+    # nothing serializing two concurrent callers for the same
+    # (installation_id, repo_full_name, branch). Nothing upstream prevents
+    # that in production either - no webhook handler enqueues a scan job
+    # with a dedup key. Whichever writer's DELETE+INSERT committed last
+    # won outright; the other writer's merged commits were not merged with
+    # it, they were gone.
+    #
+    # Reproduced deterministically here by widening the real read-to-write
+    # window with an artificial delay inside _load_with_cursor (the read
+    # step) - on the pre-fix code this reliably made the second thread's
+    # own read start while the first thread was still "working" (i.e.
+    # before the first thread had written anything), the exact interleaving
+    # that loses an update. On the fix, apply_commits holds the advisory
+    # lock across this same delay, so the second thread's read cannot start
+    # until the first thread's write has already committed and the lock
+    # is released.
+    await _insert_installation(pool, 609, "org")
+    store = PostgresRepoGraphStore(TEST_DATABASE_URL, 609, "org/repo")
+    store.apply_commits(
+        "unused",
+        "main",
+        [_touch("s0", "Root", "root@example.com", "2026-06-01T00:00:00", ("root.txt",))],
+        new_sync_sha="s0",
+        new_sync_at=datetime(2026, 6, 1),
+        reset=True,
+    )
+
+    original_load = PostgresRepoGraphStore._load_with_cursor
+
+    def _slow_load(self, cur, branch):
+        result = original_load(self, cur, branch)
+        time.sleep(0.3)
+        return result
+
+    results: dict[str, Exception] = {}
+
+    def _apply(sha, author, email, filename):
+        try:
+            store.apply_commits(
+                "unused",
+                "main",
+                [_touch(sha, author, email, "2026-06-02T00:00:00", (filename,))],
+                new_sync_sha=sha,
+                new_sync_at=datetime(2026, 6, 2),
+                reset=False,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced via `results` below
+            results[sha] = exc
+
+    with patch.object(PostgresRepoGraphStore, "_load_with_cursor", _slow_load):
+        thread_a = threading.Thread(target=_apply, args=("sa", "Alice", "a@example.com", "a.txt"))
+        thread_b = threading.Thread(target=_apply, args=("sb", "Bob", "b@example.com", "b.txt"))
+        thread_a.start()
+        time.sleep(0.05)  # let thread_a acquire the lock and start its (slow) read first
+        thread_b.start()
+        thread_a.join(timeout=5)
+        thread_b.join(timeout=5)
+
+    assert not results, f"apply_commits raised: {results}"
+    snapshot = store.load("unused", "main")
+    # Both concurrent writers' commits must survive - neither is a lost update.
+    assert "a@example.com" in snapshot.ownership
+    assert "b@example.com" in snapshot.ownership
+    assert "a.txt" in snapshot.file_churn
+    assert "b.txt" in snapshot.file_churn
+
+
+@pytest.mark.asyncio
+async def test_apply_commits_lock_does_not_serialize_different_repos(pool):
+    # The fix must not accidentally serialize every scan globally - only
+    # concurrent callers for the SAME (installation_id, repo_full_name,
+    # branch) should ever wait on each other.
+    await _insert_installation(pool, 610, "org-x")
+    await _insert_installation(pool, 611, "org-y")
+    store_a = PostgresRepoGraphStore(TEST_DATABASE_URL, 610, "org-x/repo")
+    store_b = PostgresRepoGraphStore(TEST_DATABASE_URL, 611, "org-y/repo")
+
+    original_write = PostgresRepoGraphStore._write_merged
+
+    def _slow_write(self, cur, branch, merged, new_sync_sha, new_sync_at):
+        if self._repo_full_name == "org-x/repo":
+            time.sleep(0.3)
+        return original_write(self, cur, branch, merged, new_sync_sha, new_sync_at)
+
+    with patch.object(PostgresRepoGraphStore, "_write_merged", _slow_write):
+        thread_a = threading.Thread(
+            target=lambda: store_a.apply_commits(
+                "unused",
+                "main",
+                [_touch("s1", "Alice", "a@example.com", "2026-06-01T00:00:00", ("a.txt",))],
+                new_sync_sha="s1",
+                new_sync_at=datetime(2026, 6, 1),
+                reset=True,
+            )
+        )
+        thread_a.start()
+        time.sleep(0.05)  # let thread_a acquire its lock and enter the slow write first
+
+        start = time.monotonic()
+        store_b.apply_commits(
+            "unused",
+            "main",
+            [_touch("s2", "Bob", "b@example.com", "2026-06-01T00:00:00", ("b.txt",))],
+            new_sync_sha="s2",
+            new_sync_at=datetime(2026, 6, 1),
+            reset=True,
+        )
+        elapsed = time.monotonic() - start
+        thread_a.join(timeout=5)
+
+    # store_b's own call was never patched to be slow, and a different repo
+    # must not be blocked by store_a's in-flight lock - it should return
+    # well under store_a's own artificial 0.3s delay.
+    assert elapsed < 0.2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- \`apply_commits\` read the current snapshot (\`self.load\`, its own separate connection) before opening a *second* connection to delete and re-insert the merged result - a plain read-modify-write with nothing serializing two concurrent callers for the same \`(installation_id, repo_full_name, branch)\`.
- Nothing upstream prevents that: no webhook handler enqueues a scan job with a dedup key (grepped every \`Queue(...).enqueue\` call site directly - none pass \`job_id=\`), so a second push landing while the first push's scan is still running, or a push and a PR sync event racing each other, both reach this code path.
- Whichever writer's DELETE+INSERT committed last won outright - the other writer's merged commits were **not merged** with it, they were gone, since each independently read the same stale snapshot before either had written anything.
- **Verified directly**: reproduced the lost update against the pre-fix code with two concurrent \`apply_commits\` calls for the same repo+branch (an artificial delay widening the real read-to-write window) - one writer's commit (its ownership entry and its file's churn entry) was silently absent from the final state.

## Fix
A session-scoped Postgres advisory lock (\`pg_advisory_lock\`, not \`pg_advisory_xact_lock\` - the read and the write need to be serialized together as one critical section, and xact-level locks release at COMMIT, before the method is done) keyed on the same \`(installation_id, repo_full_name, branch)\` the rows themselves are keyed on, held across one connection spanning both the read and the write.

The read (\`load\`'s own query logic) is extracted into \`_load_with_cursor\` so \`apply_commits\` can run it on the *same* connection holding the lock, instead of \`load()\`'s own separate connection/session that a lock scoped only to the write's transaction could never have serialized against.

No explicit \`pg_advisory_unlock\`: a session-scoped lock releases when the session ends regardless of how it ends, and \`with psycopg.connect(...)\` already guarantees that on every exit path. An explicit unlock in a \`finally\` was tried and rejected during development - a mid-transaction failure leaves the transaction in Postgres's own "aborted" state, where the unlock statement itself would fail and mask the real error.

A concurrent caller for a *different* installation/repo/branch hashes to a different lock key and is never blocked by this.

## Test plan
- [x] New regression test: two concurrent \`apply_commits\` calls for the same repo+branch (artificial delay to force the race window) - confirmed failing against the pre-fix code (both directly via a standalone script and via the refactored test, which fails with \`AttributeError\` since the fix's locking mechanism doesn't exist pre-fix), passing after
- [x] New regression test: the lock does not serialize *different* repos - a concurrent call for a different repo completes promptly even while another repo's call is deliberately slow
- [x] All 7 pre-existing tests still pass unchanged
- [x] Full github-app suite: 1867 passed, 8 skipped (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)