### PR TITLE
fix: local dashboard's MCP tools list inserted raw HTML instead of escaping

### DIFF
--- a/src/aletheore/dashboard.py
+++ b/src/aletheore/dashboard.py
@@ -1314,8 +1314,17 @@ function renderEndpoints(data) {
 
 function renderMcpTools(tools) {
   const el = document.getElementById('mcp-tools');
+  // Real gap found via audit: every other render function in this file
+  // (renderDeadCode, renderClusters, etc.) escapes evidence-derived text
+  // before it reaches innerHTML - this was the one exception, inserting
+  // t.name/t.description raw. Every tool registered by build_server today
+  // has a static, first-party name/description (see mcp_server.py), so
+  // this isn't reachable through a malicious repo right now - but nothing
+  // enforces that staying true, and a reviewer skimming this file would
+  // reasonably assume the escaping discipline is uniform given how
+  // consistently every other function here follows it.
   el.innerHTML = tools.map(t =>
-    '<div class="tool-row"><span class="tool-name">' + t.name + '</span> - ' + (t.description || '') + '</div>'
+    '<div class="tool-row"><span class="tool-name">' + escapeHtml(t.name) + '</span> - ' + escapeHtml(t.description || '') + '</div>'
   ).join('');
 }
 

--- a/src/tests/test_dashboard.py
+++ b/src/tests/test_dashboard.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import re
 import tempfile
 from pathlib import Path
 
@@ -574,3 +575,27 @@ def test_browser_icon_requests_are_served_rather_than_404(tmp_path):
         "/favicon.ico", "/apple-touch-icon.png", "/apple-touch-icon-precomposed.png", "/logo.png",
     ):
         assert client.get(path).status_code == 200, path
+
+
+def test_render_mcp_tools_escapes_name_and_description():
+    # Real gap found via audit: renderMcpTools was the one render function
+    # in this file inserting evidence-derived text (a tool's name/
+    # description, from /api/mcp-tools) into innerHTML without calling
+    # escapeHtml first - every other render function here (renderDeadCode,
+    # renderClusters, renderVulnerabilities, etc.) consistently does.
+    # Not reachable through a malicious repo today (every registered
+    # tool's name/description is a static, first-party string - see
+    # mcp_server.py), but nothing enforces that staying true, and this
+    # regression test pins the same escaping discipline the rest of the
+    # file already has.
+    from aletheore.dashboard import DASHBOARD_HTML
+
+    match = re.search(r"function renderMcpTools\(tools\) \{.*?\n\}", DASHBOARD_HTML, re.DOTALL)
+    assert match is not None, "renderMcpTools function not found in DASHBOARD_HTML"
+    body = match.group(0)
+
+    assert "escapeHtml(t.name)" in body
+    assert "escapeHtml(t.description" in body
+    # Guards against a regression back to the original unescaped shape:
+    # `t.name` concatenated directly with no escapeHtml() wrapping it.
+    assert "+ t.name +" not in body


### PR DESCRIPTION
## Summary
- \`renderMcpTools\` was the one render function in \`dashboard.py\`'s embedded JS inserting evidence-derived text (a tool's name/description, from \`/api/mcp-tools\`) into \`innerHTML\` without calling \`escapeHtml\` first - every other render function in this file (\`renderDeadCode\`, \`renderClusters\`, \`renderVulnerabilities\`, etc.) consistently does, several with their own explicit comments about why.
- **Honest severity note**: this is not reachable through a malicious repository today - every tool \`build_server\` registers has a static, first-party name/description (see \`mcp_server.py\`), so this is a defense-in-depth/consistency fix, not a currently exploitable vulnerability.
- But nothing enforces that staying true, and a reviewer skimming this file would reasonably assume the escaping discipline is uniform given how consistently every other function here follows it - the one exception is exactly the kind of gap that goes unnoticed until something does start passing attacker-influenced content through a tool's metadata.

## Fix
Wrap both fields in \`escapeHtml(...)\`, matching the established convention everywhere else in this file.

## Test plan
- [x] New regression test: extracts \`renderMcpTools\`'s function body from \`DASHBOARD_HTML\` and asserts both fields are escaped - confirmed failing against the pre-fix code, passing after
- [x] Full suite: 1932 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)