### PR TITLE
fix: managed-audit cooldown burned even when balance was exhausted

### DIFF
--- a/github-app/scan_worker/jobs.py
+++ b/github-app/scan_worker/jobs.py
@@ -1611,7 +1611,38 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
         evidence = json.loads(evidence_path.read_text())
         cooldown_seconds = cooldown_seconds_for_loc(total_loc_from_evidence(evidence))
         client = get_github_api_client()
-        if not check_and_reserve_managed_audit(
+
+        # Checked before reserving the cooldown slot below - real bug found
+        # via audit: check_and_reserve_managed_audit unconditionally commits
+        # the reservation the instant it returns True, with no rollback
+        # path. Checking the balance first (a plain read, no side effect)
+        # meant a request that arrives with an already-exhausted balance no
+        # longer burns this repo's next-eligible-audit timestamp for a run
+        # that produces no audit content at all - before this fix, even
+        # topping up the balance immediately after couldn't unblock a real
+        # audit on that repo until the full cooldown elapsed. This is still
+        # only a fast-fail hint, not the real enforcement - real enforcement
+        # is spend_budget.can_start_next_call() below, reserving atomically
+        # against the live total before every real LLM call this (possibly
+        # multi-call) audit makes. Same discipline as run_managed_audit_api_job
+        # - a stale read here has no financial-integrity consequence, just a
+        # possibly-later-than-ideal rejection.
+        balance_row = get_installation_row(settings.database_url, installation_id)
+        combined_balance = (
+            float(balance_row.get("base_credit_remaining_usd", 0))
+            + float(balance_row.get("topup_credit_balance_usd", 0))
+            if balance_row is not None else 0.0
+        )
+        cap_reached = combined_balance <= 0
+
+        if cap_reached:
+            body = (
+                f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
+                f"Credit balance exhausted for this installation (${combined_balance:.2f} "
+                "remaining). Resumes next billing period, or email support@aletheore.com "
+                "to top up sooner."
+            )
+        elif not check_and_reserve_managed_audit(
             settings.database_url, installation_id, repo_full_name, cooldown_seconds
         ):
             body = (
@@ -1620,78 +1651,53 @@ def run_managed_audit_pr_job(installation_id: int, repo_full_name: str, pr_numbe
                 f"{cooldown_seconds // 3600} hours. Try again later."
             )
         else:
-            # No lock: this is a fast-fail hint (skip straight to a clear PR
-            # comment when the balance is obviously already exhausted), not
-            # the enforcement itself - real enforcement is spend_budget.
-            # can_start_next_call() below, reserving atomically against the
-            # live total before every real LLM call this (possibly
-            # multi-call) audit makes. Same discipline as
-            # run_managed_audit_api_job - a stale read here has no
-            # financial-integrity consequence, just a possibly-later-than-
-            # ideal rejection.
-            balance_row = get_installation_row(settings.database_url, installation_id)
-            combined_balance = (
-                float(balance_row.get("base_credit_remaining_usd", 0))
-                + float(balance_row.get("topup_credit_balance_usd", 0))
-                if balance_row is not None else 0.0
+            # run_managed_audit can make several sequential LLM calls and
+            # has been observed to take minutes. The old
+            # installation_spend_lock check-then-record pair around the
+            # whole call left a real window: two concurrent managed
+            # audits for the same installation (different repos -
+            # check_and_reserve_managed_audit above is scoped per-repo,
+            # not per-installation) could both pass this check before
+            # either recorded a cost, and even a single run had no gate
+            # between its own individual LLM calls.
+            # _IncrementalSpendBudget closes both - the same atomic
+            # reserve-per-call primitive run_managed_audit_api_job
+            # already uses (see its own comment at this same call).
+            spend_budget = _IncrementalSpendBudget(
+                settings.database_url,
+                installation_id,
+                MANAGED_AUDIT_MODEL,
+                next_call_reserve_usd=MANAGED_AUDIT_LLM_RESERVE_USD,
+                feature="managed_audit",
             )
-            cap_reached = combined_balance <= 0
-
-            if cap_reached:
+            report_text = run_managed_audit(
+                repo_dir,
+                on_usage=spend_budget.record_usage,
+                before_llm_call=spend_budget.can_start_next_call,
+                allow_partial_report=True,
+                include_llm_suggestions=include_suggestions,
+            )
+            verification_token = _sign_and_persist_audit_report(
+                settings,
+                installation_id,
+                repo_full_name,
+                report_text,
+            )
+            if verification_token is not None:
+                verify_url = f"{settings.public_base_url}/v1/audit/{verification_token}/verify"
                 body = (
                     f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
-                    f"Credit balance exhausted for this installation (${combined_balance:.2f} "
-                    "remaining). Resumes next billing period, or email support@aletheore.com "
-                    "to top up sooner."
+                    f"{report_text}\n\n[Verify this report]({verify_url})"
+                )
+                _maybe_create_audit_certificate_check_run(
+                    client,
+                    token,
+                    repo_full_name,
+                    _git_rev_parse_head(repo_dir),
+                    verify_url,
                 )
             else:
-                # run_managed_audit can make several sequential LLM calls and
-                # has been observed to take minutes. The old
-                # installation_spend_lock check-then-record pair around the
-                # whole call left a real window: two concurrent managed
-                # audits for the same installation (different repos -
-                # check_and_reserve_managed_audit above is scoped per-repo,
-                # not per-installation) could both pass this check before
-                # either recorded a cost, and even a single run had no gate
-                # between its own individual LLM calls.
-                # _IncrementalSpendBudget closes both - the same atomic
-                # reserve-per-call primitive run_managed_audit_api_job
-                # already uses (see its own comment at this same call).
-                spend_budget = _IncrementalSpendBudget(
-                    settings.database_url,
-                    installation_id,
-                    MANAGED_AUDIT_MODEL,
-                    next_call_reserve_usd=MANAGED_AUDIT_LLM_RESERVE_USD,
-                    feature="managed_audit",
-                )
-                report_text = run_managed_audit(
-                    repo_dir,
-                    on_usage=spend_budget.record_usage,
-                    before_llm_call=spend_budget.can_start_next_call,
-                    allow_partial_report=True,
-                    include_llm_suggestions=include_suggestions,
-                )
-                verification_token = _sign_and_persist_audit_report(
-                    settings,
-                    installation_id,
-                    repo_full_name,
-                    report_text,
-                )
-                if verification_token is not None:
-                    verify_url = f"{settings.public_base_url}/v1/audit/{verification_token}/verify"
-                    body = (
-                        f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n"
-                        f"{report_text}\n\n[Verify this report]({verify_url})"
-                    )
-                    _maybe_create_audit_certificate_check_run(
-                        client,
-                        token,
-                        repo_full_name,
-                        _git_rev_parse_head(repo_dir),
-                        verify_url,
-                    )
-                else:
-                    body = f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n{report_text}"
+                body = f"{AUDIT_COMMENT_MARKER}\n### Aletheore managed audit\n\n{report_text}"
         upsert_pr_comment(
             client,
             token,

--- a/github-app/tests/test_jobs.py
+++ b/github-app/tests/test_jobs.py
@@ -2827,7 +2827,21 @@ def test_managed_audit_pr_job_skips_llm_call_when_spend_cap_reached(monkeypatch,
     assert posted["marker"] == AUDIT_COMMENT_MARKER
 
 
-def test_managed_audit_pr_job_skips_llm_call_when_rate_limited(monkeypatch, tmp_path):
+def test_managed_audit_pr_job_does_not_burn_the_cooldown_when_balance_is_exhausted(
+    monkeypatch, tmp_path
+):
+    """Real bug found via audit: check_and_reserve_managed_audit
+    unconditionally commits the repo's next-eligible-audit timestamp the
+    moment it returns True, with no rollback path. Before this fix, it
+    was called and its reservation committed BEFORE the credit balance
+    was even checked - so a request that arrived with an already-
+    exhausted balance still burned the cooldown for a run that produced
+    no audit content at all. A customer who topped up their balance
+    immediately after couldn't get a real audit on that repo until the
+    full cooldown elapsed anyway. The fix checks the balance (a plain
+    read, no side effect) before ever calling
+    check_and_reserve_managed_audit, so an exhausted balance no longer
+    consumes the reservation."""
     work = tmp_path / "work"
     work.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=work, check=True)
@@ -2853,6 +2867,77 @@ def test_managed_audit_pr_job_skips_llm_call_when_rate_limited(monkeypatch, tmp_
     monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
     monkeypatch.setattr(
         "scan_worker.jobs.get_installation_row", lambda *a, **k: {"plan": "air"}
+    )
+    monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
+    monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))
+    monkeypatch.setattr("scan_worker.jobs.get_installation_token", lambda *a, **k: "fake-token")
+    monkeypatch.setattr("scan_worker.jobs.generate_app_jwt", lambda *a, **k: "fake-jwt")
+    reserve_calls = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.check_and_reserve_managed_audit",
+        lambda *a, **k: reserve_calls.append(True) or True,
+    )
+    monkeypatch.setattr("scan_worker.jobs.managed_audit_definitely_still_cooling_down", lambda *a, **k: False)
+    monkeypatch.setattr("scan_worker.jobs.get_llm_spend_this_month", lambda *a, **k: 0.0)
+    monkeypatch.setattr("scan_worker.jobs.get_extra_seats", lambda *a, **k: 0)
+
+    llm_called = []
+    monkeypatch.setattr(
+        "scan_worker.jobs.run_managed_audit", lambda *a, **k: llm_called.append(True)
+    )
+    posted = {}
+    monkeypatch.setattr(
+        "scan_worker.jobs.upsert_pr_comment",
+        lambda client, token, repo_full_name, pr_number, body, **kwargs: posted.update(
+            body=body, marker=kwargs.get("marker")
+        ),
+    )
+    from scan_worker.jobs import AUDIT_COMMENT_MARKER, run_managed_audit_pr_job
+
+    run_managed_audit_pr_job(1, "octocat/hello-world", 42)
+
+    assert llm_called == []
+    assert "credit balance exhausted" in posted["body"].lower()
+    assert posted["marker"] == AUDIT_COMMENT_MARKER
+    # The crux of the fix: an exhausted balance must never reach the
+    # reservation call at all - the cooldown slot stays untouched, so a
+    # customer who tops up right after can get a real audit immediately.
+    assert reserve_calls == []
+
+
+def test_managed_audit_pr_job_skips_llm_call_when_rate_limited(monkeypatch, tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=work, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=work, check=True)
+    (work / "app.py").write_text("print('hello')\n")
+    subprocess.run(["git", "add", "."], cwd=work, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "commit"], cwd=work, check=True)
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=work,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(work), str(bare)], check=True)
+    subprocess.run(
+        ["git", "--git-dir", str(bare), "update-ref", "refs/pull/42/head", head_sha],
+        check=True,
+    )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused")
+    monkeypatch.setattr(
+        "scan_worker.jobs.get_installation_row",
+        # A real positive balance, not the $0 default a bare {"plan": ...}
+        # mock leaves - this test exercises the rate-limit path
+        # specifically, and (following the fix moving the balance check
+        # before the cooldown reservation) a $0 balance would report
+        # "credit balance exhausted" instead of ever reaching the rate
+        # limit at all, same as it would for a real customer.
+        lambda *a, **k: {"plan": "air", "base_credit_remaining_usd": 5.0},
     )
     monkeypatch.setattr("scan_worker.jobs.check_and_reserve_monthly_repo_scan_slot", lambda *a, **k: True)
     monkeypatch.setattr("scan_worker.jobs._clone_url", lambda repo_full_name, token: str(bare))


