### PR TITLE
fix: harden Ruby content-derived constant resolution against heredocs, reopened classes, and mixed tabs

### DIFF
--- a/src/aletheore/dead_code.py
+++ b/src/aletheore/dead_code.py
@@ -385,6 +385,45 @@ _RUBY_SCOPE_DECL_RE = re.compile(
     r"^(?P<indent>[ \t]*)(?:module|class)\s+(?P<name>[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*)"
 )
 
+# Matches a heredoc opener anywhere on a line (`sql = <<~SQL`, `<<-EOS`,
+# bare `<<EOS`), capturing the modifier (used to decide whether the
+# terminator line may be indented) and the terminator identifier itself
+# (quotes around it, if any, don't change what closes it).
+_RUBY_HEREDOC_START_RE = re.compile(r"<<([-~]?)([\"']?)([A-Za-z_]\w*)\2")
+
+
+def _ruby_lines_outside_heredocs(content: str):
+    """Yields each line of content except those inside a heredoc body.
+
+    Real bug found via audit: _RUBY_SCOPE_DECL_RE's plain text scan has
+    no awareness that Ruby source can embed arbitrary text (SQL, example
+    code, another language entirely) inside a heredoc - a heredoc body
+    line that happens to textually resemble a class/module declaration
+    (common in a job/model file building a SQL string, or a comment-block
+    example) was read as a real one, and since
+    _ruby_content_derived_constant returns on the first leaf-matching
+    declaration in file order, a fabricated declaration appearing before
+    the real one could hijack the result entirely - not just miss the
+    real namespace, but report a WRONG one, which (since a content-
+    derived candidate is only ever added, never used to override a
+    reference-based rescue) can only ever cause a false RESCUE: a
+    genuinely dead file kept alive because something elsewhere
+    coincidentally references the fabricated name.
+    """
+    terminator: str | None = None
+    terminator_can_be_indented = False
+    for line in content.splitlines():
+        if terminator is not None:
+            candidate = line.strip() if terminator_can_be_indented else line
+            if candidate == terminator:
+                terminator = None
+            continue
+        match = _RUBY_HEREDOC_START_RE.search(line)
+        if match:
+            terminator_can_be_indented = match.group(1) in ("-", "~")
+            terminator = match.group(3)
+        yield line
+
 
 def _ruby_content_derived_constant(basename_no_ext: str, content: str) -> str | None:
     """The full namespaced constant this file's own source actually
@@ -427,15 +466,48 @@ def _ruby_content_derived_constant(basename_no_ext: str, content: str) -> str | 
     long before reaching the target declaration. Indentation is a
     reliable proxy for real Ruby/Rails source, which the rubocop/standard
     ecosystem keeps close to universally consistent.
+
+    Real bug found via audit, two parts:
+
+    1. Heredoc bodies (SQL, example code, anything a job/model file might
+       build as a string) are skipped before this scan even sees them
+       (_ruby_lines_outside_heredocs) - without it, heredoc content that
+       textually resembles a class/module declaration was read as real
+       Ruby syntax, and since this function used to return on the first
+       leaf-matching declaration in file order, a fabricated declaration
+       appearing before the real one could hijack the result with a
+       WRONG constant, not just a missing one - the one way this
+       function's otherwise-additive design (a bad candidate can only
+       ever add a spurious rescue, never cause a false-dead) could
+       actually misfire.
+
+    2. Real Ruby lets a class be reopened (adding to it from more than
+       one place) - a leaf-matching declaration is no longer accepted on
+       first sight; every one in the file is considered, and the one with
+       the MOST enclosing context wins. A bare, unnamespaced stub
+       (`class TopicTimerBase; end`) appearing before the file's real,
+       namespaced definition used to win by virtue of coming first,
+       silently dropping the namespace a later reopening actually
+       supplies.
+
+    Indent comparison uses each line's raw, unexpanded whitespace length
+    (not .expandtabs()) - expanding to a fixed 8-column tab stop made a
+    single real tab (len 8 once expanded) look deeper than two real
+    spaces (len 2), inverting a genuinely shallower tab-indented
+    enclosing line's own position in the stack. Raw length has no such
+    inversion for any single consistent indent unit, tabs or spaces.
     """
     expected_leaf = "".join(word.capitalize() for word in basename_no_ext.split("_"))
     if not expected_leaf:
         return None
     declarations = [
-        (len(match.group("indent").expandtabs()), match.group("name"))
-        for match in (_RUBY_SCOPE_DECL_RE.match(line) for line in content.splitlines())
+        (len(match.group("indent")), match.group("name"))
+        for match in (
+            _RUBY_SCOPE_DECL_RE.match(line) for line in _ruby_lines_outside_heredocs(content)
+        )
         if match is not None
     ]
+    best: tuple[int, str] | None = None
     for index, (indent, name) in enumerate(declarations):
         if name.rsplit("::", 1)[-1] != expected_leaf:
             continue
@@ -445,8 +517,9 @@ def _ruby_content_derived_constant(basename_no_ext: str, content: str) -> str | 
             if prior_indent < current_indent:
                 enclosing.insert(0, prior_name)
                 current_indent = prior_indent
