### PR TITLE
fix: ignored_paths unanchored patterns wrongly restricted to repo root

### DIFF
--- a/src/aletheore/repo_config.py
+++ b/src/aletheore/repo_config.py
@@ -102,15 +102,60 @@ def parse_repo_config(raw_text: str | None) -> dict:
     return result
 
 
+def _segments_match(pattern_segments: list[str], candidate_segments: list[str]) -> bool:
+    """True if pattern_segments matches a PREFIX of candidate_segments - so a
+    directory-shaped pattern excludes everything beneath it (the pattern is
+    allowed to run out before the candidate does; the reverse isn't a
+    match). "**" is the one construct allowed to cross a "/" boundary
+    (matches zero or more whole segments); a plain "*"/"?" stays scoped to
+    one segment via fnmatch, matching real gitignore semantics rather than
+    fnmatch's own no-path-awareness "*" (which matches straight through
+    "/" - confirmed directly: the old whole-string fnmatch call made
+    "docs/*" match "docs/sub/x.md" too, when gitignore's "*" doesn't cross
+    directory boundaries)."""
+    if not pattern_segments:
+        return True
+    head, rest = pattern_segments[0], pattern_segments[1:]
+    if head == "**":
+        return any(_segments_match(rest, candidate_segments[i:]) for i in range(len(candidate_segments) + 1))
+    if not candidate_segments:
+        return False
+    return fnmatch.fnmatch(candidate_segments[0], head) and _segments_match(rest, candidate_segments[1:])
+
+
 def is_ignored(rel_path: str, patterns: list[str]) -> bool:
     """rel_path is repo-root-relative, forward-slash separated (as_posix()).
-    A pattern matches if it matches the whole path, OR if it matches any
-    parent-directory prefix of the path - so "vendor/**" (or even plain
-    "vendor") excludes everything under vendor/ without every file inside
-    needing to match the pattern individually.
+
+    Gitignore-style anchoring (per this module's own design spec, which
+    calls these "gitignore-style glob patterns"): a pattern containing a
+    "/" anywhere but a lone trailing character is anchored to the repo
+    root and only ever checked from position 0; a bare pattern with no
+    "/" (or only a trailing one) is unanchored and matches at any depth,
+    not just at the repo root.
+
+    Real bug found via audit: the previous implementation always anchored
+    every pattern to the root regardless of whether it contained a "/" -
+    confirmed directly, a plain "vendor" pattern (this function's own
+    docstring's example of something that should "exclude everything
+    under vendor/") excluded a root-level vendor/ directory but not a
+    nested one (e.g. "packages/some-lib/vendor/file.go"), the opposite of
+    gitignore's own documented unanchored-bare-name behavior this module
+    is explicitly designed to follow. A pattern matches if it equals the
+    whole path, or a parent-directory prefix of it (from the root for an
+    anchored pattern, from anywhere for an unanchored one) - so "vendor/**"
+    (anchored) or plain "vendor" (unanchored) both exclude everything
+    under a vendor/ directory without every file inside needing to match
+    individually, "vendor/**" only at the repo root, "vendor" at any
+    depth.
     """
     if not patterns:
         return False
-    parts = rel_path.split("/")
-    candidates = [rel_path] + ["/".join(parts[: i + 1]) for i in range(len(parts) - 1)]
-    return any(fnmatch.fnmatch(candidate, pattern) for candidate in candidates for pattern in patterns)
+    path_segments = rel_path.split("/")
+    for pattern in patterns:
+        body = pattern[:-1] if pattern.endswith("/") else pattern
+        anchored = pattern.startswith("/") or "/" in body
+        pattern_segments = pattern.strip("/").split("/")
+        starts = (0,) if anchored else range(len(path_segments))
+        if any(_segments_match(pattern_segments, path_segments[start:]) for start in starts):
+            return True
+    return False

--- a/src/aletheore/repo_config.py
+++ b/src/aletheore/repo_config.py
@@ -112,15 +112,44 @@ def _segments_match(pattern_segments: list[str], candidate_segments: list[str]) 
     fnmatch's own no-path-awareness "*" (which matches straight through
     "/" - confirmed directly: the old whole-string fnmatch call made
     "docs/*" match "docs/sub/x.md" too, when gitignore's "*" doesn't cross