### PR DESCRIPTION
## Summary
Found via an independent audit of `jobs.py` (this repo's hottest hotspot, not otherwise touched this session).

- `check_and_reserve_managed_audit` unconditionally commits the repo's next-eligible-audit timestamp the instant it returns `True` - it's an atomic `INSERT ... ON CONFLICT ... RETURNING`, not a lock, with no rollback path.
- `run_managed_audit_pr_job` called it and had its reservation committed **before** the installation's credit balance was even checked.
- Net effect: a request that arrives with an already-exhausted balance still burns the repo's cooldown for a run that produces zero audit content - just a "credit balance exhausted" PR comment. A customer who tops up their balance immediately after can't get a real audit on that repo until the full cooldown elapses anyway (`cooldown_seconds_for_loc`-scaled, can be hours).

## Fix
Moves the balance/`cap_reached` check (a plain read, no side effect) before the reservation call - matching the ordering already used everywhere else in this file: a spend check gates before anything scarce gets reserved, never after.

## Test plan
- [x] Verified the bug directly against the real `scan_worker.db` functions and the shared test Postgres before writing any test
- [x] New regression test asserting `check_and_reserve_managed_audit` is never called when the balance is exhausted
- [x] Verified fail-before via `git stash` (new test fails against pre-fix code)
- [x] Updated one existing test (`..._skips_llm_call_when_rate_limited`) whose mock incidentally left a $0 balance, which the fix now surfaces before the rate-limit path it was meant to exercise - given a realistic positive balance instead
- [x] All `managed_audit_pr_job` tests: 11 passed
- [x] Full `github-app` suite: 1871 passed, 8 skipped (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)