-        return "::".join(enclosing + [name])
-    return None
+        if best is None or len(enclosing) > best[0]:
+            best = (len(enclosing), "::".join(enclosing + [name]))
+    return best[1] if best is not None else None
 
 
 def _ruby_zeitwerk_constant_candidates(path: str, content: str | None = None) -> list[str]:

--- a/src/tests/test_dead_code.py
+++ b/src/tests/test_dead_code.py
@@ -1976,6 +1976,56 @@ def test_ruby_content_derived_constant_picks_nearest_enclosing_not_an_unrelated_
     assert _ruby_content_derived_constant("topic_timer_base", content) == "Jobs::TopicTimerBase"
 
 
+def test_ruby_content_derived_constant_skips_declarations_inside_a_heredoc_body():
+    # Real bug found via audit: a heredoc body building a SQL string (or any
+    # other embedded text) can textually resemble a class/module declaration.
+    # Before this fix, such a fabricated declaration - appearing earlier in
+    # the file than the real one - would hijack the result with a WRONG
+    # constant, since the old code returned on the first leaf-matching
+    # declaration in file order. The heredoc body here declares a decoy
+    # "Billing::TopicTimerBase" that must be ignored in favor of the real,
+    # differently-namespaced declaration that follows it.
+    content = (
+        "module Reports\n"
+        "  SQL = <<~SQL\n"
+        "module Billing\n"
+        "  class TopicTimerBase\n"
+        "  end\n"
+        "end\n"
+        "  SQL\n"
+        "\n"
+        "  module Jobs\n"
+        "    class TopicTimerBase < Jobs::Base\n"
+        "    end\n"
+        "  end\n"
+        "end\n"
+    )
+    assert (
+        _ruby_content_derived_constant("topic_timer_base", content)
+        == "Reports::Jobs::TopicTimerBase"
+    )
+
+
+def test_ruby_content_derived_constant_prefers_the_more_specific_reopened_class():
+    # Real Ruby allows reopening a class from more than one place. A bare,
+    # unnamespaced stub appearing before the file's real, namespaced
+    # definition must not win just because it comes first - the more
+    # specific (more deeply enclosed) declaration should be preferred.
+    content = "class TopicTimerBase\nend\n\nmodule Jobs\n  class TopicTimerBase < Jobs::Base\n  end\nend\n"
+    assert _ruby_content_derived_constant("topic_timer_base", content) == "Jobs::TopicTimerBase"
+
+
+def test_ruby_content_derived_constant_compares_raw_indentation_not_expanded_tabs():
+    # Real bug found via audit: expandtabs() normalizes a tab to an 8-column
+    # tab stop by default, so a single-tab outer indent (length 8 once
+    # expanded) numerically looked deeper than a 2-space inner indent,
+    # breaking the monotonic nesting comparison and dropping the enclosing
+    # "Jobs" namespace entirely. Comparing raw (unexpanded) indentation
+    # length avoids this for any single, internally-consistent indent unit.
+    content = "\tmodule Jobs\n  class TopicTimerBase < Jobs::Base\n  end\nend\n"
+    assert _ruby_content_derived_constant("topic_timer_base", content) == "Jobs::TopicTimerBase"
+
+
 def test_laravel_backslash_qualified_string_handler_resolves_a_nested_controller(tmp_path):
     # Flash Review finding on #666: the legacy string handler resolver
     # reduced every handler to its bare class name and always anchored


### PR DESCRIPTION
## Summary
Follow-up to #694, addressing three real gaps found by an independent audit of that PR's own fix:

- **Heredoc pollution**: a heredoc body (SQL, example code) that textually resembles a `class`/`module` declaration was read as real Ruby syntax. Since the scan returned on the first leaf-matching declaration in file order, a fabricated declaration appearing before the real one could hijack the result with a *wrong* constant - not just miss the real one. Fixed with `_ruby_lines_outside_heredocs`, a line-filter generator that tracks heredoc terminators (including the `-`/`~` indent-permitting modifiers).
- **Class-reopening**: a reopened class picked whichever declaration appeared first in the file, so a bare unnamespaced stub before the real, namespaced definition silently dropped the namespace. Now every leaf-matching declaration is considered and the most specific (most enclosing segments) one wins.
- **Tab/space mixing**: indentation comparison used `.expandtabs()`, which defaults to an 8-column tab stop - a single-tab outer indent could numerically appear deeper than a 2-space inner indent, breaking the monotonic nesting reconstruction. Comparison now uses each line's raw, unexpanded indent length.

Since a content-derived candidate is only ever *added* as a rescue candidate (never used to override a reference-based dead-code verdict), gap 1 was the one way this function could misfire in the dangerous direction: a genuinely dead file kept alive by a fabricated match, rather than a live file wrongly flagged dead.

## Test plan
- [x] Added 3 new regression tests covering each gap, using the audit's own adversarial examples
- [x] Verified fail-before via `git stash` (all 3 new tests fail against the pre-fix code)
- [x] Verified pass-after (all 3 new tests + full existing `test_dead_code.py` = 108 passed)
- [x] Full `src/aletheore` suite: 1945 passed
- [x] Manually traced all three adversarial examples against the new code via a standalone script

🤖 Generated with [Claude Code](https://claude.com/claude-code)