### PR TITLE
fix: GitHub OAuth code-exchange failure surfaced as a raw 500 + alert email

### DIFF
--- a/github-app/app_server/auth.py
+++ b/github-app/app_server/auth.py
@@ -149,6 +149,19 @@ def _fetch_primary_verified_email(access_token: str) -> str | None:
     return verified["email"] if verified else None
 
 
+class GitHubOAuthError(Exception):
+    """GitHub's own /login/oauth/access_token endpoint returns HTTP 200
+    with an {"error": ...} body (never a 4xx) for an invalid, expired, or
+    already-used authorization code - refresh_github_access_token already
+    documents and handles this exact quirk for this same endpoint's
+    grant_type=refresh_token form. Confirmed the code-exchange form has the
+    identical failure mode: a double-clicked "Authorize" button, a browser
+    back-button resubmission, or a slow network racing GitHub's code expiry
+    are all routine, real ways to hit it - not a bug, so it must not reach
+    main.py's global exception handler (a raw 500 plus an internal error
+    alert email for an entirely ordinary user action)."""
+
+
 def _exchange_code_and_fetch_user(
     code: str, client_id: str, client_secret: str
 ) -> tuple[str, str | None, dict, str | None]:
@@ -162,6 +175,10 @@ def _exchange_code_and_fetch_user(
     )
     token_response.raise_for_status()
     token_data = token_response.json()
+    if "access_token" not in token_data:
+        raise GitHubOAuthError(
+            token_data.get("error_description") or token_data.get("error") or "code exchange failed"
+        )
     access_token = token_data["access_token"]
     # Only present when the GitHub App has "Expire user authorization
     # tokens" turned on - absent (None) otherwise, and stored as such.
@@ -411,9 +428,18 @@ async def callback(code: str, request: Request, state: str | None = None, instal
     ):
         raise HTTPException(status_code=400, detail="invalid oauth state")
 
-    access_token, refresh_token, user, email = await asyncio.to_thread(
-        _exchange_code_and_fetch_user, code, settings.github_client_id, settings.github_client_secret
-    )
+    try:
+        access_token, refresh_token, user, email = await asyncio.to_thread(
+            _exchange_code_and_fetch_user, code, settings.github_client_id, settings.github_client_secret
+        )
+    except GitHubOAuthError as exc:
+        # A used-up, expired, or otherwise invalid authorization code - a
+        # routine, retryable condition (see GitHubOAuthError's own
+        # docstring), not a real error worth an internal alert or a raw
+        # 500. The code itself is single-use and already spent either way,
+        # so there's nothing to retry but a fresh /auth/login round-trip.
+        logger.info("github oauth code exchange failed (%s); redirecting to retry", exc)
+        return RedirectResponse(url="/auth/login", status_code=307)
 
     session_id = secrets.token_urlsafe(32)
     await create_session(

--- a/github-app/tests/test_auth.py
+++ b/github-app/tests/test_auth.py
@@ -768,3 +768,47 @@ def test_checkout_installation_id_and_oauth_state_do_not_cross_purposes():
     server."""
     oauth_token = sign_oauth_state("some-state-value", "a-secret")
     assert unsign_checkout_installation_id(oauth_token, "a-secret") is None
+
+
+@pytest.mark.asyncio
+async def test_callback_handles_github_200_with_error_body_gracefully(pool, monkeypatch):
+    # GitHub's own /login/oauth/access_token endpoint returns HTTP 200 with
+    # an {"error": ...} body (not a 4xx) when the authorization code is
+    # invalid, expired, or already used - the exact same quirk
+    # refresh_github_access_token already documents and handles for this
+    # same endpoint's grant_type=refresh_token form. A double-clicked
+    # "Authorize" button, a browser back-button resubmission, or a slow
+    # network racing GitHub's ~10-minute code expiry are all routine, real
+    # ways a user hits this - not a bug, but the sign-in flow previously
+    # had no handling for it at all on the code-exchange side, so it fell
+    # through to `token_data["access_token"]` raising an uncaught KeyError:
+    # a raw 500 plus main.py's global handler firing an internal error
+    # alert email for an entirely ordinary user action.
+    monkeypatch.setenv("SESSION_SECRET", "test-session-secret")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/login/oauth/access_token":
+            return httpx.Response(200, json={"error": "bad_verification_code"})
+        return httpx.Response(404)
+
+    monkeypatch.setattr(
+        "app_server.auth._github_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.github.com"),
+    )
+    monkeypatch.setattr(
+        "app_server.auth._github_oauth_http_client",
+        lambda: httpx.Client(transport=httpx.MockTransport(handler), base_url="https://github.com"),
+    )
+
+    app.state.db_pool = pool
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="https://test") as client:
+        login_response = await client.get("/auth/login", follow_redirects=False)
+        state = login_response.headers["location"].split("state=")[1]
+        response = await client.get(
+            f"/auth/callback?code=bad-code&state={state}", follow_redirects=False
+        )
+
+    # A clean redirect back to sign-in, not a raw 500.
+    assert response.status_code == 307
+    assert response.headers["location"] == "/auth/login"


### PR DESCRIPTION
## Summary
- GitHub's `/login/oauth/access_token` endpoint returns HTTP 200 with an `{"error": ...}` body (never a 4xx) for an invalid, expired, or already-used authorization code — `refresh_github_access_token`, in this same file, already documents and handles this exact quirk for this same endpoint's `grant_type=refresh_token` form: *"GitHub's refresh endpoint returns 200 with an `error` field in the body rather than a 4xx status"*.
- The code-exchange form (`_exchange_code_and_fetch_user`) has the identical failure mode, confirmed directly, but had no handling for it at all: `access_token = token_data["access_token"]` raised an uncaught `KeyError` whenever GitHub responded this way.
- A double-clicked "Authorize" button, a browser back-button resubmission, or a slow network racing GitHub's code expiry are all routine, real ways a user hits this — not a bug, but `main.py`'s global exception handler treats any uncaught exception as one: a raw 500 response plus an internal error-alert email, for an entirely ordinary user action.
- Fixed by checking for a missing `access_token` (the same check `refresh_github_access_token` already makes) and raising a new `GitHubOAuthError`, caught in the `/auth/callback` route with a clean redirect back to `/auth/login` — the code is single-use and already spent either way, so a fresh round-trip is the only real recovery.

## Test plan
- [x] New regression test: reproduced the bare `KeyError` against the pre-fix code with a mocked 200-with-error-body response (confirmed failing), then confirmed a clean 307 redirect to `/auth/login` after the fix
- [x] Full `test_auth.py`: 46 passed
- [x] Full github-app suite: 1868 passed, 8 skipped (unrelated)