-    directory boundaries)."""
-    if not pattern_segments:
-        return True
-    head, rest = pattern_segments[0], pattern_segments[1:]
-    if head == "**":
-        return any(_segments_match(rest, candidate_segments[i:]) for i in range(len(candidate_segments) + 1))
-    if not candidate_segments:
-        return False
-    return fnmatch.fnmatch(candidate_segments[0], head) and _segments_match(rest, candidate_segments[1:])
+    directory boundaries).
+
+    Real bug found via Flash Review on this same change: a naive recursive
+    "**" branch with no memoization forks into len(candidate_segments)+1
+    calls, and a pattern with several "**" segments multiplies that
+    branching at every level - exponential in the number of "**" segments.
+    ignored_paths comes from the scanned repo's own .aletheore.json,
+    untrusted input by design, so a crafted config is a real
+    denial-of-service vector - confirmed directly, a 10x"**" pattern
+    against a 25-segment path took ~60s before this fix. Memoizing by
+    (pattern index, candidate index) - scoped to this one call, not a
+    module-level cache, so it can't grow across unrelated calls - bounds
+    the whole match to O(len(pattern_segments) * len(candidate_segments))
+    states.
+    """
+    memo: dict[tuple[int, int], bool] = {}
+
+    def match(pi: int, ci: int) -> bool:
+        key = (pi, ci)
+        cached = memo.get(key)
+        if cached is not None:
+            return cached
+        if pi == len(pattern_segments):
+            result = True
+        else:
+            head = pattern_segments[pi]
+            if head == "**":
+                result = any(
+                    match(pi + 1, ci + skip) for skip in range(len(candidate_segments) - ci + 1)
+                )
+            elif ci == len(candidate_segments):
+                result = False
+            else:
+                result = fnmatch.fnmatch(candidate_segments[ci], head) and match(pi + 1, ci + 1)
+        memo[key] = result
+        return result
+
+    return match(0, 0)
 
 
 def is_ignored(rel_path: str, patterns: list[str]) -> bool:

--- a/src/tests/test_repo_config.py
+++ b/src/tests/test_repo_config.py
@@ -188,3 +188,27 @@ def test_is_ignored_directory_glob_still_excludes_everything_beneath_a_wildcard_
     # rewrite above.
     assert is_ignored("docs/x.md", ["docs/*"]) is True
     assert is_ignored("docs/sub/x.md", ["docs/*"]) is True
+
+
+def test_is_ignored_multiple_wildcard_segments_does_not_blow_up():
+    # Real bug found via Flash Review on this same PR: the naive recursive
+    # "**" branch in _segments_match forks into
+    # len(candidate_segments)+1 calls with no memoization, and a pattern
+    # with several "**" segments multiplies that branching at every level -
+    # exponential in the number of "**" segments. ignored_paths comes from
+    # the scanned repo's own .aletheore.json, untrusted input by design (
+    # that's the entire threat model this module exists under), so a
+    # crafted config is a real denial-of-service vector, not a theoretical
+    # one - confirmed directly: this exact shape took ~60s pre-fix.
+    # Bounded here to well under a second as the regression guard.
+    import time
+
+    pattern = "/".join(["**"] * 10) + "/nomatch"
+    path = "/".join(f"seg{i}" for i in range(25))
+
+    start = time.monotonic()
+    result = is_ignored(path, [pattern])
+    elapsed = time.monotonic() - start
+
+    assert result is False
+    assert elapsed < 1.0

--- a/src/tests/test_repo_config.py
+++ b/src/tests/test_repo_config.py
@@ -134,9 +134,10 @@ def test_is_ignored_exact_file_match():
 
 
 def test_is_ignored_glob_match():
-    # fnmatch's "*" crosses path separators, so a suffix pattern like this
-    # matches at any depth, not just at the repo root - the more useful
-    # default for "ignore every generated file named like this."
+    # "*.gen.go" has no "/", so it's an unanchored (gitignore-style) bare
+    # pattern - tried against every starting depth, so a suffix pattern
+    # like this matches at any depth, not just at the repo root - the more
+    # useful default for "ignore every generated file named like this."
     assert is_ignored("src/foo.gen.go", ["*.gen.go"]) is True
     assert is_ignored("foo.gen.go", ["*.gen.go"]) is True
 
@@ -153,3 +154,37 @@ def test_is_ignored_directory_glob_pattern():
 
 def test_is_ignored_no_match_returns_false():
     assert is_ignored("src/main.py", ["vendor/**", "*.gen.go"]) is False
