### PR TITLE
fix: except-body-weakened check missed cases past a no-newline marker

### DIFF
--- a/github-app/scan_worker/semantic_checks.py
+++ b/github-app/scan_worker/semantic_checks.py
@@ -125,6 +125,29 @@ def _diff_hunks_by_file(diff_text: str) -> dict[str, list[_Hunk]]:
         if line == "":
             prev_blank = True
             continue
+        if line == r"\ No newline at end of file":
+            # Real bug found via audit: git emits this literal marker line
+            # immediately after a +/- line whenever that version of the
+            # file has no trailing newline - the identical shape
+            # flash_review.py's _patch_valid_lines/_diff_valid_lines
+            # already have a dedicated fix and comment for, unfixed here.
+            # Its own tag ("\\") matches neither " ", "-", nor "+", so
+            # unguarded it was appended to raw_body as a phantom entry.
+            # _unchanged_except_body_weakened's forward walk treats that
+            # entry's incidental one-space indent (" No newline...") as
+            # real body content: whenever it's shallower than or equal to
+            # the except header's own indent (true for any except nested
+            # inside a function, the overwhelmingly common case), the walk
+            # reads it as the dedent marking the end of the block and
+            # breaks - before ever reaching the hunk's real "+" content
+            # that comes after it. That skips this file's own documented
+            # bail-out path (running out of hunk without a real dedent),
+            # silently treating an incomplete reconstruction as a complete
+            # one instead - confirmed directly, a genuine "except body
+            # weakened to bare pass" case went unreported because the walk
+            # broke on the marker before ever seeing the new "pass" line.
+            prev_blank = False
+            continue
         prev_blank = False
         if current_hunk is None or not current_file:
             continue

--- a/github-app/tests/test_flash_review.py
+++ b/github-app/tests/test_flash_review.py
@@ -2725,6 +2725,52 @@ def test_semantic_checker_finds_a_weakened_body_under_an_unchanged_except_header
     assert findings[0]["line"] == 4
 
 
+def test_semantic_checker_finds_a_weakened_body_past_a_no_newline_marker():
+    """Real bug found via audit: git emits a literal "\\ No newline at end
+    of file" line immediately after a +/- line whenever that version of
+    the file has no trailing newline - the same shape flash_review.py's
+    _patch_valid_lines/_diff_valid_lines already have a dedicated fix for,
+    unfixed here. _unchanged_except_body_weakened's forward walk read that
+    marker's own one-space indent as real body content and, since it's
+    shallower than the except header's indent (true for any except nested
+    in a function - the common case), broke out of the walk right there -
+    before ever reaching the hunk's real "+pass"/"+return True" lines that
+    follow it. That meant the walk stopped with an empty new_body instead
+    of ["pass"], so the mismatch check silently declined to report a
+    genuine "except body weakened to bare pass" case. This shape is
+    realistic, not contrived: the old file lacked a trailing newline, and
+    the same edit that weakens the handler also appends more code after
+    it (restoring a trailing newline in the process) - confirmed directly
+    that the pre-fix parser missed this exact case."""
+    source = (
+        "def close_quietly(self):\n"
+        "    try:\n"
+        "        self.conn.close()\n"
+        "    except Exception:\n"
+        "        pass\n"
+        "    return True\n"
+    )
+    diff = (
+        "--- sessions.py ---\n"
+        "@@ -1,6 +1,6 @@\n"
+        " def close_quietly(self):\n"
+        "     try:\n"
+        "         self.conn.close()\n"
+        "     except Exception:\n"
+        "-        self.failed = True\n"
+        "-        logger.warning('close failed')\n"
+        "\\ No newline at end of file\n"
+        "+        pass\n"
+        "+    return True"
+    )
+
+    findings = find_semantic_regressions(diff, {"sessions.py": source}, "")
+
+    assert len(findings) == 1
+    assert "bare `pass`" in findings[0]["issue"]
+    assert findings[0]["line"] == 4
+
+
 def test_semantic_checker_does_not_flag_an_unchanged_except_already_pass():
     """An except block that was ALREADY `pass` before this hunk, with only
     unrelated surrounding code changing nearby, must not be flagged -


### PR DESCRIPTION
## Summary
Follow-up to #689 (Flash Review grounding's own no-newline-marker fix), finding the identical bug class unfixed in a second, independent diff parser: `semantic_checks.py`'s `_diff_hunks_by_file`.

- git emits a literal `\ No newline at end of file` line immediately after a `+`/`-` line whenever that version of the file has no trailing newline.
- `_diff_hunks_by_file` appended this marker to `hunk.raw_body` as an ordinary line, tagged `\`.
- `_unchanged_except_body_weakened`'s forward walk (used to detect an *existing* except block's body being replaced with a bare `pass`, without the except line itself changing) read that tag's own one-space indent as real body content. Since it's shallower than the except header's own indent — true for any except nested inside a function, the overwhelmingly common case — the walk broke right there, before ever reaching the hunk's real added content that follows.
- Net effect: a genuine "except body weakened to bare pass" case silently went unreported whenever the edit happened to sit next to a no-newline marker (realistic: an old file lacking a trailing newline gets its handler weakened *and* more code appended after it in the same edit, which also restores the newline).

This is a missed-finding gap (fails toward silence, not a wrong report), matching this file's own conservative philosophy elsewhere — but a real one, confirmed directly with a standalone repro before writing the regression test.

## Test plan
- [x] New regression test using the exact realistic shape (old file lacked a trailing newline; the same edit weakens the handler and appends code after it)
- [x] Verified fail-before via `git stash` (new test fails against pre-fix code)
- [x] Verified pass-after (`test_flash_review.py`: 201 passed)
- [x] Full `github-app` suite: 1871 passed, 8 skipped (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)