+
+
+def test_is_ignored_unanchored_bare_name_matches_a_nested_directory():
+    # Real bug found via audit: this module's own design spec calls these
+    # "gitignore-style glob patterns," and this function's own docstring
+    # gives "vendor" (no slash) as an example of something that excludes
+    # "everything under vendor/" - but a bare, unanchored pattern like
+    # "vendor" was previously always anchored to the repo root regardless,
+    # so a nested vendor/ directory (a real, common repo shape - a
+    # monorepo package vendoring its own dependencies) was never excluded
+    # at all, contrary to both the docstring and real gitignore semantics.
+    assert is_ignored("packages/some-lib/vendor/pkg/lib.go", ["vendor"]) is True
+
+
+def test_is_ignored_anchored_pattern_still_only_matches_at_repo_root():
+    # The counterpart to the unanchored case above: a pattern with a
+    # leading slash IS anchored under gitignore rules and must not start
+    # matching at every depth just because the unanchored case now does.
+    assert is_ignored("packages/some-lib/vendor/pkg/lib.go", ["/vendor"]) is False
+    assert is_ignored("vendor/pkg/lib.go", ["/vendor"]) is True
+
+
+def test_is_ignored_directory_glob_still_excludes_everything_beneath_a_wildcard_match():
+    # is_ignored's own documented contract is broader than raw gitignore
+    # matching: ANY matched prefix (wildcard-matched segments included)
+    # excludes the whole subtree beneath it, not just that one segment -
+    # "if it matches any parent-directory prefix of the path" per this
+    # function's own docstring. Confirmed this was already the pre-fix
+    # behavior too (a plain fnmatch.fnmatch("docs/sub/x.md", "docs/*") is
+    # True, since fnmatch's own "*" already crosses "/"), so this is
+    # preserved intentionally, not a new regression from the segment-based
+    # rewrite above.
+    assert is_ignored("docs/x.md", ["docs/*"]) is True
+    assert is_ignored("docs/sub/x.md", ["docs/*"]) is True


### PR DESCRIPTION
## Summary
- \`is_ignored\` (backing \`.aletheore.json\`'s \`ignored_paths\`, used at every file-walk site across scanner/detect.py, scanner/graph.py, secrets.py, dead_code.py, licenses.py, endpoints.py, and threaded through to github-app's Flash Review path-exclusion) always anchored every pattern to the repo root regardless of whether it contained a \`/\`.
- This module's own design spec (\`docs/superpowers/specs/2026-08-09-aletheore-config-file-design.md\`) explicitly calls these **"gitignore-style glob patterns"**, and the function's own docstring gives \`"vendor"\` (no slash) as an example of something that excludes "everything under vendor/" - but a bare, unanchored pattern like \`"vendor"\` only ever excluded a **root-level** \`vendor/\` directory, never a nested one (e.g. a monorepo package vendoring its own dependencies at \`packages/some-lib/vendor/\`), contrary to both the docstring and real gitignore's documented unanchored-bare-name behavior.
- The same investigation surfaced a second, related gap: an explicitly root-anchored pattern written with a leading slash (e.g. \`"/vendor"\`) matched **nothing at all**, since the leading \`/\` was never stripped before comparing against a candidate (which, being repo-relative, never starts with \`/\`) - confirmed directly.
- This is the same anchoring bug class (and largely the same fix shape) already found and fixed in \`evidence_resolution.py\`'s CODEOWNERS matcher earlier this session (#686) - a sibling "gitignore-style" pattern matcher with the identical root cause.

## Fix
Rewrote \`is_ignored\` to match segment-by-segment (splitting both pattern and path on \`/\`) instead of a single \`fnmatch\` call per candidate, with \`**\` as the one construct allowed to cross a \`/\` boundary, and tries every starting depth for an unanchored pattern vs. only the root for an anchored one.

The existing "a matched prefix excludes everything beneath it" contract (including for a wildcard-matched segment, e.g. \`"docs/*"\` still excluding \`"docs/sub/x.md"\`) is **deliberately preserved** - confirmed this was already true of the pre-fix code too (\`fnmatch\`'s own \`*\` already crosses \`/\`), so it's this function's own intentionally broader-than-raw-gitignore contract, not something this fix changes.

## Test plan
- [x] Two new regression tests (unanchored bare name matches at any depth; leading-slash pattern stays anchored) - both confirmed failing against the pre-fix code, passing after
- [x] One new regression test locking in the "prefix match excludes subtree" contract is preserved for a wildcard-matched segment
- [x] All 5 pre-existing \`is_ignored\` tests still pass unchanged
- [x] Full suite: 1934 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)